### PR TITLE
federating db updates

### DIFF
--- a/internal/federation/federatingdb/announce.go
+++ b/internal/federation/federatingdb/announce.go
@@ -31,29 +31,31 @@ func (f *federatingDB) Announce(ctx context.Context, announce vocab.ActivityStre
 
 	targetAcctI := ctx.Value(util.APAccount)
 	if targetAcctI == nil {
-		l.Error("target account wasn't set on context")
+		// If the target account wasn't set on the context, that means this request didn't pass through the
+		// API, but came from inside GtS as the result of another activity on this instance. That being so,
+		// we can safely just ignore this activity, since we know we've already processed it elsewhere.
 		return nil
 	}
 	targetAcct, ok := targetAcctI.(*gtsmodel.Account)
 	if !ok {
-		l.Error("target account was set on context but couldn't be parsed")
+		l.Error("ANNOUNCE: target account was set on context but couldn't be parsed")
 		return nil
 	}
 
 	fromFederatorChanI := ctx.Value(util.APFromFederatorChanKey)
 	if fromFederatorChanI == nil {
-		l.Error("from federator channel wasn't set on context")
+		l.Error("ANNOUNCE: from federator channel wasn't set on context")
 		return nil
 	}
 	fromFederatorChan, ok := fromFederatorChanI.(chan gtsmodel.FromFederator)
 	if !ok {
-		l.Error("from federator channel was set on context but couldn't be parsed")
+		l.Error("ANNOUNCE: from federator channel was set on context but couldn't be parsed")
 		return nil
 	}
 
 	boost, isNew, err := f.typeConverter.ASAnnounceToStatus(announce)
 	if err != nil {
-		return fmt.Errorf("Announce: error converting announce to boost: %s", err)
+		return fmt.Errorf("ANNOUNCE: error converting announce to boost: %s", err)
 	}
 
 	if !isNew {

--- a/internal/federation/federatingdb/followers.go
+++ b/internal/federation/federatingdb/followers.go
@@ -32,19 +32,19 @@ func (f *federatingDB) Followers(c context.Context, actorIRI *url.URL) (follower
 
 	if util.IsUserPath(actorIRI) {
 		if err := f.db.GetWhere([]db.Where{{Key: "uri", Value: actorIRI.String()}}, acct); err != nil {
-			return nil, fmt.Errorf("db error getting account with uri %s: %s", actorIRI.String(), err)
+			return nil, fmt.Errorf("FOLLOWERS: db error getting account with uri %s: %s", actorIRI.String(), err)
 		}
 	} else if util.IsFollowersPath(actorIRI) {
 		if err := f.db.GetWhere([]db.Where{{Key: "followers_uri", Value: actorIRI.String()}}, acct); err != nil {
-			return nil, fmt.Errorf("db error getting account with followers uri %s: %s", actorIRI.String(), err)
+			return nil, fmt.Errorf("FOLLOWERS: db error getting account with followers uri %s: %s", actorIRI.String(), err)
 		}
 	} else {
-		return nil, fmt.Errorf("could not parse actor IRI %s as users or followers path", actorIRI.String())
+		return nil, fmt.Errorf("FOLLOWERS: could not parse actor IRI %s as users or followers path", actorIRI.String())
 	}
 
 	acctFollowers := []gtsmodel.Follow{}
 	if err := f.db.GetFollowersByAccountID(acct.ID, &acctFollowers, false); err != nil {
-		return nil, fmt.Errorf("db error getting followers for account id %s: %s", acct.ID, err)
+		return nil, fmt.Errorf("FOLLOWERS: db error getting followers for account id %s: %s", acct.ID, err)
 	}
 
 	followers = streams.NewActivityStreamsCollection()
@@ -52,11 +52,11 @@ func (f *federatingDB) Followers(c context.Context, actorIRI *url.URL) (follower
 	for _, follow := range acctFollowers {
 		gtsFollower := &gtsmodel.Account{}
 		if err := f.db.GetByID(follow.AccountID, gtsFollower); err != nil {
-			return nil, fmt.Errorf("db error getting account id %s: %s", follow.AccountID, err)
+			return nil, fmt.Errorf("FOLLOWERS: db error getting account id %s: %s", follow.AccountID, err)
 		}
 		uri, err := url.Parse(gtsFollower.URI)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing %s as url: %s", gtsFollower.URI, err)
+			return nil, fmt.Errorf("FOLLOWERS: error parsing %s as url: %s", gtsFollower.URI, err)
 		}
 		items.AppendIRI(uri)
 	}

--- a/internal/federation/federatingdb/following.go
+++ b/internal/federation/federatingdb/following.go
@@ -31,19 +31,19 @@ func (f *federatingDB) Following(c context.Context, actorIRI *url.URL) (followin
 	acct := &gtsmodel.Account{}
 	if util.IsUserPath(actorIRI) {
 		if err := f.db.GetWhere([]db.Where{{Key: "uri", Value: actorIRI.String()}}, acct); err != nil {
-			return nil, fmt.Errorf("db error getting account with uri %s: %s", actorIRI.String(), err)
+			return nil, fmt.Errorf("FOLLOWING: db error getting account with uri %s: %s", actorIRI.String(), err)
 		}
 	} else if util.IsFollowingPath(actorIRI) {
 		if err := f.db.GetWhere([]db.Where{{Key: "following_uri", Value: actorIRI.String()}}, acct); err != nil {
-			return nil, fmt.Errorf("db error getting account with following uri %s: %s", actorIRI.String(), err)
+			return nil, fmt.Errorf("FOLLOWING: db error getting account with following uri %s: %s", actorIRI.String(), err)
 		}
 	} else {
-		return nil, fmt.Errorf("could not parse actor IRI %s as users or following path", actorIRI.String())
+		return nil, fmt.Errorf("FOLLOWING: could not parse actor IRI %s as users or following path", actorIRI.String())
 	}
 
 	acctFollowing := []gtsmodel.Follow{}
 	if err := f.db.GetFollowingByAccountID(acct.ID, &acctFollowing); err != nil {
-		return nil, fmt.Errorf("db error getting following for account id %s: %s", acct.ID, err)
+		return nil, fmt.Errorf("FOLLOWING: db error getting following for account id %s: %s", acct.ID, err)
 	}
 
 	following = streams.NewActivityStreamsCollection()
@@ -51,11 +51,11 @@ func (f *federatingDB) Following(c context.Context, actorIRI *url.URL) (followin
 	for _, follow := range acctFollowing {
 		gtsFollowing := &gtsmodel.Account{}
 		if err := f.db.GetByID(follow.AccountID, gtsFollowing); err != nil {
-			return nil, fmt.Errorf("db error getting account id %s: %s", follow.AccountID, err)
+			return nil, fmt.Errorf("FOLLOWING: db error getting account id %s: %s", follow.AccountID, err)
 		}
 		uri, err := url.Parse(gtsFollowing.URI)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing %s as url: %s", gtsFollowing.URI, err)
+			return nil, fmt.Errorf("FOLLOWING: error parsing %s as url: %s", gtsFollowing.URI, err)
 		}
 		items.AppendIRI(uri)
 	}

--- a/internal/federation/federatingdb/undo.go
+++ b/internal/federation/federatingdb/undo.go
@@ -33,7 +33,9 @@ func (f *federatingDB) Undo(ctx context.Context, undo vocab.ActivityStreamsUndo)
 
 	targetAcctI := ctx.Value(util.APAccount)
 	if targetAcctI == nil {
-		l.Error("UNDO: target account wasn't set on context")
+		// If the target account wasn't set on the context, that means this request didn't pass through the
+		// API, but came from inside GtS as the result of another activity on this instance. That being so,
+		// we can safely just ignore this activity, since we know we've already processed it elsewhere.
 		return nil
 	}
 	targetAcct, ok := targetAcctI.(*gtsmodel.Account)


### PR DESCRIPTION
This PR makes logging and code more consistent across the various federating DB functions.

It also fixes the 'account was not set on context' errors which were popping up. Basically, these were caused by requests which were coming from inside GtS itself, and not being pushed through the API. The correct way of dealing with these 'errors' is to just ignore them, because they've already been processed elsewhere and aren't actually errors at all, so that's what this PR does.

In other words: is your code logging lots of errors? Remove the error logging line ;)