### PR TITLE
fix logs not working properly

### DIFF
--- a/internal/federation/federatingdb/accept.go
+++ b/internal/federation/federatingdb/accept.go
@@ -39,7 +39,7 @@ func (f *federatingDB) Accept(ctx context.Context, accept vocab.ActivityStreamsA
 		},
 	)
 
-	if l.Level >= logrus.DebugLevel {
+	if f.log.Level >= logrus.DebugLevel {
 		i, err := marshalItem(accept)
 		if err != nil {
 			return err

--- a/internal/federation/federatingdb/announce.go
+++ b/internal/federation/federatingdb/announce.go
@@ -35,7 +35,7 @@ func (f *federatingDB) Announce(ctx context.Context, announce vocab.ActivityStre
 		},
 	)
 
-	if l.Level >= logrus.DebugLevel {
+	if f.log.Level >= logrus.DebugLevel {
 		i, err := marshalItem(announce)
 		if err != nil {
 			return err

--- a/internal/federation/federatingdb/create.go
+++ b/internal/federation/federatingdb/create.go
@@ -50,7 +50,7 @@ func (f *federatingDB) Create(ctx context.Context, asType vocab.Type) error {
 		},
 	)
 
-	if l.Level >= logrus.DebugLevel {
+	if f.log.Level >= logrus.DebugLevel {
 		i, err := marshalItem(asType)
 		if err != nil {
 			return err

--- a/internal/federation/federatingdb/undo.go
+++ b/internal/federation/federatingdb/undo.go
@@ -37,7 +37,7 @@ func (f *federatingDB) Undo(ctx context.Context, undo vocab.ActivityStreamsUndo)
 		},
 	)
 
-	if l.Level >= logrus.DebugLevel {
+	if f.log.Level >= logrus.DebugLevel {
 		i, err := marshalItem(undo)
 		if err != nil {
 			return err

--- a/internal/federation/federatingdb/update.go
+++ b/internal/federation/federatingdb/update.go
@@ -47,7 +47,7 @@ func (f *federatingDB) Update(ctx context.Context, asType vocab.Type) error {
 		},
 	)
 
-	if l.Level >= logrus.DebugLevel {
+	if f.log.Level >= logrus.DebugLevel {
 		i, err := marshalItem(asType)
 		if err != nil {
 			return err

--- a/internal/federation/federatingdb/util.go
+++ b/internal/federation/federatingdb/util.go
@@ -69,7 +69,7 @@ func (f *federatingDB) NewID(ctx context.Context, t vocab.Type) (idURL *url.URL,
 		},
 	)
 
-	if l.Level >= logrus.DebugLevel {
+	if f.log.Level >= logrus.DebugLevel {
 		i, err := marshalItem(t)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
When you create a *logrus.Entry from a *logrus.Logger and then check entry.Level it always shows as 0 (ie., no logging) even when the logger you created it from had something like 5 (debug logging).

This meant that logs where the level is checked first based on the created Entry weren't working properly in the federating db.

This PR fixes that by checking the level from the Logger instead of the Entry created from it.