### PR TITLE
fix 404 on POST to `/api/v1/user/password_change`

### DIFF
--- a/internal/cliactions/server/server.go
+++ b/internal/cliactions/server/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/status"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/streaming"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/timeline"
+	userClient "github.com/superseriousbusiness/gotosocial/internal/api/client/user"
 	"github.com/superseriousbusiness/gotosocial/internal/api/s2s/nodeinfo"
 	"github.com/superseriousbusiness/gotosocial/internal/api/s2s/user"
 	"github.com/superseriousbusiness/gotosocial/internal/api/s2s/webfinger"
@@ -140,6 +141,7 @@ var Start cliactions.GTSAction = func(ctx context.Context, c *config.Config) err
 	streamingModule := streaming.New(c, processor)
 	favouritesModule := favourites.New(c, processor)
 	blocksModule := blocks.New(c, processor)
+	userClientModule := userClient.New(c, processor)
 
 	apis := []api.ClientModule{
 		// modules with middleware go first
@@ -168,6 +170,7 @@ var Start cliactions.GTSAction = func(ctx context.Context, c *config.Config) err
 		streamingModule,
 		favouritesModule,
 		blocksModule,
+		userClientModule,
 	}
 
 	for _, m := range apis {

--- a/internal/cliactions/testrig/testrig.go
+++ b/internal/cliactions/testrig/testrig.go
@@ -30,6 +30,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/status"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/streaming"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/timeline"
+	userClient "github.com/superseriousbusiness/gotosocial/internal/api/client/user"
 	"github.com/superseriousbusiness/gotosocial/internal/api/s2s/nodeinfo"
 	"github.com/superseriousbusiness/gotosocial/internal/api/s2s/user"
 	"github.com/superseriousbusiness/gotosocial/internal/api/s2s/webfinger"
@@ -100,6 +101,7 @@ var Start cliactions.GTSAction = func(ctx context.Context, _ *config.Config) err
 	streamingModule := streaming.New(c, processor)
 	favouritesModule := favourites.New(c, processor)
 	blocksModule := blocks.New(c, processor)
+	userClientModule := userClient.New(c, processor)
 
 	apis := []api.ClientModule{
 		// modules with middleware go first
@@ -128,6 +130,7 @@ var Start cliactions.GTSAction = func(ctx context.Context, _ *config.Config) err
 		streamingModule,
 		favouritesModule,
 		blocksModule,
+		userClientModule,
 	}
 
 	for _, m := range apis {


### PR DESCRIPTION
This PR properly initializes the user client module for both the testrig and server commands, fixing a total oversight where we were doing all the legwork for the user module, but not actually attaching it to the router -_-

Addresses #https://github.com/superseriousbusiness/gotosocial/issues/318