### PR TITLE
allow custom ports for webserver and le

### DIFF
--- a/GETTINGSTARTED.md
+++ b/GETTINGSTARTED.md
@@ -33,7 +33,13 @@ docker run -d --network host --user postgres -e POSTGRES_PASSWORD=some_password 
 On your local machine (not your server), with Go installed, clone the GoToSocial repository, and build the binary with the provided build script:
 
 ```bash
-./build/sh
+./build.sh
+```
+
+If you need to build for a different architecture other than the one you're running the build on (eg., you're running on a Raspberry Pi but building on an amd64 machine), you can put set `GOOS` or `GOARCH` environment variables before running the build script, eg:
+
+```bash
+GOARCH=arm64 ./build.sh
 ```
 
 ### 6: Prepare VPS
@@ -52,7 +58,7 @@ Copy your binary from your local machine onto the VPS, using something like the 
 scp ./gotosocial root@example.org:/gotosocial/gotosocial
 ```
 
-Replace `root` with whatever user you're actually running on your remote server.
+Replace `root` with whatever user you're actually running on your remote server (you wouldn't run as root right? ;).
 
 ### 8: Copy Web Dir
 
@@ -75,10 +81,12 @@ cd /gotosocial
 Then start the GoToSocial server with the following command (where `example.org` is the domain you set up in step 1, and `some_password` is the password you set for Postgres in step 4):
 
 ```bash
