### PR TITLE
Remote instance dereferencing

### DIFF
--- a/internal/federation/commonbehavior.go
+++ b/internal/federation/commonbehavior.go
@@ -20,15 +20,10 @@ package federation
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"net/url"
 
-	"github.com/go-fed/activity/pub"
 	"github.com/go-fed/activity/streams"
 	"github.com/go-fed/activity/streams/vocab"
-	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
 
 /*
@@ -100,54 +95,4 @@ func (f *federator) GetOutbox(ctx context.Context, r *http.Request) (vocab.Activ
 	// IMPLEMENTATION NOTE: For GoToSocial, we serve GETS to outboxes and inboxes through
 	// the CLIENT API, not through the federation API, so we just do nothing here.
 	return streams.NewActivityStreamsOrderedCollectionPage(), nil
-}
-
-// NewTransport returns a new Transport on behalf of a specific actor.
-//
-// The actorBoxIRI will be either the inbox or outbox of an actor who is
-// attempting to do the dereferencing or delivery. Any authentication
-// scheme applied on the request must be based on this actor. The
-// request must contain some sort of credential of the user, such as a
-// HTTP Signature.
-//
-// The gofedAgent passed in should be used by the Transport
-// implementation in the User-Agent, as well as the application-specific
-// user agent string. The gofedAgent will indicate this library's use as
-// well as the library's version number.
-//
-// Any server-wide rate-limiting that needs to occur should happen in a
-// Transport implementation. This factory function allows this to be
-// created, so peer servers are not DOS'd.
-//
-// Any retry logic should also be handled by the Transport
-// implementation.
-//
-// Note that the library will not maintain a long-lived pointer to the
-// returned Transport so that any private credentials are able to be
-// garbage collected.
-func (f *federator) NewTransport(ctx context.Context, actorBoxIRI *url.URL, gofedAgent string) (pub.Transport, error) {
-
-	var username string
-	var err error
-
-	if util.IsInboxPath(actorBoxIRI) {
-		username, err = util.ParseInboxPath(actorBoxIRI)
-		if err != nil {
-			return nil, fmt.Errorf("couldn't parse path %s as an inbox: %s", actorBoxIRI.String(), err)
-		}
-	} else if util.IsOutboxPath(actorBoxIRI) {
-		username, err = util.ParseOutboxPath(actorBoxIRI)
-		if err != nil {
-			return nil, fmt.Errorf("couldn't parse path %s as an outbox: %s", actorBoxIRI.String(), err)
-		}
-	} else {
-		return nil, fmt.Errorf("id %s was neither an inbox path nor an outbox path", actorBoxIRI.String())
-	}
-
-	account := &gtsmodel.Account{}
-	if err := f.db.GetLocalAccountByUsername(username, account); err != nil {
-		return nil, fmt.Errorf("error getting account with username %s from the db: %s", username, err)
-	}
-
-	return f.transportController.NewTransport(account.PublicKeyURI, account.PrivateKey)
 }

--- a/internal/federation/dereference.go
+++ b/internal/federation/dereference.go
@@ -1,0 +1,151 @@
+package federation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/go-fed/activity/streams"
+	"github.com/go-fed/activity/streams/vocab"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/typeutils"
+)
+
+func (f *federator) DereferenceRemoteAccount(username string, remoteAccountID *url.URL) (typeutils.Accountable, error) {
+
+	transport, err := f.GetTransportForUser(username)
+	if err != nil {
+		return nil, fmt.Errorf("transport err: %s", err)
+	}
+
+	b, err := transport.Dereference(context.Background(), remoteAccountID)
+	if err != nil {
+		return nil, fmt.Errorf("error deferencing %s: %s", remoteAccountID.String(), err)
+	}
+
+	m := make(map[string]interface{})
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("error unmarshalling bytes into json: %s", err)
+	}
+
+	t, err := streams.ToType(context.Background(), m)
+	if err != nil {
+		return nil, fmt.Errorf("error resolving json into ap vocab type: %s", err)
+	}
+
+	switch t.GetTypeName() {
+	case string(gtsmodel.ActivityStreamsPerson):
+		p, ok := t.(vocab.ActivityStreamsPerson)
+		if !ok {
+			return nil, errors.New("error resolving type as activitystreams person")
+		}
+		return p, nil
+	case string(gtsmodel.ActivityStreamsApplication):
+		p, ok := t.(vocab.ActivityStreamsApplication)
+		if !ok {
+			return nil, errors.New("error resolving type as activitystreams application")
+		}
+		return p, nil
+	case string(gtsmodel.ActivityStreamsService):
+		p, ok := t.(vocab.ActivityStreamsService)
+		if !ok {
+			return nil, errors.New("error resolving type as activitystreams service")
+		}
+		return p, nil
+	}
+
+	return nil, fmt.Errorf("type name %s not supported", t.GetTypeName())
+}
+
+func (f *federator) DereferenceRemoteStatus(username string, remoteStatusID *url.URL) (typeutils.Statusable, error) {
+	transport, err := f.GetTransportForUser(username)
+	if err != nil {
+		return nil, fmt.Errorf("transport err: %s", err)
+	}
+
+	b, err := transport.Dereference(context.Background(), remoteStatusID)
+	if err != nil {
+		return nil, fmt.Errorf("error deferencing %s: %s", remoteStatusID.String(), err)
+	}
+
+	m := make(map[string]interface{})
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("error unmarshalling bytes into json: %s", err)
+	}
+
+	t, err := streams.ToType(context.Background(), m)
+	if err != nil {
+		return nil, fmt.Errorf("error resolving json into ap vocab type: %s", err)
+	}
+
+	// Article, Document, Image, Video, Note, Page, Event, Place, Mention, Profile
+	switch t.GetTypeName() {
+	case gtsmodel.ActivityStreamsArticle:
+		p, ok := t.(vocab.ActivityStreamsArticle)
+		if !ok {
+			return nil, errors.New("error resolving type as ActivityStreamsArticle")
+		}
+		return p, nil
+	case gtsmodel.ActivityStreamsDocument:
+		p, ok := t.(vocab.ActivityStreamsDocument)
+		if !ok {
+			return nil, errors.New("error resolving type as ActivityStreamsDocument")
+		}
+		return p, nil
+	case gtsmodel.ActivityStreamsImage:
+		p, ok := t.(vocab.ActivityStreamsImage)
+		if !ok {
+			return nil, errors.New("error resolving type as ActivityStreamsImage")
+		}
+		return p, nil
+	case gtsmodel.ActivityStreamsVideo:
+		p, ok := t.(vocab.ActivityStreamsVideo)
+		if !ok {
+			return nil, errors.New("error resolving type as ActivityStreamsVideo")
+		}
+		return p, nil
+	case gtsmodel.ActivityStreamsNote:
+		p, ok := t.(vocab.ActivityStreamsNote)
+		if !ok {
+			return nil, errors.New("error resolving type as ActivityStreamsNote")
+		}
+		return p, nil
+	case gtsmodel.ActivityStreamsPage:
+		p, ok := t.(vocab.ActivityStreamsPage)
+		if !ok {
+			return nil, errors.New("error resolving type as ActivityStreamsPage")
+		}
+		return p, nil
+	case gtsmodel.ActivityStreamsEvent:
+		p, ok := t.(vocab.ActivityStreamsEvent)
+		if !ok {
+			return nil, errors.New("error resolving type as ActivityStreamsEvent")
+		}
+		return p, nil
+	case gtsmodel.ActivityStreamsPlace:
+		p, ok := t.(vocab.ActivityStreamsPlace)
+		if !ok {
+			return nil, errors.New("error resolving type as ActivityStreamsPlace")
+		}
+		return p, nil
+	case gtsmodel.ActivityStreamsProfile:
+		p, ok := t.(vocab.ActivityStreamsProfile)
+		if !ok {
+			return nil, errors.New("error resolving type as ActivityStreamsProfile")
+		}
+		return p, nil
+	}
+
+	return nil, fmt.Errorf("type name %s not supported", t.GetTypeName())
+}
+
+func (f *federator) DereferenceRemoteInstance(username string, remoteInstanceURI *url.URL) (*gtsmodel.Instance, error) {
+	transport, err := f.GetTransportForUser(username)
+	if err != nil {
+		return nil, fmt.Errorf("transport err: %s", err)
+	}
+
+	return transport.DereferenceInstance(context.Background(), remoteInstanceURI)
+}

--- a/internal/federation/dereference.go
+++ b/internal/federation/dereference.go
@@ -14,6 +14,8 @@ import (
 )
 
 func (f *federator) DereferenceRemoteAccount(username string, remoteAccountID *url.URL) (typeutils.Accountable, error) {
+	f.startHandshake(username, remoteAccountID)
+	defer f.stopHandshake(username, remoteAccountID)
 
 	transport, err := f.GetTransportForUser(username)
 	if err != nil {

--- a/internal/federation/federatingprotocol.go
+++ b/internal/federation/federatingprotocol.go
@@ -125,6 +125,18 @@ func (f *federator) AuthenticatePostInbox(ctx context.Context, w http.ResponseWr
 		return ctx, false, fmt.Errorf("not authenticated: %s", err)
 	}
 
+	// authentication has passed, so add an instance entry for this instance if it hasn't been done already
+	i := &gtsmodel.Instance{}
+	if err := f.db.GetWhere([]db.Where{{Key: "domain", Value: publicKeyOwnerURI.Host, CaseInsensitive: true}}, i); err != nil {
+		if _, ok := err.(db.ErrNoEntries); !ok {
+			// there's been an actual error
+			return ctx, false, fmt.Errorf("error getting requesting account with public key id %s: %s", publicKeyOwnerURI.String(), err)
+		}
+		// we don't have an entry for this instance yet so create it
+		var err error
+		i, err := f.DereferenceRemoteInstance()
+	}
+
 	requestingAccount := &gtsmodel.Account{}
 	if err := f.db.GetWhere([]db.Where{{Key: "uri", Value: publicKeyOwnerURI.String()}}, requestingAccount); err != nil {
 		// there's been a proper error so return it

--- a/internal/federation/federatingprotocol.go
+++ b/internal/federation/federatingprotocol.go
@@ -136,7 +136,7 @@ func (f *federator) AuthenticatePostInbox(ctx context.Context, w http.ResponseWr
 		// we don't have an entry for this instance yet so dereference it
 		i, err = f.DereferenceRemoteInstance(username, &url.URL{
 			Scheme: publicKeyOwnerURI.Scheme,
-			Host: publicKeyOwnerURI.Host,
+			Host:   publicKeyOwnerURI.Host,
 		})
 		if err != nil {
 			return nil, false, fmt.Errorf("could not dereference new remote instance %s during AuthenticatePostInbox: %s", publicKeyOwnerURI.Host, err)

--- a/internal/federation/federatingprotocol.go
+++ b/internal/federation/federatingprotocol.go
@@ -132,9 +132,20 @@ func (f *federator) AuthenticatePostInbox(ctx context.Context, w http.ResponseWr
 			// there's been an actual error
 			return ctx, false, fmt.Errorf("error getting requesting account with public key id %s: %s", publicKeyOwnerURI.String(), err)
 		}
-		// we don't have an entry for this instance yet so create it
-		var err error
-		i, err := f.DereferenceRemoteInstance()
+
+		// we don't have an entry for this instance yet so dereference it
+		i, err = f.DereferenceRemoteInstance(username, &url.URL{
+			Scheme: publicKeyOwnerURI.Scheme,
+			Host: publicKeyOwnerURI.Host,
+		})
+		if err != nil {
+			return nil, false, fmt.Errorf("could not dereference new remote instance %s during AuthenticatePostInbox: %s", publicKeyOwnerURI.Host, err)
+		}
+
+		// and put it in the db
+		if err := f.db.Put(i); err != nil {
+			return nil, false, fmt.Errorf("error inserting newly dereferenced instance %s: %s", publicKeyOwnerURI.Host, err)
+		}
 	}
 
 	requestingAccount := &gtsmodel.Account{}

--- a/internal/federation/federator.go
+++ b/internal/federation/federator.go
@@ -25,10 +25,10 @@ import (
 
 	"github.com/go-fed/activity/pub"
 	"github.com/sirupsen/logrus"
-	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/federation/federatingdb"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/transport"
 	"github.com/superseriousbusiness/gotosocial/internal/typeutils"
 )
@@ -51,8 +51,9 @@ type Federator interface {
 	// DereferenceRemoteStatus can be used to get the representation of a remote status, based on its ID (which is a URI).
 	// The given username will be used to create a transport for making outgoing requests. See the implementation for more detailed comments.
 	DereferenceRemoteStatus(username string, remoteStatusID *url.URL) (typeutils.Statusable, error)
-	// DereferenceRemoteInstance
-	DereferenceRemoteInstance(username string, remoteInstanceURI *url.URL) (*apimodel.Instance, error)
+	// DereferenceRemoteInstance takes the URL of a remote instance, and a username (optional) to spin up a transport with. It then
+	// does its damnedest to get some kind of information back about the instance, trying /api/v1/instance, then /.well-known/nodeinfo
+	DereferenceRemoteInstance(username string, remoteInstanceURI *url.URL) (*gtsmodel.Instance, error)
 	// GetTransportForUser returns a new transport initialized with the key credentials belonging to the given username.
 	// This can be used for making signed http requests.
 	//

--- a/internal/federation/federator.go
+++ b/internal/federation/federator.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/go-fed/activity/pub"
 	"github.com/sirupsen/logrus"
+	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/federation/federatingdb"
@@ -50,6 +51,8 @@ type Federator interface {
 	// DereferenceRemoteStatus can be used to get the representation of a remote status, based on its ID (which is a URI).
 	// The given username will be used to create a transport for making outgoing requests. See the implementation for more detailed comments.
 	DereferenceRemoteStatus(username string, remoteStatusID *url.URL) (typeutils.Statusable, error)
+	// DereferenceRemoteInstance
+	DereferenceRemoteInstance(username string, remoteInstanceURI *url.URL) (*apimodel.Instance, error)
 	// GetTransportForUser returns a new transport initialized with the key credentials belonging to the given username.
 	// This can be used for making signed http requests.
 	//

--- a/internal/federation/transport.go
+++ b/internal/federation/transport.go
@@ -1,0 +1,84 @@
+package federation
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/go-fed/activity/pub"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/transport"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
+)
+
+// NewTransport returns a new Transport on behalf of a specific actor.
+//
+// The actorBoxIRI will be either the inbox or outbox of an actor who is
+// attempting to do the dereferencing or delivery. Any authentication
+// scheme applied on the request must be based on this actor. The
+// request must contain some sort of credential of the user, such as a
+// HTTP Signature.
+//
+// The gofedAgent passed in should be used by the Transport
+// implementation in the User-Agent, as well as the application-specific
+// user agent string. The gofedAgent will indicate this library's use as
+// well as the library's version number.
+//
+// Any server-wide rate-limiting that needs to occur should happen in a
+// Transport implementation. This factory function allows this to be
+// created, so peer servers are not DOS'd.
+//
+// Any retry logic should also be handled by the Transport
+// implementation.
+//
+// Note that the library will not maintain a long-lived pointer to the
+// returned Transport so that any private credentials are able to be
+// garbage collected.
+func (f *federator) NewTransport(ctx context.Context, actorBoxIRI *url.URL, gofedAgent string) (pub.Transport, error) {
+
+	var username string
+	var err error
+
+	if util.IsInboxPath(actorBoxIRI) {
+		username, err = util.ParseInboxPath(actorBoxIRI)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't parse path %s as an inbox: %s", actorBoxIRI.String(), err)
+		}
+	} else if util.IsOutboxPath(actorBoxIRI) {
+		username, err = util.ParseOutboxPath(actorBoxIRI)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't parse path %s as an outbox: %s", actorBoxIRI.String(), err)
+		}
+	} else {
+		return nil, fmt.Errorf("id %s was neither an inbox path nor an outbox path", actorBoxIRI.String())
+	}
+
+	account := &gtsmodel.Account{}
+	if err := f.db.GetLocalAccountByUsername(username, account); err != nil {
+		return nil, fmt.Errorf("error getting account with username %s from the db: %s", username, err)
+	}
+
+	return f.transportController.NewTransport(account.PublicKeyURI, account.PrivateKey)
+}
+
+func (f *federator) GetTransportForUser(username string) (transport.Transport, error) {
+	// We need an account to use to create a transport for dereferecing something.
+	// If a username has been given, we can fetch the account with that username and use it.
+	// Otherwise, we can take the instance account and use those credentials to make the request.
+	ourAccount := &gtsmodel.Account{}
+	var u string
+	if username == "" {
+		u = f.config.Host
+	} else {
+		u = username
+	}
+	if err := f.db.GetLocalAccountByUsername(u, ourAccount); err != nil {
+		return nil, fmt.Errorf("error getting account %s from db: %s", username, err)
+	}
+
+	transport, err := f.transportController.NewTransport(ourAccount.PublicKeyURI, ourAccount.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("error creating transport for user %s: %s", username, err)
+	}
+	return transport, nil
+}

--- a/internal/federation/util.go
+++ b/internal/federation/util.go
@@ -37,6 +37,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/transport"
 	"github.com/superseriousbusiness/gotosocial/internal/typeutils"
+	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 )
 
 /*
@@ -134,7 +135,8 @@ func (f *federator) AuthenticateFederatedRequest(username string, r *http.Reques
 	var pkOwnerURI *url.URL
 	requestingRemoteAccount := &gtsmodel.Account{}
 	requestingLocalAccount := &gtsmodel.Account{}
-	if strings.EqualFold(requestingPublicKeyID.Host, f.config.Host) {
+	requestingHost := requestingPublicKeyID.Host
+	if strings.EqualFold(requestingHost, f.config.Host) {
 		// LOCAL ACCOUNT REQUEST
 		// the request is coming from INSIDE THE HOUSE so skip the remote dereferencing
 		if err := f.db.GetWhere([]db.Where{{Key: "public_key_uri", Value: requestingPublicKeyID.String()}}, requestingLocalAccount); err != nil {
@@ -340,6 +342,15 @@ func (f *federator) DereferenceRemoteStatus(username string, remoteStatusID *url
 	}
 
 	return nil, fmt.Errorf("type name %s not supported", t.GetTypeName())
+}
+
+func (f *federator) DereferenceRemoteInstance(username string, remoteInstanceURI *url.URL) (*apimodel.Instance, error) {
+	transport, err := f.GetTransportForUser(username)
+	if err != nil {
+		return nil, fmt.Errorf("transport err: %s", err)
+	}
+
+	return transport.DereferenceInstance(context.Background(), remoteInstanceURI)
 }
 
 func (f *federator) GetTransportForUser(username string) (transport.Transport, error) {

--- a/internal/gtsmodel/instance.go
+++ b/internal/gtsmodel/instance.go
@@ -28,6 +28,8 @@ type Instance struct {
 	Terms string
 	// Contact email address for this instance
 	ContactEmail string
+	// Username of the contact account for this instance
+	ContactAccountUsername string
 	// Contact account ID in the database for this instance
 	ContactAccountID string `pg:"type:CHAR(26)"`
 	// Reputation score of this instance

--- a/internal/transport/deliver.go
+++ b/internal/transport/deliver.go
@@ -1,0 +1,16 @@
+package transport
+
+import (
+	"context"
+	"net/url"
+)
+
+func (t *transport) BatchDeliver(c context.Context, b []byte, recipients []*url.URL) error {
+	return t.sigTransport.BatchDeliver(c, b, recipients)
+}
+
+func (t *transport) Deliver(c context.Context, b []byte, to *url.URL) error {
+	l := t.log.WithField("func", "Deliver")
+	l.Debugf("performing POST to %s", to.String())
+	return t.sigTransport.Deliver(c, b, to)
+}

--- a/internal/transport/dereference.go
+++ b/internal/transport/dereference.go
@@ -1,0 +1,12 @@
+package transport
+
+import (
+	"context"
+	"net/url"
+)
+
+func (t *transport) Dereference(c context.Context, iri *url.URL) ([]byte, error) {
+	l := t.log.WithField("func", "Dereference")
+	l.Debugf("performing GET to %s", iri.String())
+	return t.sigTransport.Dereference(c, iri)
+}

--- a/internal/transport/derefinstance.go
+++ b/internal/transport/derefinstance.go
@@ -27,7 +27,7 @@ func (t *transport) DereferenceInstance(c context.Context, iri *url.URL) (*gtsmo
 	//
 	// This will only work with Mastodon-api compatible instances: Mastodon, some Pleroma instances, GoToSocial.
 	l.Debugf("trying to dereference instance %s by /api/v1/instance", iri.Host)
-	i, err = dereferenceByAPIV1Instance(t, c, iri)
+	i, err = dereferenceByAPIV1Instance(c, t, iri)
 	if err == nil {
 		l.Debugf("successfully dereferenced instance using /api/v1/instance")
 		return i, nil
@@ -37,7 +37,7 @@ func (t *transport) DereferenceInstance(c context.Context, iri *url.URL) (*gtsmo
 	// If that doesn't work, try to dereference using /.well-known/nodeinfo.
 	// This will involve two API calls and return less info overall, but should be more widely compatible.
 	l.Debugf("trying to dereference instance %s by /.well-known/nodeinfo", iri.Host)
-	i, err = dereferenceByNodeInfo(t, c, iri)
+	i, err = dereferenceByNodeInfo(c, t, iri)
 	if err == nil {
 		l.Debugf("successfully dereferenced instance using /.well-known/nodeinfo")
 		return i, nil
@@ -58,7 +58,7 @@ func (t *transport) DereferenceInstance(c context.Context, iri *url.URL) (*gtsmo
 	}, nil
 }
 
-func dereferenceByAPIV1Instance(t *transport, c context.Context, iri *url.URL) (*gtsmodel.Instance, error) {
+func dereferenceByAPIV1Instance(c context.Context, t *transport, iri *url.URL) (*gtsmodel.Instance, error) {
 	l := t.log.WithField("func", "dereferenceByAPIV1Instance")
 
 	cleanIRI := &url.URL{
@@ -131,13 +131,13 @@ func dereferenceByAPIV1Instance(t *transport, c context.Context, iri *url.URL) (
 	return i, nil
 }
 
-func dereferenceByNodeInfo(t *transport, c context.Context, iri *url.URL) (*gtsmodel.Instance, error) {
-	niIRI, err := callNodeInfoWellKnown(t, c, iri)
+func dereferenceByNodeInfo(c context.Context, t *transport, iri *url.URL) (*gtsmodel.Instance, error) {
+	niIRI, err := callNodeInfoWellKnown(c, t, iri)
 	if err != nil {
 		return nil, fmt.Errorf("dereferenceByNodeInfo: error during initial call to well-known nodeinfo: %s", err)
 	}
 
-	ni, err := callNodeInfo(t, c, niIRI)
+	ni, err := callNodeInfo(c, t, niIRI)
 	if err != nil {
 		return nil, fmt.Errorf("dereferenceByNodeInfo: error doing second call to nodeinfo uri %s: %s", niIRI.String(), err)
 	}
@@ -216,7 +216,7 @@ func dereferenceByNodeInfo(t *transport, c context.Context, iri *url.URL) (*gtsm
 	return i, nil
 }
 
-func callNodeInfoWellKnown(t *transport, c context.Context, iri *url.URL) (*url.URL, error) {
+func callNodeInfoWellKnown(c context.Context, t *transport, iri *url.URL) (*url.URL, error) {
 	l := t.log.WithField("func", "callNodeInfoWellKnown")
 
 	cleanIRI := &url.URL{
@@ -281,7 +281,7 @@ func callNodeInfoWellKnown(t *transport, c context.Context, iri *url.URL) (*url.
 	return nodeinfoHref, nil
 }
 
-func callNodeInfo(t *transport, c context.Context, iri *url.URL) (*apimodel.Nodeinfo, error) {
+func callNodeInfo(c context.Context, t *transport, iri *url.URL) (*apimodel.Nodeinfo, error) {
 	l := t.log.WithField("func", "callNodeInfo")
 
 	l.Debugf("performing GET to %s", iri.String())

--- a/internal/transport/derefinstance.go
+++ b/internal/transport/derefinstance.go
@@ -180,6 +180,6 @@ func dereferenceByNodeInfo(t *transport, c context.Context, iri *url.URL) (*gtsm
 	if nodeinfoHref == nil {
 		return nil, errors.New("could not find nodeinfo rel in well known response")
 	}
-aaaaaaaaaaaaaaaaa // do the second query
+    // TODO: do the second query
 	return nil, errors.New("not yet implemented")
 }

--- a/internal/transport/derefinstance.go
+++ b/internal/transport/derefinstance.go
@@ -1,0 +1,185 @@
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/id"
+)
+
+func (t *transport) DereferenceInstance(c context.Context, iri *url.URL) (*gtsmodel.Instance, error) {
+	l := t.log.WithField("func", "DereferenceInstance")
+
+	var i *gtsmodel.Instance
+	var err error
+
+	// First try to dereference using /api/v1/instance.
+	// This will provide the most complete picture of an instance, and avoid unnecessary api calls.
+	//
+	// This will only work with Mastodon-api compatible instances: Mastodon, some Pleroma instances, GoToSocial.
+	l.Debugf("trying to dereference instance %s by /api/v1/instance", iri.Host)
+	i, err = dereferenceByAPIV1Instance(t, c, iri)
+	if err == nil {
+		l.Debugf("successfully dereferenced instance using /api/v1/instance")
+		return i, nil
+	}
+	l.Debugf("couldn't dereference instance using /api/v1/instance: %s", err)
+
+	// If that doesn't work, try to dereference using /.well-known/nodeinfo.
+	// This will involve two API calls and return less info overall, but should be more widely compatible.
+	l.Debugf("trying to dereference instance %s by /.well-known/nodeinfo", iri.Host)
+	i, err = dereferenceByNodeInfo(t, c, iri)
+	if err == nil {
+		l.Debugf("successfully dereferenced instance using /.well-known/nodeinfo")
+		return i, nil
+	}
+	l.Debugf("couldn't dereference instance using /.well-known/nodeinfo: %s", err)
+
+	return nil, fmt.Errorf("couldn't dereference instance %s using either /api/v1/instance or /.well-known/nodeinfo", iri.Host)
+}
+
+func dereferenceByAPIV1Instance(t *transport, c context.Context, iri *url.URL) (*gtsmodel.Instance, error) {
+	l := t.log.WithField("func", "dereferenceByAPIV1Instance")
+
+	cleanIRI := &url.URL{
+		Scheme: iri.Scheme,
+		Host:   iri.Host,
+		Path:   "api/v1/instance",
+	}
+
+	l.Debugf("performing GET to %s", cleanIRI.String())
+	req, err := http.NewRequest("GET", cleanIRI.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(c)
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Date", t.clock.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05")+" GMT")
+	req.Header.Add("User-Agent", fmt.Sprintf("%s %s", t.appAgent, t.gofedAgent))
+	req.Header.Set("Host", cleanIRI.Host)
+	t.getSignerMu.Lock()
+	err = t.getSigner.SignRequest(t.privkey, t.pubKeyID, req, nil)
+	t.getSignerMu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET request to %s failed (%d): %s", cleanIRI.String(), resp.StatusCode, resp.Status)
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(b) == 0 {
+		return nil, errors.New("response bytes was len 0")
+	}
+
+	// try to parse the returned bytes directly into an Instance model
+	apiResp := &apimodel.Instance{}
+	if err := json.Unmarshal(b, apiResp); err != nil {
+		return nil, err
+	}
+
+	var contactUsername string
+	if apiResp.ContactAccount != nil {
+		contactUsername = apiResp.ContactAccount.Username
+	}
+
+	ulid, err := id.NewRandomULID()
+	if err != nil {
+		return nil, err
+	}
+
+	i := &gtsmodel.Instance{
+		ID:                     ulid,
+		Domain:                 iri.Host,
+		Title:                  apiResp.Title,
+		URI:                    fmt.Sprintf("%s://%s", iri.Scheme, iri.Host),
+		ShortDescription:       apiResp.ShortDescription,
+		Description:            apiResp.Description,
+		ContactEmail:           apiResp.Email,
+		ContactAccountUsername: contactUsername,
+		Version:                apiResp.Version,
+	}
+
+	return i, nil
+}
+
+func dereferenceByNodeInfo(t *transport, c context.Context, iri *url.URL) (*gtsmodel.Instance, error) {
+	l := t.log.WithField("func", "dereferenceByNodeInfo")
+
+	cleanIRI := &url.URL{
+		Scheme: iri.Scheme,
+		Host:   iri.Host,
+		Path:   ".well-known/nodeinfo",
+	}
+
+	l.Debugf("performing GET to %s", cleanIRI.String())
+	req, err := http.NewRequest("GET", cleanIRI.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(c)
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Date", t.clock.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05")+" GMT")
+	req.Header.Add("User-Agent", fmt.Sprintf("%s %s", t.appAgent, t.gofedAgent))
+	req.Header.Set("Host", cleanIRI.Host)
+	t.getSignerMu.Lock()
+	err = t.getSigner.SignRequest(t.privkey, t.pubKeyID, req, nil)
+	t.getSignerMu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET request to %s failed (%d): %s", cleanIRI.String(), resp.StatusCode, resp.Status)
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(b) == 0 {
+		return nil, errors.New("dereferenceByNodeInfo: response bytes was len 0")
+	}
+
+	wellKnownResp := &apimodel.WellKnownResponse{}
+	if err := json.Unmarshal(b, wellKnownResp); err != nil {
+		return nil, fmt.Errorf("dereferenceByNodeInfo: could not unmarshal server response as WellKnownResponse: %s", err)
+	}
+
+	// look through the links for the first one that matches the nodeinfo schema, this is what we need
+	var nodeinfoHref *url.URL
+	for _, l := range wellKnownResp.Links {
+		if l.Href == "" || !strings.HasPrefix(l.Rel, "http://nodeinfo.diaspora.software/ns/schema") {
+			continue
+		}
+		nodeinfoHref, err = url.Parse(l.Href)
+		if err != nil {
+			return nil, fmt.Errorf("dereferenceByNodeInfo: couldn't parse url %s: %s", l.Href, err)
+		}
+	}
+	if nodeinfoHref == nil {
+		return nil, errors.New("could not find nodeinfo rel in well known response")
+	}
+aaaaaaaaaaaaaaaaa // do the second query
+	return nil, errors.New("not yet implemented")
+}

--- a/internal/transport/derefmedia.go
+++ b/internal/transport/derefmedia.go
@@ -1,0 +1,42 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+func (t *transport) DereferenceMedia(c context.Context, iri *url.URL, expectedContentType string) ([]byte, error) {
+	l := t.log.WithField("func", "DereferenceMedia")
+	l.Debugf("performing GET to %s", iri.String())
+	req, err := http.NewRequest("GET", iri.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(c)
+	if expectedContentType == "" {
+		req.Header.Add("Accept", "*/*")
+	} else {
+		req.Header.Add("Accept", expectedContentType)
+	}
+	req.Header.Add("Date", t.clock.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05")+" GMT")
+	req.Header.Add("User-Agent", fmt.Sprintf("%s %s", t.appAgent, t.gofedAgent))
+	req.Header.Set("Host", iri.Host)
+	t.getSignerMu.Lock()
+	err = t.getSigner.SignRequest(t.privkey, t.pubKeyID, req, nil)
+	t.getSignerMu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET request to %s failed (%d): %s", iri.String(), resp.StatusCode, resp.Status)
+	}
+	return ioutil.ReadAll(resp.Body)
+}

