### PR TITLE
anticipating / warning of / preventing cryptic sqlite errors

### DIFF
--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -140,20 +140,31 @@ func NewBunDBService(ctx context.Context, c *config.Config) (db.DB, error) {
 			return nil, fmt.Errorf("could not open sqlite db: could not determine parent folder permissions for '%s': %s", providedPath, err)
 		}
 		parentFolderStat := parentFolderInfo.Sys().(*syscall.Stat_t)
-		readWritableBecauseUser := ((parentFolderInfo.Mode() & 0600) == 0600) && os.Geteuid() == int(parentFolderStat.Uid)
-		readWritableBecauseGroup := ((parentFolderInfo.Mode() & 0060) == 0060) && os.Getegid() == int(parentFolderStat.Gid)
-		readWritableBecauseEveryone := ((parentFolderInfo.Mode() & 0006) == 0006)
+		processUserOwnsFolder := os.Geteuid() == int(parentFolderStat.Uid)
+		processIsRunningAsRoot := os.Geteuid() == 0
+		processHasGroupMatchForFolder := os.Getegid() == int(parentFolderStat.Gid)
+		folderAllowsOwnerToReadAndWrite := (parentFolderInfo.Mode() & 0600) == 0600
+		folderAllowsGroupMembersToReadAndWrite := (parentFolderInfo.Mode() & 0060) == 0060
+		folderAllowsAnyoneToReadAndWrite := (parentFolderInfo.Mode() & 0006) == 0006
+		readWritableBecauseUser := processUserOwnsFolder && folderAllowsOwnerToReadAndWrite
+		// could use os.Getgroups() here to determine if the process user has membership in the group for the folder...
+		// but does it really matter that much just for a warning message? 99% of the time the process UID should own the folder anyways
+		readWritableBecauseGroup := processHasGroupMatchForFolder && folderAllowsGroupMembersToReadAndWrite
+
+		logrus.Infof("attempting to open sqlite database at %s", providedPath)
+		if !(processIsRunningAsRoot || readWritableBecauseUser || readWritableBecauseGroup || folderAllowsAnyoneToReadAndWrite) {
+			logrus.Warnf("WARNING: parent folder permissions for '%s' do not seem to allow us to read and write", providedPath)
+			if !processUserOwnsFolder {
+				logrus.Warnf("GoToSocial is running as user id %d, however the folder is owned by user %d", os.Geteuid(), int(parentFolderStat.Uid))
+			} else if !folderAllowsOwnerToReadAndWrite {
+				logrus.Warnf("GoToSocial (user id %d) owns the folder, however the owner is not allowed to read and write", os.Geteuid())
+			}
+		}
 
 		// Append our own SQLite preferences
 		c.DBConfig.Address = "file:" + c.DBConfig.Address + "?cache=shared"
 
-		logrus.Infof("attempting to open sqlite database with address %s", c.DBConfig.Address)
-		if !(readWritableBecauseUser || readWritableBecauseGroup || readWritableBecauseEveryone) {
-			logrus.Warnf("WARNING: parent folder permissions for '%s' do not seem to allow us to read and write", providedPath)
-		}
-
 		// Open new DB instance
