### PR TITLE
Derive visibility fixes

### DIFF
--- a/internal/ap/extract.go
+++ b/internal/ap/extract.go
@@ -253,7 +253,7 @@ func ExtractSummary(i WithSummary) (string, error) {
 		}
 	}
 
-	return "", errors.New("could not extract summary")
+	return "", nil
 }
 
 // ExtractDiscoverable extracts the Discoverable boolean of an interface.

--- a/internal/ap/extractvisibility_test.go
+++ b/internal/ap/extractvisibility_test.go
@@ -1,0 +1,71 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package ap_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/ap"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+)
+
+type ExtractVisibilityTestSuite struct {
+	ExtractTestSuite
+}
+
+func (suite *ExtractVisibilityTestSuite) TestExtractVisibilityPublic() {
+	a := suite.addressable1
+	visibility, err := ap.ExtractVisibility(a, "http://localhost:8080/users/the_mighty_zork/followers")
+	suite.NoError(err)
+	suite.Equal(visibility, gtsmodel.VisibilityPublic)
+}
+
+func (suite *ExtractVisibilityTestSuite) TestExtractVisibilityUnlocked() {
+	a := suite.addressable2
+	visibility, err := ap.ExtractVisibility(a, "http://localhost:8080/users/the_mighty_zork/followers")
+	suite.NoError(err)
+	suite.Equal(visibility, gtsmodel.VisibilityUnlocked)
+}
+
+func (suite *ExtractVisibilityTestSuite) TestExtractVisibilityFollowersOnly() {
+	a := suite.addressable3
+	visibility, err := ap.ExtractVisibility(a, "http://localhost:8080/users/the_mighty_zork/followers")
+	suite.NoError(err)
+	suite.Equal(visibility, gtsmodel.VisibilityFollowersOnly)
+}
+
+func (suite *ExtractVisibilityTestSuite) TestExtractVisibilityFollowersOnlyAnnounce() {
+	// https://github.com/superseriousbusiness/gotosocial/issues/267
+	a := suite.addressable4
+	visibility, err := ap.ExtractVisibility(a, "https://example.org/users/someone/followers")
+	suite.NoError(err)
+	suite.Equal(visibility, gtsmodel.VisibilityFollowersOnly)
+}
+
+func (suite *ExtractVisibilityTestSuite) TestExtractVisibilityDirect() {
+	a := suite.addressable5
+	visibility, err := ap.ExtractVisibility(a, "http://localhost:8080/users/the_mighty_zork/followers")
+	suite.NoError(err)
+	suite.Equal(visibility, gtsmodel.VisibilityDirect)
+}
+
+func TestExtractVisibilityTestSuite(t *testing.T) {
+	suite.Run(t, &ExtractVisibilityTestSuite{})
+}

--- a/internal/ap/interfaces.go
+++ b/internal/ap/interfaces.go
@@ -133,6 +133,12 @@ type Announceable interface {
 	WithCC
 }
 
