### PR TITLE
fix the annoying infinite handshake bug (tested)

### DIFF
--- a/internal/federation/handshake.go
+++ b/internal/federation/handshake.go
@@ -1,0 +1,80 @@
+package federation
+
+import "net/url"
+
+func (f *federator) Handshaking(username string, remoteAccountID *url.URL) bool {
+	f.handshakeSync.Lock()
+	defer f.handshakeSync.Unlock()
+
+	if f.handshakes == nil {
+		// handshakes isn't even initialized yet so we can't be handshaking with anyone
+		return false
+	}
+
+	remoteIDs, ok := f.handshakes[username];
+	if !ok {
+		// user isn't handshaking with anyone, bail
+		return false
+	}
+
+	for _, id := range remoteIDs {
+		if id.String() == remoteAccountID.String() {
+			// we are currently handshaking with the remote account, yep
+			return true
+		}
+	}
+
+	// didn't find it which means we're not handshaking
+	return false
+}
+
+func (f *federator) startHandshake(username string, remoteAccountID *url.URL) {
+	f.handshakeSync.Lock()
+	defer f.handshakeSync.Unlock()
+
+	// lazily initialize handshakes
+	if f.handshakes == nil {
+		f.handshakes = make(map[string][]*url.URL)
+	}
+
+	remoteIDs, ok := f.handshakes[username]
+	if !ok {
+		// there was nothing in there yet, so just add this entry and return
+		f.handshakes[username] = []*url.URL{remoteAccountID}
+		return
+	}
+
+	// add the remote ID to the slice
+	remoteIDs = append(remoteIDs, remoteAccountID)
+	f.handshakes[username] = remoteIDs
+}
+
+func (f *federator) stopHandshake(username string, remoteAccountID *url.URL) {
+	f.handshakeSync.Lock()
+	defer f.handshakeSync.Unlock()
+
+	if f.handshakes == nil {
+		return
+	}
+
+	remoteIDs, ok := f.handshakes[username]
+	if !ok {
+		// there was nothing in there yet anyway so just bail
+		return
+	}
+
+	newRemoteIDs := []*url.URL{}
+	for _, id := range remoteIDs {
+		if id.String() != remoteAccountID.String() {
+			newRemoteIDs = append(newRemoteIDs, id)
+		}
+	}
+
+	if len(newRemoteIDs) == 0 {
+		// there are no handshakes so just remove this user entry from the map and save a few bytes
+		delete(f.handshakes, username)
+	} else {
+		// there are still other handshakes ongoing
+		f.handshakes[username] = newRemoteIDs
+	}
+}

--- a/internal/federation/util.go
+++ b/internal/federation/util.go
@@ -213,6 +213,8 @@ func (f *federator) AuthenticateFederatedRequest(username string, r *http.Reques
 }
 
 func (f *federator) DereferenceRemoteAccount(username string, remoteAccountID *url.URL) (typeutils.Accountable, error) {
+	f.startHandshake(username, remoteAccountID)
+	defer f.stopHandshake(username, remoteAccountID)
 
 	transport, err := f.GetTransportForUser(username)
 	if err != nil {


### PR DESCRIPTION
This PR fixes the annoying infinite handshake bug between two gotosocial servers:

* Add a 'Handshaking' function to the Federator, so that structs with access to a federator can check whether a handshake is currently in progress with a remote user.
* If a handshake is in progress already (ie., we're already dereferencing a remote user) don't try to dereference them again as part of authorization.

In other words, we short-circuit the broken-ass loop by saying 'okay, if these two servers are trying to dereference each other at the same time, just have them give up their information to each other'.