### PR TITLE
Fix image description unnecessarily html-escaping innocent characters

### DIFF
--- a/internal/processing/media/create.go
+++ b/internal/processing/media/create.go
@@ -56,7 +56,7 @@ func (p *processor) Create(ctx context.Context, account *gtsmodel.Account, form 
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
 		AccountID:   account.ID,
-		Description: text.RemoveHTML(form.Description),
+		Description: text.SanitizeCaption(form.Description),
 		FileMeta: gtsmodel.FileMeta{
 			Focus: gtsmodel.Focus{
 				X: focusx,

--- a/internal/processing/media/update.go
+++ b/internal/processing/media/update.go
@@ -45,7 +45,7 @@ func (p *processor) Update(ctx context.Context, account *gtsmodel.Account, media
 	}
 
 	if form.Description != nil {
-		attachment.Description = text.RemoveHTML(*form.Description)
+		attachment.Description = text.SanitizeCaption(*form.Description)
 		if err := p.db.UpdateByPrimaryKey(ctx, attachment); err != nil {
 			return nil, gtserror.NewErrorInternalError(fmt.Errorf("database error updating description: %s", err))
 		}

--- a/internal/text/caption.go
+++ b/internal/text/caption.go
@@ -1,0 +1,29 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package text
+
+// SanitizeCaption runs image captions (or indeed any plain text) through basic sanitization.
+// It returns plain text rather than HTML, in contrast to other functions in this package.
+func SanitizeCaption(in string) string {
+	content := preformat(in)
+
+	content = RemoveHTML(content)
+
+	return postformat(content)
+}

--- a/internal/text/caption_test.go
+++ b/internal/text/caption_test.go
@@ -1,0 +1,82 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package text_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/text"
+)
+
+type CaptionTestSuite struct {
+	suite.Suite
+}
+
+func (suite *CaptionTestSuite) TestSanitizeCaption1() {
+	dodgyCaption := "<script>console.log('haha!')</script>this is just a normal caption ;)"
+	sanitized := text.SanitizeCaption(dodgyCaption)
+	suite.Equal("this is just a normal caption ;)", sanitized)
+}
+
+func (suite *CaptionTestSuite) TestSanitizeCaption2() {
+	dodgyCaption := "<em>here's a LOUD caption</em>"
+	sanitized := text.SanitizeCaption(dodgyCaption)
+	suite.Equal("here's a LOUD caption", sanitized)
+}
+
+func (suite *CaptionTestSuite) TestSanitizeCaption3() {
+	dodgyCaption := ""
+	sanitized := text.SanitizeCaption(dodgyCaption)
+	suite.Equal("", sanitized)
+}
+
+func (suite *CaptionTestSuite) TestSanitizeCaption4() {
+	dodgyCaption := `
+
+
+here is
+a multi line
+caption
+with some newlines
+
+
+
+`
+	sanitized := text.SanitizeCaption(dodgyCaption)
+	suite.Equal("here is\na multi line\ncaption\nwith some newlines", sanitized)
+}
+
+func (suite *CaptionTestSuite) TestSanitizeCaption5() {
+	// html-escaped: "<script>console.log('aha!')</script> hello world"
+	dodgyCaption := `&lt;script&gt;console.log(&apos;aha!&apos;)&lt;/script&gt; hello world`
+	sanitized := text.SanitizeCaption(dodgyCaption)
+	suite.Equal("hello world", sanitized)
+}
+
+func (suite *CaptionTestSuite) TestSanitizeCaption6() {
+	// html-encoded: "<script>console.log('aha!')</script> hello world"
+	dodgyCaption := `&lt;&#115;&#99;&#114;&#105;&#112;&#116;&gt;&#99;&#111;&#110;&#115;&#111;&#108;&#101;&period;&#108;&#111;&#103;&lpar;&apos;&#97;&#104;&#97;&excl;&apos;&rpar;&lt;&sol;&#115;&#99;&#114;&#105;&#112;&#116;&gt;&#32;&#104;&#101;&#108;&#108;&#111;&#32;&#119;&#111;&#114;&#108;&#100;`
+	sanitized := text.SanitizeCaption(dodgyCaption)
+	suite.Equal("hello world", sanitized)
+}
+
+func TestCaptionTestSuite(t *testing.T) {
+	suite.Run(t, new(CaptionTestSuite))
+}

--- a/internal/text/common_test.go
+++ b/internal/text/common_test.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
-	"github.com/superseriousbusiness/gotosocial/internal/text"
-	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
 const (
@@ -72,30 +70,6 @@ and linking to my own status: https://localhost:8080/@the_mighty_zork/statuses/0
 
 type CommonTestSuite struct {
 	TextStandardTestSuite
-}
-
-func (suite *CommonTestSuite) SetupSuite() {
-	suite.testTokens = testrig.NewTestTokens()
-	suite.testClients = testrig.NewTestClients()
-	suite.testApplications = testrig.NewTestApplications()
-	suite.testUsers = testrig.NewTestUsers()
-	suite.testAccounts = testrig.NewTestAccounts()
-	suite.testAttachments = testrig.NewTestAttachments()
-	suite.testStatuses = testrig.NewTestStatuses()
-	suite.testTags = testrig.NewTestTags()
-	suite.testMentions = testrig.NewTestMentions()
-}
-
-func (suite *CommonTestSuite) SetupTest() {
-	suite.config = testrig.NewTestConfig()
-	suite.db = testrig.NewTestDB()
-	suite.formatter = text.NewFormatter(suite.config, suite.db)
-
-	testrig.StandardDBSetup(suite.db, nil)
-}
-
-func (suite *CommonTestSuite) TearDownTest() {
-	testrig.StandardDBTeardown(suite.db)
 }
 
 func (suite *CommonTestSuite) TestReplaceMentions() {

--- a/internal/text/formatter_test.go
+++ b/internal/text/formatter_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/text"
+	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
-// nolint
 type TextStandardTestSuite struct {
 	// standard suite interfaces
 	suite.Suite
@@ -46,4 +46,28 @@ type TextStandardTestSuite struct {
 
 	// module being tested
 	formatter text.Formatter
+}
+
+func (suite *TextStandardTestSuite) SetupSuite() {
+	suite.testTokens = testrig.NewTestTokens()
+	suite.testClients = testrig.NewTestClients()
+	suite.testApplications = testrig.NewTestApplications()
+	suite.testUsers = testrig.NewTestUsers()
+	suite.testAccounts = testrig.NewTestAccounts()
+	suite.testAttachments = testrig.NewTestAttachments()
+	suite.testStatuses = testrig.NewTestStatuses()
+	suite.testTags = testrig.NewTestTags()
+	suite.testMentions = testrig.NewTestMentions()
+}
+
+func (suite *TextStandardTestSuite) SetupTest() {
+	suite.config = testrig.NewTestConfig()
+	suite.db = testrig.NewTestDB()
+	suite.formatter = text.NewFormatter(suite.config, suite.db)
+
+	testrig.StandardDBSetup(suite.db, nil)
+}
+
+func (suite *TextStandardTestSuite) TearDownTest() {
+	testrig.StandardDBTeardown(suite.db)
 }

--- a/internal/text/link_test.go
+++ b/internal/text/link_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/gotosocial/internal/text"
-	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
 const text1 = `
@@ -68,29 +67,6 @@ what happens when we already have a link within an href?
 
 type LinkTestSuite struct {
 	TextStandardTestSuite
-}
-
-func (suite *LinkTestSuite) SetupSuite() {
-	suite.testTokens = testrig.NewTestTokens()
-	suite.testClients = testrig.NewTestClients()
-	suite.testApplications = testrig.NewTestApplications()
-	suite.testUsers = testrig.NewTestUsers()
-	suite.testAccounts = testrig.NewTestAccounts()
-	suite.testAttachments = testrig.NewTestAttachments()
-	suite.testStatuses = testrig.NewTestStatuses()
-	suite.testTags = testrig.NewTestTags()
-}
-
-func (suite *LinkTestSuite) SetupTest() {
-	suite.config = testrig.NewTestConfig()
-	suite.db = testrig.NewTestDB()
-	suite.formatter = text.NewFormatter(suite.config, suite.db)
-
-	testrig.StandardDBSetup(suite.db, nil)
-}
-
-func (suite *LinkTestSuite) TearDownTest() {
-	testrig.StandardDBTeardown(suite.db)
 }
 
 func (suite *LinkTestSuite) TestParseSimple() {

--- a/internal/text/markdown_test.go
+++ b/internal/text/markdown_test.go
@@ -25,8 +25,6 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
-	"github.com/superseriousbusiness/gotosocial/internal/text"
-	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
 const (
@@ -65,30 +63,6 @@ that was some JSON :)
 
 type MarkdownTestSuite struct {
 	TextStandardTestSuite
-}
-
-func (suite *MarkdownTestSuite) SetupSuite() {
-	suite.testTokens = testrig.NewTestTokens()
-	suite.testClients = testrig.NewTestClients()
-	suite.testApplications = testrig.NewTestApplications()
-	suite.testUsers = testrig.NewTestUsers()
-	suite.testAccounts = testrig.NewTestAccounts()
-	suite.testAttachments = testrig.NewTestAttachments()
-	suite.testStatuses = testrig.NewTestStatuses()
-	suite.testTags = testrig.NewTestTags()
-	suite.testMentions = testrig.NewTestMentions()
-}
-
-func (suite *MarkdownTestSuite) SetupTest() {
-	suite.config = testrig.NewTestConfig()
-	suite.db = testrig.NewTestDB()
-	suite.formatter = text.NewFormatter(suite.config, suite.db)
-
-	testrig.StandardDBSetup(suite.db, suite.testAccounts)
-}
-
-func (suite *MarkdownTestSuite) TearDownTest() {
-	testrig.StandardDBTeardown(suite.db)
 }
 
 func (suite *MarkdownTestSuite) TestParseSimple() {

--- a/internal/text/plain_test.go
+++ b/internal/text/plain_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
-	"github.com/superseriousbusiness/gotosocial/internal/text"
-	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
 const (
@@ -47,30 +45,6 @@ Text`
 
 type PlainTestSuite struct {
 	TextStandardTestSuite
-}
-
-func (suite *PlainTestSuite) SetupSuite() {
-	suite.testTokens = testrig.NewTestTokens()
-	suite.testClients = testrig.NewTestClients()
-	suite.testApplications = testrig.NewTestApplications()
-	suite.testUsers = testrig.NewTestUsers()
-	suite.testAccounts = testrig.NewTestAccounts()
-	suite.testAttachments = testrig.NewTestAttachments()
-	suite.testStatuses = testrig.NewTestStatuses()
-	suite.testTags = testrig.NewTestTags()
-	suite.testMentions = testrig.NewTestMentions()
-}
-
-func (suite *PlainTestSuite) SetupTest() {
-	suite.config = testrig.NewTestConfig()
-	suite.db = testrig.NewTestDB()
-	suite.formatter = text.NewFormatter(suite.config, suite.db)
-
-	testrig.StandardDBSetup(suite.db, nil)
-}
-
-func (suite *PlainTestSuite) TearDownTest() {
-	testrig.StandardDBTeardown(suite.db)
 }
 
 func (suite *PlainTestSuite) TestParseSimple() {


### PR DESCRIPTION
This PR implements a SanitizeCaption function in the text formatter for processing image descriptions. It's similar to other text-formatting functions in that package, but it doesn't format text into html, it just preformats, unescapes, and postformats.

This resolves an issue where characters like `'` were being HTML-escaped in image captions, which led to weird-looking alt-text.

Closes https://github.com/superseriousbusiness/gotosocial/issues/305