+// Addressable represents the minimum interface for an addressed activity.
+type Addressable interface {
+	WithTo
+	WithCC
+}
+
 // CollectionPageable represents the minimum interface for an activitystreams 'CollectionPage' object.
 type CollectionPageable interface {
 	WithJSONLDId

--- a/internal/api/s2s/user/inboxpost_test.go
+++ b/internal/api/s2s/user/inboxpost_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/go-fed/activity/pub"
 	"github.com/go-fed/activity/streams"
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/gotosocial/internal/api/s2s/user"
@@ -247,7 +248,7 @@ func (suite *InboxPostTestSuite) TestPostUpdate() {
 
 	// Set the To of the update as public
 	updateTo := streams.NewActivityStreamsToProperty()
-	updateTo.AppendIRI(testrig.URLMustParse("https://www.w3.org/ns/activitystreams#Public"))
+	updateTo.AppendIRI(testrig.URLMustParse(pub.PublicActivityPubIRI))
 	update.SetActivityStreamsTo(updateTo)
 
 	// set the cc of the update to the receivingAccount
@@ -370,7 +371,7 @@ func (suite *InboxPostTestSuite) TestPostDelete() {
 
 	// Set the To of the delete as public
 	deleteTo := streams.NewActivityStreamsToProperty()
-	deleteTo.AppendIRI(testrig.URLMustParse("https://www.w3.org/ns/activitystreams#Public"))
+	deleteTo.AppendIRI(testrig.URLMustParse(pub.PublicActivityPubIRI))
 	delete.SetActivityStreamsTo(deleteTo)
 
 	// set some random-ass ID for the activity

--- a/internal/typeutils/converter.go
+++ b/internal/typeutils/converter.go
@@ -32,10 +32,6 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 )
 
-const (
-	asPublicURI = "https://www.w3.org/ns/activitystreams#Public"
-)
-
 // TypeConverter is an interface for the common action of converting between apimodule (frontend, serializable) models,
 // internal gts models used in the database, and activitypub models used in federation.
 //

--- a/internal/typeutils/internaltoas.go
+++ b/internal/typeutils/internaltoas.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/go-fed/activity/pub"
 	"github.com/go-fed/activity/streams"
 	"github.com/go-fed/activity/streams/vocab"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
@@ -444,9 +445,9 @@ func (c *converter) StatusToAS(ctx context.Context, s *gtsmodel.Status) (vocab.A
 		return nil, fmt.Errorf("StatusToAS: error parsing url %s: %s", s.Account.FollowersURI, err)
 	}
 
-	publicURI, err := url.Parse(asPublicURI)
+	publicURI, err := url.Parse(pub.PublicActivityPubIRI)
 	if err != nil {
-		return nil, fmt.Errorf("StatusToAS: error parsing url %s: %s", asPublicURI, err)
+		return nil, fmt.Errorf("StatusToAS: error parsing url %s: %s", pub.PublicActivityPubIRI, err)
 	}
 
 	// to and cc
@@ -795,9 +796,9 @@ func (c *converter) BoostToAS(ctx context.Context, boostWrapperStatus *gtsmodel.
 		return nil, fmt.Errorf("BoostToAS: error parsing uri %s: %s", boostedAccount.URI, err)
 	}
 
-	publicURI, err := url.Parse(asPublicURI)
+	publicURI, err := url.Parse(pub.PublicActivityPubIRI)
 	if err != nil {
-		return nil, fmt.Errorf("BoostToAS: error parsing uri %s: %s", asPublicURI, err)
+		return nil, fmt.Errorf("BoostToAS: error parsing uri %s: %s", pub.PublicActivityPubIRI, err)
 	}
 
 	ccProp := streams.NewActivityStreamsCcProperty()

--- a/internal/typeutils/wrap.go
+++ b/internal/typeutils/wrap.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/go-fed/activity/pub"
 	"github.com/go-fed/activity/streams"
 	"github.com/go-fed/activity/streams/vocab"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
@@ -46,9 +47,9 @@ func (c *converter) WrapPersonInUpdate(person vocab.ActivityStreamsPerson, origi
 	update.SetActivityStreamsObject(objectProp)
 
 	// to should be public
-	toURI, err := url.Parse(asPublicURI)
+	toURI, err := url.Parse(pub.PublicActivityPubIRI)
 	if err != nil {
-		return nil, fmt.Errorf("WrapPersonInUpdate: error parsing url %s: %s", asPublicURI, err)
+		return nil, fmt.Errorf("WrapPersonInUpdate: error parsing url %s: %s", pub.PublicActivityPubIRI, err)
 	}
 	toProp := streams.NewActivityStreamsToProperty()
 	toProp.AppendIRI(toURI)

--- a/testrig/testmodels.go
+++ b/testrig/testmodels.go
@@ -1387,7 +1387,7 @@ func NewTestFediStatuses() map[string]vocab.ActivityStreamsNote {
 			"",
 			URLMustParse("https://unknown-instance.com/users/brand_new_person"),
 			[]*url.URL{
-				URLMustParse("https://www.w3.org/ns/activitystreams#Public"),
+				URLMustParse(pub.PublicActivityPubIRI),
 			},
 			[]*url.URL{},
 			false,
@@ -1401,7 +1401,7 @@ func NewTestFediStatuses() map[string]vocab.ActivityStreamsNote {
 			"",
 			URLMustParse("https://unknown-instance.com/users/brand_new_person"),
 			[]*url.URL{
-				URLMustParse("https://www.w3.org/ns/activitystreams#Public"),
+				URLMustParse(pub.PublicActivityPubIRI),
 			},
 			[]*url.URL{},
 			false,


### PR DESCRIPTION
This PR fixes up and tests visibility derivation for messages coming in over the federation API. It consolidates the separate logics for checking visibility of announces and notes, and moves it all to the `ap` package with the other extract functions. Also adds tests for expected visibility behavior.

closes https://github.com/superseriousbusiness/gotosocial/issues/267