### PR TITLE
Block/unblock

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -56,8 +56,8 @@ Things are moving on the project! As of July 2021 you can now:
     * [ ] /api/v1/accounts/:id/identity_proofs GET          (Get identity proofs for this account)
     * [x] /api/v1/accounts/:id/follow POST                  (Follow this account)
     * [x] /api/v1/accounts/:id/unfollow POST                (Unfollow this account)
-    * [ ] /api/v1/accounts/:id/block POST                   (Block this account)
-    * [ ] /api/v1/accounts/:id/unblock POST                 (Unblock this account)
+    * [x] /api/v1/accounts/:id/block POST                   (Block this account)
+    * [x] /api/v1/accounts/:id/unblock POST                 (Unblock this account)
     * [ ] /api/v1/accounts/:id/mute POST                    (Mute this account)
     * [ ] /api/v1/accounts/:id/unmute POST                  (Unmute this account)
     * [ ] /api/v1/accounts/:id/pin POST                     (Feature this account on profile)
@@ -71,8 +71,8 @@ Things are moving on the project! As of July 2021 you can now:
     * [x] /api/v1/favourites GET                            (See faved statuses)
   * [ ] Mutes
     * [ ] /api/v1/mutes GET                                 (See list of muted accounts)
-  * [ ] Blocks
-    * [ ] /api/v1/blocks GET                                (See list of blocked accounts)
+  * [x] Blocks
+    * [x] /api/v1/blocks GET                                (See list of blocked accounts)
   * [ ] Domain Blocks
     * [x] /api/v1/domain_blocks GET                         (See list of domain blocks)
     * [x] /api/v1/domain_blocks POST                        (Create a domain block)

--- a/internal/api/client/account/account.go
+++ b/internal/api/client/account/account.go
@@ -61,10 +61,14 @@ const (
 	GetFollowingPath = BasePathWithID + "/following"
 	// GetRelationshipsPath is for showing an account's relationship with other accounts
 	GetRelationshipsPath = BasePath + "/relationships"
-	// PostFollowPath is for POSTing new follows to, and updating existing follows
-	PostFollowPath = BasePathWithID + "/follow"
-	// PostUnfollowPath is for POSTing an unfollow
-	PostUnfollowPath = BasePathWithID + "/unfollow"
+	// FollowPath is for POSTing new follows to, and updating existing follows
+	FollowPath = BasePathWithID + "/follow"
+	// UnfollowPath is for POSTing an unfollow
+	UnfollowPath = BasePathWithID + "/unfollow"
+	// BlockPath is for creating a block of an account
+	BlockPath = BasePathWithID + "/block"
+	// UnblockPath is for removing a block of an account
+	UnblockPath = BasePathWithID + "/unblock"
 )
 
 // Module implements the ClientAPIModule interface for account-related actions
@@ -85,15 +89,33 @@ func New(config *config.Config, processor processing.Processor, log *logrus.Logg
 
 // Route attaches all routes from this module to the given router
 func (m *Module) Route(r router.Router) error {
+	// create account
 	r.AttachHandler(http.MethodPost, BasePath, m.AccountCreatePOSTHandler)
+
+	// get account
 	r.AttachHandler(http.MethodGet, BasePathWithID, m.muxHandler)
+
+	// modify account
 	r.AttachHandler(http.MethodPatch, BasePathWithID, m.muxHandler)
+
+	// get account's statuses
 	r.AttachHandler(http.MethodGet, GetStatusesPath, m.AccountStatusesGETHandler)
+
+	// get following or followers
 	r.AttachHandler(http.MethodGet, GetFollowersPath, m.AccountFollowersGETHandler)
 	r.AttachHandler(http.MethodGet, GetFollowingPath, m.AccountFollowingGETHandler)
+
+	// get relationship with account
 	r.AttachHandler(http.MethodGet, GetRelationshipsPath, m.AccountRelationshipsGETHandler)
-	r.AttachHandler(http.MethodPost, PostFollowPath, m.AccountFollowPOSTHandler)
-	r.AttachHandler(http.MethodPost, PostUnfollowPath, m.AccountUnfollowPOSTHandler)
+
+	// follow or unfollow account
+	r.AttachHandler(http.MethodPost, FollowPath, m.AccountFollowPOSTHandler)
+	r.AttachHandler(http.MethodPost, UnfollowPath, m.AccountUnfollowPOSTHandler)
+
+	// block or unblock account
+	r.AttachHandler(http.MethodPost, BlockPath, m.AccountBlockPOSTHandler)
+	r.AttachHandler(http.MethodPost, UnblockPath, m.AccountUnblockPOSTHandler)
+
 	return nil
 }
 

--- a/internal/api/client/account/block.go
+++ b/internal/api/client/account/block.go
@@ -1,0 +1,48 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package account
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/oauth"
+)
+
+func (m *Module) AccountBlockPOSTHandler(c *gin.Context) {
+	authed, err := oauth.Authed(c, true, true, true, true)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	targetAcctID := c.Param(IDKey)
+	if targetAcctID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no account id specified"})
+		return
+	}
+
+	relationship, errWithCode := m.processor.AccountBlockCreate(authed, targetAcctID)
+	if errWithCode != nil {
+		c.JSON(errWithCode.Code(), gin.H{"error": errWithCode.Safe()})
+		return
+	}
+
+	c.JSON(http.StatusOK, relationship)
+}

--- a/internal/api/client/account/block.go
+++ b/internal/api/client/account/block.go
@@ -25,6 +25,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
+// AccountBlockPOSTHandler handles the creation of a block from the authed account targeting the given account ID.
 func (m *Module) AccountBlockPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {

--- a/internal/api/client/account/unblock.go
+++ b/internal/api/client/account/unblock.go
@@ -25,6 +25,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
+// AccountUnblockPOSTHandler handles the removal of a block from the authed account targeting the given account ID.
 func (m *Module) AccountUnblockPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {

--- a/internal/api/client/account/unblock.go
+++ b/internal/api/client/account/unblock.go
@@ -1,0 +1,48 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package account
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/oauth"
+)
+
+func (m *Module) AccountUnblockPOSTHandler(c *gin.Context) {
+	authed, err := oauth.Authed(c, true, true, true, true)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	targetAcctID := c.Param(IDKey)
+	if targetAcctID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no account id specified"})
+		return
+	}
+
+	relationship, errWithCode := m.processor.AccountBlockRemove(authed, targetAcctID)
+	if errWithCode != nil {
+		c.JSON(errWithCode.Code(), gin.H{"error": errWithCode.Safe()})
+		return
+	}
+
+	c.JSON(http.StatusOK, relationship)
+}

--- a/internal/api/client/blocks/blocks.go
+++ b/internal/api/client/blocks/blocks.go
@@ -1,0 +1,63 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package blocks
+
+import (
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/processing"
+	"github.com/superseriousbusiness/gotosocial/internal/router"
+)
+
+const (
+	// BasePath is the base URI path for serving favourites
+	BasePath = "/api/v1/blocks"
+
+	// MaxIDKey is the url query for setting a max ID to return
+	MaxIDKey = "max_id"
+	// SinceIDKey is the url query for returning results newer than the given ID
+	SinceIDKey = "since_id"
+	// LimitKey is for specifying maximum number of results to return.
+	LimitKey = "limit"
+)
+
+// Module implements the ClientAPIModule interface for everything relating to viewing blocks
+type Module struct {
+	config    *config.Config
+	processor processing.Processor
+	log       *logrus.Logger
+}
+
+// New returns a new blocks module
+func New(config *config.Config, processor processing.Processor, log *logrus.Logger) api.ClientModule {
+	return &Module{
+		config:    config,
+		processor: processor,
+		log:       log,
+	}
+}
+
+// Route attaches all routes from this module to the given router
+func (m *Module) Route(r router.Router) error {
+	r.AttachHandler(http.MethodGet, BasePath, m.BlocksGETHandler)
+	return nil
+}

