### PR TITLE
separate public key handler

### DIFF
--- a/internal/api/s2s/user/publickeyget.go
+++ b/internal/api/s2s/user/publickeyget.go
@@ -1,0 +1,45 @@
+package user
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// PublicKeyGETHandler should be served at eg https://example.org/users/:username/main-key.
+//
+// The goal here is to return a MINIMAL activitypub representation of an account
+// in the form of a vocab.ActivityStreamsPerson. The account will only contain the id,
+// public key, username, and type of the account.
+func (m *Module) PublicKeyGETHandler(c *gin.Context) {
+	l := m.log.WithFields(logrus.Fields{
+		"func": "PublicKeyGETHandler",
+		"url":  c.Request.RequestURI,
+	})
+
+	requestedUsername := c.Param(UsernameKey)
+	if requestedUsername == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no username specified in request"})
+		return
+	}
+
+	// make sure this actually an AP request
+	format := c.NegotiateFormat(ActivityPubAcceptHeaders...)
+	if format == "" {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": "could not negotiate format with given Accept header(s)"})
+		return
+	}
+	l.Tracef("negotiated format: %s", format)
+
+	// make a copy of the context to pass along so we don't break anything
+	cp := c.Copy()
+	user, err := m.processor.GetFediUser(requestedUsername, cp.Request) // GetFediUser handles auth as well
+	if err != nil {
+		l.Info(err.Error())
+		c.JSON(err.Code(), gin.H{"error": err.Safe()})
+		return
+	}
+
+	c.JSON(http.StatusOK, user)
+}

--- a/internal/api/s2s/user/user.go
+++ b/internal/api/s2s/user/user.go
@@ -40,6 +40,8 @@ const (
 	// Use this anywhere you need to know the username of the user being queried.
 	// Eg https://example.org/users/:username
 	UsersBasePathWithUsername = UsersBasePath + "/:" + UsernameKey
+	// UsersPublicKeyPath is a path to a user's public key, for serving bare minimum AP representations.
+	UsersPublicKeyPath = UsersBasePathWithUsername + "/" + util.PublicKeyPath
 	// UsersInboxPath is for serving POST requests to a user's inbox with the given username key.
 	UsersInboxPath = UsersBasePathWithUsername + "/" + util.InboxPath
 	// UsersFollowersPath is for serving GET request's to a user's followers list, with the given username key.
@@ -80,5 +82,6 @@ func (m *Module) Route(s router.Router) error {
 	s.AttachHandler(http.MethodGet, UsersFollowersPath, m.FollowersGETHandler)
 	s.AttachHandler(http.MethodGet, UsersFollowingPath, m.FollowingGETHandler)
 	s.AttachHandler(http.MethodGet, UsersStatusPath, m.StatusGETHandler)
+	s.AttachHandler(http.MethodGet, UsersPublicKeyPath, m.PublicKeyGETHandler)
 	return nil
 }

--- a/internal/gtsmodel/account.go
+++ b/internal/gtsmodel/account.go
@@ -76,7 +76,7 @@ type Account struct {
 	*/
 
 	// Does this account need an approval for new followers?
-	Locked bool `pg:",default:false"`
+	Locked bool `pg:",default:true"`
 	// Should this account be shown in the instance's profile directory?
 	Discoverable bool `pg:",default:false"`
 	// Default post privacy for this account

--- a/internal/typeutils/converter.go
+++ b/internal/typeutils/converter.go
@@ -122,6 +122,7 @@ type TypeConverter interface {
 
 	// AccountToAS converts a gts model account into an activity streams person, suitable for federation
 	AccountToAS(a *gtsmodel.Account) (vocab.ActivityStreamsPerson, error)
+	AccountToASMinimal(a *gtsmodel.Account) (vocab.ActivityStreamsPerson, error)
 	// StatusToAS converts a gts model status into an activity streams note, suitable for federation
 	StatusToAS(s *gtsmodel.Status) (vocab.ActivityStreamsNote, error)
 	// FollowToASFollow converts a gts model Follow into an activity streams Follow, suitable for federation

--- a/internal/util/regexes.go
+++ b/internal/util/regexes.go
@@ -60,6 +60,9 @@ var (
 	// userPathRegex parses a path that validates and captures the username part from eg /users/example_username
 	userPathRegex = regexp.MustCompile(userPathRegexString)
 
+	userPublicKeyPathRegexString = fmt.Sprintf(`^?/%s/(%s)/%s`, UsersPath, usernameRegexString, PublicKeyPath)
+	userPublicKeyPathRegex = regexp.MustCompile(userPublicKeyPathRegexString)
+
 	inboxPathRegexString = fmt.Sprintf(`^/?%s/(%s)/%s$`, UsersPath, usernameRegexString, InboxPath)
 	// inboxPathRegex parses a path that validates and captures the username part from eg /users/example_username/inbox
 	inboxPathRegex = regexp.MustCompile(inboxPathRegexString)

--- a/internal/util/uri.go
+++ b/internal/util/uri.go
@@ -140,7 +140,7 @@ func GenerateURIsForAccount(username string, protocol string, host string) *User
 	followingURI := fmt.Sprintf("%s/%s", userURI, FollowingPath)
 	likedURI := fmt.Sprintf("%s/%s", userURI, LikedPath)
 	collectionURI := fmt.Sprintf("%s/%s/%s", userURI, CollectionsPath, FeaturedPath)
-	publicKeyURI := fmt.Sprintf("%s#%s", userURI, PublicKeyPath)
+	publicKeyURI := fmt.Sprintf("%s/%s", userURI, PublicKeyPath)
 
 	return &UserURIs{
 		HostURL:     hostURL,
@@ -207,6 +207,11 @@ func IsLikePath(id *url.URL) bool {
 // IsStatusesPath returns true if the given URL path corresponds to eg /users/example_username/statuses/SOME_ULID_OF_A_STATUS
 func IsStatusesPath(id *url.URL) bool {
 	return statusesPathRegex.MatchString(id.Path)
+}
+
+// IsPublicKeyPath returns true if the given URL path corresponds to eg /users/example_username/main-key
+func IsPublicKeyPath(id *url.URL) bool {
+	return userPublicKeyPathRegex.MatchString(id.Path)
 }
 
 // ParseStatusesPath returns the username and ulid from a path such as /users/example_username/statuses/SOME_ULID_OF_A_STATUS


### PR DESCRIPTION
now supports serving bare minimum responses to public key requests, so that servers can bypass normal authentication if they just want to get a public key (for example, if two servers who haven't communicated yet are talking to each other)

This solves a case where two gotosocial servers would get stuck in a handshake loop because they kept asking each other GIMME UR PUBLIC KEY and the other one was like NO GIMME YOURS, due to the way authentication worked before