### PR TITLE
clean up some weirdness in the router

### DIFF
--- a/internal/cliactions/server/server.go
+++ b/internal/cliactions/server/server.go
@@ -67,6 +67,7 @@ var models []interface{} = []interface{}{
 	&gtsmodel.Emoji{},
 	&gtsmodel.Instance{},
 	&gtsmodel.Notification{},
+	&gtsmodel.RouterSession{},
 	&oauth.Token{},
 	&oauth.Client{},
 }
@@ -94,7 +95,7 @@ var Start cliactions.GTSAction = func(ctx context.Context, c *config.Config, log
 
 	federatingDB := federatingdb.New(dbService, c, log)
 
-	router, err := router.New(c, log)
+	router, err := router.New(c, dbService, log)
 	if err != nil {
 		return fmt.Errorf("error creating router: %s", err)
 	}

--- a/internal/cliactions/testrig/testrig.go
+++ b/internal/cliactions/testrig/testrig.go
@@ -44,7 +44,7 @@ var Start cliactions.GTSAction = func(ctx context.Context, _ *config.Config, log
 	c := testrig.NewTestConfig()
 	dbService := testrig.NewTestDB()
 	testrig.StandardDBSetup(dbService)
-	router := testrig.NewTestRouter()
+	router := testrig.NewTestRouter(dbService)
 	storageBackend := testrig.NewTestStorage()
 	testrig.StandardStorageSetup(storageBackend, "./testrig/media")
 

--- a/internal/gtsmodel/routersession.go
+++ b/internal/gtsmodel/routersession.go
@@ -16,18 +16,11 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package testrig
+package gtsmodel
 
-import (
-	"github.com/superseriousbusiness/gotosocial/internal/db"
-	"github.com/superseriousbusiness/gotosocial/internal/router"
-)
-
-// NewTestRouter returns a Router suitable for testing
-func NewTestRouter(db db.DB) router.Router {
-	r, err := router.New(NewTestConfig(), db, NewTestLog())
-	if err != nil {
-		panic(err)
-	}
-	return r
+// RouterSession is used to store and retrieve settings for a router session.
+type RouterSession struct {
+	ID    string `pg:"type:CHAR(26),pk,notnull"`
+	Auth  []byte `pg:",notnull"`
+	Crypt []byte `pg:",notnull"`
 }

--- a/internal/router/attach.go
+++ b/internal/router/attach.go
@@ -1,0 +1,41 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package router
+
+import "github.com/gin-gonic/gin"
+
+// AttachHandler attaches the given gin.HandlerFunc to the router with the specified method and path.
+// If the path is set to ANY, then the handlerfunc will be used for ALL methods at its given path.
+func (r *router) AttachHandler(method string, path string, handler gin.HandlerFunc) {
+	if method == "ANY" {
+		r.engine.Any(path, handler)
+	} else {
+		r.engine.Handle(method, path, handler)
+	}
+}
+
+// AttachMiddleware attaches a gin middleware to the router that will be used globally
+func (r *router) AttachMiddleware(middleware gin.HandlerFunc) {
+	r.engine.Use(middleware)
+}
+
+// AttachNoRouteHandler attaches a gin.HandlerFunc to NoRoute to handle 404's
+func (r *router) AttachNoRouteHandler(handler gin.HandlerFunc) {
+	r.engine.NoRoute(handler)
+}

--- a/internal/router/cors.go
+++ b/internal/router/cors.go
@@ -1,0 +1,88 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package router
+
+import (
+	"time"
+
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+)
+
+var corsConfig = cors.Config{
+	// TODO: make this customizable so instance admins can specify an origin for CORS requests
+	AllowAllOrigins: true,
+
+	// adds the following:
+	// 	"chrome-extension://"
+	// 	"safari-extension://"
+	// 	"moz-extension://"
+	// 	"ms-browser-extension://"
+	AllowBrowserExtensions: true,
+	AllowMethods: []string{
+		"POST",
+		"PUT",
+		"DELETE",
+		"GET",
+		"PATCH",
+		"OPTIONS",
+	},
+	AllowHeaders: []string{
+		// basic cors stuff
+		"Origin",
+		"Content-Length",
+		"Content-Type",
+
+		// needed to pass oauth bearer tokens
+		"Authorization",
+
+		// needed for websocket upgrade requests
+		"Upgrade",
+		"Sec-WebSocket-Extensions",
+		"Sec-WebSocket-Key",
+		"Sec-WebSocket-Protocol",
+		"Sec-WebSocket-Version",
+		"Connection",
+	},
+	AllowWebSockets: true,
+	ExposeHeaders: []string{
+		// needed for accessing next/prev links when making GET timeline requests
+		"Link",
+
+		// needed so clients can handle rate limits
+		"X-RateLimit-Reset",
+		"X-RateLimit-Limit",
+		"X-RateLimit-Remaining",
+		"X-Request-Id",
+
+		// websocket stuff
+		"Connection",
+		"Sec-WebSocket-Accept",
+		"Upgrade",
+	},
+	MaxAge: 2 * time.Minute,
+}
+
+// useCors attaches the corsConfig above to the given gin engine
+func useCors(cfg *config.Config, engine *gin.Engine) error {
+	c := cors.New(corsConfig)
+	engine.Use(c)
+	return nil
+}

--- a/internal/router/session.go
+++ b/internal/router/session.go
@@ -1,0 +1,100 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package router
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/memstore"
+	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/id"
+)
+
+func useSession(cfg *config.Config, dbService db.DB, engine *gin.Engine) error {
+	// check if we have a saved router session already
+	routerSessions := []*gtsmodel.RouterSession{}
+	if err := dbService.GetAll(&routerSessions); err != nil {
+		if _, ok := err.(db.ErrNoEntries); !ok {
+			// proper error occurred
+			return err
+		}
+	}
+
+	var rs *gtsmodel.RouterSession
+	if len(routerSessions) == 1 {
+		// we have a router session stored
+		rs = routerSessions[0]
+	} else if len(routerSessions) == 0 {
+		// we have no router sessions so we need to create a new one
+		var err error
+		rs, err = routerSession(dbService)
+		if err != nil {
+			return fmt.Errorf("error creating new router session: %s", err)
+		}
+	} else {
+		// we should only have one router session stored ever
+		return errors.New("we had more than one router session in the db")
+	}
+
+	if rs == nil {
+		return errors.New("error getting or creating router session: router session was nil")
+	}
+
+	store := memstore.NewStore(rs.Auth, rs.Crypt)
+	sessionName := fmt.Sprintf("gotosocial-%s", cfg.Host)
+	engine.Use(sessions.Sessions(sessionName, store))
+	return nil
+}
+
+// routerSession generates a new router session with random auth and crypt bytes,
+// puts it in the database for persistence, and returns it for use.
+func routerSession(dbService db.DB) (*gtsmodel.RouterSession, error) {
+	auth := make([]byte, 32)
+	crypt := make([]byte, 32)
+
+	if _, err := rand.Read(auth); err != nil {
+		return nil, err
+	}
+	if _, err := rand.Read(crypt); err != nil {
+		return nil, err
+	}
+
+	rid, err := id.NewULID()
+	if err != nil {
+		return nil, err
+	}
+
+	rs := &gtsmodel.RouterSession{
+		ID:    rid,
+		Auth:  auth,
+		Crypt: crypt,
+	}
+
+	if err := dbService.Put(rs); err != nil {
+		return nil, err
+	}
+
+	return rs, nil
+}

--- a/internal/router/template.go
+++ b/internal/router/template.go
@@ -1,0 +1,23 @@
+package router
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+)
+
+// loadTemplates loads html templates for use by the given engine
+func loadTemplates(cfg *config.Config, engine *gin.Engine) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("error getting current working directory: %s", err)
+	}
+
+	tmPath := filepath.Join(cwd, fmt.Sprintf("%s*", cfg.TemplateConfig.BaseDir))
+
+	engine.LoadHTMLGlob(tmPath)
+	return nil
+}

--- a/testrig/db.go
+++ b/testrig/db.go
@@ -47,6 +47,7 @@ var testModels []interface{} = []interface{}{
 	&gtsmodel.Emoji{},
 	&gtsmodel.Instance{},
 	&gtsmodel.Notification{},
+	&gtsmodel.RouterSession{},
 	&oauth.Token{},
 	&oauth.Client{},
 }


### PR DESCRIPTION
* Clean up some of the cookie/session weirdness that was causing half-done logins to persist across authorize attempts.
* Rearrange some of the router code so it's tidier.
* Persist auth and crypt session keys between restarts by storing the router session in the db.