-
 		sqldb, err = sql.Open("sqlite", c.DBConfig.Address)
 		if err != nil {
 			return nil, fmt.Errorf("could not open sqlite db: %s", err)

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -137,18 +137,18 @@ func NewBunDBService(ctx context.Context, c *config.Config) (db.DB, error) {
 		if c.DBConfig.Address != ":memory:" {
 			absPathForLog, err := filepath.Abs(c.DBConfig.Address)
 			if err != nil {
-				absPathForLog = c.DBConfig.Address
-			}
-			logrus.Infof("attempting to open sqlite database at %s", absPathForLog)
-
-			exists, err := util.FilePathExistsAndIsReadWritable(c.DBConfig.Address)
-
-			if !exists {
-				return nil, fmt.Errorf("could not open sqlite db: %s", err)
-			} else if err != nil {
-				logrus.Warnf("WARNING (sqlite initialization): %s", err)
+				return nil, fmt.Errorf("could not open sqlite db: could not determine absolute filepath for '%s': %s", c.DBConfig.Address, err)
 			}
 
+			err = util.FilePathOk(c.DBConfig.Address)
+			if err != nil {
+				return nil, fmt.Errorf("could not open sqlite db: checking read/write access failed: %s", err)
+			} else {
+				logrus.Infof(
+					"file or directory exists and permissions seem ok, attempting to open sqlite database at '%s'",
+					absPathForLog,
+				)
+			}
 		}
 
 		// Append our own SQLite preferences

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -131,33 +131,38 @@ func NewBunDBService(ctx context.Context, c *config.Config) (db.DB, error) {
 		c.DBConfig.Address = strings.Split(c.DBConfig.Address, "?")[0]
 		c.DBConfig.Address = strings.TrimPrefix(c.DBConfig.Address, "file:")
 
-		providedPath, err := filepath.Abs(c.DBConfig.Address)
-		if err != nil {
-			providedPath = c.DBConfig.Address
-		}
-		parentFolderInfo, err := os.Stat(filepath.Dir(providedPath))
-		if err != nil {
-			return nil, fmt.Errorf("could not open sqlite db: could not determine parent folder permissions for '%s': %s", providedPath, err)
-		}
-		parentFolderStat := parentFolderInfo.Sys().(*syscall.Stat_t)
-		processUserOwnsFolder := os.Geteuid() == int(parentFolderStat.Uid)
-		processIsRunningAsRoot := os.Geteuid() == 0
-		processHasGroupMatchForFolder := os.Getegid() == int(parentFolderStat.Gid)
-		folderAllowsOwnerToReadAndWrite := (parentFolderInfo.Mode() & 0600) == 0600
-		folderAllowsGroupMembersToReadAndWrite := (parentFolderInfo.Mode() & 0060) == 0060
-		folderAllowsAnyoneToReadAndWrite := (parentFolderInfo.Mode() & 0006) == 0006
-		readWritableBecauseUser := processUserOwnsFolder && folderAllowsOwnerToReadAndWrite
-		// could use os.Getgroups() here to determine if the process user has membership in the group for the folder...
-		// but does it really matter that much just for a warning message? 99% of the time the process UID should own the folder anyways
-		readWritableBecauseGroup := processHasGroupMatchForFolder && folderAllowsGroupMembersToReadAndWrite
+		// if we are about to try to create/open a sqlite database file, we should do some checking to ensure
+		// that the place this file is about to be opened even exists and allows us to read and write.
+		// if it doesn't, sqlite will return extremely cryptic errors... so we pre-empt this and warn the user ourselves
+		if c.DBConfig.Address != ":memory:" {
+			providedPath, err := filepath.Abs(c.DBConfig.Address)
+			if err != nil {
+				providedPath = c.DBConfig.Address
+			}
+			parentFolderInfo, err := os.Stat(filepath.Dir(providedPath))
+			if err != nil {
+				return nil, fmt.Errorf("could not open sqlite db: could not determine parent folder permissions for '%s': %s", providedPath, err)
+			}
+			parentFolderStat := parentFolderInfo.Sys().(*syscall.Stat_t)
+			processUserOwnsFolder := os.Geteuid() == int(parentFolderStat.Uid)
+			processIsRunningAsRoot := os.Geteuid() == 0
+			processHasGroupMatchForFolder := os.Getegid() == int(parentFolderStat.Gid)
+			folderAllowsOwnerToReadAndWrite := (parentFolderInfo.Mode() & 0600) == 0600
+			folderAllowsGroupMembersToReadAndWrite := (parentFolderInfo.Mode() & 0060) == 0060
+			folderAllowsAnyoneToReadAndWrite := (parentFolderInfo.Mode() & 0006) == 0006
+			readWritableBecauseUser := processUserOwnsFolder && folderAllowsOwnerToReadAndWrite
+			// could use os.Getgroups() here to determine if the process user has membership in the group for the folder...
+			// but does it really matter that much just for a warning message? 99% of the time the process UID should own the folder anyways
+			readWritableBecauseGroup := processHasGroupMatchForFolder && folderAllowsGroupMembersToReadAndWrite
 
-		logrus.Infof("attempting to open sqlite database at %s", providedPath)
-		if !(processIsRunningAsRoot || readWritableBecauseUser || readWritableBecauseGroup || folderAllowsAnyoneToReadAndWrite) {
-			logrus.Warnf("WARNING: parent folder permissions for '%s' do not seem to allow us to read and write", providedPath)
-			if !processUserOwnsFolder {
-				logrus.Warnf("GoToSocial is running as user id %d, however the folder is owned by user %d", os.Geteuid(), int(parentFolderStat.Uid))
-			} else if !folderAllowsOwnerToReadAndWrite {
-				logrus.Warnf("GoToSocial (user id %d) owns the folder, however the owner is not allowed to read and write", os.Geteuid())
+			logrus.Infof("attempting to open sqlite database at %s", providedPath)
+			if !(processIsRunningAsRoot || readWritableBecauseUser || readWritableBecauseGroup || folderAllowsAnyoneToReadAndWrite) {
+				logrus.Warnf("WARNING: parent folder permissions for '%s' do not seem to allow us to read and write", providedPath)
+				if !processUserOwnsFolder {
+					logrus.Warnf("GoToSocial is running as user id %d, however the folder is owned by user %d", os.Geteuid(), int(parentFolderStat.Uid))
+				} else if !folderAllowsOwnerToReadAndWrite {
+					logrus.Warnf("GoToSocial (user id %d) owns the folder, however the owner is not allowed to read and write", os.Geteuid())
+				}
 			}
 		}
 

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -27,8 +27,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/ReneKroon/ttlcache"
@@ -123,16 +125,35 @@ func NewBunDBService(ctx context.Context, c *config.Config) (db.DB, error) {
 		conn = WrapDBConn(bun.NewDB(sqldb, pgdialect.New()))
 	case dbTypeSqlite:
 		// SQLITE
+		var err error
 
 		// Drop anything fancy from DB address
 		c.DBConfig.Address = strings.Split(c.DBConfig.Address, "?")[0]
 		c.DBConfig.Address = strings.TrimPrefix(c.DBConfig.Address, "file:")
 
+		providedPath, err := filepath.Abs(c.DBConfig.Address)
+		if err != nil {
+			providedPath = c.DBConfig.Address
+		}
+		parentFolderInfo, err := os.Stat(filepath.Dir(providedPath))
+		if err != nil {
+			return nil, fmt.Errorf("could not open sqlite db: could not determine parent folder permissions for '%s': %s", providedPath, err)
+		}
+		parentFolderStat := parentFolderInfo.Sys().(*syscall.Stat_t)
+		readWritableBecauseUser := ((parentFolderInfo.Mode() & 0600) == 0600) && os.Geteuid() == int(parentFolderStat.Uid)
+		readWritableBecauseGroup := ((parentFolderInfo.Mode() & 0060) == 0060) && os.Getegid() == int(parentFolderStat.Gid)
+		readWritableBecauseEveryone := ((parentFolderInfo.Mode() & 0006) == 0006)
+
 		// Append our own SQLite preferences
 		c.DBConfig.Address = "file:" + c.DBConfig.Address + "?cache=shared"
 
+		logrus.Infof("attempting to open sqlite database with address %s", c.DBConfig.Address)
+		if !(readWritableBecauseUser || readWritableBecauseGroup || readWritableBecauseEveryone) {
+			logrus.Warnf("WARNING: parent folder permissions for '%s' do not seem to allow us to read and write", providedPath)
+		}
+
 		// Open new DB instance
-		var err error
+
 		sqldb, err = sql.Open("sqlite", c.DBConfig.Address)
 		if err != nil {
 			return nil, fmt.Errorf("could not open sqlite db: %s", err)

--- a/internal/util/filesystem.go
+++ b/internal/util/filesystem.go
@@ -60,7 +60,7 @@ func FilePathOk(path string) error {
 
 			err = os.Remove(ioTestFilename)
 			if err != nil {
-				return fmt.Errorf("I cannot read and write a file inside '%s', but deleting it failed: %s", folderPath, err)
+				return fmt.Errorf("I can read and write a file inside '%s', but deleting it failed: %s", folderPath, err)
 			}
 
 			return nil

--- a/internal/util/filesystem.go
+++ b/internal/util/filesystem.go
@@ -41,8 +41,6 @@ func FilePathOk(path string) error {
 	onlyOwnerCanReadAndWrite := fs.FileMode(0600)
 
 	theFile, err := os.OpenFile(absPath, os.O_RDWR, onlyOwnerCanReadAndWrite)
-	defer theFile.Close()
-
 	if err != nil {
 
 		if os.IsNotExist(err) {
@@ -70,6 +68,8 @@ func FilePathOk(path string) error {
 
 		return err
 	}
+
+	theFile.Close()
 
 	return nil
 }

--- a/internal/util/filesystem.go
+++ b/internal/util/filesystem.go
@@ -1,0 +1,61 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func FilePathExistsAndIsReadWritable(path string) (exists bool, err error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+	parentFolderInfo, err := os.Stat(filepath.Dir(absPath))
+	if err != nil {
+		return false, fmt.Errorf("could not determine parent folder permissions for '%s': %s", absPath, err)
+	}
+	parentFolderStat := parentFolderInfo.Sys().(*syscall.Stat_t)
+	processUserOwnsFolder := os.Geteuid() == int(parentFolderStat.Uid)
+	processIsRunningAsRoot := os.Geteuid() == 0
+	processHasGroupMatchForFolder := os.Getegid() == int(parentFolderStat.Gid)
+	folderAllowsOwnerToReadAndWrite := (parentFolderInfo.Mode() & 0600) == 0600
+	folderAllowsGroupMembersToReadAndWrite := (parentFolderInfo.Mode() & 0060) == 0060
+	folderAllowsAnyoneToReadAndWrite := (parentFolderInfo.Mode() & 0006) == 0006
+	readWritableBecauseUser := processUserOwnsFolder && folderAllowsOwnerToReadAndWrite
+	// could use os.Getgroups() here to determine if the process user has membership in the group for the folder...
+	// but does it really matter that much just for a warning message? 99% of the time the process UID should own the folder anyways
+	readWritableBecauseGroup := processHasGroupMatchForFolder && folderAllowsGroupMembersToReadAndWrite
+
+	if !(processIsRunningAsRoot || readWritableBecauseUser || readWritableBecauseGroup || folderAllowsAnyoneToReadAndWrite) {
+		extraInfo := ""
+		if !processUserOwnsFolder {
+			extraInfo = fmt.Sprintf(": GoToSocial is running as user id %d, however the folder is owned by user %d", os.Geteuid(), int(parentFolderStat.Uid))
+		} else if !folderAllowsOwnerToReadAndWrite {
+			extraInfo = fmt.Sprintf(": GoToSocial (user id %d) owns the folder, however the owner is not allowed to read and write", os.Geteuid())
+		}
+
+		return true, fmt.Errorf("parent folder permissions for '%s' do not seem to allow us to read and write%s", absPath, extraInfo)
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
I manually tested 4 cases on linux:

1. parent folder does not exist
1. folder not owned by UID / GID of process
1. folder not readable+writable by user/group/everyone
1. and of course the happy path where everything works 