### PR TITLE
Auth flow fixes

### DIFF
--- a/internal/api/client/auth/auth.go
+++ b/internal/api/client/auth/auth.go
@@ -36,7 +36,25 @@ const (
 	OauthTokenPath = "/oauth/token"
 	// OauthAuthorizePath is the API path for authorization requests (eg., authorize this app to act on my behalf as a user)
 	OauthAuthorizePath = "/oauth/authorize"
+
+	sessionUserID       = "userid"
+	sessionClientID     = "client_id"
+	sessionRedirectURI  = "redirect_uri"
+	sessionForceLogin   = "force_login"
+	sessionResponseType = "response_type"
+	sessionCode         = "code"
+	sessionScope        = "scope"
 )
+
+var sessionKeys []string = []string{
+	sessionUserID,
+	sessionClientID,
+	sessionRedirectURI,
+	sessionForceLogin,
+	sessionResponseType,
+	sessionCode,
+	sessionScope,
+}
 
 // Module implements the ClientAPIModule interface for
 type Module struct {

--- a/internal/api/client/auth/authorize.go
+++ b/internal/api/client/auth/authorize.go
@@ -157,7 +157,7 @@ func (m *Module) AuthorizePOSTHandler(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "session missing scope"})
 		return
 	}
-	
+
 	userID, ok := s.Get(sessionUserID).(string)
 	if !ok {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "session missing userid"})

--- a/internal/api/client/auth/signin.go
+++ b/internal/api/client/auth/signin.go
@@ -62,7 +62,7 @@ func (m *Module) SignInPOSTHandler(c *gin.Context) {
 		return
 	}
 
-	s.Set("userid", userid)
+	s.Set(sessionUserID, userid)
 	if err := s.Save(); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -107,7 +107,7 @@ func (m *Module) ValidatePassword(email string, password string) (userid string,
 
 	// If we've made it this far the email/password is correct, so we can just return the id of the user.
 	userid = gtsUser.ID
-	l.Debugf("returning (%s, %s)", userid, err)
+	l.Tracef("returning (%s, %s)", userid, err)
 	return
 }
 

--- a/internal/api/client/auth/signin.go
+++ b/internal/api/client/auth/signin.go
@@ -107,7 +107,7 @@ func (m *Module) ValidatePassword(email string, password string) (userid string,
 
 	// If we've made it this far the email/password is correct, so we can just return the id of the user.
 	userid = gtsUser.ID
-	l.Tracef("returning (%s, %s)", userid, err)
+	l.Debugf("returning (%s, %s)", userid, err)
 	return
 }
 

--- a/internal/api/model/oauth.go
+++ b/internal/api/model/oauth.go
@@ -22,16 +22,16 @@ package model
 // See here: https://docs.joinmastodon.org/methods/apps/oauth/
 type OAuthAuthorize struct {
 	// Forces the user to re-login, which is necessary for authorizing with multiple accounts from the same instance.
-	ForceLogin string `form:"force_login,omitempty"`
+	ForceLogin string `form:"force_login" json:"force_login"`
 	// Should be set equal to `code`.
-	ResponseType string `form:"response_type"`
+	ResponseType string `form:"response_type" json:"response_type"`
 	// Client ID, obtained during app registration.
-	ClientID string `form:"client_id"`
+	ClientID string `form:"client_id" json:"client_id"`
 	// Set a URI to redirect the user to.
 	// If this parameter is set to urn:ietf:wg:oauth:2.0:oob then the authorization code will be shown instead.
 	// Must match one of the redirect URIs declared during app registration.
-	RedirectURI string `form:"redirect_uri"`
+	RedirectURI string `form:"redirect_uri" json:"redirect_uri"`
 	// List of requested OAuth scopes, separated by spaces (or by pluses, if using query parameters).
 	// Must be a subset of scopes declared during app registration. If not provided, defaults to read.
-	Scope string `form:"scope,omitempty"`
+	Scope string `form:"scope" json:"scope"`
 }

--- a/internal/router/session.go
+++ b/internal/router/session.go
@@ -22,6 +22,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/memstore"
@@ -63,6 +64,14 @@ func useSession(cfg *config.Config, dbService db.DB, engine *gin.Engine) error {
 	}
 
 	store := memstore.NewStore(rs.Auth, rs.Crypt)
+	store.Options(sessions.Options{
+		Path:     "/",
+		Domain:   cfg.Host,
+		MaxAge:   120,                     // 2 minutes
+		Secure:   true,                    // only use cookie over https
+		HttpOnly: true,                    // exclude javascript from inspecting cookie
+		SameSite: http.SameSiteStrictMode, // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-cookie-same-site-00#section-4.1.1
+	})
 	sessionName := fmt.Sprintf("gotosocial-%s", cfg.Host)
 	engine.Use(sessions.Sessions(sessionName, store))
 	return nil


### PR DESCRIPTION
This PR fixes the auth flow which I managed to break last time!

Previously, we were setting options on cookies like so:

```
s.Options(sessions.Options{
		MaxAge:   120,  // 2 minutes
	})
```

and what we actually need to do is set them like so:

```
	store.Options(sessions.Options{
		Path:     "/",
		Domain:   cfg.Host,
		MaxAge:   120,  // 2 minutes
		Secure:   true, // only use cookie over https
		HttpOnly: true, // exclude javascript from inspecting cookie
		SameSite: http.SameSiteStrictMode,
	})
```

Reason: `Path` defaults to `/` if you set no options at all. However, if you set *any* options then `Path` is overwritten to an empty string. Because we were setting MaxAge and not Path, path ended up empty so the browser wouldn't send cookies during the auth flow!

Now it's fixed up so that cookie settings are properly created when the store is initialized. Nice!