--- a/internal/api/client/blocks/blocksget.go
+++ b/internal/api/client/blocks/blocksget.go
@@ -1,0 +1,75 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package blocks
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/oauth"
+)
+
+// BlocksGETHandler handles GETting blocks.
+func (m *Module) BlocksGETHandler(c *gin.Context) {
+	l := m.log.WithField("func", "PublicTimelineGETHandler")
+
+	authed, err := oauth.Authed(c, true, true, true, true)
+	if err != nil {
+		l.Debugf("error authing: %s", err)
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	maxID := ""
+	maxIDString := c.Query(MaxIDKey)
+	if maxIDString != "" {
+		maxID = maxIDString
+	}
+
+	sinceID := ""
+	sinceIDString := c.Query(SinceIDKey)
+	if sinceIDString != "" {
+		sinceID = sinceIDString
+	}
+
+	limit := 20
+	limitString := c.Query(LimitKey)
+	if limitString != "" {
+		i, err := strconv.ParseInt(limitString, 10, 64)
+		if err != nil {
+			l.Debugf("error parsing limit string: %s", err)
+			c.JSON(http.StatusBadRequest, gin.H{"error": "couldn't parse limit query param"})
+			return
+		}
+		limit = int(i)
+	}
+
+	resp, errWithCode := m.processor.BlocksGet(authed, maxID, sinceID, limit)
+	if errWithCode != nil {
+		l.Debugf("error from processor BlocksGet: %s", errWithCode)
+		c.JSON(errWithCode.Code(), gin.H{"error": errWithCode.Safe()})
+		return
+	}
+
+	if resp.LinkHeader != "" {
+		c.Header("Link", resp.LinkHeader)
+	}
+	c.JSON(http.StatusOK, resp.Accounts)
+}

--- a/internal/api/client/streaming/stream.go
+++ b/internal/api/client/streaming/stream.go
@@ -67,23 +67,23 @@ sendLoop:
 		select {
 		case m := <-stream.Messages:
 			// we've got a streaming message!!
-			l.Debug("received message from stream")
+			l.Trace("received message from stream")
 			if err := conn.WriteJSON(m); err != nil {
-				l.Infof("error writing json to websocket connection: %s", err)
+				l.Debugf("error writing json to websocket connection: %s", err)
 				// if something is wrong we want to bail and drop the connection -- the client will create a new one
 				break sendLoop
 			}
-			l.Debug("wrote message into websocket connection")
+			l.Trace("wrote message into websocket connection")
 		case <-t.C:
-			l.Debug("received TICK from ticker")
+			l.Trace("received TICK from ticker")
 			if err := conn.WriteMessage(websocket.PingMessage, []byte(": ping")); err != nil {
-				l.Infof("error writing ping to websocket connection: %s", err)
+				l.Debugf("error writing ping to websocket connection: %s", err)
 				// if something is wrong we want to bail and drop the connection -- the client will create a new one
 				break sendLoop
 			}
-			l.Debug("wrote ping message into websocket connection")
+			l.Trace("wrote ping message into websocket connection")
 		}
 	}
 
-	l.Debug("leaving StreamGETHandler")
+	l.Trace("leaving StreamGETHandler")
 }

--- a/internal/api/model/block.go
+++ b/internal/api/model/block.go
@@ -1,0 +1,26 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package model
+
+// BlocksResponse wraps a slice of accounts, ready to be serialized, along with the Link
+// header for the previous and next queries, to be returned to the client.
+type BlocksResponse struct {
+	Accounts   []*Account
+	LinkHeader string
+}

