### PR TITLE
don't catch mentions within links

### DIFF
--- a/internal/regexes/regexes.go
+++ b/internal/regexes/regexes.go
@@ -52,8 +52,8 @@ var (
 	// such as @whatever_user@example.org, returning whatever_user and example.org (without the @ symbols)
 	MentionName = regexp.MustCompile(mentionName)
 
-	// mention regex can be played around with here: https://regex101.com/r/qwM9D3/1
-	mentionFinder = `(?:\B)(@\w+(?:@[a-zA-Z0-9_\-\.]+)?)(?:\B)?`
+	// mention regex can be played around with here: https://regex101.com/r/G1oGR0/1
+	mentionFinder = `(?:^|\s)(@\w+(?:@[a-zA-Z0-9_\-\.]+)?)`
 	// MentionFinder extracts mentions from a piece of text.
 	MentionFinder = regexp.MustCompile(mentionFinder)
 

--- a/internal/util/statustools_test.go
+++ b/internal/util/statustools_test.go
@@ -30,6 +30,17 @@ type StatusTestSuite struct {
 	suite.Suite
 }
 
+func (suite *StatusTestSuite) TestLinkNoMention() {
+	statusText := `here's a link to a post by zork:
+
+https://localhost:8080/@the_mighty_zork/statuses/01FGVP55XMF2K6316MQRX6PFG1
+
+that link shouldn't come out formatted as a mention!`
+
+	menchies := util.DeriveMentionsFromText(statusText)
+	suite.Empty(menchies)
+}
+
 func (suite *StatusTestSuite) TestDeriveMentionsOK() {
 	statusText := `@dumpsterqueer@example.org testing testing
 


### PR DESCRIPTION
This PR updates our mention finder regex very slightly to avoid finding mentions incorrectly within links. Solution was to add a little bit to the beginning of the regex specifying that we want either a line beginning or some kind of whitespace to precede a mention, otherwise skip it.

Also add a test for this.

See the regex in action here: https://regex101.com/r/G1oGR0/1/

PR also removes a bit of the weirdness in the regex which I don't know why I put there in the first place!

Closes https://github.com/superseriousbusiness/gotosocial/issues/223