### PR TITLE
skip account on error instead of returning error

### DIFF
--- a/internal/federation/federatingdb/followers.go
+++ b/internal/federation/federatingdb/followers.go
@@ -54,8 +54,15 @@ func (f *federatingDB) Followers(ctx context.Context, actorIRI *url.URL) (follow
 		if follow.Account == nil {
 			followAccount, err := f.db.GetAccountByID(ctx, follow.AccountID)
 			if err != nil {
-				l.Errorf("FOLLOWERS: db error getting account id %s: %s", follow.AccountID, err)
-				continue
+				errWrapped := fmt.Errorf("FOLLOWERS: db error getting account id %s: %s", follow.AccountID, err)
+				if err == db.ErrNoEntries {
+					// no entry for this account id so it's probably been deleted and we haven't caught up yet
+					l.Error(errWrapped)
+					continue
+				} else {
+					// proper error
+					return nil, errWrapped
+				}
 			}
 			follow.Account = followAccount
 		}

--- a/internal/federation/federatingdb/followers.go
+++ b/internal/federation/federatingdb/followers.go
@@ -54,7 +54,8 @@ func (f *federatingDB) Followers(ctx context.Context, actorIRI *url.URL) (follow
 		if follow.Account == nil {
 			followAccount, err := f.db.GetAccountByID(ctx, follow.AccountID)
 			if err != nil {
-				return nil, fmt.Errorf("FOLLOWERS: db error getting account id %s: %s", follow.AccountID, err)
+				l.Errorf("FOLLOWERS: db error getting account id %s: %s", follow.AccountID, err)
+				continue
 			}
 			follow.Account = followAccount
 		}

--- a/internal/federation/federatingdb/following.go
+++ b/internal/federation/federatingdb/following.go
@@ -67,7 +67,8 @@ func (f *federatingDB) Following(ctx context.Context, actorIRI *url.URL) (follow
 		if follow.Account == nil {
 			followAccount, err := f.db.GetAccountByID(ctx, follow.AccountID)
 			if err != nil {
-				return nil, fmt.Errorf("FOLLOWING: db error getting account id %s: %s", follow.AccountID, err)
+				l.Errorf("FOLLOWING: db error getting account id %s: %s", follow.AccountID, err)
+				continue
 			}
 			follow.Account = followAccount
 		}

--- a/internal/federation/federatingdb/following.go
+++ b/internal/federation/federatingdb/following.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-fed/activity/streams"
 	"github.com/go-fed/activity/streams/vocab"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
@@ -67,8 +68,15 @@ func (f *federatingDB) Following(ctx context.Context, actorIRI *url.URL) (follow
 		if follow.Account == nil {
 			followAccount, err := f.db.GetAccountByID(ctx, follow.AccountID)
 			if err != nil {
-				l.Errorf("FOLLOWING: db error getting account id %s: %s", follow.AccountID, err)
-				continue
+				errWrapped := fmt.Errorf("FOLLOWING: db error getting account id %s: %s", follow.AccountID, err)
+				if err == db.ErrNoEntries {
+					// no entry for this account id so it's probably been deleted and we haven't caught up yet
+					l.Error(errWrapped)
+					continue
+				} else {
+					// proper error
+					return nil, errWrapped
+				}
 			}
 			follow.Account = followAccount
 		}


### PR DESCRIPTION
This PR allows the following/followers federatedDB functions to continue if there's an error fetching a particular account while selecting an account's followers or following. This can happen in cases where an account has just been deleted, for example.