--- a/internal/cliactions/server/server.go
+++ b/internal/cliactions/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/admin"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/app"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/auth"
+	"github.com/superseriousbusiness/gotosocial/internal/api/client/blocks"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/emoji"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/favourites"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/fileserver"
@@ -143,6 +144,7 @@ var Start cliactions.GTSAction = func(ctx context.Context, c *config.Config, log
 	securityModule := security.New(c, dbService, log)
 	streamingModule := streaming.New(c, processor, log)
 	favouritesModule := favourites.New(c, processor, log)
+	blocksModule := blocks.New(c, processor, log)
 
 	apis := []api.ClientModule{
 		// modules with middleware go first
@@ -170,6 +172,7 @@ var Start cliactions.GTSAction = func(ctx context.Context, c *config.Config, log
 		listsModule,
 		streamingModule,
 		favouritesModule,
+		blocksModule,
 	}
 
 	for _, m := range apis {

--- a/internal/cliactions/testrig/testrig.go
+++ b/internal/cliactions/testrig/testrig.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/admin"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/app"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/auth"
+	"github.com/superseriousbusiness/gotosocial/internal/api/client/blocks"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/emoji"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/favourites"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/fileserver"
@@ -88,6 +89,7 @@ var Start cliactions.GTSAction = func(ctx context.Context, _ *config.Config, log
 	securityModule := security.New(c, dbService, log)
 	streamingModule := streaming.New(c, processor, log)
 	favouritesModule := favourites.New(c, processor, log)
+	blocksModule := blocks.New(c, processor, log)
 
 	apis := []api.ClientModule{
 		// modules with middleware go first
@@ -115,6 +117,7 @@ var Start cliactions.GTSAction = func(ctx context.Context, _ *config.Config, log
 		listsModule,
 		streamingModule,
 		favouritesModule,
+		blocksModule,
 	}
 
 	for _, m := range apis {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -159,6 +159,8 @@ type DB interface {
 	// In case of no entries, a 'no entries' error will be returned
 	GetStatusesForAccount(accountID string, limit int, excludeReplies bool, maxID string, pinnedOnly bool, mediaOnly bool) ([]*gtsmodel.Status, error)
 
+	GetBlocksForAccount(accountID string, maxID string, sinceID string, limit int) ([]*gtsmodel.Account, string, string, error)
+
 	// GetLastStatusForAccountID simply gets the most recent status by the given account.
 	// The given slice 'status' pointer will be set to the result of the query, whatever it is.
 	// In case of no entries, a 'no entries' error will be returned

--- a/internal/db/pg/blocks.go
+++ b/internal/db/pg/blocks.go
@@ -1,0 +1,67 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package pg
+
+import (
+	"github.com/go-pg/pg/v10"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+)
+
+func (ps *postgresService) GetBlocksForAccount(accountID string, maxID string, sinceID string, limit int) ([]*gtsmodel.Account, string, string, error) {
+	blocks := []*gtsmodel.Block{}
+
+	fq := ps.conn.Model(&blocks).
+		Where("block.account_id = ?", accountID).
+		Relation("TargetAccount").
+		Order("block.id DESC")
+
+	if maxID != "" {
+		fq = fq.Where("block.id < ?", maxID)
+	}
+
+	if sinceID != "" {
+		fq = fq.Where("block.id > ?", sinceID)
+	}
+
+	if limit > 0 {
+		fq = fq.Limit(limit)
+	}
+
+	err := fq.Select()
+	if err != nil {
+		if err == pg.ErrNoRows {
+			return nil, "", "", db.ErrNoEntries{}
+		}
+		return nil, "", "", err
+	}
+
+	if len(blocks) == 0 {
+		return nil, "", "", db.ErrNoEntries{}
+	}
+
+	accounts := []*gtsmodel.Account{}
+	for _, b := range blocks {
+		accounts = append(accounts, b.TargetAccount)
+	}
+
+	nextMaxID := blocks[len(blocks)-1].ID
+	prevMinID := blocks[0].ID
+	return accounts, nextMaxID, prevMinID, nil
+}

--- a/internal/federation/dereference.go
+++ b/internal/federation/dereference.go
@@ -393,6 +393,7 @@ func (f *federator) DereferenceAnnounce(announce *gtsmodel.Status, requestingUse
 		announce.Language = boostedStatus.Language
 		announce.Text = boostedStatus.Text
 		announce.BoostOfID = boostedStatus.ID
+		announce.BoostOfAccountID = boostedStatus.AccountID
 		announce.Visibility = boostedStatus.Visibility
 		announce.VisibilityAdvanced = boostedStatus.VisibilityAdvanced
 		announce.GTSBoostedStatus = boostedStatus
@@ -477,6 +478,7 @@ func (f *federator) DereferenceAnnounce(announce *gtsmodel.Status, requestingUse
 	announce.Language = boostedStatus.Language
 	announce.Text = boostedStatus.Text
 	announce.BoostOfID = boostedStatus.ID
+	announce.BoostOfAccountID = boostedStatus.AccountID
 	announce.Visibility = boostedStatus.Visibility
 	announce.VisibilityAdvanced = boostedStatus.VisibilityAdvanced
 	announce.GTSBoostedStatus = boostedStatus

--- a/internal/federation/federatingdb/util.go
+++ b/internal/federation/federatingdb/util.go
@@ -139,7 +139,7 @@ func (f *federatingDB) NewID(c context.Context, t vocab.Type) (idURL *url.URL, e
 		// ID might already be set on an announce we've created, so check it here and return it if it is
 		announce, ok := t.(vocab.ActivityStreamsAnnounce)
 		if !ok {
-			return nil, errors.New("newid: fave couldn't be parsed into vocab.ActivityStreamsAnnounce")
+			return nil, errors.New("newid: announce couldn't be parsed into vocab.ActivityStreamsAnnounce")
 		}
 		idProp := announce.GetJSONLDId()
 		if idProp != nil {
@@ -152,9 +152,35 @@ func (f *federatingDB) NewID(c context.Context, t vocab.Type) (idURL *url.URL, e
 		// ID might already be set on an update we've created, so check it here and return it if it is
 		update, ok := t.(vocab.ActivityStreamsUpdate)
 		if !ok {
-			return nil, errors.New("newid: fave couldn't be parsed into vocab.ActivityStreamsUpdate")
+			return nil, errors.New("newid: update couldn't be parsed into vocab.ActivityStreamsUpdate")
 		}
 		idProp := update.GetJSONLDId()
+		if idProp != nil {
+			if idProp.IsIRI() {
+				return idProp.GetIRI(), nil
+			}
+		}
+	case gtsmodel.ActivityStreamsBlock:
+		// BLOCK
+		// ID might already be set on a block we've created, so check it here and return it if it is
+		block, ok := t.(vocab.ActivityStreamsBlock)
+		if !ok {
+			return nil, errors.New("newid: block couldn't be parsed into vocab.ActivityStreamsBlock")
+		}
+		idProp := block.GetJSONLDId()
+		if idProp != nil {
+			if idProp.IsIRI() {
+				return idProp.GetIRI(), nil
+			}
+		}
+	case gtsmodel.ActivityStreamsUndo:
+		// UNDO
+		// ID might already be set on an undo we've created, so check it here and return it if it is
+		undo, ok := t.(vocab.ActivityStreamsUndo)
+		if !ok {
+			return nil, errors.New("newid: undo couldn't be parsed into vocab.ActivityStreamsUndo")
+		}
+		idProp := undo.GetJSONLDId()
 		if idProp != nil {
 			if idProp.IsIRI() {
 				return idProp.GetIRI(), nil

--- a/internal/gtsmodel/block.go
+++ b/internal/gtsmodel/block.go
@@ -11,9 +11,11 @@ type Block struct {
 	// When was this block updated
 	UpdatedAt time.Time `pg:"type:timestamp,notnull,default:now()"`
 	// Who created this block?
-	AccountID string `pg:"type:CHAR(26),notnull"`
+	AccountID string   `pg:"type:CHAR(26),notnull"`
+	Account   *Account `pg:"rel:has-one"`
 	// Who is targeted by this block?
-	TargetAccountID string `pg:"type:CHAR(26),notnull"`
+	TargetAccountID string   `pg:"type:CHAR(26),notnull"`
+	TargetAccount   *Account `pg:"rel:has-one"`
 	// Activitypub URI for this block
-	URI string
+	URI string `pg:",notnull"`
 }

--- a/internal/gtsmodel/status.go
+++ b/internal/gtsmodel/status.go
@@ -56,6 +56,8 @@ type Status struct {
 	InReplyToAccountID string `pg:"type:CHAR(26)"`
 	// id of the status this status is a boost of
 	BoostOfID string `pg:"type:CHAR(26)"`
+	// id of the account that owns the boosted status
+	BoostOfAccountID string `pg:"type:CHAR(26)"`
 	// cw string for this status
 	ContentWarning string
 	// visibility entry for this status

--- a/internal/processing/account.go
+++ b/internal/processing/account.go
@@ -59,3 +59,11 @@ func (p *processor) AccountFollowCreate(authed *oauth.Auth, form *apimodel.Accou
 func (p *processor) AccountFollowRemove(authed *oauth.Auth, targetAccountID string) (*apimodel.Relationship, gtserror.WithCode) {
 	return p.accountProcessor.FollowRemove(authed.Account, targetAccountID)
 }
+
+func (p *processor) AccountBlockCreate(authed *oauth.Auth, targetAccountID string) (*apimodel.Relationship, gtserror.WithCode) {
+	return p.accountProcessor.BlockCreate(authed.Account, targetAccountID)
+}
+
+func (p *processor) AccountBlockRemove(authed *oauth.Auth, targetAccountID string) (*apimodel.Relationship, gtserror.WithCode) {
+	return p.accountProcessor.BlockRemove(authed.Account, targetAccountID)
+}

--- a/internal/processing/account/account.go
+++ b/internal/processing/account/account.go
@@ -59,6 +59,11 @@ type Processor interface {
 	FollowCreate(requestingAccount *gtsmodel.Account, form *apimodel.AccountFollowRequest) (*apimodel.Relationship, gtserror.WithCode)
 	// FollowRemove handles the removal of a follow/follow request to an account, either remote or local.
 	FollowRemove(requestingAccount *gtsmodel.Account, targetAccountID string) (*apimodel.Relationship, gtserror.WithCode)
+	// BlockCreate handles the creation of a block from requestingAccount to targetAccountID, either remote or local.
+	BlockCreate(requestingAccount *gtsmodel.Account, targetAccountID string) (*apimodel.Relationship, gtserror.WithCode)
+	// BlockRemove handles the removal of a block from requestingAccount to targetAccountID, either remote or local.
+	BlockRemove(requestingAccount *gtsmodel.Account, targetAccountID string) (*apimodel.Relationship, gtserror.WithCode)
+
 	// UpdateHeader does the dirty work of checking the header part of an account update form,
 	// parsing and checking the image, and doing the necessary updates in the database for this to become
 	// the account's new header image.

--- a/internal/processing/account/createblock.go
+++ b/internal/processing/account/createblock.go
@@ -1,0 +1,155 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package account
+
+import (
+	"fmt"
+
+	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/id"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
+)
+
+func (p *processor) BlockCreate(requestingAccount *gtsmodel.Account, targetAccountID string) (*apimodel.Relationship, gtserror.WithCode) {
+	// make sure the target account actually exists in our db
+	targetAcct := &gtsmodel.Account{}
+	if err := p.db.GetByID(targetAccountID, targetAcct); err != nil {
+		if _, ok := err.(db.ErrNoEntries); ok {
+			return nil, gtserror.NewErrorNotFound(fmt.Errorf("BlockCreate: account %s not found in the db: %s", targetAccountID, err))
+		}
+	}
+
+	// if requestingAccount already blocks target account, we don't need to do anything
+	block := &gtsmodel.Block{}
+	if err := p.db.GetWhere([]db.Where{
+		{Key: "account_id", Value: requestingAccount.ID},
+		{Key: "target_account_id", Value: targetAccountID},
+	}, block); err == nil {
+		// block already exists, just return relationship
+		return p.RelationshipGet(requestingAccount, targetAccountID)
+	}
+
+	// make the block
+	newBlockID, err := id.NewULID()
+	if err != nil {
+		return nil, gtserror.NewErrorInternalError(err)
+	}
+	block.ID = newBlockID
+	block.AccountID = requestingAccount.ID
+	block.Account = requestingAccount
+	block.TargetAccountID = targetAccountID
+	block.TargetAccount = targetAcct
+	block.URI = util.GenerateURIForBlock(requestingAccount.Username, p.config.Protocol, p.config.Host, newBlockID)
+
+	// whack it in the database
+	if err := p.db.Put(block); err != nil {
+		return nil, gtserror.NewErrorInternalError(fmt.Errorf("BlockCreate: error creating block in db: %s", err))
+	}
+
+	// clear any follows or follow requests from the blocked account to the target account -- this is a simple delete
+	if err := p.db.DeleteWhere([]db.Where{
+		{Key: "account_id", Value: targetAccountID},
+		{Key: "target_account_id", Value: requestingAccount.ID},
+	}, &gtsmodel.Follow{}); err != nil {
+		return nil, gtserror.NewErrorInternalError(fmt.Errorf("BlockCreate: error removing follow in db: %s", err))
+	}
+	if err := p.db.DeleteWhere([]db.Where{
+		{Key: "account_id", Value: targetAccountID},
+		{Key: "target_account_id", Value: requestingAccount.ID},
+	}, &gtsmodel.FollowRequest{}); err != nil {
+		return nil, gtserror.NewErrorInternalError(fmt.Errorf("BlockCreate: error removing follow in db: %s", err))
+	}
+
+	// clear any follows or follow requests from the requesting account to the target account --
+	// this might require federation so we need to pass some messages around
+
+	// check if a follow request exists from the requesting account to the target account, and remove it if it does (storing the URI for later)
+	var frChanged bool
+	var frURI string
+	fr := &gtsmodel.FollowRequest{}
+	if err := p.db.GetWhere([]db.Where{
+		{Key: "account_id", Value: requestingAccount.ID},
+		{Key: "target_account_id", Value: targetAccountID},
+	}, fr); err == nil {
+		frURI = fr.URI
+		if err := p.db.DeleteByID(fr.ID, fr); err != nil {
+			return nil, gtserror.NewErrorInternalError(fmt.Errorf("BlockCreate: error removing follow request from db: %s", err))
+		}
+		frChanged = true
+	}
+
+	// now do the same thing for any existing follow
+	var fChanged bool
+	var fURI string
+	f := &gtsmodel.Follow{}
+	if err := p.db.GetWhere([]db.Where{
+		{Key: "account_id", Value: requestingAccount.ID},
+		{Key: "target_account_id", Value: targetAccountID},
+	}, f); err == nil {
+		fURI = f.URI
+		if err := p.db.DeleteByID(f.ID, f); err != nil {
+			return nil, gtserror.NewErrorInternalError(fmt.Errorf("BlockCreate: error removing follow from db: %s", err))
+		}
+		fChanged = true
+	}
+
+	// follow request status changed so send the UNDO activity to the channel for async processing
+	if frChanged {
+		p.fromClientAPI <- gtsmodel.FromClientAPI{
+			APObjectType:   gtsmodel.ActivityStreamsFollow,
+			APActivityType: gtsmodel.ActivityStreamsUndo,
+			GTSModel: &gtsmodel.Follow{
+				AccountID:       requestingAccount.ID,
+				TargetAccountID: targetAccountID,
+				URI:             frURI,
+			},
+			OriginAccount: requestingAccount,
+			TargetAccount: targetAcct,
+		}
+	}
+
+	// follow status changed so send the UNDO activity to the channel for async processing
+	if fChanged {
+		p.fromClientAPI <- gtsmodel.FromClientAPI{
+			APObjectType:   gtsmodel.ActivityStreamsFollow,
+			APActivityType: gtsmodel.ActivityStreamsUndo,
+			GTSModel: &gtsmodel.Follow{
+				AccountID:       requestingAccount.ID,
+				TargetAccountID: targetAccountID,
+				URI:             fURI,
+			},
+			OriginAccount: requestingAccount,
+			TargetAccount: targetAcct,
+		}
+	}
+
+	// handle the rest of the block process asynchronously
+	p.fromClientAPI <- gtsmodel.FromClientAPI{
+		APObjectType:   gtsmodel.ActivityStreamsBlock,
+		APActivityType: gtsmodel.ActivityStreamsCreate,
+		GTSModel:       block,
+		OriginAccount:  requestingAccount,
+		TargetAccount:  targetAcct,
+	}
+
+	return p.RelationshipGet(requestingAccount, targetAccountID)
+}

--- a/internal/processing/account/removeblock.go
+++ b/internal/processing/account/removeblock.go
@@ -1,0 +1,67 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package account
+
+import (
+	"fmt"
+
+	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+)
+
+func (p *processor) BlockRemove(requestingAccount *gtsmodel.Account, targetAccountID string) (*apimodel.Relationship, gtserror.WithCode) {
+	// make sure the target account actually exists in our db
+	targetAcct := &gtsmodel.Account{}
+	if err := p.db.GetByID(targetAccountID, targetAcct); err != nil {
+		if _, ok := err.(db.ErrNoEntries); ok {
+			return nil, gtserror.NewErrorNotFound(fmt.Errorf("BlockRemove: account %s not found in the db: %s", targetAccountID, err))
+		}
+	}
+
+	// check if a block exists, and remove it if it does (storing the URI for later)
+	var blockChanged bool
+	block := &gtsmodel.Block{}
+	if err := p.db.GetWhere([]db.Where{
+		{Key: "account_id", Value: requestingAccount.ID},
+		{Key: "target_account_id", Value: targetAccountID},
+	}, block); err == nil {
+		block.Account = requestingAccount
+		block.TargetAccount = targetAcct
+		if err := p.db.DeleteByID(block.ID, &gtsmodel.Block{}); err != nil {
+			return nil, gtserror.NewErrorInternalError(fmt.Errorf("BlockRemove: error removing block from db: %s", err))
+		}
+		blockChanged = true
+	}
+
+	// block status changed so send the UNDO activity to the channel for async processing
+	if blockChanged {
+		p.fromClientAPI <- gtsmodel.FromClientAPI{
+			APObjectType:   gtsmodel.ActivityStreamsBlock,
+			APActivityType: gtsmodel.ActivityStreamsUndo,
+			GTSModel:       block,
+			OriginAccount:  requestingAccount,
+			TargetAccount:  targetAcct,
+		}
+	}
+
+	// return whatever relationship results from all this
+	return p.RelationshipGet(requestingAccount, targetAccountID)
+}

--- a/internal/processing/blocks.go
+++ b/internal/processing/blocks.go
@@ -43,7 +43,7 @@ func (p *processor) BlocksGet(authed *oauth.Auth, maxID string, sinceID string, 
 
 	apiAccounts := []*apimodel.Account{}
 	for _, a := range accounts {
-		apiAccount, err := p.tc.AccountToMastoPublic(a)
+		apiAccount, err := p.tc.AccountToMastoBlocked(a)
 		if err != nil {
 			continue
 		}

--- a/internal/processing/blocks.go
+++ b/internal/processing/blocks.go
@@ -1,0 +1,83 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package processing
+
+import (
+	"fmt"
+	"net/url"
+
+	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+	"github.com/superseriousbusiness/gotosocial/internal/oauth"
+)
+
+func (p *processor) BlocksGet(authed *oauth.Auth, maxID string, sinceID string, limit int) (*apimodel.BlocksResponse, gtserror.WithCode) {
+	accounts, nextMaxID, prevMinID, err := p.db.GetBlocksForAccount(authed.Account.ID, maxID, sinceID, limit)
+	if err != nil {
+		if _, ok := err.(db.ErrNoEntries); ok {
+			// there are just no entries
+			return &apimodel.BlocksResponse{
+				Accounts: []*apimodel.Account{},
+			}, nil
+		}
+		// there's an actual error
+		return nil, gtserror.NewErrorInternalError(err)
+	}
+
+	apiAccounts := []*apimodel.Account{}
+	for _, a := range accounts {
+		apiAccount, err := p.tc.AccountToMastoPublic(a)
+		if err != nil {
+			continue
+		}
+		apiAccounts = append(apiAccounts, apiAccount)
+	}
+
+	return p.packageBlocksResponse(apiAccounts, "/api/v1/blocks", nextMaxID, prevMinID, limit)
+}
+
+func (p *processor) packageBlocksResponse(accounts []*apimodel.Account, path string, nextMaxID string, prevMinID string, limit int) (*apimodel.BlocksResponse, gtserror.WithCode) {
+	resp := &apimodel.BlocksResponse{
+		Accounts: []*apimodel.Account{},
+	}
+	resp.Accounts = accounts
+
+	// prepare the next and previous links
+	if len(accounts) != 0 {
+		nextLink := &url.URL{
+			Scheme:   p.config.Protocol,
+			Host:     p.config.Host,
+			Path:     path,
+			RawQuery: fmt.Sprintf("limit=%d&max_id=%s", limit, nextMaxID),
+		}
+		next := fmt.Sprintf("<%s>; rel=\"next\"", nextLink.String())
+
+		prevLink := &url.URL{
+			Scheme:   p.config.Protocol,
+			Host:     p.config.Host,
+			Path:     path,
+			RawQuery: fmt.Sprintf("limit=%d&min_id=%s", limit, prevMinID),
+		}
+		prev := fmt.Sprintf("<%s>; rel=\"prev\"", prevLink.String())
+		resp.LinkHeader = fmt.Sprintf("%s, %s", next, prev)
+	}
+
+	return resp, nil
+}

--- a/internal/processing/fromclientapi.go
+++ b/internal/processing/fromclientapi.go
@@ -99,7 +99,14 @@ func (p *processor) processFromClientAPI(clientMsg gtsmodel.FromClientAPI) error
 				return errors.New("block was not parseable as *gtsmodel.Block")
 			}
 
-			// TODO: remove any of the blocking account's statuses from the blocked account's timeline
+			// remove any of the blocking account's statuses from the blocked account's timeline, and vice versa
+			if err := p.timelineManager.WipeStatusesFromAccountID(block.AccountID, block.TargetAccountID); err != nil {
+				return err
+			}
+			if err := p.timelineManager.WipeStatusesFromAccountID(block.TargetAccountID, block.AccountID); err != nil {
+				return err
+			}
+
 			// TODO: same with notifications
 			// TODO: same with bookmarks
 

--- a/internal/processing/fromclientapi.go
+++ b/internal/processing/fromclientapi.go
@@ -76,7 +76,6 @@ func (p *processor) processFromClientAPI(clientMsg gtsmodel.FromClientAPI) error
 			}
 
 			return p.federateFave(fave, clientMsg.OriginAccount, clientMsg.TargetAccount)
-
 		case gtsmodel.ActivityStreamsAnnounce:
 			// CREATE BOOST/ANNOUNCE
 			boostWrapperStatus, ok := clientMsg.GTSModel.(*gtsmodel.Status)
@@ -93,6 +92,18 @@ func (p *processor) processFromClientAPI(clientMsg gtsmodel.FromClientAPI) error
 			}
 
 			return p.federateAnnounce(boostWrapperStatus, clientMsg.OriginAccount, clientMsg.TargetAccount)
+		case gtsmodel.ActivityStreamsBlock:
+			// CREATE BLOCK
+			block, ok := clientMsg.GTSModel.(*gtsmodel.Block)
+			if !ok {
+				return errors.New("block was not parseable as *gtsmodel.Block")
+			}
+
+			// TODO: remove any of the blocking account's statuses from the blocked account's timeline
+			// TODO: same with notifications
+			// TODO: same with bookmarks
+
+			return p.federateBlock(block)
 		}
 	case gtsmodel.ActivityStreamsUpdate:
 		// UPDATE
@@ -132,6 +143,13 @@ func (p *processor) processFromClientAPI(clientMsg gtsmodel.FromClientAPI) error
 				return errors.New("undo was not parseable as *gtsmodel.Follow")
 			}
 			return p.federateUnfollow(follow, clientMsg.OriginAccount, clientMsg.TargetAccount)
+		case gtsmodel.ActivityStreamsBlock:
+			// UNDO BLOCK
+			block, ok := clientMsg.GTSModel.(*gtsmodel.Block)
+			if !ok {
+				return errors.New("undo was not parseable as *gtsmodel.Block")
+			}
+			return p.federateUnblock(block)
 		case gtsmodel.ActivityStreamsLike:
 			// UNDO LIKE/FAVE
 			fave, ok := clientMsg.GTSModel.(*gtsmodel.StatusFave)
@@ -528,5 +546,95 @@ func (p *processor) federateAccountUpdate(updatedAccount *gtsmodel.Account, orig
 	}
 
 	_, err = p.federator.FederatingActor().Send(context.Background(), outboxIRI, update)
+	return err
+}
+
+func (p *processor) federateBlock(block *gtsmodel.Block) error {
+	if block.Account == nil {
+		a := &gtsmodel.Account{}
+		if err := p.db.GetByID(block.AccountID, a); err != nil {
+			return fmt.Errorf("federateBlock: error getting block account from database: %s", err)
+		}
+		block.Account = a
+	}
+
+	if block.TargetAccount == nil {
+		a := &gtsmodel.Account{}
+		if err := p.db.GetByID(block.TargetAccountID, a); err != nil {
+			return fmt.Errorf("federateBlock: error getting block target account from database: %s", err)
+		}
+		block.TargetAccount = a
+	}
+
+	// if both accounts are local there's nothing to do here
+	if block.Account.Domain == "" && block.TargetAccount.Domain == "" {
+		return nil
+	}
+
+	asBlock, err := p.tc.BlockToAS(block)
+	if err != nil {
+		return fmt.Errorf("federateBlock: error converting block to AS format: %s", err)
+	}
+
+	outboxIRI, err := url.Parse(block.Account.OutboxURI)
+	if err != nil {
+		return fmt.Errorf("federateBlock: error parsing outboxURI %s: %s", block.Account.OutboxURI, err)
+	}
+
+	_, err = p.federator.FederatingActor().Send(context.Background(), outboxIRI, asBlock)
+	return err
+}
+
+func (p *processor) federateUnblock(block *gtsmodel.Block) error {
+	if block.Account == nil {
+		a := &gtsmodel.Account{}
+		if err := p.db.GetByID(block.AccountID, a); err != nil {
+			return fmt.Errorf("federateUnblock: error getting block account from database: %s", err)
+		}
+		block.Account = a
+	}
+
+	if block.TargetAccount == nil {
+		a := &gtsmodel.Account{}
+		if err := p.db.GetByID(block.TargetAccountID, a); err != nil {
+			return fmt.Errorf("federateUnblock: error getting block target account from database: %s", err)
+		}
+		block.TargetAccount = a
+	}
+
+	// if both accounts are local there's nothing to do here
+	if block.Account.Domain == "" && block.TargetAccount.Domain == "" {
+		return nil
+	}
+
+	asBlock, err := p.tc.BlockToAS(block)
+	if err != nil {
+		return fmt.Errorf("federateUnblock: error converting block to AS format: %s", err)
+	}
+
+	targetAccountURI, err := url.Parse(block.TargetAccount.URI)
+	if err != nil {
+		return fmt.Errorf("federateUnblock: error parsing uri %s: %s", block.TargetAccount.URI, err)
+	}
+
+	// create an Undo and set the appropriate actor on it
+	undo := streams.NewActivityStreamsUndo()
+	undo.SetActivityStreamsActor(asBlock.GetActivityStreamsActor())
+
+	// Set the block as the 'object' property.
+	undoObject := streams.NewActivityStreamsObjectProperty()
+	undoObject.AppendActivityStreamsBlock(asBlock)
+	undo.SetActivityStreamsObject(undoObject)
+
+	// Set the To of the undo as the target of the block
+	undoTo := streams.NewActivityStreamsToProperty()
+	undoTo.AppendIRI(targetAccountURI)
+	undo.SetActivityStreamsTo(undoTo)
+
+	outboxIRI, err := url.Parse(block.Account.OutboxURI)
+	if err != nil {
+		return fmt.Errorf("federateUnblock: error parsing outboxURI %s: %s", block.Account.OutboxURI, err)
+	}
+	_, err = p.federator.FederatingActor().Send(context.Background(), outboxIRI, undo)
 	return err
 }

--- a/internal/processing/fromfederator.go
+++ b/internal/processing/fromfederator.go
@@ -129,8 +129,18 @@ func (p *processor) processFromFederator(federatorMsg gtsmodel.FromFederator) er
 			}
 		case gtsmodel.ActivityStreamsBlock:
 			// CREATE A BLOCK
+			block, ok := federatorMsg.GTSModel.(*gtsmodel.Block)
+			if !ok {
+				return errors.New("block was not parseable as *gtsmodel.Block")
+			}
 
-			// TODO: remove any of the blocking account's statuses from the blocked account's timeline
+			// remove any of the blocking account's statuses from the blocked account's timeline, and vice versa
+			if err := p.timelineManager.WipeStatusesFromAccountID(block.AccountID, block.TargetAccountID); err != nil {
+				return err
+			}
+			if err := p.timelineManager.WipeStatusesFromAccountID(block.TargetAccountID, block.AccountID); err != nil {
+				return err
+			}
 			// TODO: same with notifications
 			// TODO: same with bookmarks
 		}

--- a/internal/processing/fromfederator.go
+++ b/internal/processing/fromfederator.go
@@ -34,7 +34,7 @@ func (p *processor) processFromFederator(federatorMsg gtsmodel.FromFederator) er
 		"federatorMsg": fmt.Sprintf("%+v", federatorMsg),
 	})
 
-	l.Debug("entering function PROCESS FROM FEDERATOR")
+	l.Trace("entering function PROCESS FROM FEDERATOR")
 
 	switch federatorMsg.APActivityType {
 	case gtsmodel.ActivityStreamsCreate:
@@ -47,7 +47,7 @@ func (p *processor) processFromFederator(federatorMsg gtsmodel.FromFederator) er
 				return errors.New("note was not parseable as *gtsmodel.Status")
 			}
 
-			l.Debug("will now derefence incoming status")
+			l.Trace("will now derefence incoming status")
 			if err := p.federator.DereferenceStatusFields(incomingStatus, federatorMsg.ReceivingAccount.Username); err != nil {
 				return fmt.Errorf("error dereferencing status from federator: %s", err)
 			}
@@ -70,7 +70,7 @@ func (p *processor) processFromFederator(federatorMsg gtsmodel.FromFederator) er
 				return errors.New("profile was not parseable as *gtsmodel.Account")
 			}
 
-			l.Debug("will now derefence incoming account")
+			l.Trace("will now derefence incoming account")
 			if err := p.federator.DereferenceAccountFields(incomingAccount, "", false); err != nil {
 				return fmt.Errorf("error dereferencing account from federator: %s", err)
 			}
@@ -127,6 +127,12 @@ func (p *processor) processFromFederator(federatorMsg gtsmodel.FromFederator) er
 			if err := p.notifyAnnounce(incomingAnnounce); err != nil {
 				return err
 			}
+		case gtsmodel.ActivityStreamsBlock:
+			// CREATE A BLOCK
+
+			// TODO: remove any of the blocking account's statuses from the blocked account's timeline
+			// TODO: same with notifications
+			// TODO: same with bookmarks
 		}
 	case gtsmodel.ActivityStreamsUpdate:
 		// UPDATE
@@ -138,7 +144,7 @@ func (p *processor) processFromFederator(federatorMsg gtsmodel.FromFederator) er
 				return errors.New("profile was not parseable as *gtsmodel.Account")
 			}
 
-			l.Debug("will now derefence incoming account")
+			l.Trace("will now derefence incoming account")
 			if err := p.federator.DereferenceAccountFields(incomingAccount, federatorMsg.ReceivingAccount.Username, true); err != nil {
 				return fmt.Errorf("error dereferencing account from federator: %s", err)
 			}

--- a/internal/processing/processor.go
+++ b/internal/processing/processor.go
@@ -82,6 +82,10 @@ type Processor interface {
 	AccountFollowCreate(authed *oauth.Auth, form *apimodel.AccountFollowRequest) (*apimodel.Relationship, gtserror.WithCode)
 	// AccountFollowRemove handles the removal of a follow/follow request to an account, either remote or local.
 	AccountFollowRemove(authed *oauth.Auth, targetAccountID string) (*apimodel.Relationship, gtserror.WithCode)
+	// AccountBlockCreate handles the creation of a block from authed account to target account, either remote or local.
+	AccountBlockCreate(authed *oauth.Auth, targetAccountID string) (*apimodel.Relationship, gtserror.WithCode)
+	// AccountBlockRemove handles the removal of a block from authed account to target account, either remote or local.
+	AccountBlockRemove(authed *oauth.Auth, targetAccountID string) (*apimodel.Relationship, gtserror.WithCode)
 
 	// AdminEmojiCreate handles the creation of a new instance emoji by an admin, using the given form.
 	AdminEmojiCreate(authed *oauth.Auth, form *apimodel.EmojiCreateRequest) (*apimodel.Emoji, error)
@@ -98,6 +102,9 @@ type Processor interface {
 
 	// AppCreate processes the creation of a new API application
 	AppCreate(authed *oauth.Auth, form *apimodel.ApplicationCreateRequest) (*apimodel.Application, error)
+
+	// BlocksGet returns a list of accounts blocked by the requesting account.
+	BlocksGet(authed *oauth.Auth, maxID string, sinceID string, limit int) (*apimodel.BlocksResponse, gtserror.WithCode)
 
 	// FileGet handles the fetching of a media attachment file via the fileserver.
 	FileGet(authed *oauth.Auth, form *apimodel.GetContentRequestForm) (*apimodel.Content, error)
@@ -275,14 +282,14 @@ func (p *processor) Start() error {
 		for {
 			select {
 			case clientMsg := <-p.fromClientAPI:
-				p.log.Infof("received message FROM client API: %+v", clientMsg)
+				p.log.Tracef("received message FROM client API: %+v", clientMsg)
 				go func() {
 					if err := p.processFromClientAPI(clientMsg); err != nil {
 						p.log.Error(err)
 					}
 				}()
 			case federatorMsg := <-p.fromFederator:
-				p.log.Infof("received message FROM federator: %+v", federatorMsg)
+				p.log.Tracef("received message FROM federator: %+v", federatorMsg)
 				go func() {
 					if err := p.processFromFederator(federatorMsg); err != nil {
 						p.log.Error(err)

--- a/internal/timeline/get.go
+++ b/internal/timeline/get.go
@@ -1,3 +1,21 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package timeline
 
 import (

--- a/internal/timeline/index.go
+++ b/internal/timeline/index.go
@@ -1,3 +1,21 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package timeline
 
 import (
@@ -44,7 +62,7 @@ grabloop:
 	}
 
 	for _, s := range filtered {
-		if _, err := t.IndexOne(s.CreatedAt, s.ID, s.BoostOfID); err != nil {
+		if _, err := t.IndexOne(s.CreatedAt, s.ID, s.BoostOfID, s.AccountID, s.BoostOfAccountID); err != nil {
 			return fmt.Errorf("IndexBefore: error indexing status with id %s: %s", s.ID, err)
 		}
 	}
@@ -79,7 +97,7 @@ grabloop:
 	}
 
 	for _, s := range filtered {
-		if _, err := t.IndexOne(s.CreatedAt, s.ID, s.BoostOfID); err != nil {
+		if _, err := t.IndexOne(s.CreatedAt, s.ID, s.BoostOfID, s.AccountID, s.BoostOfAccountID); err != nil {
 			return fmt.Errorf("IndexBehind: error indexing status with id %s: %s", s.ID, err)
 		}
 	}
@@ -91,24 +109,29 @@ func (t *timeline) IndexOneByID(statusID string) error {
 	return nil
 }
 
-func (t *timeline) IndexOne(statusCreatedAt time.Time, statusID string, boostOfID string) (bool, error) {
+func (t *timeline) IndexOne(statusCreatedAt time.Time, statusID string, boostOfID string, accountID string, boostOfAccountID string) (bool, error) {
 	t.Lock()
 	defer t.Unlock()
 
 	postIndexEntry := &postIndexEntry{
-		statusID:  statusID,
-		boostOfID: boostOfID,
+		statusID:         statusID,
+		boostOfID:        boostOfID,
+		accountID:        accountID,
+		boostOfAccountID: boostOfAccountID,
 	}
 
 	return t.postIndex.insertIndexed(postIndexEntry)
 }
 
-func (t *timeline) IndexAndPrepareOne(statusCreatedAt time.Time, statusID string) (bool, error) {
+func (t *timeline) IndexAndPrepareOne(statusCreatedAt time.Time, statusID string, boostOfID string, accountID string, boostOfAccountID string) (bool, error) {
 	t.Lock()
 	defer t.Unlock()
 
 	postIndexEntry := &postIndexEntry{
-		statusID: statusID,
+		statusID:         statusID,
+		boostOfID:        boostOfID,
+		accountID:        accountID,
+		boostOfAccountID: boostOfAccountID,
 	}
 
 	inserted, err := t.postIndex.insertIndexed(postIndexEntry)

--- a/internal/timeline/postindex.go
+++ b/internal/timeline/postindex.go
@@ -1,3 +1,21 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package timeline
 
 import (
@@ -10,8 +28,10 @@ type postIndex struct {
 }
 
 type postIndexEntry struct {
-	statusID  string
-	boostOfID string
+	statusID         string
+	boostOfID        string
+	accountID        string
+	boostOfAccountID string
 }
 
 func (p *postIndex) insertIndexed(i *postIndexEntry) (bool, error) {

--- a/internal/timeline/prepare.go
+++ b/internal/timeline/prepare.go
@@ -1,3 +1,21 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package timeline
 
 import (
@@ -207,8 +225,11 @@ func (t *timeline) prepare(statusID string) error {
 
 	// shove it in prepared posts as a prepared posts entry
 	preparedPostsEntry := &preparedPostsEntry{
-		statusID: statusID,
-		prepared: apiModelStatus,
+		statusID:         gtsStatus.ID,
+		boostOfID:        gtsStatus.BoostOfID,
+		accountID:        gtsStatus.AccountID,
+		boostOfAccountID: gtsStatus.BoostOfAccountID,
+		prepared:         apiModelStatus,
 	}
 
 	return t.preparedPosts.insertPrepared(preparedPostsEntry)

--- a/internal/timeline/preparedposts.go
+++ b/internal/timeline/preparedposts.go
@@ -1,3 +1,21 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package timeline
 
 import (
@@ -12,8 +30,11 @@ type preparedPosts struct {
 }
 
 type preparedPostsEntry struct {
-	statusID string
-	prepared *apimodel.Status
+	statusID         string
+	boostOfID        string
+	accountID        string
+	boostOfAccountID string
+	prepared         *apimodel.Status
 }
 
 func (p *preparedPosts) insertPrepared(i *preparedPostsEntry) error {

--- a/internal/timeline/remove.go
+++ b/internal/timeline/remove.go
@@ -81,7 +81,7 @@ func (t *timeline) RemoveAllBy(accountID string) (int, error) {
 	l := t.log.WithFields(logrus.Fields{
 		"func":            "RemoveAllBy",
 		"accountTimeline": t.accountID,
-		"accountID":        accountID,
+		"accountID":       accountID,
 	})
 	t.Lock()
 	defer t.Unlock()

--- a/internal/timeline/remove.go
+++ b/internal/timeline/remove.go
@@ -1,3 +1,21 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package timeline
 
 import (
@@ -45,6 +63,58 @@ func (t *timeline) Remove(statusID string) (int, error) {
 				return removed, errors.New("Remove: could not parse e as a preparedPostsEntry")
 			}
 			if entry.statusID == statusID {
+				l.Debug("found status in preparedPosts")
+				removePrepared = append(removePrepared, e)
+			}
+		}
+	}
+	for _, e := range removePrepared {
+		t.preparedPosts.data.Remove(e)
+		removed = removed + 1
+	}
+
+	l.Debugf("removed %d entries", removed)
+	return removed, nil
+}
+
+func (t *timeline) RemoveAllBy(accountID string) (int, error) {
+	l := t.log.WithFields(logrus.Fields{
+		"func":            "RemoveAllBy",
+		"accountTimeline": t.accountID,
+		"accountID":        accountID,
+	})
+	t.Lock()
+	defer t.Unlock()
+	var removed int
+
+	// remove entr(ies) from the post index
+	removeIndexes := []*list.Element{}
+	if t.postIndex != nil && t.postIndex.data != nil {
+		for e := t.postIndex.data.Front(); e != nil; e = e.Next() {
+			entry, ok := e.Value.(*postIndexEntry)
+			if !ok {
+				return removed, errors.New("Remove: could not parse e as a postIndexEntry")
+			}
+			if entry.accountID == accountID || entry.boostOfAccountID == accountID {
+				l.Debug("found status in postIndex")
+				removeIndexes = append(removeIndexes, e)
+			}
+		}
+	}
+	for _, e := range removeIndexes {
+		t.postIndex.data.Remove(e)
+		removed = removed + 1
+	}
+
+	// remove entr(ies) from prepared posts
+	removePrepared := []*list.Element{}
+	if t.preparedPosts != nil && t.preparedPosts.data != nil {
+		for e := t.preparedPosts.data.Front(); e != nil; e = e.Next() {
+			entry, ok := e.Value.(*preparedPostsEntry)
+			if !ok {
+				return removed, errors.New("Remove: could not parse e as a preparedPostsEntry")
+			}
+			if entry.accountID == accountID || entry.boostOfAccountID == accountID {
 				l.Debug("found status in preparedPosts")
 				removePrepared = append(removePrepared, e)
 			}

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -65,7 +65,7 @@ type Timeline interface {
 	//
 	// The returned bool indicates whether or not the status was actually inserted into the timeline. This will be false
 	// if the status is a boost and the original post or another boost of it already exists < boostReinsertionDepth back in the timeline.
-	IndexOne(statusCreatedAt time.Time, statusID string, boostOfID string) (bool, error)
+	IndexOne(statusCreatedAt time.Time, statusID string, boostOfID string, accountID string, boostOfAccountID string) (bool, error)
 
 	// OldestIndexedPostID returns the id of the rearmost (ie., the oldest) indexed post, or an error if something goes wrong.
 	// If nothing goes wrong but there's no oldest post, an empty string will be returned so make sure to check for this.
@@ -85,7 +85,7 @@ type Timeline interface {
 	//
 	// The returned bool indicates whether or not the status was actually inserted into the timeline. This will be false
 	// if the status is a boost and the original post or another boost of it already exists < boostReinsertionDepth back in the timeline.
-	IndexAndPrepareOne(statusCreatedAt time.Time, statusID string) (bool, error)
+	IndexAndPrepareOne(statusCreatedAt time.Time, statusID string, boostOfID string, accountID string, boostOfAccountID string) (bool, error)
 	// OldestPreparedPostID returns the id of the rearmost (ie., the oldest) prepared post, or an error if something goes wrong.
 	// If nothing goes wrong but there's no oldest post, an empty string will be returned so make sure to check for this.
 	OldestPreparedPostID() (string, error)
@@ -109,6 +109,10 @@ type Timeline interface {
 	//
 	// The returned int indicates the amount of entries that were removed.
 	Remove(statusID string) (int, error)
+	// RemoveAllBy removes all statuses by the given accountID, from both the index and prepared posts.
+	//
+	// The returned int indicates the amount of entries that were removed.
+	RemoveAllBy(accountID string) (int, error)
 }
 
 // timeline fulfils the Timeline interface

--- a/internal/typeutils/asinterfaces.go
+++ b/internal/typeutils/asinterfaces.go
@@ -111,6 +111,15 @@ type Likeable interface {
 	withObject
 }
 
+// Blockable represents the minimum interface for an activitystreams 'block' activity.
+type Blockable interface {
+	withJSONLDId
+	withTypeName
+
+	withActor
+	withObject
+}
+
 // Announceable represents the minimum interface for an activitystreams 'announce' activity.
 type Announceable interface {
 	withJSONLDId

--- a/internal/typeutils/converter.go
+++ b/internal/typeutils/converter.go
@@ -48,6 +48,10 @@ type TypeConverter interface {
 	// if something goes wrong. The returned account should be ready to serialize on an API level, and may NOT have sensitive fields.
 	// In other words, this is the public record that the server has of an account.
 	AccountToMastoPublic(account *gtsmodel.Account) (*model.Account, error)
+	// AccountToMastoBlocked takes a db model account as a param, and returns a mastotype account, or an error if
+	// something goes wrong. The returned account will be a bare minimum representation of the account. This function should be used
+	// when someone wants to view an account they've blocked.
+	AccountToMastoBlocked(account *gtsmodel.Account) (*model.Account, error)
 	// AppToMastoSensitive takes a db model application as a param, and returns a populated mastotype application, or an error
 	// if something goes wrong. The returned application should be ready to serialize on an API level, and may have sensitive fields
 	// (such as client id and client secret), so serve it only to an authorized user who should have permission to see it.

--- a/internal/typeutils/converter.go
+++ b/internal/typeutils/converter.go
@@ -104,6 +104,8 @@ type TypeConverter interface {
 	ASFollowToFollow(followable Followable) (*gtsmodel.Follow, error)
 	// ASLikeToFave converts a remote activitystreams 'like' representation into a gts model status fave.
 	ASLikeToFave(likeable Likeable) (*gtsmodel.StatusFave, error)
+	// ASBlockToBlock converts a remote activity streams 'block' representation into a gts model block.
+	ASBlockToBlock(blockable Blockable) (*gtsmodel.Block, error)
 	// ASAnnounceToStatus converts an activitystreams 'announce' into a status.
 	//
 	// The returned bool indicates whether this status is new (true) or not new (false).
@@ -124,6 +126,11 @@ type TypeConverter interface {
 
 	// AccountToAS converts a gts model account into an activity streams person, suitable for federation
 	AccountToAS(a *gtsmodel.Account) (vocab.ActivityStreamsPerson, error)
+	// AccountToASMinimal converts a gts model account into an activity streams person, suitable for federation.
+	//
+	// The returned account will just have the Type, Username, PublicKey, and ID properties set. This is
+	// suitable for serving to requesters to whom we want to give as little information as possible because
+	// we don't trust them (yet).
 	AccountToASMinimal(a *gtsmodel.Account) (vocab.ActivityStreamsPerson, error)
 	// StatusToAS converts a gts model status into an activity streams note, suitable for federation
 	StatusToAS(s *gtsmodel.Status) (vocab.ActivityStreamsNote, error)
@@ -137,6 +144,8 @@ type TypeConverter interface {
 	FaveToAS(f *gtsmodel.StatusFave) (vocab.ActivityStreamsLike, error)
 	// BoostToAS converts a gts model boost into an activityStreams ANNOUNCE, suitable for federation
 	BoostToAS(boostWrapperStatus *gtsmodel.Status, boostingAccount *gtsmodel.Account, boostedAccount *gtsmodel.Account) (vocab.ActivityStreamsAnnounce, error)
+	// BlockToAS converts a gts model block into an activityStreams BLOCK, suitable for federation.
+	BlockToAS(block *gtsmodel.Block) (vocab.ActivityStreamsBlock, error)
 
 	/*
 		INTERNAL (gts) MODEL TO INTERNAL MODEL

--- a/internal/typeutils/internal.go
+++ b/internal/typeutils/internal.go
@@ -67,6 +67,7 @@ func (c *converter) StatusToBoost(s *gtsmodel.Status, boostingAccount *gtsmodel.
 		Language:            s.Language,
 		Text:                s.Text,
 		BoostOfID:           s.ID,
+		BoostOfAccountID:    s.AccountID,
 		Visibility:          s.Visibility,
 		VisibilityAdvanced:  s.VisibilityAdvanced,
 

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -150,6 +150,11 @@ func (c *converter) AccountToMastoPublic(a *gtsmodel.Account) (*model.Account, e
 		acct = a.Username
 	}
 
+	var suspended bool
+	if !a.SuspendedAt.IsZero() {
+		suspended = true
+	}
+
 	return &model.Account{
 		ID:             a.ID,
 		Username:       a.Username,
@@ -170,6 +175,7 @@ func (c *converter) AccountToMastoPublic(a *gtsmodel.Account) (*model.Account, e
 		LastStatusAt:   lastStatusAt,
 		Emojis:         emojis, // TODO: implement this
 		Fields:         fields,
+		Suspended:      suspended,
 	}, nil
 }
 
@@ -183,14 +189,20 @@ func (c *converter) AccountToMastoBlocked(a *gtsmodel.Account) (*model.Account, 
 		acct = a.Username
 	}
 
+	var suspended bool
+	if !a.SuspendedAt.IsZero() {
+		suspended = true
+	}
+
 	return &model.Account{
-		ID:             a.ID,
-		Username:       a.Username,
-		Acct:           acct,
-		DisplayName:    a.Username,
-		Bot:            a.Bot,
-		CreatedAt:      a.CreatedAt.Format(time.RFC3339),
-		URL:            a.URL,
+		ID:          a.ID,
+		Username:    a.Username,
+		Acct:        acct,
+		DisplayName: a.DisplayName,
+		Bot:         a.Bot,
+		CreatedAt:   a.CreatedAt.Format(time.RFC3339),
+		URL:         a.URL,
+		Suspended:   suspended,
 	}, nil
 }
 

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -173,6 +173,27 @@ func (c *converter) AccountToMastoPublic(a *gtsmodel.Account) (*model.Account, e
 	}, nil
 }
 
+func (c *converter) AccountToMastoBlocked(a *gtsmodel.Account) (*model.Account, error) {
+	var acct string
+	if a.Domain != "" {
+		// this is a remote user
+		acct = fmt.Sprintf("%s@%s", a.Username, a.Domain)
+	} else {
+		// this is a local user
+		acct = a.Username
+	}
+
+	return &model.Account{
+		ID:             a.ID,
+		Username:       a.Username,
+		Acct:           acct,
+		DisplayName:    a.Username,
+		Bot:            a.Bot,
+		CreatedAt:      a.CreatedAt.Format(time.RFC3339),
+		URL:            a.URL,
+	}, nil
+}
+
 func (c *converter) AppToMastoSensitive(a *gtsmodel.Application) (*model.Application, error) {
 	return &model.Application{
 		ID:           a.ID,

--- a/internal/util/regexes.go
+++ b/internal/util/regexes.go
@@ -104,4 +104,9 @@ var (
 	// from eg /users/example_username/statuses/01F7XT5JZW1WMVSW1KADS8PVDH
 	// The regex can be played with here: https://regex101.com/r/G9zuxQ/1
 	statusesPathRegex = regexp.MustCompile(statusesPathRegexString)
+
+	blockPathRegexString = fmt.Sprintf(`^/?%s/(%s)/%s/(%s)$`, UsersPath, usernameRegexString, BlocksPath, ulidRegexString)
+	// blockPathRegex parses a path that validates and captures the username part and the ulid part
+	// from eg /users/example_username/blocks/01F7XT5JZW1WMVSW1KADS8PVDH
+	blockPathRegex = regexp.MustCompile(blockPathRegexString)
 )

--- a/internal/util/uri.go
+++ b/internal/util/uri.go
@@ -50,6 +50,8 @@ const (
 	FollowPath = "follow"
 	// UpdatePath is used to generate the URI for an account update
 	UpdatePath = "updates"
+	// BlocksPath is used to generate the URI for a block
+	BlocksPath = "blocks"
 )
 
 // APContextKey is a type used specifically for settings values on contexts within go-fed AP request chains
@@ -122,6 +124,12 @@ func GenerateURIForLike(username string, protocol string, host string, thisFaved
 // https://example.org/users/whatever_user#updates/01F7XTH1QGBAPMGF49WJZ91XGC
 func GenerateURIForUpdate(username string, protocol string, host string, thisUpdateID string) string {
 	return fmt.Sprintf("%s://%s/%s/%s#%s/%s", protocol, host, UsersPath, username, UpdatePath, thisUpdateID)
+}
+
+// GenerateURIForBlock returns the AP URI for a new block activity -- something like:
+// https://example.org/users/whatever_user/blocks/01F7XTH1QGBAPMGF49WJZ91XGC
+func GenerateURIForBlock(username string, protocol string, host string, thisBlockID string) string {
+	return fmt.Sprintf("%s://%s/%s/%s/%s/%s", protocol, host, UsersPath, username, BlocksPath, thisBlockID)
 }
 
 // GenerateURIsForAccount throws together a bunch of URIs for the given username, with the given protocol and host.
@@ -214,6 +222,11 @@ func IsPublicKeyPath(id *url.URL) bool {
 	return userPublicKeyPathRegex.MatchString(id.Path)
 }
 
+// IsBlockPath returns true if the given URL path corresponds to eg /users/example_username/blocks/SOME_ULID_OF_A_BLOCK
+func IsBlockPath(id *url.URL) bool {
+	return blockPathRegex.MatchString(id.Path)
+}
+
 // ParseStatusesPath returns the username and ulid from a path such as /users/example_username/statuses/SOME_ULID_OF_A_STATUS
 func ParseStatusesPath(id *url.URL) (username string, ulid string, err error) {
 	matches := statusesPathRegex.FindStringSubmatch(id.Path)
@@ -284,6 +297,18 @@ func ParseFollowingPath(id *url.URL) (username string, err error) {
 // ParseLikedPath returns the username and ulid from a path such as /users/example_username/liked/SOME_ULID_OF_A_STATUS
 func ParseLikedPath(id *url.URL) (username string, ulid string, err error) {
 	matches := likePathRegex.FindStringSubmatch(id.Path)
+	if len(matches) != 3 {
+		err = fmt.Errorf("expected 3 matches but matches length was %d", len(matches))
+		return
+	}
+	username = matches[1]
+	ulid = matches[2]
+	return
+}
+
+// ParseBlockPath returns the username and ulid from a path such as /users/example_username/blocks/SOME_ULID_OF_A_BLOCK
+func ParseBlockPath(id *url.URL) (username string, ulid string, err error) {
+	matches := blockPathRegex.FindStringSubmatch(id.Path)
 	if len(matches) != 3 {
 		err = fmt.Errorf("expected 3 matches but matches length was %d", len(matches))
 		return


### PR DESCRIPTION
This PR enables the following API endpoints:

* `api/v1/account/:id/block` - POST - block account with id
* `/api/v1/account/:id/unblock` - POST - unblock account with id
* `/api/v1/blocks` - GET - view list of blocked accounts

Side effects of blocking are also handled:

* Block is federated to remote instance.
* Posts from blocked account are removed from your timeline (including boosts made by that account or boosts of that account).
* Posts from your account are removed from blocked account's timeline (including boosts made by you account or boosts of you).
* Any follows/follow requests between blocker and blockee are undone and these undos are federated if necessary.
* When you view a blocked profile, you will now see only a minimal representation of the profile -- username, display name, URL.
* Blocked account will be forbidden from accessing your AP inbox or interacting with you.
* New posts from blocked account will not appear in your timeline.
* Boosts of blocked account will not appear in your timeline.
* Replies to blocked account will not appear in your timeline. 

In other words, this PR provides standard blocking functionality between accounts.

Things we might want to implement later on:

* Stream deletes via websocket for every post from blocked account in the blocker's timeline (in other words, remove blocked posts without the user having to hit refresh).
* Allow a user to choose whether or not the block should be federated to the blockee's instance.