### PR TITLE
handle remote account deletion more systematically

### DIFF
--- a/internal/api/s2s/user/user_test.go
+++ b/internal/api/s2s/user/user_test.go
@@ -53,6 +53,7 @@ type UserStandardTestSuite struct {
 	testAccounts     map[string]*gtsmodel.Account
 	testAttachments  map[string]*gtsmodel.MediaAttachment
 	testStatuses     map[string]*gtsmodel.Status
+	testBlocks       map[string]*gtsmodel.Block
 
 	// module being tested
 	userModule *user.Module
@@ -66,6 +67,7 @@ func (suite *UserStandardTestSuite) SetupSuite() {
 	suite.testAccounts = testrig.NewTestAccounts()
 	suite.testAttachments = testrig.NewTestAttachments()
 	suite.testStatuses = testrig.NewTestStatuses()
+	suite.testBlocks = testrig.NewTestBlocks()
 }
 
 func (suite *UserStandardTestSuite) SetupTest() {

--- a/internal/federation/federatingdb/delete.go
+++ b/internal/federation/federatingdb/delete.go
@@ -89,10 +89,7 @@ func (f *federatingDB) Delete(ctx context.Context, id *url.URL) error {
 	a, err := f.db.GetAccountByURI(ctx, id.String())
 	if err == nil {
 		// it's an account
-		l.Debugf("uri is for an account with id: %s", a.ID)
-		if err := f.db.DeleteByID(ctx, a.ID, &gtsmodel.Account{}); err != nil {
-			return fmt.Errorf("DELETE: err deleting account: %s", err)
-		}
+		l.Debugf("uri is for an account with id %s, passing delete message to the processor", a.ID)
 		fromFederatorChan <- messages.FromFederator{
 			APObjectType:     ap.ObjectProfile,
 			APActivityType:   ap.ActivityDelete,

--- a/internal/processing/fromfederator.go
+++ b/internal/processing/fromfederator.go
@@ -181,7 +181,13 @@ func (p *processor) ProcessFromFederator(ctx context.Context, federatorMsg messa
 			return p.deleteStatusFromTimelines(ctx, statusToDelete)
 		case ap.ObjectProfile:
 			// DELETE A PROFILE/ACCOUNT
-			// TODO: handle side effects of account deletion here: delete all objects, statuses, media etc associated with account
+			// handle side effects of account deletion here: delete all objects, statuses, media etc associated with account
+			account, ok := federatorMsg.GTSModel.(*gtsmodel.Account)
+			if !ok {
+				return errors.New("account delete was not parseable as *gtsmodel.Account")
+			}
+
+			return p.accountProcessor.Delete(ctx, account, account.ID)
 		}
 	case ap.ActivityAccept:
 		// ACCEPT

--- a/internal/processing/processor_test.go
+++ b/internal/processing/processor_test.go
@@ -62,6 +62,7 @@ type ProcessingStandardTestSuite struct {
 	testTags         map[string]*gtsmodel.Tag
 	testMentions     map[string]*gtsmodel.Mention
 	testAutheds      map[string]*oauth.Auth
+	testBlocks       map[string]*gtsmodel.Block
 
 	processor processing.Processor
 }
@@ -83,6 +84,7 @@ func (suite *ProcessingStandardTestSuite) SetupSuite() {
 			Account:     suite.testAccounts["local_account_1"],
 		},
 	}
+	suite.testBlocks = testrig.NewTestBlocks()
 }
 
 func (suite *ProcessingStandardTestSuite) SetupTest() {


### PR DESCRIPTION
This PR brings federated account deletes in line with the same behavior used when suspending an account or doing a domain block: remove account's statuses, follows, etc, etc, etc, etc, and just leave a stub of the account in the database.

Addresses #253 