--- a/internal/transport/finger.go
+++ b/internal/transport/finger.go
@@ -1,0 +1,48 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+func (t *transport) Finger(c context.Context, targetUsername string, targetDomain string) ([]byte, error) {
+	l := t.log.WithField("func", "Finger")
+	urlString := fmt.Sprintf("https://%s/.well-known/webfinger?resource=acct:%s@%s", targetDomain, targetUsername, targetDomain)
+	l.Debugf("performing GET to %s", urlString)
+
+	iri, err := url.Parse(urlString)
+	if err != nil {
+		return nil, fmt.Errorf("Finger: error parsing url %s: %s", urlString, err)
+	}
+
+	l.Debugf("performing GET to %s", iri.String())
+
+	req, err := http.NewRequest("GET", iri.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(c)
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Accept", "application/jrd+json")
+	req.Header.Add("Date", t.clock.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05")+" GMT")
+	req.Header.Add("User-Agent", fmt.Sprintf("%s %s", t.appAgent, t.gofedAgent))
+	req.Header.Set("Host", iri.Host)
+	t.getSignerMu.Lock()
+	err = t.getSigner.SignRequest(t.privkey, t.pubKeyID, req, nil)
+	t.getSignerMu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET request to %s failed (%d): %s", iri.String(), resp.StatusCode, resp.Status)
+	}
+	return ioutil.ReadAll(resp.Body)
+}

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -3,18 +3,13 @@ package transport
 import (
 	"context"
 	"crypto"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
 	"net/url"
 	"sync"
 
 	"github.com/go-fed/activity/pub"
 	"github.com/go-fed/httpsig"
 	"github.com/sirupsen/logrus"
-	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 )
 
 // Transport wraps the pub.Transport interface with some additional
@@ -24,7 +19,7 @@ type Transport interface {
 	// DereferenceMedia fetches the bytes of the given media attachment IRI, with the expectedContentType.
 	DereferenceMedia(c context.Context, iri *url.URL, expectedContentType string) ([]byte, error)
 	// DereferenceInstance dereferences remote instance information, first by checking /api/v1/instance, and then by checking /.well-known/nodeinfo.
-	DereferenceInstance(c context.Context, iri *url.URL) (*apimodel.Instance, error)
+	DereferenceInstance(c context.Context, iri *url.URL) (*gtsmodel.Instance, error)
 	// Finger performs a webfinger request with the given username and domain, and returns the bytes from the response body.
 	Finger(c context.Context, targetUsername string, targetDomains string) ([]byte, error)
 }
@@ -41,174 +36,4 @@ type transport struct {
 	getSigner    httpsig.Signer
 	getSignerMu  *sync.Mutex
 	log          *logrus.Logger
-}
-
-func (t *transport) BatchDeliver(c context.Context, b []byte, recipients []*url.URL) error {
-	return t.sigTransport.BatchDeliver(c, b, recipients)
-}
-
-func (t *transport) Deliver(c context.Context, b []byte, to *url.URL) error {
-	l := t.log.WithField("func", "Deliver")
-	l.Debugf("performing POST to %s", to.String())
-	return t.sigTransport.Deliver(c, b, to)
-}
-
-func (t *transport) Dereference(c context.Context, iri *url.URL) ([]byte, error) {
-	l := t.log.WithField("func", "Dereference")
-	l.Debugf("performing GET to %s", iri.String())
-	return t.sigTransport.Dereference(c, iri)
-}
-
-func (t *transport) DereferenceMedia(c context.Context, iri *url.URL, expectedContentType string) ([]byte, error) {
-	l := t.log.WithField("func", "DereferenceMedia")
-	l.Debugf("performing GET to %s", iri.String())
-	req, err := http.NewRequest("GET", iri.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(c)
-	if expectedContentType == "" {
-		req.Header.Add("Accept", "*/*")
-	} else {
-		req.Header.Add("Accept", expectedContentType)
-	}
-	req.Header.Add("Date", t.clock.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05")+" GMT")
-	req.Header.Add("User-Agent", fmt.Sprintf("%s %s", t.appAgent, t.gofedAgent))
-	req.Header.Set("Host", iri.Host)
-	t.getSignerMu.Lock()
-	err = t.getSigner.SignRequest(t.privkey, t.pubKeyID, req, nil)
-	t.getSignerMu.Unlock()
-	if err != nil {
-		return nil, err
-	}
-	resp, err := t.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET request to %s failed (%d): %s", iri.String(), resp.StatusCode, resp.Status)
-	}
-	return ioutil.ReadAll(resp.Body)
-}
-
-func (t *transport) Finger(c context.Context, targetUsername string, targetDomain string) ([]byte, error) {
-	l := t.log.WithField("func", "Finger")
-	urlString := fmt.Sprintf("https://%s/.well-known/webfinger?resource=acct:%s@%s", targetDomain, targetUsername, targetDomain)
-	l.Debugf("performing GET to %s", urlString)
-
-	iri, err := url.Parse(urlString)
-	if err != nil {
-		return nil, fmt.Errorf("Finger: error parsing url %s: %s", urlString, err)
-	}
-
-	l.Debugf("performing GET to %s", iri.String())
-
-	req, err := http.NewRequest("GET", iri.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(c)
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Accept", "application/jrd+json")
-	req.Header.Add("Date", t.clock.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05")+" GMT")
-	req.Header.Add("User-Agent", fmt.Sprintf("%s %s", t.appAgent, t.gofedAgent))
-	req.Header.Set("Host", iri.Host)
-	t.getSignerMu.Lock()
-	err = t.getSigner.SignRequest(t.privkey, t.pubKeyID, req, nil)
-	t.getSignerMu.Unlock()
-	if err != nil {
-		return nil, err
-	}
-	resp, err := t.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET request to %s failed (%d): %s", iri.String(), resp.StatusCode, resp.Status)
-	}
-	return ioutil.ReadAll(resp.Body)
-}
-
-func (t *transport) DereferenceInstance(c context.Context, iri *url.URL) (*apimodel.Instance, error) {
-	l := t.log.WithField("func", "DereferenceInstance")
-
-	var i *apimodel.Instance
-	var err error
-
-	// First try to dereference using /api/v1/instance.
-	// This will provide the most complete picture of an instance, and avoid unnecessary api calls.
-	//
-	// This will only work with Mastodon-api compatible instances: Mastodon, some Pleroma instances, GoToSocial.
-	l.Debugf("trying to dereference instance %s by /api/v1/instance", iri.Host)
-	i, err = dereferenceByAPIV1Instance(t, c, iri)
-	if err == nil {
-		l.Debugf("successfully dereferenced instance using /api/v1/instance")
-		return i, nil
-	}
-	l.Debugf("couldn't dereference instance using /api/v1/instance: %s", err)
-
-	// If that doesn't work, try to dereference using /.well-known/nodeinfo.
-	// This will involve two API calls and return less info overall, but should be more widely compatible.
-	l.Debugf("trying to dereference instance %s by /.well-known/nodeinfo", iri.Host)
-	i, err = dereferenceByNodeInfo(t, c, iri)
-	if err == nil {
-		l.Debugf("successfully dereferenced instance using /.well-known/nodeinfo")
-		return i, nil
-	}
-	l.Debugf("couldn't dereference instance using /.well-known/nodeinfo: %s", err)
-
-	return nil, fmt.Errorf("couldn't dereference instance %s using either /api/v1/instance or /.well-known/nodeinfo", iri.Host)
-}
-
-func dereferenceByAPIV1Instance(t *transport, c context.Context, iri *url.URL) (*apimodel.Instance, error) {
-	l := t.log.WithField("func", "dereferenceByAPIV1Instance")
-
-	cleanIRI := &url.URL{
-		Scheme: iri.Scheme,
-		Host:   iri.Host,
-		Path:   "api/v1/instance",
-	}
-
-	l.Debugf("performing GET to %s", cleanIRI.String())
-	req, err := http.NewRequest("GET", cleanIRI.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(c)
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("Date", t.clock.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05")+" GMT")
-	req.Header.Add("User-Agent", fmt.Sprintf("%s %s", t.appAgent, t.gofedAgent))
-	req.Header.Set("Host", cleanIRI.Host)
-	t.getSignerMu.Lock()
-	err = t.getSigner.SignRequest(t.privkey, t.pubKeyID, req, nil)
-	t.getSignerMu.Unlock()
-	if err != nil {
-		return nil, err
-	}
-	resp, err := t.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET request to %s failed (%d): %s", cleanIRI.String(), resp.StatusCode, resp.Status)
-	}
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	// try to parse the returned bytes directly into an Instance model
-	i := &apimodel.Instance{}
-	if err := json.Unmarshal(b, i); err != nil {
-		return nil, err
-	}
-
-	return i, nil
-}
-
-func dereferenceByNodeInfo(t *transport, c context.Context, iri *url.URL) (*apimodel.Instance, error) {
-	return nil, errors.New("not yet implemented")
 }

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -3,6 +3,8 @@ package transport
 import (
 	"context"
 	"crypto"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -12,13 +14,17 @@ import (
 	"github.com/go-fed/activity/pub"
 	"github.com/go-fed/httpsig"
 	"github.com/sirupsen/logrus"
+	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 )
 
 // Transport wraps the pub.Transport interface with some additional
 // functionality for fetching remote media.
 type Transport interface {
 	pub.Transport
+	// DereferenceMedia fetches the bytes of the given media attachment IRI, with the expectedContentType.
 	DereferenceMedia(c context.Context, iri *url.URL, expectedContentType string) ([]byte, error)
+	// DereferenceInstance dereferences remote instance information, first by checking /api/v1/instance, and then by checking /.well-known/nodeinfo.
+	DereferenceInstance(c context.Context, iri *url.URL) (*apimodel.Instance, error)
 	// Finger performs a webfinger request with the given username and domain, and returns the bytes from the response body.
 	Finger(c context.Context, targetUsername string, targetDomains string) ([]byte, error)
 }
@@ -123,4 +129,86 @@ func (t *transport) Finger(c context.Context, targetUsername string, targetDomai
 		return nil, fmt.Errorf("GET request to %s failed (%d): %s", iri.String(), resp.StatusCode, resp.Status)
 	}
 	return ioutil.ReadAll(resp.Body)
+}
+
+func (t *transport) DereferenceInstance(c context.Context, iri *url.URL) (*apimodel.Instance, error) {
+	l := t.log.WithField("func", "DereferenceInstance")
+
+	var i *apimodel.Instance
+	var err error
+
+	// First try to dereference using /api/v1/instance.
+	// This will provide the most complete picture of an instance, and avoid unnecessary api calls.
+	//
+	// This will only work with Mastodon-api compatible instances: Mastodon, some Pleroma instances, GoToSocial.
+	l.Debugf("trying to dereference instance %s by /api/v1/instance", iri.Host)
+	i, err = dereferenceByAPIV1Instance(t, c, iri)
+	if err == nil {
+		l.Debugf("successfully dereferenced instance using /api/v1/instance")
+		return i, nil
+	}
+	l.Debugf("couldn't dereference instance using /api/v1/instance: %s", err)
+
+	// If that doesn't work, try to dereference using /.well-known/nodeinfo.
+	// This will involve two API calls and return less info overall, but should be more widely compatible.
+	l.Debugf("trying to dereference instance %s by /.well-known/nodeinfo", iri.Host)
+	i, err = dereferenceByNodeInfo(t, c, iri)
+	if err == nil {
+		l.Debugf("successfully dereferenced instance using /.well-known/nodeinfo")
+		return i, nil
+	}
+	l.Debugf("couldn't dereference instance using /.well-known/nodeinfo: %s", err)
+
+	return nil, fmt.Errorf("couldn't dereference instance %s using either /api/v1/instance or /.well-known/nodeinfo", iri.Host)
+}
+
+func dereferenceByAPIV1Instance(t *transport, c context.Context, iri *url.URL) (*apimodel.Instance, error) {
+	l := t.log.WithField("func", "dereferenceByAPIV1Instance")
+
+	cleanIRI := &url.URL{
+		Scheme: iri.Scheme,
+		Host:   iri.Host,
+		Path:   "api/v1/instance",
+	}
+
+	l.Debugf("performing GET to %s", cleanIRI.String())
+	req, err := http.NewRequest("GET", cleanIRI.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(c)
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Date", t.clock.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05")+" GMT")
+	req.Header.Add("User-Agent", fmt.Sprintf("%s %s", t.appAgent, t.gofedAgent))
+	req.Header.Set("Host", cleanIRI.Host)
+	t.getSignerMu.Lock()
+	err = t.getSigner.SignRequest(t.privkey, t.pubKeyID, req, nil)
+	t.getSignerMu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET request to %s failed (%d): %s", cleanIRI.String(), resp.StatusCode, resp.Status)
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// try to parse the returned bytes directly into an Instance model
+	i := &apimodel.Instance{}
+	if err := json.Unmarshal(b, i); err != nil {
+		return nil, err
+	}
+
+	return i, nil
+}
+
+func dereferenceByNodeInfo(t *transport, c context.Context, iri *url.URL) (*apimodel.Instance, error) {
+	return nil, errors.New("not yet implemented")
 }


### PR DESCRIPTION
Remote instances are now dereferenced when they post to an inbox on a GtS instance.

* Dereferencing will be done first by checking the `/api/v1/instance` endpoint of an instance.
* If that doesn't work, `/.well-known/nodeinfo` will be checked.
* If that doesn't work, only a minimal representation of the instance will be stored.

A new field was added to the Instance database model. To create it:

`alter table instances add column contact_account_username text;`
