### PR TITLE
lil webfingy fix

### DIFF
--- a/internal/api/s2s/user/followers.go
+++ b/internal/api/s2s/user/followers.go
@@ -20,6 +20,8 @@ package user
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -55,12 +57,20 @@ func (m *Module) FollowersGETHandler(c *gin.Context) {
 		ctx = context.WithValue(ctx, util.APRequestingPublicKeyVerifier, verifier)
 	}
 
-	user, err := m.processor.GetFediFollowers(ctx, requestedUsername, c.Request.URL) // GetFediUser handles auth as well
+	followers, err := m.processor.GetFediFollowers(ctx, requestedUsername, c.Request.URL) // GetFediUser handles auth as well
 	if err != nil {
 		l.Info(err.Error())
 		c.JSON(err.Code(), gin.H{"error": err.Safe()})
 		return
 	}
 
-	c.JSON(http.StatusOK, user)
+	b, mErr := json.Marshal(followers)
+	if mErr != nil {
+		err := fmt.Errorf("could not marshal json: %s", mErr)
+		l.Error(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Data(http.StatusOK, format, b)
 }

--- a/internal/api/s2s/user/publickeyget.go
+++ b/internal/api/s2s/user/publickeyget.go
@@ -2,6 +2,8 @@ package user
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -48,5 +50,13 @@ func (m *Module) PublicKeyGETHandler(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, user)
+	b, mErr := json.Marshal(user)
+	if mErr != nil {
+		err := fmt.Errorf("could not marshal json: %s", mErr)
+		l.Error(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Data(http.StatusOK, format, b)
 }

--- a/internal/api/s2s/user/statusget.go
+++ b/internal/api/s2s/user/statusget.go
@@ -2,6 +2,8 @@ package user
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -50,5 +52,13 @@ func (m *Module) StatusGETHandler(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, status)
+	b, mErr := json.Marshal(status)
+	if mErr != nil {
+		err := fmt.Errorf("could not marshal json: %s", mErr)
+		l.Error(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Data(http.StatusOK, format, b)
 }

--- a/internal/api/s2s/user/userget.go
+++ b/internal/api/s2s/user/userget.go
@@ -20,6 +20,8 @@ package user
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -70,5 +72,13 @@ func (m *Module) UsersGETHandler(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, user)
+	b, mErr := json.Marshal(user)
+	if mErr != nil {
+		err := fmt.Errorf("could not marshal json: %s", mErr)
+		l.Error(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Data(http.StatusOK, format, b)
 }

--- a/internal/api/s2s/webfinger/webfingerget.go
+++ b/internal/api/s2s/webfinger/webfingerget.go
@@ -64,7 +64,7 @@ func (m *Module) WebfingerGETRequest(c *gin.Context) {
 		return
 	}
 
-	if accountDomain != m.config.AccountDomain {
+	if accountDomain != m.config.AccountDomain && accountDomain != m.config.Host {
 		l.Debugf("aborting request because accountDomain %s does not belong to this instance", accountDomain)
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("accountDomain %s does not belong to this instance", accountDomain)})
 		return


### PR DESCRIPTION
This allows webfinger requests to be served for both `host` and `accountDomain`.

For example, we have a server with `host` of `gts.superseriousbusiness.org` and `accountDomain` of `superseriousbusiness.org`

The following query:

```bash
curl -L "https://superseriousbusiness.org/.well-known/webfinger?resource=acct:test@superseriousbusiness.org"  | jq
```

returns

```json
{
  "subject": "acct:test@superseriousbusiness.org",
  "aliases": [
    "https://gts.superseriousbusiness.org/users/test",
    "https://gts.superseriousbusiness.org/@test"
  ],
  "links": [
    {
      "rel": "http://webfinger.net/rel/profile-page",
      "type": "text/html",
      "href": "https://gts.superseriousbusiness.org/@test"
    },
    {
      "rel": "self",
      "type": "application/activity+json",
      "href": "https://gts.superseriousbusiness.org/users/test"
    }
  ]
}
```

and

```bash
curl -L "https://gts.superseriousbusiness.org/.well-known/webfinger?resource=acct:test@gts.superseriousbusiness.org"  | jq
```

returns

```json
{
  "subject": "acct:test@superseriousbusiness.org",
  "aliases": [
    "https://gts.superseriousbusiness.org/users/test",
    "https://gts.superseriousbusiness.org/@test"
  ],
  "links": [
    {
      "rel": "http://webfinger.net/rel/profile-page",
      "type": "text/html",
      "href": "https://gts.superseriousbusiness.org/@test"
    },
    {
      "rel": "self",
      "type": "application/activity+json",
      "href": "https://gts.superseriousbusiness.org/users/test"
    }
  ]
}
```

This should allow webfinger to work properly from remote instances in cases where `host` and `accountDomain` are set differently.

Closes https://github.com/superseriousbusiness/gotosocial/issues/105