### PR TITLE
Weird notif issue

### DIFF
--- a/internal/processing/fromclientapi.go
+++ b/internal/processing/fromclientapi.go
@@ -73,7 +73,7 @@ func (p *processor) ProcessFromClientAPI(ctx context.Context, clientMsg messages
 				return errors.New("fave was not parseable as *gtsmodel.StatusFave")
 			}
 
-			if err := p.notifyFave(ctx, fave, clientMsg.TargetAccount); err != nil {
+			if err := p.notifyFave(ctx, fave); err != nil {
 				return err
 			}
 

--- a/internal/processing/fromcommon.go
+++ b/internal/processing/fromcommon.go
@@ -190,8 +190,17 @@ func (p *processor) notifyFollow(ctx context.Context, follow *gtsmodel.Follow, t
 	return nil
 }
 
-func (p *processor) notifyFave(ctx context.Context, fave *gtsmodel.StatusFave, targetAccount *gtsmodel.Account) error {
-	// return if this isn't a local account
+func (p *processor) notifyFave(ctx context.Context, fave *gtsmodel.StatusFave) error {
+	if fave.TargetAccount == nil {
+		a, err := p.db.GetAccountByID(ctx, fave.TargetAccountID)
+		if err != nil {
+			return err
+		}
+		fave.TargetAccount = a
+	}
+	targetAccount := fave.TargetAccount
+	
+	// just return if target isn't a local account
 	if targetAccount.Domain != "" {
 		return nil
 	}

--- a/internal/processing/fromcommon.go
+++ b/internal/processing/fromcommon.go
@@ -199,7 +199,7 @@ func (p *processor) notifyFave(ctx context.Context, fave *gtsmodel.StatusFave) e
 		fave.TargetAccount = a
 	}
 	targetAccount := fave.TargetAccount
-	
+
 	// just return if target isn't a local account
 	if targetAccount.Domain != "" {
 		return nil

--- a/internal/processing/fromfederator.go
+++ b/internal/processing/fromfederator.go
@@ -73,7 +73,7 @@ func (p *processor) ProcessFromFederator(ctx context.Context, federatorMsg messa
 				return errors.New("like was not parseable as *gtsmodel.StatusFave")
 			}
 
-			if err := p.notifyFave(ctx, incomingFave, federatorMsg.ReceivingAccount); err != nil {
+			if err := p.notifyFave(ctx, incomingFave); err != nil {
 				return err
 			}
 		case ap.ActivityFollow:


### PR DESCRIPTION
This PR fixes an issue where notifications were being streamed to a user for faves on statuses owned by other people.

The issue was caused by GtS assuming that any faves that arrived in an inbox should be faves of a status created by the inbox owner. However, other implementations like Misskey seem to federate faves by an account to all followers of that account, regardless of who actually posted the status.

The fix was to check who the fave was directed at before streaming a notification, rather than just assuming that the inbox owner and the status fave target owner are the same.