### PR TITLE
tests + announce notification fix

### DIFF
--- a/internal/db/bundb/account_test.go
+++ b/internal/db/bundb/account_test.go
@@ -24,35 +24,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
-	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
 type AccountTestSuite struct {
 	BunDBStandardTestSuite
-}
-
-func (suite *AccountTestSuite) SetupSuite() {
-	suite.testTokens = testrig.NewTestTokens()
-	suite.testClients = testrig.NewTestClients()
-	suite.testApplications = testrig.NewTestApplications()
-	suite.testUsers = testrig.NewTestUsers()
-	suite.testAccounts = testrig.NewTestAccounts()
-	suite.testAttachments = testrig.NewTestAttachments()
-	suite.testStatuses = testrig.NewTestStatuses()
-	suite.testTags = testrig.NewTestTags()
-	suite.testMentions = testrig.NewTestMentions()
-}
-
-func (suite *AccountTestSuite) SetupTest() {
-	suite.config = testrig.NewTestConfig()
-	suite.db = testrig.NewTestDB()
-	suite.log = testrig.NewTestLog()
-
-	testrig.StandardDBSetup(suite.db, suite.testAccounts)
-}
-
-func (suite *AccountTestSuite) TearDownTest() {
-	testrig.StandardDBTeardown(suite.db)
 }
 
 func (suite *AccountTestSuite) TestGetAccountByIDWithExtras() {

--- a/internal/db/bundb/basic_test.go
+++ b/internal/db/bundb/basic_test.go
@@ -24,35 +24,10 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
-	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
 type BasicTestSuite struct {
 	BunDBStandardTestSuite
-}
-
-func (suite *BasicTestSuite) SetupSuite() {
-	suite.testTokens = testrig.NewTestTokens()
-	suite.testClients = testrig.NewTestClients()
-	suite.testApplications = testrig.NewTestApplications()
-	suite.testUsers = testrig.NewTestUsers()
-	suite.testAccounts = testrig.NewTestAccounts()
-	suite.testAttachments = testrig.NewTestAttachments()
-	suite.testStatuses = testrig.NewTestStatuses()
-	suite.testTags = testrig.NewTestTags()
-	suite.testMentions = testrig.NewTestMentions()
-}
-
-func (suite *BasicTestSuite) SetupTest() {
-	suite.config = testrig.NewTestConfig()
-	suite.db = testrig.NewTestDB()
-	suite.log = testrig.NewTestLog()
-
-	testrig.StandardDBSetup(suite.db, suite.testAccounts)
-}
-
-func (suite *BasicTestSuite) TearDownTest() {
-	testrig.StandardDBTeardown(suite.db)
 }
 
 func (suite *BasicTestSuite) TestGetAccountByID() {

--- a/internal/db/bundb/bundb_test.go
+++ b/internal/db/bundb/bundb_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
 type BunDBStandardTestSuite struct {
@@ -43,4 +44,28 @@ type BunDBStandardTestSuite struct {
 	testStatuses     map[string]*gtsmodel.Status
 	testTags         map[string]*gtsmodel.Tag
 	testMentions     map[string]*gtsmodel.Mention
+}
+
+func (suite *BunDBStandardTestSuite) SetupSuite() {
+	suite.testTokens = testrig.NewTestTokens()
+	suite.testClients = testrig.NewTestClients()
+	suite.testApplications = testrig.NewTestApplications()
+	suite.testUsers = testrig.NewTestUsers()
+	suite.testAccounts = testrig.NewTestAccounts()
+	suite.testAttachments = testrig.NewTestAttachments()
+	suite.testStatuses = testrig.NewTestStatuses()
+	suite.testTags = testrig.NewTestTags()
+	suite.testMentions = testrig.NewTestMentions()
+}
+
+func (suite *BunDBStandardTestSuite) SetupTest() {
+	suite.config = testrig.NewTestConfig()
+	suite.db = testrig.NewTestDB()
+	suite.log = testrig.NewTestLog()
+
+	testrig.StandardDBSetup(suite.db, suite.testAccounts)
+}
+
+func (suite *BunDBStandardTestSuite) TearDownTest() {
+	testrig.StandardDBTeardown(suite.db)
 }

--- a/internal/db/bundb/mention_test.go
+++ b/internal/db/bundb/mention_test.go
@@ -1,0 +1,65 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package bundb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type MentionTestSuite struct {
+	BunDBStandardTestSuite
+}
+
+func (suite *MentionTestSuite) TestGetMention() {
+	m := suite.testMentions["local_user_2_mention_zork"]
+
+	dbMention, err := suite.db.GetMention(context.Background(), m.ID)
+	suite.NoError(err)
+	suite.NotNil(dbMention)
+	suite.Equal(m.ID, dbMention.ID)
+	suite.Equal(m.OriginAccountID, dbMention.OriginAccountID)
+	suite.NotNil(dbMention.OriginAccount)
+	suite.Equal(m.TargetAccountID, dbMention.TargetAccountID)
+	suite.NotNil(dbMention.TargetAccount)
+	suite.Equal(m.StatusID, dbMention.StatusID)
+	suite.NotNil(dbMention.Status)
+}
+
+func (suite *MentionTestSuite) TestGetMentions() {
+	m := suite.testMentions["local_user_2_mention_zork"]
+
+	dbMentions, err := suite.db.GetMentions(context.Background(), []string{m.ID})
+	suite.NoError(err)
+	suite.Len(dbMentions, 1)
+	dbMention := dbMentions[0]
+	suite.Equal(m.ID, dbMention.ID)
+	suite.Equal(m.OriginAccountID, dbMention.OriginAccountID)
+	suite.NotNil(dbMention.OriginAccount)
+	suite.Equal(m.TargetAccountID, dbMention.TargetAccountID)
+	suite.NotNil(dbMention.TargetAccount)
+	suite.Equal(m.StatusID, dbMention.StatusID)
+	suite.NotNil(dbMention.Status)
+}
+
+func TestMentionTestSuite(t *testing.T) {
+	suite.Run(t, new(MentionTestSuite))
+}

--- a/internal/db/bundb/relationship_test.go
+++ b/internal/db/bundb/relationship_test.go
@@ -25,35 +25,10 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
-	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
 type RelationshipTestSuite struct {
 	BunDBStandardTestSuite
-}
-
-func (suite *RelationshipTestSuite) SetupSuite() {
-	suite.testTokens = testrig.NewTestTokens()
-	suite.testClients = testrig.NewTestClients()
-	suite.testApplications = testrig.NewTestApplications()
-	suite.testUsers = testrig.NewTestUsers()
-	suite.testAccounts = testrig.NewTestAccounts()
-	suite.testAttachments = testrig.NewTestAttachments()
-	suite.testStatuses = testrig.NewTestStatuses()
-	suite.testTags = testrig.NewTestTags()
-	suite.testMentions = testrig.NewTestMentions()
-}
-
-func (suite *RelationshipTestSuite) SetupTest() {
-	suite.config = testrig.NewTestConfig()
-	suite.db = testrig.NewTestDB()
-	suite.log = testrig.NewTestLog()
-
-	testrig.StandardDBSetup(suite.db, suite.testAccounts)
-}
-
-func (suite *RelationshipTestSuite) TearDownTest() {
-	testrig.StandardDBTeardown(suite.db)
 }
 
 func (suite *RelationshipTestSuite) TestIsBlocked() {

--- a/internal/db/bundb/status_test.go
+++ b/internal/db/bundb/status_test.go
@@ -25,35 +25,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
-	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
 type StatusTestSuite struct {
 	BunDBStandardTestSuite
-}
-
-func (suite *StatusTestSuite) SetupSuite() {
-	suite.testTokens = testrig.NewTestTokens()
-	suite.testClients = testrig.NewTestClients()
-	suite.testApplications = testrig.NewTestApplications()
-	suite.testUsers = testrig.NewTestUsers()
-	suite.testAccounts = testrig.NewTestAccounts()
-	suite.testAttachments = testrig.NewTestAttachments()
-	suite.testStatuses = testrig.NewTestStatuses()
-	suite.testTags = testrig.NewTestTags()
-	suite.testMentions = testrig.NewTestMentions()
-}
-
-func (suite *StatusTestSuite) SetupTest() {
-	suite.config = testrig.NewTestConfig()
-	suite.db = testrig.NewTestDB()
-	suite.log = testrig.NewTestLog()
-
-	testrig.StandardDBSetup(suite.db, suite.testAccounts)
-}
-
-func (suite *StatusTestSuite) TearDownTest() {
-	testrig.StandardDBTeardown(suite.db)
 }
 
 func (suite *StatusTestSuite) TestGetStatusByID() {

--- a/internal/db/bundb/timeline_test.go
+++ b/internal/db/bundb/timeline_test.go
@@ -23,35 +23,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
 type TimelineTestSuite struct {
 	BunDBStandardTestSuite
-}
-
-func (suite *TimelineTestSuite) SetupSuite() {
-	suite.testTokens = testrig.NewTestTokens()
-	suite.testClients = testrig.NewTestClients()
-	suite.testApplications = testrig.NewTestApplications()
-	suite.testUsers = testrig.NewTestUsers()
-	suite.testAccounts = testrig.NewTestAccounts()
-	suite.testAttachments = testrig.NewTestAttachments()
-	suite.testStatuses = testrig.NewTestStatuses()
-	suite.testTags = testrig.NewTestTags()
-	suite.testMentions = testrig.NewTestMentions()
-}
-
-func (suite *TimelineTestSuite) SetupTest() {
-	suite.config = testrig.NewTestConfig()
-	suite.db = testrig.NewTestDB()
-	suite.log = testrig.NewTestLog()
-
-	testrig.StandardDBSetup(suite.db, suite.testAccounts)
-}
-
-func (suite *TimelineTestSuite) TearDownTest() {
-	testrig.StandardDBTeardown(suite.db)
 }
 
 func (suite *TimelineTestSuite) TestGetPublicTimeline() {

--- a/internal/processing/fromclientapi.go
+++ b/internal/processing/fromclientapi.go
@@ -31,7 +31,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/messages"
 )
 
-func (p *processor) processFromClientAPI(ctx context.Context, clientMsg messages.FromClientAPI) error {
+func (p *processor) ProcessFromClientAPI(ctx context.Context, clientMsg messages.FromClientAPI) error {
 	switch clientMsg.APActivityType {
 	case ap.ActivityCreate:
 		// CREATE

--- a/internal/processing/fromcommon.go
+++ b/internal/processing/fromcommon.go
@@ -61,17 +61,15 @@ func (p *processor) notifyStatus(ctx context.Context, status *gtsmodel.Status) e
 		}
 
 		// make sure a notif doesn't already exist for this mention
-		err := p.db.GetWhere(ctx, []db.Where{
+		if err := p.db.GetWhere(ctx, []db.Where{
 			{Key: "notification_type", Value: gtsmodel.NotificationMention},
 			{Key: "target_account_id", Value: m.TargetAccountID},
-			{Key: "origin_account_id", Value: status.AccountID},
-			{Key: "status_id", Value: status.ID},
-		}, &gtsmodel.Notification{})
-		if err == nil {
+			{Key: "origin_account_id", Value: m.OriginAccountID},
+			{Key: "status_id", Value: m.StatusID},
+		}, &gtsmodel.Notification{}); err == nil {
 			// notification exists already so just continue
 			continue
-		}
-		if err != db.ErrNoEntries {
+		} else if err != db.ErrNoEntries {
 			// there's a real error in the db
 			return fmt.Errorf("notifyStatus: error checking existence of notification for mention with id %s : %s", m.ID, err)
 		}
@@ -254,7 +252,7 @@ func (p *processor) notifyAnnounce(ctx context.Context, status *gtsmodel.Status)
 		status.BoostOfAccount = boostedAcct
 	}
 
-	if status.BoostOfAccount.Domain == "" {
+	if status.BoostOfAccount.Domain != "" {
 		// remote account, nothing to do
 		return nil
 	}

--- a/internal/processing/fromfederator.go
+++ b/internal/processing/fromfederator.go
@@ -32,7 +32,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/messages"
 )
 
-func (p *processor) processFromFederator(ctx context.Context, federatorMsg messages.FromFederator) error {
+func (p *processor) ProcessFromFederator(ctx context.Context, federatorMsg messages.FromFederator) error {
 	l := p.log.WithFields(logrus.Fields{
 		"func":         "processFromFederator",
 		"federatorMsg": fmt.Sprintf("%+v", federatorMsg),
@@ -104,9 +104,7 @@ func (p *processor) processFromFederator(ctx context.Context, federatorMsg messa
 			incomingAnnounce.ID = incomingAnnounceID
 
 			if err := p.db.PutStatus(ctx, incomingAnnounce); err != nil {
-				if err != db.ErrNoEntries {
-					return fmt.Errorf("error adding dereferenced announce to the db: %s", err)
-				}
+				return fmt.Errorf("error adding dereferenced announce to the db: %s", err)
 			}
 
 			if err := p.timelineStatus(ctx, incomingAnnounce); err != nil {

--- a/internal/processing/fromfederator_test.go
+++ b/internal/processing/fromfederator_test.go
@@ -1,0 +1,86 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package processing_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/ap"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/messages"
+)
+
+type FromFederatorTestSuite struct {
+	ProcessingStandardTestSuite
+}
+
+// remote_account_1 boosts the first status of local_account_1
+func (suite *FromFederatorTestSuite) TestProcessFederationAnnounce() {
+	boostedStatus := suite.testStatuses["local_account_1_status_1"]
+	boostingAccount := suite.testAccounts["remote_account_1"]
+	announceStatus := &gtsmodel.Status{}
+	announceStatus.URI = "https://example.org/some-announce-uri"
+	announceStatus.BoostOf = &gtsmodel.Status{
+		URI: boostedStatus.URI,
+	}
+	announceStatus.CreatedAt = time.Now()
+	announceStatus.UpdatedAt = time.Now()
+	announceStatus.AccountID = boostingAccount.ID
+	announceStatus.AccountURI = boostingAccount.URI
+	announceStatus.Account = boostingAccount
+	announceStatus.Visibility = boostedStatus.Visibility
+
+	err := suite.processor.ProcessFromFederator(context.Background(), messages.FromFederator{
+		APObjectType:     ap.ActivityAnnounce,
+		APActivityType:   ap.ActivityCreate,
+		GTSModel:         announceStatus,
+		ReceivingAccount: suite.testAccounts["local_account_1"],
+	})
+	suite.NoError(err)
+
+	// side effects should be triggered
+	// 1. status should have an ID, and be in the database
+	suite.NotEmpty(announceStatus.ID)
+	_, err = suite.db.GetStatusByID(context.Background(), announceStatus.ID)
+	suite.NoError(err)
+
+	// 2. a notification should exist for the announce
+	where := []db.Where{
+		{
+			Key:   "status_id",
+			Value: announceStatus.ID,
+		},
+	}
+	notif := &gtsmodel.Notification{}
+	err = suite.db.GetWhere(context.Background(), where, notif)
+	suite.NoError(err)
+	suite.Equal(gtsmodel.NotificationReblog, notif.NotificationType)
+	suite.Equal(boostedStatus.AccountID, notif.TargetAccountID)
+	suite.Equal(announceStatus.AccountID, notif.OriginAccountID)
+	suite.Equal(announceStatus.ID, notif.StatusID)
+	suite.False(notif.Read)
+}
+
+func TestFromFederatorTestSuite(t *testing.T) {
+	suite.Run(t, &FromFederatorTestSuite{})
+}

--- a/internal/processing/notification_test.go
+++ b/internal/processing/notification_test.go
@@ -16,7 +16,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package bundb_test
+package processing_test
 
 import (
 	"context"
@@ -25,28 +25,23 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type SessionTestSuite struct {
-	BunDBStandardTestSuite
+type NotificationTestSuite struct {
+	ProcessingStandardTestSuite
 }
 
-func (suite *SessionTestSuite) TestGetSession() {
-	session, err := suite.db.GetSession(context.Background())
+// get a notification where someone has liked our status
+func (suite *NotificationTestSuite) TestGetNotifications() {
+	receivingAccount := suite.testAccounts["local_account_1"]
+	notifs, err := suite.processor.NotificationsGet(context.Background(), suite.testAutheds["local_account_1"], 10, "", "")
 	suite.NoError(err)
-	suite.NotNil(session)
-	suite.NotEmpty(session.Auth)
-	suite.NotEmpty(session.Crypt)
-	suite.NotEmpty(session.ID)
-
-	// TODO -- the same session should be returned with consecutive selects
-	// right now there's an issue with bytea in bun, so uncomment this when that issue is fixed: https://github.com/uptrace/bun/issues/122
-	// session2, err := suite.db.GetSession(context.Background())
-	// suite.NoError(err)
-	// suite.NotNil(session2)
-	// suite.Equal(session.Auth, session2.Auth)
-	// suite.Equal(session.Crypt, session2.Crypt)
-	// suite.Equal(session.ID, session2.ID)
+	suite.Len(notifs, 1)
+	notif := notifs[0]
+	suite.NotNil(notif.Status)
+	suite.NotNil(notif.Status)
+	suite.NotNil(notif.Status.Account)
+	suite.Equal(receivingAccount.ID, notif.Status.Account.ID)
 }
 
-func TestSessionTestSuite(t *testing.T) {
-	suite.Run(t, new(SessionTestSuite))
+func TestNotificationTestSuite(t *testing.T) {
+	suite.Run(t, &NotificationTestSuite{})
 }

--- a/internal/processing/processor.go
+++ b/internal/processing/processor.go
@@ -56,6 +56,10 @@ type Processor interface {
 	Start(ctx context.Context) error
 	// Stop stops the processor cleanly, finishing handling any remaining messages before closing down.
 	Stop() error
+	// ProcessFromClientAPI processes one message coming from the clientAPI channel, and triggers appropriate side effects.
+	ProcessFromClientAPI(ctx context.Context, clientMsg messages.FromClientAPI) error
+	// ProcessFromFederator processes one message coming from the federator channel, and triggers appropriate side effects.
+	ProcessFromFederator(ctx context.Context, federatorMsg messages.FromFederator) error
 
 	/*
 		CLIENT API-FACING PROCESSING FUNCTIONS
@@ -290,14 +294,14 @@ func (p *processor) Start(ctx context.Context) error {
 			case clientMsg := <-p.fromClientAPI:
 				p.log.Tracef("received message FROM client API: %+v", clientMsg)
 				go func() {
-					if err := p.processFromClientAPI(ctx, clientMsg); err != nil {
+					if err := p.ProcessFromClientAPI(ctx, clientMsg); err != nil {
 						p.log.Error(err)
 					}
 				}()
 			case federatorMsg := <-p.fromFederator:
 				p.log.Tracef("received message FROM federator: %+v", federatorMsg)
 				go func() {
-					if err := p.processFromFederator(ctx, federatorMsg); err != nil {
+					if err := p.ProcessFromFederator(ctx, federatorMsg); err != nil {
 						p.log.Error(err)
 					}
 				}()

--- a/internal/processing/processor_test.go
+++ b/internal/processing/processor_test.go
@@ -1,0 +1,124 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package processing_test
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/blob"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/federation"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/media"
+	"github.com/superseriousbusiness/gotosocial/internal/oauth"
+	"github.com/superseriousbusiness/gotosocial/internal/processing"
+	"github.com/superseriousbusiness/gotosocial/internal/timeline"
+	"github.com/superseriousbusiness/gotosocial/internal/transport"
+	"github.com/superseriousbusiness/gotosocial/internal/typeutils"
+	"github.com/superseriousbusiness/gotosocial/testrig"
+)
+
+type ProcessingStandardTestSuite struct {
+	// standard suite interfaces
+	suite.Suite
+	config              *config.Config
+	db                  db.DB
+	log                 *logrus.Logger
+	storage             blob.Storage
+	typeconverter       typeutils.TypeConverter
+	transportController transport.Controller
+	federator           federation.Federator
+	oauthServer         oauth.Server
+	mediaHandler        media.Handler
+	timelineManager     timeline.Manager
+
+	// standard suite models
+	testTokens       map[string]*gtsmodel.Token
+	testClients      map[string]*gtsmodel.Client
+	testApplications map[string]*gtsmodel.Application
+	testUsers        map[string]*gtsmodel.User
+	testAccounts     map[string]*gtsmodel.Account
+	testAttachments  map[string]*gtsmodel.MediaAttachment
+	testStatuses     map[string]*gtsmodel.Status
+	testTags         map[string]*gtsmodel.Tag
+	testMentions     map[string]*gtsmodel.Mention
+	testAutheds      map[string]*oauth.Auth
+
+	processor processing.Processor
+}
+
+func (suite *ProcessingStandardTestSuite) SetupSuite() {
+	suite.testTokens = testrig.NewTestTokens()
+	suite.testClients = testrig.NewTestClients()
+	suite.testApplications = testrig.NewTestApplications()
+	suite.testUsers = testrig.NewTestUsers()
+	suite.testAccounts = testrig.NewTestAccounts()
+	suite.testAttachments = testrig.NewTestAttachments()
+	suite.testStatuses = testrig.NewTestStatuses()
+	suite.testTags = testrig.NewTestTags()
+	suite.testMentions = testrig.NewTestMentions()
+	suite.testAutheds = map[string]*oauth.Auth{
+		"local_account_1": {
+			Application: suite.testApplications["local_account_1"],
+			User:        suite.testUsers["local_account_1"],
+			Account:     suite.testAccounts["local_account_1"],
+		},
+	}
+}
+
+func (suite *ProcessingStandardTestSuite) SetupTest() {
+	suite.config = testrig.NewTestConfig()
+	suite.db = testrig.NewTestDB()
+	suite.log = testrig.NewTestLog()
+	suite.storage = testrig.NewTestStorage()
+	suite.typeconverter = testrig.NewTestTypeConverter(suite.db)
+	suite.transportController = testrig.NewTestTransportController(testrig.NewMockHTTPClient(nil), suite.db)
+	suite.federator = testrig.NewTestFederator(suite.db, suite.transportController, suite.storage)
+	suite.oauthServer = testrig.NewTestOauthServer(suite.db)
+	suite.mediaHandler = testrig.NewTestMediaHandler(suite.db, suite.storage)
+	suite.timelineManager = testrig.NewTestTimelineManager(suite.db)
+
+	suite.processor = processing.NewProcessor(
+		suite.config,
+		suite.typeconverter,
+		suite.federator,
+		suite.oauthServer,
+		suite.mediaHandler,
+		suite.storage,
+		suite.timelineManager,
+		suite.db,
+		suite.log)
+
+	testrig.StandardDBSetup(suite.db, suite.testAccounts)
+	testrig.StandardStorageSetup(suite.storage, "../../testrig/media")
+	if err := suite.processor.Start(context.Background()); err != nil {
+		panic(err)
+	}
+}
+
+func (suite *ProcessingStandardTestSuite) TearDownTest() {
+	testrig.StandardDBTeardown(suite.db)
+	testrig.StandardStorageTeardown(suite.storage)
+	if err := suite.processor.Stop(); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
This PR fixes a tiny issue with reblog/boost notifications not being created (replacing `==` with `!=` in one file -- https://github.com/superseriousbusiness/gotosocial/pull/193/files#diff-4702c34f947db9e2ac6ce9f82430f5ac32d518f76ba4dc3e9963383a2d2f9499R255), and adds some tests to validate that notifications are created when a boost/reblog is processed.

It also adds a couple of tests elsewhere, and tidies up some existing tests.

closes #170 