-./gotosocial --host example.org --storage-serve-host example.org --letsencrypt-enabled=true server start
+./gotosocial --host example.org --port 443 --storage-serve-host example.org --letsencrypt-enabled=true server start
 ```
 
 The server should now start up and you should be able to access the splash page by navigating to your domain in the browser. Note that it might take up to a minute or so for your LetsEncrypt certificates to be created for the first time, so refresh a few times if necessary.
+
+Note that for this example we're assuming that we're allowed to run on port 443 (standard https port), and that nothing else is running on this port.
 
 ### 10: Create and confirm your user
 

--- a/cmd/gotosocial/generalflags.go
+++ b/cmd/gotosocial/generalflags.go
@@ -62,5 +62,11 @@ func generalFlags(flagNames, envNames config.Flags, defaults config.Defaults) []
 			Value:   defaults.Protocol,
 			EnvVars: []string{envNames.Protocol},
 		},
+		&cli.IntFlag{
+			Name:    flagNames.Port,
+			Usage:   "Port to use for GoToSocial. Change this to 443 if you're running the binary directly on the host machine.",
+			Value:   defaults.Port,
+			EnvVars: []string{envNames.Port},
+		},
 	}
 }

--- a/cmd/gotosocial/letsencryptflags.go
+++ b/cmd/gotosocial/letsencryptflags.go
@@ -31,6 +31,12 @@ func letsEncryptFlags(flagNames, envNames config.Flags, defaults config.Defaults
 			Value:   defaults.LetsEncryptEnabled,
 			EnvVars: []string{envNames.LetsEncryptEnabled},
 		},
+		&cli.IntFlag{
+			Name:    flagNames.LetsEncryptPort,
+			Usage:   "Port to listen on for letsencrypt certificate challenges. Must not be the same as the GtS webserver/API port.",
+			Value:   defaults.LetsEncryptPort,
+			EnvVars: []string{envNames.LetsEncryptPort},
+		},
 		&cli.StringFlag{
 			Name:    flagNames.LetsEncryptCertDir,
 			Usage:   "Directory to store acquired letsencrypt certificates.",

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -48,9 +48,21 @@ host: "localhost"
 accountDomain: ""
 
 # String. Protocol to use for the server. Only change to http for local testing!
+# This should be the protocol part of the URI that your server is actually reachable on. So even if you're
+# running GoToSocial behind a reverse proxy that handles SSL certificates for you, instead of using built-in
+# letsencrypt, it should still be https.
 # Options: ["http","https"]
 # Default: "https"
 protocol: "https"
+
+# Int. Listen port for the GoToSocial webserver + API. If you're running behind a reverse proxy and/or in a docker,
+# container, just set this to whatever you like (or leave the default), and make sure it's forwarded properly.
+# If you are running with built-in letsencrypt enabled, and running GoToSocial directly on a host machine, you will
+# probably want to set this to 443 (standard https port), unless you have other services already using that port.
+# This *MUST NOT* be the same as the letsencrypt port specified below, unless letsencrypt is turned off.
+# Examples: [443, 6666, 8080]
+# Default: 8080
+port: 8080
 
 ############################
 ##### DATABASE CONFIG ######
@@ -256,15 +268,20 @@ statuses:
 letsEncrypt:
 
   # Bool. Whether or not letsencrypt should be enabled for the server.
-  # If true, the server will serve on port 443 (https) and obtain letsencrypt
-  # certificates automatically.
-  # If false, the server will serve on port 8080 (http), and the rest of the settings
-  # here will be ignored.
+  # If false, the rest of the settings here will be ignored.
   # You should only change this if you want to serve GoToSocial behind a reverse proxy
   # like Traefik, HAProxy, or Nginx.
   # Options: [true, false]
   # Default: true
   enabled: true
+
+  # Int. Port to listen for letsencrypt certificate challenges on.
+  # If letsencrypt is enabled, this port must be reachable or you won't be able to obtain certs.
+  # If letsencrypt is disabled, this port will not be used.
+  # This *must not* be the same as the webserver/API port specified above.
+  # Examples: [80, 8000, 1312]
+  # Default: 80
+  port: 80
 
   # String. Directory in which to store LetsEncrypt certificates.
   # It is a good move to make this a sub-path within your storage directory, as it makes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	Host              string             `yaml:"host"`
 	AccountDomain     string             `yaml:"accountDomain"`
 	Protocol          string             `yaml:"protocol"`
+	Port              int                `yaml:"port"`
 	DBConfig          *DBConfig          `yaml:"db"`
 	TemplateConfig    *TemplateConfig    `yaml:"template"`
 	AccountsConfig    *AccountsConfig    `yaml:"accounts"`
@@ -148,6 +149,10 @@ func (c *Config) ParseCLIFlags(f KeyedFlags, version string) error {
 	}
 	if c.Protocol == "" {
 		return errors.New("protocol was not set")
+	}
+
+	if c.Port == 0 || f.IsSet(fn.Port) {
+		c.Port = f.Int(fn.Port)
 	}
 
 	// db flags
@@ -262,6 +267,10 @@ func (c *Config) ParseCLIFlags(f KeyedFlags, version string) error {
 		c.LetsEncryptConfig.Enabled = f.Bool(fn.LetsEncryptEnabled)
 	}
 
+	if c.LetsEncryptConfig.Port == 0 || f.IsSet(fn.LetsEncryptPort) {
+		c.LetsEncryptConfig.Port = f.Int(fn.LetsEncryptPort)
+	}
+
 	if c.LetsEncryptConfig.CertDir == "" || f.IsSet(fn.LetsEncryptCertDir) {
 		c.LetsEncryptConfig.CertDir = f.String(fn.LetsEncryptCertDir)
 	}
@@ -329,6 +338,7 @@ type Flags struct {
 	Host            string
 	AccountDomain   string
 	Protocol        string
+	Port            string
 
 	DbType      string
 	DbAddress   string
@@ -366,6 +376,7 @@ type Flags struct {
 	LetsEncryptEnabled      string
 	LetsEncryptCertDir      string
 	LetsEncryptEmailAddress string
+	LetsEncryptPort         string
 
 	OIDCEnabled          string
 	OIDCIdpName          string
@@ -384,6 +395,7 @@ type Defaults struct {
 	Host            string
 	AccountDomain   string
 	Protocol        string
+	Port            int
 	SoftwareVersion string
 
 	DbType      string
@@ -422,6 +434,7 @@ type Defaults struct {
 	LetsEncryptEnabled      bool
 	LetsEncryptCertDir      string
 	LetsEncryptEmailAddress string
+	LetsEncryptPort         int
 
 	OIDCEnabled          bool
 	OIDCIdpName          string
@@ -442,6 +455,7 @@ func GetFlagNames() Flags {
 		Host:            "host",
 		AccountDomain:   "account-domain",
 		Protocol:        "protocol",
+		Port:            "port",
 
 		DbType:      "db-type",
 		DbAddress:   "db-address",
@@ -477,6 +491,7 @@ func GetFlagNames() Flags {
 		StatusesMaxMediaFiles:      "statuses-max-media-files",
 
 		LetsEncryptEnabled:      "letsencrypt-enabled",
+		LetsEncryptPort:         "letsencrypt-port",
 		LetsEncryptCertDir:      "letsencrypt-cert-dir",
 		LetsEncryptEmailAddress: "letsencrypt-email",
 
@@ -500,6 +515,7 @@ func GetEnvNames() Flags {
 		Host:            "GTS_HOST",
 		AccountDomain:   "GTS_ACCOUNT_DOMAIN",
 		Protocol:        "GTS_PROTOCOL",
+		Port:            "GTS_PORT",
 
 		DbType:      "GTS_DB_TYPE",
 		DbAddress:   "GTS_DB_ADDRESS",
@@ -535,6 +551,7 @@ func GetEnvNames() Flags {
 		StatusesMaxMediaFiles:      "GTS_STATUSES_MAX_MEDIA_FILES",
 
 		LetsEncryptEnabled:      "GTS_LETSENCRYPT_ENABLED",
+		LetsEncryptPort:         "GTS_LETSENCRYPT_PORT",
 		LetsEncryptCertDir:      "GTS_LETSENCRYPT_CERT_DIR",
 		LetsEncryptEmailAddress: "GTS_LETSENCRYPT_EMAIL",
 

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -10,6 +10,7 @@ func TestDefault() *Config {
 		ApplicationName: defaults.ApplicationName,
 		Host:            defaults.Host,
 		Protocol:        defaults.Protocol,
+		Port:            defaults.Port,
 		SoftwareVersion: defaults.SoftwareVersion,
 		DBConfig: &DBConfig{
 			Type:            defaults.DbType,
@@ -51,6 +52,7 @@ func TestDefault() *Config {
 		},
 		LetsEncryptConfig: &LetsEncryptConfig{
 			Enabled:      defaults.LetsEncryptEnabled,
+			Port:         defaults.LetsEncryptPort,
 			CertDir:      defaults.LetsEncryptCertDir,
 			EmailAddress: defaults.LetsEncryptEmailAddress,
 		},
@@ -115,6 +117,7 @@ func Default() *Config {
 		},
 		LetsEncryptConfig: &LetsEncryptConfig{
 			Enabled:      defaults.LetsEncryptEnabled,
+			Port:         defaults.LetsEncryptPort,
 			CertDir:      defaults.LetsEncryptCertDir,
 			EmailAddress: defaults.LetsEncryptEmailAddress,
 		},
@@ -140,6 +143,7 @@ func GetDefaults() Defaults {
 		Host:            "",
 		AccountDomain:   "",
 		Protocol:        "https",
+		Port:            8080,
 
 		DbType:      "postgres",
 		DbAddress:   "localhost",
@@ -175,6 +179,7 @@ func GetDefaults() Defaults {
 		StatusesMaxMediaFiles:      6,
 
 		LetsEncryptEnabled:      true,
+		LetsEncryptPort:         80,
 		LetsEncryptCertDir:      "/gotosocial/storage/certs",
 		LetsEncryptEmailAddress: "",
 
@@ -197,6 +202,7 @@ func GetTestDefaults() Defaults {
 		Host:            "localhost:8080",
 		AccountDomain:   "",
 		Protocol:        "http",
+		Port:            8080,
 
 		DbType:     "postgres",
 		DbAddress:  "localhost",
@@ -230,6 +236,7 @@ func GetTestDefaults() Defaults {
 		StatusesMaxMediaFiles:      6,
 
 		LetsEncryptEnabled:      false,
+		LetsEncryptPort:         0,
 		LetsEncryptCertDir:      "",
 		LetsEncryptEmailAddress: "",
 

--- a/internal/config/letsencrypt.go
+++ b/internal/config/letsencrypt.go
@@ -3,9 +3,11 @@ package config
 // LetsEncryptConfig wraps everything needed to manage letsencrypt certificates from within gotosocial.
 type LetsEncryptConfig struct {
 	// Should letsencrypt certificate fetching be enabled?
-	Enabled bool
+	Enabled bool `yaml:"enabled"`
+	// What port should the server listen for letsencrypt challenges on?
+	Port int `yaml:"port"`
 	// Where should certificates be stored?
-	CertDir string
+	CertDir string `yaml:"certDir"`
 	// Email address to pass to letsencrypt for notifications about certificate expiry etc.
-	EmailAddress string
+	EmailAddress string `yaml:"emailAddress"`
 }


### PR DESCRIPTION
This PR allows custom ports to be selected for both the GTS webserver/API, and the letsencrypt certificate challenge.

For LE:

```yaml
# Config pertaining to the automatic acquisition and use of LetsEncrypt HTTPS certificates.
letsEncrypt:

[...]

  # Int. Port to listen for letsencrypt certificate challenges on.
  # If letsencrypt is enabled, this port must be reachable or you won't be able to obtain certs.
  # If letsencrypt is disabled, this port will not be used.
  # This *must not* be the same as the webserver/API port specified above.
  # Examples: [80, 8000, 1312]
  # Default: 80
  port: 80
```

And for the webserver/api port:

```yaml
# Int. Listen port for the GoToSocial webserver + API. If you're running behind a reverse proxy and/or in a docker,
# container, just set this to whatever you like (or leave the default), and make sure it's forwarded properly.
# If you are running with built-in letsencrypt enabled, and running GoToSocial directly on a host machine, you will
# probably want to set this to 443 (standard https port), unless you have other services already using that port.
# This *MUST NOT* be the same as the letsencrypt port specified below, unless letsencrypt is turned off.
# Examples: [443, 6666, 8080]
# Default: 8080
port: 8080
```

These values can also be set by the cli flags `--port` and `--letsencrypt-port` or by env vars `GTS_PORT` and `GTS_LETSENCRYPT_PORT`

Closes https://github.com/superseriousbusiness/gotosocial/issues/43