### PR TITLE
build and bundle admin console + web assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.16.4-alpine3.13 AS builder
+# STEP ONE: build the GoToSocial binary
+FROM golang:1.16.4-alpine3.13 AS binary_builder
 RUN apk update && apk upgrade --no-cache
 RUN apk add git
 
@@ -23,15 +24,40 @@ ADD build.sh /go/src/github.com/superseriousbusiness/gotosocial/build.sh
 # do the build step
 RUN ./build.sh
 
+# STEP TWO: build the web assets
+FROM node:16.5.0-alpine3.11 AS web_builder
+RUN apk update && apk upgrade --no-cache
+
+COPY web /web
+WORKDIR /web/source
+
+RUN yarn install
+RUN node build.js
+
+# STEP THREE: bundle the admin webapp
+FROM node:16.5.0-alpine3.11 AS admin_builder
+RUN apk update && apk upgrade --no-cache
+RUN apk add git
+
+RUN git clone https://github.com/superseriousbusiness/gotosocial-admin
+WORKDIR /gotosocial-admin
+
+RUN npm install
+RUN node index.js
+
+# STEP FOUR: build the final container
 FROM alpine:3.13 AS executor
 RUN apk update && apk upgrade --no-cache
 
 # copy over the binary from the first stage
 RUN mkdir -p /gotosocial/storage
-COPY --from=builder /go/src/github.com/superseriousbusiness/gotosocial/gotosocial /gotosocial/gotosocial
+COPY --from=binary_builder /go/src/github.com/superseriousbusiness/gotosocial/gotosocial /gotosocial/gotosocial
 
 # copy over the web directory with templates etc
-COPY web /gotosocial/web
+COPY --from=web_builder web /gotosocial/web
+
+# copy over the admin directory
+COPY --from=admin_builder /gotosocial-admin/public /gotosocial/web/assets/admin
 
 # make the gotosocial group and user
 RUN addgroup -g 1000 gotosocial


### PR DESCRIPTION
This PR alters the Dockerfile to compile + bundle the static web assets inside the final Dockerfile, meaning that the build no longer needs to be triggered manually when updating the web stuff.

It also adds a step to pull and build the admin console (https://github.com/superseriousbusiness/gotosocial-admin), so that it's included in the final container at the path: `https://example.org/admin`.

Closes https://github.com/superseriousbusiness/gotosocial/issues/79