### PR TITLE
Timeline loop fix

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,6 +14,11 @@ steps:
 # See: https://golangci-lint.run/
 - name: lint
   image: golangci/golangci-lint:v1.41.1
+  volumes:
+  - name: go-build
+    path: /root/.cache/go-build
+  - name: golangci-lint-cache
+    path: /root/.cache/golangci-lint
   commands:
   - golangci-lint run --timeout 5m0s --tests=false --verbose
   when:
@@ -23,6 +28,9 @@ steps:
 
 - name: test
   image: golang:1.16.4
+  volumes:
+  - name: go-build
+    path: /root/.cache/go-build
   environment:
     GTS_DB_ADDRESS: postgres
   commands:
@@ -49,15 +57,30 @@ steps:
       exclude:
         - pull_request
 
-services:
-# We need this postgres service running for the test step.
+# We need a postgres service running for the test step.
 # See: https://docs.drone.io/pipeline/docker/syntax/services/
+services:
 - name: postgres
   image: postgres
   environment:
     POSTGRES_PASSWORD: postgres
+  when:
+    event:
+      include:
+        - pull_request
+
+# We can speed up builds significantly by caching build artifacts between runs.
+# See: https://docs.drone.io/pipeline/docker/syntax/volumes/host/
+volumes:
+- name: go-build-cache
+  host:
+    path: /drone/gotosocial/go-build
+- name: golangci-lint-cache
+  host:
+    path: /drone/gotosocial/golangci-lint
+
 ---
 kind: signature
-hmac: 888b0a9964be9bddad325a8eab0f54350f3cd36c333564ad4333811b4841b640
+hmac: 0241187feb5302278e4e3d8460157e9ec6a2c57eb5d427719e712b8a1b6da8e0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,7 @@ steps:
 - name: lint
   image: golangci/golangci-lint:v1.41.1
   volumes:
-  - name: go-build
+  - name: go-build-cache
     path: /root/.cache/go-build
   - name: golangci-lint-cache
     path: /root/.cache/golangci-lint
@@ -29,7 +29,7 @@ steps:
 - name: test
   image: golang:1.16.4
   volumes:
-  - name: go-build
+  - name: go-build-cache
     path: /root/.cache/go-build
   environment:
     GTS_DB_ADDRESS: postgres
@@ -81,6 +81,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 0241187feb5302278e4e3d8460157e9ec6a2c57eb5d427719e712b8a1b6da8e0
+hmac: 9134975e238ab9f92a7f75ccc11279e8d5edddb87f10165ed3c7d23fdd9c8a11
 
 ...

