### PR TITLE
Use IPv6 doc prefix for docs

### DIFF
--- a/cmd/gotosocial/generalflags.go
+++ b/cmd/gotosocial/generalflags.go
@@ -64,7 +64,7 @@ func generalFlags(flagNames, envNames config.Flags, defaults config.Defaults) []
 		},
 		&cli.StringFlag{
 			Name:    flagNames.BindAddress,
-			Usage:   "Bind address to use for the GoToSocial server (eg., 0.0.0.0, 172.138.0.9, [::], localhost). For ipv6, enclose the address in square brackets, eg [2a02:1807:1430:500:13f5:5efb:3f3a:1191]. Default binds to all interfaces.",
+			Usage:   "Bind address to use for the GoToSocial server (eg., 0.0.0.0, 172.138.0.9, [::], localhost). For ipv6, enclose the address in square brackets, eg [2001:db8::fed1]. Default binds to all interfaces.",
 			Value:   defaults.BindAddress,
 			EnvVars: []string{envNames.BindAddress},
 		},

--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -53,7 +53,7 @@ protocol: "https"
 # Default value will bind to all interfaces.
 # You probably won't need to change this unless you're setting GoToSocial up in some fancy way or
 # you have specific networking requirements.
-# Examples: ["0.0.0.0", "172.128.0.16", "localhost", "[::]", "[2a02:1807:1430:500:13f5:5efb:3f3a:1191]"]
+# Examples: ["0.0.0.0", "172.128.0.16", "localhost", "[::]", "[2001:db8::fed1]"]
 # Default: "0.0.0.0"
 bindAddress: "0.0.0.0"
 

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -60,7 +60,7 @@ protocol: "https"
 # Default value will bind to all interfaces.
 # You probably won't need to change this unless you're setting GoToSocial up in some fancy way or
 # you have specific networking requirements.
-# Examples: ["0.0.0.0", "172.128.0.16", "localhost", "[::]", "[2a02:1807:1430:500:13f5:5efb:3f3a:1191]"]
+# Examples: ["0.0.0.0", "172.128.0.16", "localhost", "[::]", "[2001:db8::fed1]"]
 # Default: "0.0.0.0"
 bindAddress: "0.0.0.0"
 


### PR DESCRIPTION
IPv6 has a dedicated prefix for documentation and examples, this commit makes use of it for `BindAddress` config flag docs and examples.