### PR TITLE
fix broken GetInstanceAccount selector

### DIFF
--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -127,13 +127,13 @@ func (a *accountDB) GetInstanceAccount(ctx context.Context, domain string) (*gts
 
 	q := a.newAccountQ(account)
 
-	if domain == "" {
+	if domain != "" {
 		q = q.
 			Where("account.username = ?", domain).
 			Where("account.domain = ?", domain)
 	} else {
 		q = q.
-			Where("account.username = ?", domain).
+			Where("account.username = ?", a.config.Host).
 			WhereGroup(" AND ", whereEmptyOrNull("domain"))
 	}
 

--- a/internal/db/bundb/admin_test.go
+++ b/internal/db/bundb/admin_test.go
@@ -37,7 +37,7 @@ func (suite *AdminTestSuite) TestCreateInstanceAccount() {
 	testrig.CreateTestTables(suite.db)
 
 	// make sure there's no instance account in the db yet
-	acct, err := suite.db.GetInstanceAccount(context.Background(), suite.config.Host)
+	acct, err := suite.db.GetInstanceAccount(context.Background(), "")
 	suite.Error(err)
 	suite.Nil(acct)
 
@@ -46,7 +46,7 @@ func (suite *AdminTestSuite) TestCreateInstanceAccount() {
 	suite.NoError(err)
 
 	// and now check it exists
-	acct, err = suite.db.GetInstanceAccount(context.Background(), suite.config.Host)
+	acct, err = suite.db.GetInstanceAccount(context.Background(), "")
 	suite.NoError(err)
 	suite.NotNil(acct)
 }


### PR DESCRIPTION
Fix a broken query in the database for pulling the instance account out of the database.