--- a/internal/db/pg/timeline.go
+++ b/internal/db/pg/timeline.go
@@ -28,31 +28,46 @@ import (
 
 func (ps *postgresService) GetHomeTimelineForAccount(accountID string, maxID string, sinceID string, minID string, limit int, local bool) ([]*gtsmodel.Status, error) {
 	statuses := []*gtsmodel.Status{}
-
 	q := ps.conn.Model(&statuses)
-
+	
 	q = q.ColumnExpr("status.*").
+		// Find out who accountID follows.
 		Join("LEFT JOIN follows AS f ON f.target_account_id = status.account_id").
-		Where("f.account_id = ?", accountID).
+		// Use a WhereGroup here to specify that we want EITHER statuses posted by accounts that accountID follows,
+		// OR statuses posted by accountID itself (since a user should be able to see their own statuses).
+		//
+		// This is equivalent to something like WHERE ... AND (... OR ...)
+		// See: https://pg.uptrace.dev/queries/#select
+		WhereGroup(func(q *pg.Query) (*pg.Query, error) {
+			q = q.WhereOr("f.account_id = ?", accountID).
+				WhereOr("status.account_id = ?", accountID)
+			return q, nil
+		}).
+		// Sort by highest ID (newest) to lowest ID (oldest)
 		Order("status.id DESC")
 
 	if maxID != "" {
+		// return only statuses LOWER (ie., older) than maxID
 		q = q.Where("status.id < ?", maxID)
 	}
 
 	if sinceID != "" {
+		// return only statuses HIGHER (ie., newer) than sinceID
 		q = q.Where("status.id > ?", sinceID)
 	}
 
 	if minID != "" {
+		// return only statuses HIGHER (ie., newer) than minID
 		q = q.Where("status.id > ?", minID)
 	}
 
 	if local {
+		// return only statuses posted by local account havers
 		q = q.Where("status.local = ?", local)
 	}
 
 	if limit > 0 {
+		// limit amount of statuses returned
 		q = q.Limit(limit)
 	}
 

--- a/internal/db/pg/timeline.go
+++ b/internal/db/pg/timeline.go
@@ -29,7 +29,7 @@ import (
 func (ps *postgresService) GetHomeTimelineForAccount(accountID string, maxID string, sinceID string, minID string, limit int, local bool) ([]*gtsmodel.Status, error) {
 	statuses := []*gtsmodel.Status{}
 	q := ps.conn.Model(&statuses)
-	
+
 	q = q.ColumnExpr("status.*").
 		// Find out who accountID follows.
 		Join("LEFT JOIN follows AS f ON f.target_account_id = status.account_id").

--- a/internal/processing/processor.go
+++ b/internal/processing/processor.go
@@ -304,7 +304,7 @@ func (p *processor) Start() error {
 			}
 		}
 	}()
-	return p.initTimelines()
+	return nil
 }
 
 // Stop stops the processor cleanly, finishing handling any remaining messages before closing down.

--- a/internal/timeline/get.go
+++ b/internal/timeline/get.go
@@ -135,8 +135,8 @@ func (t *timeline) GetXFromTop(amount int) ([]*apimodel.Status, error) {
 
 func (t *timeline) GetXBehindID(amount int, behindID string, attempts *int) ([]*apimodel.Status, error) {
 	l := t.log.WithFields(logrus.Fields{
-		"func": "GetXBehindID",
-		"amount": amount,
+		"func":     "GetXBehindID",
+		"amount":   amount,
 		"behindID": behindID,
 		"attempts": *attempts,
 	})

--- a/internal/timeline/get.go
+++ b/internal/timeline/get.go
@@ -174,7 +174,7 @@ findMarkLoop:
 	// we didn't find it, so we need to make sure it's indexed and prepared and then try again
 	// this can happen when a user asks for really old posts
 	if behindIDMark == nil {
-		if err := t.IndexBehind(behindID, amount); err != nil {
+		if err := t.IndexBehind(behindID, true, amount); err != nil {
 			return nil, fmt.Errorf("GetXBehindID: error indexing behind and including ID %s", behindID)
 		}
 		if err := t.PrepareBehind(behindID, amount); err != nil {

--- a/internal/timeline/get.go
+++ b/internal/timeline/get.go
@@ -174,9 +174,6 @@ findMarkLoop:
 	// we didn't find it, so we need to make sure it's indexed and prepared and then try again
 	// this can happen when a user asks for really old posts
 	if behindIDMark == nil {
-		if err := t.IndexBehind(behindID, true, amount); err != nil {
-			return nil, fmt.Errorf("GetXBehindID: error indexing behind and including ID %s", behindID)
-		}
 		if err := t.PrepareBehind(behindID, amount); err != nil {
 			return nil, fmt.Errorf("GetXBehindID: error preparing behind and including ID %s", behindID)
 		}

--- a/internal/timeline/get_test.go
+++ b/internal/timeline/get_test.go
@@ -19,9 +19,7 @@
 package timeline_test
 
 import (
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/gotosocial/internal/timeline"
@@ -66,20 +64,138 @@ func (suite *GetTestSuite) TearDownTest() {
 	testrig.StandardDBTeardown(suite.db)
 }
 
-func (suite *GetTestSuite) TestGet() {
-	// get 10 from the top
-	statuses, err := suite.timeline.Get(10, "", "", "")
+func (suite *GetTestSuite) TestGetDefault() {
+	// get 10 from the top and don't prepare the next query
+	statuses, err := suite.timeline.Get(10, "", "", "", false)
 	if err != nil {
 		suite.FailNow(err.Error())
 	}
 
-	fmt.Println(len(statuses))
-	fmt.Println(len(statuses))
-	fmt.Println(len(statuses))
-	fmt.Println(len(statuses))
-	fmt.Println(len(statuses))
-	fmt.Println(len(statuses))
-	time.Sleep(1 * time.Second)
+	suite.Len(statuses, 10)
+
+	// statuses should be sorted highest to lowest ID
+	var highest string
+	for i, s := range statuses {
+		if i == 0 {
+			highest = s.ID
+		} else {
+			suite.Less(s.ID, highest)
+			highest = s.ID
+		}
+	}
+}
+
+func (suite *GetTestSuite) TestGetXFromTop() {
+	// get 5 from the top
+	statuses, err := suite.timeline.GetXFromTop(5)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Len(statuses, 5)
+
+	// statuses should be sorted highest to lowest ID
+	var highest string
+	for i, s := range statuses {
+		if i == 0 {
+			highest = s.ID
+		} else {
+			suite.Less(s.ID, highest)
+			highest = s.ID
+		}
+	}
+}
+
+func (suite *GetTestSuite) TestGetXBehindID() {
+	// get 3 behind the 'middle' id
+	var attempts *int
+	a := 5
+	attempts = &a
+	statuses, err := suite.timeline.GetXBehindID(3, "01F8MHBQCBTDKN6X5VHGMMN4MA", attempts)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Len(statuses, 3)
+
+	// statuses should be sorted highest to lowest ID
+	// all status IDs should be less than the behindID
+	var highest string
+	for i, s := range statuses {
+		if i == 0 {
+			highest = s.ID
+		} else {
+			suite.Less(s.ID, highest)
+			highest = s.ID
+		}
+		suite.Less(s.ID, "01F8MHBQCBTDKN6X5VHGMMN4MA")
+	}
+}
+
+func (suite *GetTestSuite) TestGetXBehindID0() {
+	// try to get behind 0, the lowest possible ID
+	var attempts *int
+	a := 5
+	attempts = &a
+	statuses, err := suite.timeline.GetXBehindID(3, "0", attempts)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// there's nothing beyond it so len should be 0
+	suite.Len(statuses, 0)
+}
+
+func (suite *GetTestSuite) TestGetXBehindNonexistentReasonableID() {
+	// try to get behind an id that doesn't exist, but is close to one that does so we should still get statuses back
+	var attempts *int
+	a := 5
+	attempts = &a
+	statuses, err := suite.timeline.GetXBehindID(3, "01F8MHBQCBTDKN6X5VHGMMN4MB", attempts) // change the last A to a B
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+	suite.Len(statuses, 3)
+
+	// statuses should be sorted highest to lowest ID
+	// all status IDs should be less than the behindID
+	var highest string
+	for i, s := range statuses {
+		if i == 0 {
+			highest = s.ID
+		} else {
+			suite.Less(s.ID, highest)
+			highest = s.ID
+		}
+		suite.Less(s.ID, "01F8MHBCN8120SYH7D5S050MGK")
+	}
+}
+
+func (suite *GetTestSuite) TestGetXBehindVeryHighID() {
+	// try to get behind an id that doesn't exist, and is higher than any other ID we could possibly have
+	var attempts *int
+	a := 5
+	attempts = &a
+	statuses, err := suite.timeline.GetXBehindID(7, "9998MHBQCBTDKN6X5VHGMMN4MA", attempts)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// we should get all 7 statuses we asked for because they all have lower IDs than the very high ID given in the query
+	suite.Len(statuses, 7)
+
+	// statuses should be sorted highest to lowest ID
+	// all status IDs should be less than the behindID
+	var highest string
+	for i, s := range statuses {
+		if i == 0 {
+			highest = s.ID
+		} else {
+			suite.Less(s.ID, highest)
+			highest = s.ID
+		}
+		suite.Less(s.ID, "9998MHBQCBTDKN6X5VHGMMN4MA")
+	}
 }
 
 func TestGetTestSuite(t *testing.T) {

--- a/internal/timeline/get_test.go
+++ b/internal/timeline/get_test.go
@@ -20,6 +20,7 @@ package timeline_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/gotosocial/internal/timeline"
@@ -85,6 +86,193 @@ func (suite *GetTestSuite) TestGetDefault() {
 	}
 }
 
+func (suite *GetTestSuite) TestGetDefaultPrepareNext() {
+	// get 10 from the top and prepare the next query
+	statuses, err := suite.timeline.Get(10, "", "", "", true)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Len(statuses, 10)
+
+	// statuses should be sorted highest to lowest ID
+	var highest string
+	for i, s := range statuses {
+		if i == 0 {
+			highest = s.ID
+		} else {
+			suite.Less(s.ID, highest)
+			highest = s.ID
+		}
+	}
+
+	// sleep a second so the next query can run
+	time.Sleep(1 * time.Second)
+}
+
+func (suite *GetTestSuite) TestGetMaxID() {
+	// ask for 10 with a max ID somewhere in the middle of the stack
+	statuses, err := suite.timeline.Get(10, "01F8MHBQCBTDKN6X5VHGMMN4MA", "", "", false)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// we should only get 6 statuses back, since we asked for a max ID that excludes some of our entries
+	suite.Len(statuses, 6)
+
+	// statuses should be sorted highest to lowest ID
+	var highest string
+	for i, s := range statuses {
+		if i == 0 {
+			highest = s.ID
+		} else {
+			suite.Less(s.ID, highest)
+			highest = s.ID
+		}
+	}
+}
+
+func (suite *GetTestSuite) TestGetMaxIDPrepareNext() {
+	// ask for 10 with a max ID somewhere in the middle of the stack
+	statuses, err := suite.timeline.Get(10, "01F8MHBQCBTDKN6X5VHGMMN4MA", "", "", true)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// we should only get 6 statuses back, since we asked for a max ID that excludes some of our entries
+	suite.Len(statuses, 6)
+
+	// statuses should be sorted highest to lowest ID
+	var highest string
+	for i, s := range statuses {
+		if i == 0 {
+			highest = s.ID
+		} else {
+			suite.Less(s.ID, highest)
+			highest = s.ID
+		}
+	}
+
+	// sleep a second so the next query can run
+	time.Sleep(1 * time.Second)
+}
+
+func (suite *GetTestSuite) TestGetMinID() {
+	// ask for 10 with a min ID somewhere in the middle of the stack
+	statuses, err := suite.timeline.Get(10, "", "01F8MHBQCBTDKN6X5VHGMMN4MA", "", false)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// we should only get 5 statuses back, since we asked for a min ID that excludes some of our entries
+	suite.Len(statuses, 5)
+
+	// statuses should be sorted highest to lowest ID
+	var highest string
+	for i, s := range statuses {
+		if i == 0 {
+			highest = s.ID
+		} else {
+			suite.Less(s.ID, highest)
+			highest = s.ID
+		}
+	}
+}
+
+func (suite *GetTestSuite) TestGetSinceID() {
+	// ask for 10 with a since ID somewhere in the middle of the stack
+	statuses, err := suite.timeline.Get(10, "", "", "01F8MHBQCBTDKN6X5VHGMMN4MA", false)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// we should only get 5 statuses back, since we asked for a since ID that excludes some of our entries
+	suite.Len(statuses, 5)
+
+	// statuses should be sorted highest to lowest ID
+	var highest string
+	for i, s := range statuses {
+		if i == 0 {
+			highest = s.ID
+		} else {
+			suite.Less(s.ID, highest)
+			highest = s.ID
+		}
+	}
+}
+
+func (suite *GetTestSuite) TestGetSinceIDPrepareNext() {
+	// ask for 10 with a since ID somewhere in the middle of the stack
+	statuses, err := suite.timeline.Get(10, "", "", "01F8MHBQCBTDKN6X5VHGMMN4MA", true)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// we should only get 5 statuses back, since we asked for a since ID that excludes some of our entries
+	suite.Len(statuses, 5)
+
+	// statuses should be sorted highest to lowest ID
+	var highest string
+	for i, s := range statuses {
+		if i == 0 {
+			highest = s.ID
+		} else {
+			suite.Less(s.ID, highest)
+			highest = s.ID
+		}
+	}
+
+	// sleep a second so the next query can run
+	time.Sleep(1 * time.Second)
+}
+
+func (suite *GetTestSuite) TestGetBetweenID() {
+	// ask for 10 between these two IDs
+	statuses, err := suite.timeline.Get(10, "01F8MHCP5P2NWYQ416SBA0XSEV", "", "01F8MHBQCBTDKN6X5VHGMMN4MA", false)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// we should only get 2 statuses back, since there are only two statuses between the given IDs
+	suite.Len(statuses, 2)
+
+	// statuses should be sorted highest to lowest ID
+	var highest string
+	for i, s := range statuses {
+		if i == 0 {
+			highest = s.ID
+		} else {
+			suite.Less(s.ID, highest)
+			highest = s.ID
+		}
+	}
+}
+
+func (suite *GetTestSuite) TestGetBetweenIDPrepareNext() {
+	// ask for 10 between these two IDs
+	statuses, err := suite.timeline.Get(10, "01F8MHCP5P2NWYQ416SBA0XSEV", "", "01F8MHBQCBTDKN6X5VHGMMN4MA", true)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// we should only get 2 statuses back, since there are only two statuses between the given IDs
+	suite.Len(statuses, 2)
+
+	// statuses should be sorted highest to lowest ID
+	var highest string
+	for i, s := range statuses {
+		if i == 0 {
+			highest = s.ID
+		} else {
+			suite.Less(s.ID, highest)
+			highest = s.ID
+		}
+	}
+
+	// sleep a second so the next query can run
+	time.Sleep(1 * time.Second)
+}
+
 func (suite *GetTestSuite) TestGetXFromTop() {
 	// get 5 from the top
 	statuses, err := suite.timeline.GetXFromTop(5)
@@ -109,7 +297,7 @@ func (suite *GetTestSuite) TestGetXFromTop() {
 func (suite *GetTestSuite) TestGetXBehindID() {
 	// get 3 behind the 'middle' id
 	var attempts *int
-	a := 5
+	a := 0
 	attempts = &a
 	statuses, err := suite.timeline.GetXBehindID(3, "01F8MHBQCBTDKN6X5VHGMMN4MA", attempts)
 	if err != nil {
@@ -135,7 +323,7 @@ func (suite *GetTestSuite) TestGetXBehindID() {
 func (suite *GetTestSuite) TestGetXBehindID0() {
 	// try to get behind 0, the lowest possible ID
 	var attempts *int
-	a := 5
+	a := 0
 	attempts = &a
 	statuses, err := suite.timeline.GetXBehindID(3, "0", attempts)
 	if err != nil {
@@ -149,7 +337,7 @@ func (suite *GetTestSuite) TestGetXBehindID0() {
 func (suite *GetTestSuite) TestGetXBehindNonexistentReasonableID() {
 	// try to get behind an id that doesn't exist, but is close to one that does so we should still get statuses back
 	var attempts *int
-	a := 5
+	a := 0
 	attempts = &a
 	statuses, err := suite.timeline.GetXBehindID(3, "01F8MHBQCBTDKN6X5VHGMMN4MB", attempts) // change the last A to a B
 	if err != nil {
@@ -174,7 +362,7 @@ func (suite *GetTestSuite) TestGetXBehindNonexistentReasonableID() {
 func (suite *GetTestSuite) TestGetXBehindVeryHighID() {
 	// try to get behind an id that doesn't exist, and is higher than any other ID we could possibly have
 	var attempts *int
-	a := 5
+	a := 0
 	attempts = &a
 	statuses, err := suite.timeline.GetXBehindID(7, "9998MHBQCBTDKN6X5VHGMMN4MA", attempts)
 	if err != nil {
@@ -195,6 +383,52 @@ func (suite *GetTestSuite) TestGetXBehindVeryHighID() {
 			highest = s.ID
 		}
 		suite.Less(s.ID, "9998MHBQCBTDKN6X5VHGMMN4MA")
+	}
+}
+
+func (suite *GetTestSuite) TestGetXBeforeID() {
+	// get 3 before the 'middle' id
+	statuses, err := suite.timeline.GetXBeforeID(3, "01F8MHBQCBTDKN6X5VHGMMN4MA", true)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Len(statuses, 3)
+
+	// statuses should be sorted highest to lowest ID
+	// all status IDs should be greater than the beforeID
+	var highest string
+	for i, s := range statuses {
+		if i == 0 {
+			highest = s.ID
+		} else {
+			suite.Less(s.ID, highest)
+			highest = s.ID
+		}
+		suite.Greater(s.ID, "01F8MHBQCBTDKN6X5VHGMMN4MA")
+	}
+}
+
+func (suite *GetTestSuite) TestGetXBeforeIDNoStartFromTop() {
+	// get 3 before the 'middle' id
+	statuses, err := suite.timeline.GetXBeforeID(3, "01F8MHBQCBTDKN6X5VHGMMN4MA", false)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Len(statuses, 3)
+
+	// statuses should be sorted lowest to highest ID
+	// all status IDs should be greater than the beforeID
+	var lowest string
+	for i, s := range statuses {
+		if i == 0 {
+			lowest = s.ID
+		} else {
+			suite.Greater(s.ID, lowest)
+			lowest = s.ID
+		}
+		suite.Greater(s.ID, "01F8MHBQCBTDKN6X5VHGMMN4MA")
 	}
 }
 

--- a/internal/timeline/get_test.go
+++ b/internal/timeline/get_test.go
@@ -66,13 +66,14 @@ func (suite *GetTestSuite) TearDownTest() {
 }
 
 func (suite *GetTestSuite) TestGetDefault() {
-	// get 10 from the top and don't prepare the next query
-	statuses, err := suite.timeline.Get(10, "", "", "", false)
+	// get 10 20 the top and don't prepare the next query
+	statuses, err := suite.timeline.Get(20, "", "", "", false)
 	if err != nil {
 		suite.FailNow(err.Error())
 	}
 
-	suite.Len(statuses, 10)
+	// we only have 12 statuses in the test suite
+	suite.Len(statuses, 12)
 
 	// statuses should be sorted highest to lowest ID
 	var highest string

--- a/internal/timeline/get_test.go
+++ b/internal/timeline/get_test.go
@@ -1,0 +1,87 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package timeline_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/timeline"
+	"github.com/superseriousbusiness/gotosocial/testrig"
+)
+
+type GetTestSuite struct {
+	TimelineStandardTestSuite
+}
+
+func (suite *GetTestSuite) SetupSuite() {
+	suite.testAccounts = testrig.NewTestAccounts()
+	suite.testStatuses = testrig.NewTestStatuses()
+}
+
+func (suite *GetTestSuite) SetupTest() {
+	suite.config = testrig.NewTestConfig()
+	suite.db = testrig.NewTestDB()
+	suite.log = testrig.NewTestLog()
+	suite.tc = testrig.NewTestTypeConverter(suite.db)
+
+	testrig.StandardDBSetup(suite.db, nil)
+
+	// let's take local_account_1 as the timeline owner
+	tl, err := timeline.NewTimeline(suite.testAccounts["local_account_1"].ID, suite.db, suite.tc, suite.log)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// prepare the timeline by just shoving all test statuses in it -- let's not be fussy about who sees what
+	for _, s := range suite.testStatuses {
+		_, err := tl.IndexAndPrepareOne(s.CreatedAt, s.ID, s.BoostOfID, s.AccountID, s.BoostOfAccountID)
+		if err != nil {
+			suite.FailNow(err.Error())
+		}
+	}
+
+	suite.timeline = tl
+}
+
+func (suite *GetTestSuite) TearDownTest() {
+	testrig.StandardDBTeardown(suite.db)
+}
+
+func (suite *GetTestSuite) TestGet() {
+	// get 10 from the top
+	statuses, err := suite.timeline.Get(10, "", "", "")
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	fmt.Println(len(statuses))
+	fmt.Println(len(statuses))
+	fmt.Println(len(statuses))
+	fmt.Println(len(statuses))
+	fmt.Println(len(statuses))
+	fmt.Println(len(statuses))
+	time.Sleep(1 * time.Second)
+}
+
+func TestGetTestSuite(t *testing.T) {
+	suite.Run(t, new(GetTestSuite))
+}

--- a/internal/timeline/index_test.go
+++ b/internal/timeline/index_test.go
@@ -1,0 +1,193 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package timeline_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/timeline"
+	"github.com/superseriousbusiness/gotosocial/testrig"
+)
+
+type IndexTestSuite struct {
+	TimelineStandardTestSuite
+}
+
+func (suite *IndexTestSuite) SetupSuite() {
+	suite.testAccounts = testrig.NewTestAccounts()
+	suite.testStatuses = testrig.NewTestStatuses()
+}
+
+func (suite *IndexTestSuite) SetupTest() {
+	suite.config = testrig.NewTestConfig()
+	suite.db = testrig.NewTestDB()
+	suite.log = testrig.NewTestLog()
+	suite.tc = testrig.NewTestTypeConverter(suite.db)
+
+	testrig.StandardDBSetup(suite.db, nil)
+
+	// let's take local_account_1 as the timeline owner, and start with an empty timeline
+	tl, err := timeline.NewTimeline(suite.testAccounts["local_account_1"].ID, suite.db, suite.tc, suite.log)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+	suite.timeline = tl
+}
+
+func (suite *IndexTestSuite) TearDownTest() {
+	testrig.StandardDBTeardown(suite.db)
+}
+
+func (suite *IndexTestSuite) TestIndexBeforeLowID() {
+	// index 10 before the lowest status ID possible
+	err := suite.timeline.IndexBefore("00000000000000000000000000", true, 10)
+	suite.NoError(err)
+
+	// the oldest indexed post should be the lowest one we have in our testrig
+	postID, err := suite.timeline.OldestIndexedPostID()
+	suite.NoError(err)
+	suite.Equal("01F8MH75CBF9JFX4ZAD54N0W0R", postID)
+
+	// indexLength should only be 6 because that's all this user has hometimelineable
+	indexLength := suite.timeline.PostIndexLength()
+	suite.Equal(6, indexLength)
+}
+
+func (suite *IndexTestSuite) TestIndexBeforeHighID() {
+	// index 10 before the highest status ID possible
+	err := suite.timeline.IndexBefore("ZZZZZZZZZZZZZZZZZZZZZZZZZZ", true, 10)
+	suite.NoError(err)
+
+	// the oldest indexed post should be empty
+	postID, err := suite.timeline.OldestIndexedPostID()
+	suite.NoError(err)
+	suite.Empty(postID)
+
+	// indexLength should be 0
+	indexLength := suite.timeline.PostIndexLength()
+	suite.Equal(0, indexLength)
+}
+
+func (suite *IndexTestSuite) TestIndexBehindHighID() {
+	// index 10 behind the highest status ID possible
+	err := suite.timeline.IndexBehind("ZZZZZZZZZZZZZZZZZZZZZZZZZZ", true, 10)
+	suite.NoError(err)
+
+	// the newest indexed post should be the highest one we have in our testrig
+	postID, err := suite.timeline.NewestIndexedPostID()
+	suite.NoError(err)
+	suite.Equal("01F8MHCP5P2NWYQ416SBA0XSEV", postID)
+
+	// indexLength should only be 6 because that's all this user has hometimelineable
+	indexLength := suite.timeline.PostIndexLength()
+	suite.Equal(6, indexLength)
+}
+
+func (suite *IndexTestSuite) TestIndexBehindLowID() {
+	// index 10 behind the lowest status ID possible
+	err := suite.timeline.IndexBehind("00000000000000000000000000", true, 10)
+	suite.NoError(err)
+
+	// the newest indexed post should be empty
+	postID, err := suite.timeline.NewestIndexedPostID()
+	suite.NoError(err)
+	suite.Empty(postID)
+
+	// indexLength should be 0
+	indexLength := suite.timeline.PostIndexLength()
+	suite.Equal(0, indexLength)
+}
+
+func (suite *IndexTestSuite) TestOldestIndexedPostIDEmpty() {
+	// the oldest indexed post should be an empty string since there's nothing indexed yet
+	postID, err := suite.timeline.OldestIndexedPostID()
+	suite.NoError(err)
+	suite.Empty(postID)
+
+	// indexLength should be 0
+	indexLength := suite.timeline.PostIndexLength()
+	suite.Equal(0, indexLength)
+}
+
+func (suite *IndexTestSuite) TestNewestIndexedPostIDEmpty() {
+	// the newest indexed post should be an empty string since there's nothing indexed yet
+	postID, err := suite.timeline.NewestIndexedPostID()
+	suite.NoError(err)
+	suite.Empty(postID)
+
+	// indexLength should be 0
+	indexLength := suite.timeline.PostIndexLength()
+	suite.Equal(0, indexLength)
+}
+
+func (suite *IndexTestSuite) TestIndexAlreadyIndexed() {
+	testStatus := suite.testStatuses["local_account_1_status_1"]
+
+	// index one post -- it should be indexed
+	indexed, err := suite.timeline.IndexOne(testStatus.CreatedAt, testStatus.ID, testStatus.BoostOfID, testStatus.AccountID, testStatus.BoostOfAccountID)
+	suite.NoError(err)
+	suite.True(indexed)
+
+	// try to index the same post again -- it should not be indexed
+	indexed, err = suite.timeline.IndexOne(testStatus.CreatedAt, testStatus.ID, testStatus.BoostOfID, testStatus.AccountID, testStatus.BoostOfAccountID)
+	suite.NoError(err)
+	suite.False(indexed)
+}
+
+func (suite *IndexTestSuite) TestIndexAndPrepareAlreadyIndexedAndPrepared() {
+	testStatus := suite.testStatuses["local_account_1_status_1"]
+
+	// index and prepare one post -- it should be indexed
+	indexed, err := suite.timeline.IndexAndPrepareOne(testStatus.CreatedAt, testStatus.ID, testStatus.BoostOfID, testStatus.AccountID, testStatus.BoostOfAccountID)
+	suite.NoError(err)
+	suite.True(indexed)
+
+	// try to index and prepare the same post again -- it should not be indexed
+	indexed, err = suite.timeline.IndexAndPrepareOne(testStatus.CreatedAt, testStatus.ID, testStatus.BoostOfID, testStatus.AccountID, testStatus.BoostOfAccountID)
+	suite.NoError(err)
+	suite.False(indexed)
+}
+
+func (suite *IndexTestSuite) TestIndexBoostOfAlreadyIndexed() {
+	testStatus := suite.testStatuses["local_account_1_status_1"]
+	boostOfTestStatus := &gtsmodel.Status{
+		CreatedAt:        time.Now(),
+		ID:               "01FD4TA6G2Z6M7W8NJQ3K5WXYD",
+		BoostOfID:        testStatus.ID,
+		AccountID:        "01FD4TAY1C0NGEJVE9CCCX7QKS",
+		BoostOfAccountID: testStatus.AccountID,
+	}
+
+	// index one post -- it should be indexed
+	indexed, err := suite.timeline.IndexOne(testStatus.CreatedAt, testStatus.ID, testStatus.BoostOfID, testStatus.AccountID, testStatus.BoostOfAccountID)
+	suite.NoError(err)
+	suite.True(indexed)
+
+	// try to index the a boost of that post -- it should not be indexed
+	indexed, err = suite.timeline.IndexOne(boostOfTestStatus.CreatedAt, boostOfTestStatus.ID, boostOfTestStatus.BoostOfID, boostOfTestStatus.AccountID, boostOfTestStatus.BoostOfAccountID)
+	suite.NoError(err)
+	suite.False(indexed)
+}
+
+func TestIndexTestSuite(t *testing.T) {
+	suite.Run(t, new(IndexTestSuite))
+}

--- a/internal/timeline/index_test.go
+++ b/internal/timeline/index_test.go
@@ -65,11 +65,11 @@ func (suite *IndexTestSuite) TestIndexBeforeLowID() {
 	// the oldest indexed post should be the lowest one we have in our testrig
 	postID, err := suite.timeline.OldestIndexedPostID()
 	suite.NoError(err)
-	suite.Equal("01F8MH75CBF9JFX4ZAD54N0W0R", postID)
+	suite.Equal("01F8MHAAY43M6RJ473VQFCVH37", postID)
 
-	// indexLength should only be 6 because that's all this user has hometimelineable
+	// indexLength should only be 9 because that's all this user has hometimelineable
 	indexLength := suite.timeline.PostIndexLength()
-	suite.Equal(6, indexLength)
+	suite.Equal(9, indexLength)
 }
 
 func (suite *IndexTestSuite) TestIndexBeforeHighID() {
@@ -95,11 +95,11 @@ func (suite *IndexTestSuite) TestIndexBehindHighID() {
 	// the newest indexed post should be the highest one we have in our testrig
 	postID, err := suite.timeline.NewestIndexedPostID()
 	suite.NoError(err)
-	suite.Equal("01F8MHCP5P2NWYQ416SBA0XSEV", postID)
+	suite.Equal("01FCTA44PW9H1TB328S9AQXKDS", postID)
 
-	// indexLength should only be 6 because that's all this user has hometimelineable
+	// indexLength should only be 11 because that's all this user has hometimelineable
 	indexLength := suite.timeline.PostIndexLength()
-	suite.Equal(6, indexLength)
+	suite.Equal(11, indexLength)
 }
 
 func (suite *IndexTestSuite) TestIndexBehindLowID() {

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -75,11 +75,11 @@ type Manager interface {
 	// PrepareXFromTop prepares limit n amount of posts, based on their indexed representations, from the top of the index.
 	PrepareXFromTop(timelineAccountID string, limit int) error
 	// Remove removes one status from the timeline of the given timelineAccountID
-	Remove(statusID string, timelineAccountID string) (int, error)
+	Remove(timelineAccountID string, statusID string) (int, error)
 	// WipeStatusFromAllTimelines removes one status from the index and prepared posts of all timelines
 	WipeStatusFromAllTimelines(statusID string) error
 	// WipeStatusesFromAccountID removes all statuses by the given accountID from the timelineAccountID's timelines.
-	WipeStatusesFromAccountID(accountID string, timelineAccountID string) error
+	WipeStatusesFromAccountID(timelineAccountID string, accountID string) error
 }
 
 // NewManager returns a new timeline manager with the given database, typeconverter, config, and log.
@@ -133,7 +133,7 @@ func (m *manager) IngestAndPrepare(status *gtsmodel.Status, timelineAccountID st
 	return t.IndexAndPrepareOne(status.CreatedAt, status.ID, status.BoostOfID, status.AccountID, status.BoostOfAccountID)
 }
 
-func (m *manager) Remove(statusID string, timelineAccountID string) (int, error) {
+func (m *manager) Remove(timelineAccountID string, statusID string) (int, error) {
 	l := m.log.WithFields(logrus.Fields{
 		"func":              "Remove",
 		"timelineAccountID": timelineAccountID,
@@ -221,7 +221,7 @@ func (m *manager) WipeStatusFromAllTimelines(statusID string) error {
 	return err
 }
 
-func (m *manager) WipeStatusesFromAccountID(accountID string, timelineAccountID string) error {
+func (m *manager) WipeStatusesFromAccountID(timelineAccountID string, accountID string) error {
 	t, err := m.getOrCreateTimeline(timelineAccountID)
 	if err != nil {
 		return err

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -160,7 +160,7 @@ func (m *manager) HomeTimeline(timelineAccountID string, maxID string, sinceID s
 		return nil, err
 	}
 
-	statuses, err := t.Get(limit, maxID, sinceID, minID)
+	statuses, err := t.Get(limit, maxID, sinceID, minID, true)
 	if err != nil {
 		l.Errorf("error getting statuses: %s", err)
 	}

--- a/internal/timeline/manager_test.go
+++ b/internal/timeline/manager_test.go
@@ -1,0 +1,142 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package timeline_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/testrig"
+)
+
+type ManagerTestSuite struct {
+	TimelineStandardTestSuite
+}
+
+func (suite *ManagerTestSuite) SetupSuite() {
+	suite.testAccounts = testrig.NewTestAccounts()
+	suite.testStatuses = testrig.NewTestStatuses()
+}
+
+func (suite *ManagerTestSuite) SetupTest() {
+	suite.config = testrig.NewTestConfig()
+	suite.db = testrig.NewTestDB()
+	suite.log = testrig.NewTestLog()
+	suite.tc = testrig.NewTestTypeConverter(suite.db)
+
+	testrig.StandardDBSetup(suite.db, nil)
+
+	manager := testrig.NewTestTimelineManager(suite.db)
+	suite.manager = manager
+}
+
+func (suite *ManagerTestSuite) TearDownTest() {
+	testrig.StandardDBTeardown(suite.db)
+}
+
+func (suite *ManagerTestSuite) TestManagerIntegration() {
+	testAccount := suite.testAccounts["local_account_1"]
+
+	// should start at 0
+	indexedLen := suite.manager.GetIndexedLength(testAccount.ID)
+	suite.Equal(0, indexedLen)
+
+	// oldestIndexed should be empty string since there's nothing indexed
+	oldestIndexed, err := suite.manager.GetOldestIndexedID(testAccount.ID)
+	suite.NoError(err)
+	suite.Empty(oldestIndexed)
+
+	// trigger status preparation
+	err = suite.manager.PrepareXFromTop(testAccount.ID, 20)
+	suite.NoError(err)
+
+	// local_account_1 can see 6 statuses out of the testrig statuses in its home timeline
+	indexedLen = suite.manager.GetIndexedLength(testAccount.ID)
+	suite.Equal(6, indexedLen)
+
+	// oldest should now be set
+	oldestIndexed, err = suite.manager.GetOldestIndexedID(testAccount.ID)
+	suite.NoError(err)
+	suite.Equal("01F8MH75CBF9JFX4ZAD54N0W0R", oldestIndexed)
+
+	// get hometimeline
+	statuses, err := suite.manager.HomeTimeline(testAccount.ID, "", "", "", 20, false)
+	suite.NoError(err)
+	suite.Len(statuses, 6)
+
+	// now wipe the last status from all timelines, as though it had been deleted by the owner
+	err = suite.manager.WipeStatusFromAllTimelines("01F8MH75CBF9JFX4ZAD54N0W0R")
+	suite.NoError(err)
+
+	// timeline should be shorter
+	indexedLen = suite.manager.GetIndexedLength(testAccount.ID)
+	suite.Equal(5, indexedLen)
+
+	// oldest should now be different
+	oldestIndexed, err = suite.manager.GetOldestIndexedID(testAccount.ID)
+	suite.NoError(err)
+	suite.Equal("01F8MHAAY43M6RJ473VQFCVH37", oldestIndexed)
+
+	// delete the new oldest status specifically from this timeline, as though local_account_1 had muted or blocked it
+	removed, err := suite.manager.Remove(testAccount.ID, "01F8MHAAY43M6RJ473VQFCVH37")
+	suite.NoError(err)
+	suite.Equal(2, removed) // 1 status should be removed, but from both indexed and prepared, so 2 removals total
+
+	// timeline should be shorter
+	indexedLen = suite.manager.GetIndexedLength(testAccount.ID)
+	suite.Equal(4, indexedLen)
+
+	// oldest should now be different
+	oldestIndexed, err = suite.manager.GetOldestIndexedID(testAccount.ID)
+	suite.NoError(err)
+	suite.Equal("01F8MHBQCBTDKN6X5VHGMMN4MA", oldestIndexed)
+
+	// now remove all entries by local_account_2 from the timeline
+	err = suite.manager.WipeStatusesFromAccountID(testAccount.ID, suite.testAccounts["local_account_2"].ID)
+	suite.NoError(err)
+
+	// timeline should be empty now
+	indexedLen = suite.manager.GetIndexedLength(testAccount.ID)
+	suite.Equal(0, indexedLen)
+
+	// ingest 1 into the timeline
+	status1 := suite.testStatuses["admin_account_status_1"]
+	ingested, err := suite.manager.Ingest(status1, testAccount.ID)
+	suite.NoError(err)
+	suite.True(ingested)
+
+	// ingest and prepare another one into the timeline
+	status2 := suite.testStatuses["admin_account_status_2"]
+	ingested, err = suite.manager.IngestAndPrepare(status2, testAccount.ID)
+	suite.NoError(err)
+	suite.True(ingested)
+
+	// timeline should be length 2 now
+	indexedLen = suite.manager.GetIndexedLength(testAccount.ID)
+	suite.Equal(2, indexedLen)
+
+	// try to ingest status 2 again
+	ingested, err = suite.manager.IngestAndPrepare(status2, testAccount.ID)
+	suite.NoError(err)
+	suite.False(ingested) // should be false since it's a duplicate
+}
+
+func TestManagerTestSuite(t *testing.T) {
+	suite.Run(t, new(ManagerTestSuite))
+}

--- a/internal/timeline/manager_test.go
+++ b/internal/timeline/manager_test.go
@@ -66,9 +66,9 @@ func (suite *ManagerTestSuite) TestManagerIntegration() {
 	err = suite.manager.PrepareXFromTop(testAccount.ID, 20)
 	suite.NoError(err)
 
-	// local_account_1 can see 6 statuses out of the testrig statuses in its home timeline
+	// local_account_1 can see 11 statuses out of the testrig statuses in its home timeline
 	indexedLen = suite.manager.GetIndexedLength(testAccount.ID)
-	suite.Equal(6, indexedLen)
+	suite.Equal(11, indexedLen)
 
 	// oldest should now be set
 	oldestIndexed, err = suite.manager.GetOldestIndexedID(testAccount.ID)
@@ -78,7 +78,7 @@ func (suite *ManagerTestSuite) TestManagerIntegration() {
 	// get hometimeline
 	statuses, err := suite.manager.HomeTimeline(testAccount.ID, "", "", "", 20, false)
 	suite.NoError(err)
-	suite.Len(statuses, 6)
+	suite.Len(statuses, 11)
 
 	// now wipe the last status from all timelines, as though it had been deleted by the owner
 	err = suite.manager.WipeStatusFromAllTimelines("01F8MH75CBF9JFX4ZAD54N0W0R")
@@ -86,26 +86,26 @@ func (suite *ManagerTestSuite) TestManagerIntegration() {
 
 	// timeline should be shorter
 	indexedLen = suite.manager.GetIndexedLength(testAccount.ID)
-	suite.Equal(5, indexedLen)
+	suite.Equal(10, indexedLen)
 
 	// oldest should now be different
 	oldestIndexed, err = suite.manager.GetOldestIndexedID(testAccount.ID)
 	suite.NoError(err)
-	suite.Equal("01F8MHAAY43M6RJ473VQFCVH37", oldestIndexed)
+	suite.Equal("01F8MH82FYRXD2RC6108DAJ5HB", oldestIndexed)
 
 	// delete the new oldest status specifically from this timeline, as though local_account_1 had muted or blocked it
-	removed, err := suite.manager.Remove(testAccount.ID, "01F8MHAAY43M6RJ473VQFCVH37")
+	removed, err := suite.manager.Remove(testAccount.ID, "01F8MH82FYRXD2RC6108DAJ5HB")
 	suite.NoError(err)
 	suite.Equal(2, removed) // 1 status should be removed, but from both indexed and prepared, so 2 removals total
 
 	// timeline should be shorter
 	indexedLen = suite.manager.GetIndexedLength(testAccount.ID)
-	suite.Equal(4, indexedLen)
+	suite.Equal(9, indexedLen)
 
 	// oldest should now be different
 	oldestIndexed, err = suite.manager.GetOldestIndexedID(testAccount.ID)
 	suite.NoError(err)
-	suite.Equal("01F8MHBQCBTDKN6X5VHGMMN4MA", oldestIndexed)
+	suite.Equal("01F8MHAAY43M6RJ473VQFCVH37", oldestIndexed)
 
 	// now remove all entries by local_account_2 from the timeline
 	err = suite.manager.WipeStatusesFromAccountID(testAccount.ID, suite.testAccounts["local_account_2"].ID)
@@ -113,7 +113,7 @@ func (suite *ManagerTestSuite) TestManagerIntegration() {
 
 	// timeline should be empty now
 	indexedLen = suite.manager.GetIndexedLength(testAccount.ID)
-	suite.Equal(0, indexedLen)
+	suite.Equal(5, indexedLen)
 
 	// ingest 1 into the timeline
 	status1 := suite.testStatuses["admin_account_status_1"]
@@ -122,14 +122,14 @@ func (suite *ManagerTestSuite) TestManagerIntegration() {
 	suite.True(ingested)
 
 	// ingest and prepare another one into the timeline
-	status2 := suite.testStatuses["admin_account_status_2"]
+	status2 := suite.testStatuses["local_account_2_status_1"]
 	ingested, err = suite.manager.IngestAndPrepare(status2, testAccount.ID)
 	suite.NoError(err)
 	suite.True(ingested)
 
-	// timeline should be length 2 now
+	// timeline should be longer now
 	indexedLen = suite.manager.GetIndexedLength(testAccount.ID)
-	suite.Equal(2, indexedLen)
+	suite.Equal(7, indexedLen)
 
 	// try to ingest status 2 again
 	ingested, err = suite.manager.IngestAndPrepare(status2, testAccount.ID)

--- a/internal/timeline/prepare.go
+++ b/internal/timeline/prepare.go
@@ -30,13 +30,12 @@ import (
 
 func (t *timeline) prepareNextQuery(amount int, maxID string, sinceID string, minID string) error {
 	l := t.log.WithFields(logrus.Fields{
-		"func": "prepareNextQuery",
-		"amount": amount,
-		"maxID": maxID,
+		"func":    "prepareNextQuery",
+		"amount":  amount,
+		"maxID":   maxID,
 		"sinceID": sinceID,
-		"minID": minID,
+		"minID":   minID,
 	})
-
 
 	var err error
 
@@ -171,7 +170,7 @@ prepareloop:
 
 func (t *timeline) PrepareFromTop(amount int) error {
 	l := t.log.WithFields(logrus.Fields{
-		"func": "PrepareFromTop",
+		"func":   "PrepareFromTop",
 		"amount": amount,
 	})
 

--- a/internal/timeline/prepare.go
+++ b/internal/timeline/prepare.go
@@ -29,18 +29,30 @@ import (
 )
 
 func (t *timeline) prepareNextQuery(amount int, maxID string, sinceID string, minID string) error {
+	l := t.log.WithFields(logrus.Fields{
+		"func": "prepareNextQuery",
+		"amount": amount,
+		"maxID": maxID,
+		"sinceID": sinceID,
+		"minID": minID,
+	})
+
+
 	var err error
 
 	// maxID is defined but sinceID isn't so take from behind
 	if maxID != "" && sinceID == "" {
+		l.Debug("preparing behind maxID")
 		err = t.PrepareBehind(maxID, amount)
 	}
 
 	// maxID isn't defined, but sinceID || minID are, so take x before
 	if maxID == "" && sinceID != "" {
+		l.Debug("preparing before sinceID")
 		err = t.PrepareBefore(sinceID, false, amount)
 	}
 	if maxID == "" && minID != "" {
+		l.Debug("preparing before minID")
 		err = t.PrepareBefore(minID, false, amount)
 	}
 
@@ -48,13 +60,14 @@ func (t *timeline) prepareNextQuery(amount int, maxID string, sinceID string, mi
 }
 
 func (t *timeline) PrepareBehind(statusID string, amount int) error {
-	t.Lock()
-	defer t.Unlock()
-
 	// lazily initialize prepared posts if it hasn't been done already
 	if t.preparedPosts.data == nil {
 		t.preparedPosts.data = &list.List{}
 		t.preparedPosts.data.Init()
+	}
+
+	if err := t.IndexBehind(statusID, true, amount); err != nil {
+		return fmt.Errorf("PrepareBehind: error indexing behind id %s: %s", statusID, err)
 	}
 
 	// if the postindex is nil, nothing has been indexed yet so there's nothing to prepare
@@ -64,6 +77,8 @@ func (t *timeline) PrepareBehind(statusID string, amount int) error {
 
 	var prepared int
 	var preparing bool
+	t.Lock()
+	defer t.Unlock()
 prepareloop:
 	for e := t.postIndex.data.Front(); e != nil; e = e.Next() {
 		entry, ok := e.Value.(*postIndexEntry)

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -73,6 +73,12 @@ type Timeline interface {
 	// OldestIndexedPostID returns the id of the rearmost (ie., the oldest) indexed post, or an error if something goes wrong.
 	// If nothing goes wrong but there's no oldest post, an empty string will be returned so make sure to check for this.
 	OldestIndexedPostID() (string, error)
+	// NewestIndexedPostID returns the id of the frontmost (ie., the newest) indexed post, or an error if something goes wrong.
+	// If nothing goes wrong but there's no newest post, an empty string will be returned so make sure to check for this.
+	NewestIndexedPostID() (string, error)
+
+	IndexBefore(statusID string, include bool, amount int) error
+	IndexBehind(statusID string, include bool, amount int) error
 
 	/*
 		PREPARATION FUNCTIONS

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -50,7 +50,7 @@ type Timeline interface {
 	// This will NOT include the status with the given ID.
 	//
 	// This corresponds to an api call to /timelines/home?since_id=WHATEVER
-	GetXBeforeID(amount int, sinceID string, startFromTop bool, attempts *int) ([]*apimodel.Status, error)
+	GetXBeforeID(amount int, sinceID string, startFromTop bool) ([]*apimodel.Status, error)
 	// GetXBetweenID returns x amount of posts from the given maxID, up to the given id, from newest to oldest.
 	// This will NOT include the status with the given IDs.
 	//

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -38,7 +38,10 @@ type Timeline interface {
 		RETRIEVAL FUNCTIONS
 	*/
 
-	Get(amount int, maxID string, sinceID string, minID string) ([]*apimodel.Status, error)
+	// Get returns an amount of statuses with the given parameters.
+	// If prepareNext is true, then the next predicted query will be prepared already in a goroutine,
+	// to make the next call to Get faster.
+	Get(amount int, maxID string, sinceID string, minID string, prepareNext bool) ([]*apimodel.Status, error)
 	// GetXFromTop returns x amount of posts from the top of the timeline, from newest to oldest.
 	GetXFromTop(amount int) ([]*apimodel.Status, error)
 	// GetXBehindID returns x amount of posts from the given id onwards, from newest to oldest.

--- a/internal/timeline/timeline_test.go
+++ b/internal/timeline/timeline_test.go
@@ -1,0 +1,42 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package timeline_test
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/timeline"
+	"github.com/superseriousbusiness/gotosocial/internal/typeutils"
+)
+
+type TimelineStandardTestSuite struct {
+	suite.Suite
+	config *config.Config
+	db     db.DB
+	log    *logrus.Logger
+	tc     typeutils.TypeConverter
+
+	testAccounts map[string]*gtsmodel.Account
+	testStatuses map[string]*gtsmodel.Status
+
+	timeline timeline.Timeline
+}

--- a/internal/timeline/timeline_test.go
+++ b/internal/timeline/timeline_test.go
@@ -39,4 +39,5 @@ type TimelineStandardTestSuite struct {
 	testStatuses map[string]*gtsmodel.Status
 
 	timeline timeline.Timeline
+	manager  timeline.Manager
 }


### PR DESCRIPTION
This PR:

1. Fixes some bugs in the timeline code where an infinite db-fetching loop was occurring and eating up precious CPU and mem.
2. Removes the pre-caching of timelines on startup -- now they're just cached on first GET to timeline instead.
3. Adds a bunch of tests for timelines where there were 0 before!
4. Modifies the drone.yml to cache some go artifacts between runs. 