### PR TITLE
Add `Accept` header negotiation to relevant API endpoints

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -12,6 +12,24 @@ definitions:
     title: A FileHeader describes a file part of a multipart request.
     type: object
     x-go-package: mime/multipart
+  Link:
+    description: See https://webfinger.net/
+    properties:
+      href:
+        type: string
+        x-go-name: Href
+      rel:
+        type: string
+        x-go-name: Rel
+      template:
+        type: string
+        x-go-name: Template
+      type:
+        type: string
+        x-go-name: Type
+    title: Link represents one 'link' in a slice of links returned from a lookup request.
+    type: object
+    x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
   MIMEHeader:
     additionalProperties:
       items:
@@ -1748,6 +1766,28 @@ definitions:
     type: object
     x-go-name: UpdateSource
     x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+  wellKnownResponse:
+    description: See https://webfinger.net/
+    properties:
+      aliases:
+        items:
+          type: string
+        type: array
+        x-go-name: Aliases
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
+        x-go-name: Links
+      subject:
+        type: string
+        x-go-name: Subject
+    title: |-
+      WellKnownResponse represents the response to either a webfinger request for an 'acct' resource, or a request to nodeinfo.
+      For example, it would be returned from https://example.org/.well-known/webfinger?resource=acct:some_username@example.org
+    type: object
+    x-go-name: WellKnownResponse
+    x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
 host: example.org
 info:
   contact:
@@ -1760,6 +1800,21 @@ info:
   title: GoToSocial
   version: REPLACE_ME
 paths:
+  /.well-known/nodeinfo:
+    get:
+      description: "eg. `{\"links\":[{\"rel\":\"http://nodeinfo.diaspora.software/ns/schema/2.0\",\"href\":\"http://example.org/nodeinfo/2.0\"}]}`
+        \nSee: https://nodeinfo.diaspora.software/protocol.html"
+      operationId: nodeInfoWellKnownGet
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ""
+          schema:
+            $ref: '#/definitions/wellKnownResponse'
+      summary: Directs callers to /nodeinfo/2.0.
+      tags:
+      - nodeinfo
   /api/v1/accounts:
     post:
       consumes:
@@ -3609,18 +3664,16 @@ paths:
       - user
   /nodeinfo/2.0:
     get:
-      operationId: accountGet
+      description: 'See: https://nodeinfo.diaspora.software/schema.html'
+      operationId: nodeInfoGet
       produces:
-      - application/json
+      - application/json; profile="http://nodeinfo.diaspora.software/ns/schema/2.0#"
       responses:
         "200":
           description: ""
           schema:
             $ref: '#/definitions/nodeinfo'
-      security:
-      - OAuth2 Bearer:
-        - read:accounts
-      summary: 'Returns a compliant nodeinfo response to node info queries. See: https://nodeinfo.diaspora.software/.'
+      summary: Returns a compliant nodeinfo response to node info queries.
       tags:
       - nodeinfo
   /users/{username}/outbox:

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -1798,7 +1798,7 @@ info:
     name: AGPL3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: GoToSocial
-  version: REPLACE_ME
+  version: 0.0.1
 paths:
   /.well-known/nodeinfo:
     get:
@@ -1818,9 +1818,14 @@ paths:
       - nodeinfo
   /.well-known/webfinger:
     get:
-      description: "For example, a GET to `https://goblin.technology/.well-known/webfinger?resource=acct:tobi@goblin.technology`
-        would return: \n\n```\n{\"subject\":\"acct:tobi@goblin.technology\",\"aliases\":[\"https://goblin.technology/users/tobi\",\"https://goblin.technology/@tobi\"],\"links\":[{\"rel\":\"http://webfinger.net/rel/profile-page\",\"type\":\"text/html\",\"href\":\"https://goblin.technology/@tobi\"},{\"rel\":\"self\",\"type\":\"application/activity+json\",\"href\":\"https://goblin.technology/users/tobi\"}]}\n```\n\nSee:
-        https://webfinger.net/"
+      description: |-
+        For example, a GET to `https://goblin.technology/.well-known/webfinger?resource=acct:tobi@goblin.technology` would return:
+
+        ```
+        {"subject":"acct:tobi@goblin.technology","aliases":["https://goblin.technology/users/tobi","https://goblin.technology/@tobi"],"links":[{"rel":"http://webfinger.net/rel/profile-page","type":"text/html","href":"https://goblin.technology/@tobi"},{"rel":"self","type":"application/activity+json","href":"https://goblin.technology/users/tobi"}]}
+        ```
+
+        See: https://webfinger.net/
       operationId: webfingerGet
       produces:
       - application/json

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -1802,8 +1802,9 @@ info:
 paths:
   /.well-known/nodeinfo:
     get:
-      description: "eg. `{\"links\":[{\"rel\":\"http://nodeinfo.diaspora.software/ns/schema/2.0\",\"href\":\"http://example.org/nodeinfo/2.0\"}]}`
-        \nSee: https://nodeinfo.diaspora.software/protocol.html"
+      description: |-
+        eg. `{"links":[{"rel":"http://nodeinfo.diaspora.software/ns/schema/2.0","href":"http://example.org/nodeinfo/2.0"}]}`
+        See: https://nodeinfo.diaspora.software/protocol.html
       operationId: nodeInfoWellKnownGet
       produces:
       - application/json
@@ -1815,6 +1816,22 @@ paths:
       summary: Directs callers to /nodeinfo/2.0.
       tags:
       - nodeinfo
+  /.well-known/webfinger:
+    get:
+      description: "For example, a GET to `https://goblin.technology/.well-known/webfinger?resource=acct:tobi@goblin.technology`
+        would return: \n\n```\n{\"subject\":\"acct:tobi@goblin.technology\",\"aliases\":[\"https://goblin.technology/users/tobi\",\"https://goblin.technology/@tobi\"],\"links\":[{\"rel\":\"http://webfinger.net/rel/profile-page\",\"type\":\"text/html\",\"href\":\"https://goblin.technology/@tobi\"},{\"rel\":\"self\",\"type\":\"application/activity+json\",\"href\":\"https://goblin.technology/users/tobi\"}]}\n```\n\nSee:
+        https://webfinger.net/"
+      operationId: webfingerGet
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ""
+          schema:
+            $ref: '#/definitions/wellKnownResponse'
+      summary: Handles webfinger account lookup requests.
+      tags:
+      - webfinger
   /api/v1/accounts:
     post:
       consumes:

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -49,6 +49,48 @@ definitions:
     title: Mention represents a mention of another account.
     type: object
     x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+  NodeInfoServices:
+    properties:
+      inbound:
+        items:
+          type: string
+        type: array
+        x-go-name: Inbound
+      outbound:
+        items:
+          type: string
+        type: array
+        x-go-name: Outbound
+    title: NodeInfoServices represents inbound and outbound services that this node
+      offers connections to.
+    type: object
+    x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+  NodeInfoSoftware:
+    properties:
+      name:
+        example: gotosocial
+        type: string
+        x-go-name: Name
+      version:
+        example: 0.1.2 1234567
+        type: string
+        x-go-name: Version
+    title: NodeInfoSoftware represents the name and version number of the software
+      of this node.
+    type: object
+    x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+  NodeInfoUsage:
+    properties:
+      users:
+        $ref: '#/definitions/NodeInfoUsers'
+    title: NodeInfoUsage represents usage information about this server, such as number
+      of users.
+    type: object
+    x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+  NodeInfoUsers:
+    title: NodeInfoUsers is a stub for usage information, currently empty.
+    type: object
+    x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
   Source:
     description: Returned as an additional entity when verifying and updated credentials,
       as an attribute of Account.
@@ -1122,6 +1164,42 @@ definitions:
     type: object
     x-go-name: MediaMeta
     x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+  nodeinfo:
+    description: 'See: https://nodeinfo.diaspora.software/schema.html'
+    properties:
+      metadata:
+        additionalProperties:
+          type: object
+        description: Free form key value pairs for software specific values. Clients
+          should not rely on any specific key present.
+        type: object
+        x-go-name: Metadata
+      openRegistrations:
+        description: Whether this server allows open self-registration.
+        example: false
+        type: boolean
+        x-go-name: OpenRegistrations
+      protocols:
+        description: The protocols supported on this server.
+        items:
+          type: string
+        type: array
+        x-go-name: Protocols
+      services:
+        $ref: '#/definitions/NodeInfoServices'
+      software:
+        $ref: '#/definitions/NodeInfoSoftware'
+      usage:
+        $ref: '#/definitions/NodeInfoUsage'
+      version:
+        description: The schema version
+        example: "2.0"
+        type: string
+        x-go-name: Version
+    title: Nodeinfo represents a version 2.1 or version 2.0 nodeinfo schema.
+    type: object
+    x-go-name: Nodeinfo
+    x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
   oauthToken:
     properties:
       access_token:
@@ -1680,7 +1758,7 @@ info:
     name: AGPL3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html
   title: GoToSocial
-  version: 0.0.1
+  version: REPLACE_ME
 paths:
   /api/v1/accounts:
     post:
@@ -3529,6 +3607,22 @@ paths:
       summary: Change the password of authenticated user.
       tags:
       - user
+  /nodeinfo/2.0:
+    get:
+      operationId: accountGet
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ""
+          schema:
+            $ref: '#/definitions/nodeinfo'
+      security:
+      - OAuth2 Bearer:
+        - read:accounts
+      summary: 'Returns a compliant nodeinfo response to node info queries. See: https://nodeinfo.diaspora.software/.'
+      tags:
+      - nodeinfo
   /users/{username}/outbox:
     get:
       description: |-

--- a/internal/api/client/account/account_test.go
+++ b/internal/api/client/account/account_test.go
@@ -95,5 +95,7 @@ func (suite *AccountStandardTestSuite) newContext(recorder *httptest.ResponseRec
 		ctx.Request.Header.Set("Content-Type", bodyContentType)
 	}
 
+	ctx.Request.Header.Set("accept", "application/json")
+
 	return ctx
 }

--- a/internal/api/client/account/accountcreate.go
+++ b/internal/api/client/account/accountcreate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
@@ -75,6 +76,11 @@ func (m *Module) AccountCreatePOSTHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("couldn't auth: %s", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/account/accountget.go
+++ b/internal/api/client/account/accountget.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -61,6 +62,11 @@ func (m *Module) AccountGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/account/accountupdate.go
+++ b/internal/api/client/account/accountupdate.go
@@ -20,11 +20,13 @@ package account
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"strconv"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
@@ -109,6 +111,11 @@ func (m *Module) AccountUpdateCredentialsPATCHHandler(c *gin.Context) {
 		return
 	}
 	l.Tracef("retrieved account %+v", authed.Account.ID)
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
+		return
+	}
 
 	form, err := parseUpdateAccountForm(c)
 	if err != nil {

--- a/internal/api/client/account/accountverify.go
+++ b/internal/api/client/account/accountverify.go
@@ -19,10 +19,12 @@
 package account
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -57,6 +59,11 @@ func (m *Module) AccountVerifyGETHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("couldn't auth: %s", err)
 		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/account/block.go
+++ b/internal/api/client/account/block.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -63,6 +64,11 @@ func (m *Module) AccountBlockPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/account/follow.go
+++ b/internal/api/client/account/follow.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
@@ -84,6 +85,11 @@ func (m *Module) AccountFollowPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/account/followers.go
+++ b/internal/api/client/account/followers.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -65,6 +66,11 @@ func (m *Module) AccountFollowersGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/account/following.go
+++ b/internal/api/client/account/following.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -65,6 +66,11 @@ func (m *Module) AccountFollowingGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/account/relationships.go
+++ b/internal/api/client/account/relationships.go
@@ -1,10 +1,12 @@
 package account
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
@@ -54,6 +56,11 @@ func (m *Module) AccountRelationshipsGETHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("error authing: %s", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/account/statuses.go
+++ b/internal/api/client/account/statuses.go
@@ -19,11 +19,13 @@
 package account
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"strconv"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -115,6 +117,11 @@ func (m *Module) AccountStatusesGETHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("error authing: %s", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/account/unblock.go
+++ b/internal/api/client/account/unblock.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -63,6 +64,11 @@ func (m *Module) AccountUnblockPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/account/unfollow.go
+++ b/internal/api/client/account/unfollow.go
@@ -19,10 +19,12 @@
 package account
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -66,6 +68,11 @@ func (m *Module) AccountUnfollowPOSTHandler(c *gin.Context) {
 	if err != nil {
 		l.Debug(err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/admin/domainblockcreate.go
+++ b/internal/api/client/admin/domainblockcreate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
@@ -107,6 +108,11 @@ func (m *Module) DomainBlocksPOSTHandler(c *gin.Context) {
 	if !authed.User.Admin {
 		l.Debugf("user %s not an admin", authed.User.ID)
 		c.JSON(http.StatusForbidden, gin.H{"error": "not an admin"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/admin/domainblockdelete.go
+++ b/internal/api/client/admin/domainblockdelete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -59,6 +60,11 @@ func (m *Module) DomainBlockDELETEHandler(c *gin.Context) {
 	if !authed.User.Admin {
 		l.Debugf("user %s not an admin", authed.User.ID)
 		c.JSON(http.StatusForbidden, gin.H{"error": "not an admin"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/admin/domainblockget.go
+++ b/internal/api/client/admin/domainblockget.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -60,6 +61,11 @@ func (m *Module) DomainBlockGETHandler(c *gin.Context) {
 	if !authed.User.Admin {
 		l.Debugf("user %s not an admin", authed.User.ID)
 		c.JSON(http.StatusForbidden, gin.H{"error": "not an admin"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/admin/domainblocksget.go
+++ b/internal/api/client/admin/domainblocksget.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -66,6 +67,11 @@ func (m *Module) DomainBlocksGETHandler(c *gin.Context) {
 	if !authed.User.Admin {
 		l.Debugf("user %s not an admin", authed.User.ID)
 		c.JSON(http.StatusForbidden, gin.H{"error": "not an admin"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/admin/emojicreate.go
+++ b/internal/api/client/admin/emojicreate.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/media"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
@@ -91,6 +92,11 @@ func (m *Module) emojiCreatePOSTHandler(c *gin.Context) {
 	if !authed.User.Admin {
 		l.Debugf("user %s not an admin", authed.User.ID)
 		c.JSON(http.StatusForbidden, gin.H{"error": "not an admin"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/app/appcreate.go
+++ b/internal/api/client/app/appcreate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
@@ -78,6 +79,11 @@ func (m *Module) AppsPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, false, false, false, false)
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/auth/authorize.go
+++ b/internal/api/client/auth/authorize.go
@@ -21,14 +21,16 @@ package auth
 import (
 	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
@@ -40,6 +42,11 @@ import (
 func (m *Module) AuthorizeGETHandler(c *gin.Context) {
 	l := logrus.WithField("func", "AuthorizeGETHandler")
 	s := sessions.Default(c)
+
+	if _, err := api.NegotiateAccept(c, api.HTMLAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
+		return
+	}
 
 	// UserID will be set in the session by AuthorizePOSTHandler if the caller has already gone through the authentication flow
 	// If it's not set, then we don't know yet who the user is, so we need to redirect them to the sign in page.

--- a/internal/api/client/auth/signin.go
+++ b/internal/api/client/auth/signin.go
@@ -21,11 +21,13 @@ package auth
 import (
 	"context"
 	"errors"
-	"github.com/sirupsen/logrus"
 	"net/http"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"golang.org/x/crypto/bcrypt"
@@ -43,6 +45,12 @@ type login struct {
 func (m *Module) SignInGETHandler(c *gin.Context) {
 	l := logrus.WithField("func", "SignInGETHandler")
 	l.Trace("entering sign in handler")
+
+	if _, err := api.NegotiateAccept(c, api.HTMLAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
+		return
+	}
+
 	if m.idp != nil {
 		s := sessions.Default(c)
 

--- a/internal/api/client/auth/token.go
+++ b/internal/api/client/auth/token.go
@@ -19,9 +19,11 @@
 package auth
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
+
+	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 
 	"github.com/gin-gonic/gin"
 )
@@ -40,6 +42,11 @@ type tokenBody struct {
 func (m *Module) TokenPOSTHandler(c *gin.Context) {
 	l := logrus.WithField("func", "TokenPOSTHandler")
 	l.Trace("entered TokenPOSTHandler")
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
+		return
+	}
 
 	form := &tokenBody{}
 	if err := c.ShouldBind(form); err == nil {

--- a/internal/api/client/blocks/blocksget.go
+++ b/internal/api/client/blocks/blocksget.go
@@ -19,11 +19,13 @@
 package blocks
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"strconv"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -91,6 +93,11 @@ func (m *Module) BlocksGETHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("error authing: %s", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/emoji/emojisget.go
+++ b/internal/api/client/emoji/emojisget.go
@@ -4,9 +4,15 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 )
 
 // EmojisGETHandler returns a list of custom emojis enabled on the instance
 func (m *Module) EmojisGETHandler(c *gin.Context) {
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
+		return
+	}
+
 	c.JSON(http.StatusOK, []string{})
 }

--- a/internal/api/client/favourites/favouritesget.go
+++ b/internal/api/client/favourites/favouritesget.go
@@ -1,11 +1,13 @@
 package favourites
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"strconv"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -17,6 +19,11 @@ func (m *Module) FavouritesGETHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("error authing: %s", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/fileserver/servefile_test.go
+++ b/internal/api/client/fileserver/servefile_test.go
@@ -123,6 +123,7 @@ func (suite *ServeFileTestSuite) TestServeOriginalFileSuccessful() {
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 	ctx.Request = httptest.NewRequest(http.MethodGet, targetAttachment.URL, nil)
+	ctx.Request.Header.Set("accept", "*/*")
 
 	// normally the router would populate these params from the path values,
 	// but because we're calling the ServeFile function directly, we need to set them manually.

--- a/internal/api/client/filter/filtersget.go
+++ b/internal/api/client/filter/filtersget.go
@@ -4,9 +4,15 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 )
 
 // FiltersGETHandler returns a list of filters set by/for the authed account
 func (m *Module) FiltersGETHandler(c *gin.Context) {
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
+		return
+	}
+
 	c.JSON(http.StatusOK, []string{})
 }

--- a/internal/api/client/followrequest/authorize.go
+++ b/internal/api/client/followrequest/authorize.go
@@ -19,10 +19,12 @@
 package followrequest
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -73,6 +75,11 @@ func (m *Module) FollowRequestAuthorizePOSTHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("couldn't auth: %s", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/followrequest/followrequest_test.go
+++ b/internal/api/client/followrequest/followrequest_test.go
@@ -106,6 +106,7 @@ func (suite *FollowRequestStandardTestSuite) newContext(recorder *httptest.Respo
 	if bodyContentType != "" {
 		ctx.Request.Header.Set("Content-Type", bodyContentType)
 	}
+	ctx.Request.Header.Set("accept", "application/json")
 
 	return ctx
 }

--- a/internal/api/client/followrequest/get.go
+++ b/internal/api/client/followrequest/get.go
@@ -19,10 +19,12 @@
 package followrequest
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -80,6 +82,11 @@ func (m *Module) FollowRequestGETHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("couldn't auth: %s", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/followrequest/reject.go
+++ b/internal/api/client/followrequest/reject.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -71,6 +72,11 @@ func (m *Module) FollowRequestRejectPOSTHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("couldn't auth: %s", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/instance/instanceget.go
+++ b/internal/api/client/instance/instanceget.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 
 	"github.com/gin-gonic/gin"
@@ -34,6 +35,11 @@ import (
 //      description: internal error
 func (m *Module) InstanceInformationGETHandler(c *gin.Context) {
 	l := logrus.WithField("func", "InstanceInformationGETHandler")
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
+		return
+	}
 
 	host := viper.GetString(config.Keys.Host)
 

--- a/internal/api/client/instance/instancepatch.go
+++ b/internal/api/client/instance/instancepatch.go
@@ -1,10 +1,12 @@
 package instance
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
@@ -90,6 +92,11 @@ func (m *Module) InstanceUpdatePATCHHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("couldn't auth: %s", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/list/listsgets.go
+++ b/internal/api/client/list/listsgets.go
@@ -4,9 +4,15 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 )
 
 // ListsGETHandler returns a list of lists created by/for the authed account
 func (m *Module) ListsGETHandler(c *gin.Context) {
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
+		return
+	}
+
 	c.JSON(http.StatusOK, []string{})
 }

--- a/internal/api/client/media/mediacreate.go
+++ b/internal/api/client/media/mediacreate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
@@ -90,6 +91,11 @@ func (m *Module) MediaCreatePOSTHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("couldn't auth: %s", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/media/mediacreate_test.go
+++ b/internal/api/client/media/mediacreate_test.go
@@ -149,6 +149,7 @@ func (suite *MediaCreateTestSuite) TestStatusCreatePOSTImageHandlerSuccessful() 
 	}
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", mediamodule.BasePath), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
 	ctx.Request.Header.Set("Content-Type", w.FormDataContentType())
+	ctx.Request.Header.Set("accept", "application/json")
 
 	// do the actual request
 	suite.mediaModule.MediaCreatePOSTHandler(ctx)

--- a/internal/api/client/media/mediaget.go
+++ b/internal/api/client/media/mediaget.go
@@ -19,10 +19,12 @@
 package media
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -67,6 +69,11 @@ func (m *Module) MediaGETHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("couldn't auth: %s", err)
 		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/media/mediaupdate.go
+++ b/internal/api/client/media/mediaupdate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
@@ -99,6 +100,11 @@ func (m *Module) MediaPUTHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("couldn't auth: %s", err)
 		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/notification/notificationsget.go
+++ b/internal/api/client/notification/notificationsget.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -41,6 +42,11 @@ func (m *Module) NotificationsGETHandler(c *gin.Context) {
 	if err != nil {
 		l.Errorf("error authing status faved by request: %s", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "not authed"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/search/searchget.go
+++ b/internal/api/client/search/searchget.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
@@ -68,6 +69,11 @@ func (m *Module) SearchGETHandler(c *gin.Context) {
 	if err != nil {
 		l.Errorf("error authing search request: %s", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "not authed"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/status/statusboost.go
+++ b/internal/api/client/status/statusboost.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -74,10 +75,15 @@ func (m *Module) StatusBoostPOSTHandler(c *gin.Context) {
 	})
 	l.Debugf("entering function")
 
-	authed, err := oauth.Authed(c, true, false, true, true) // we don't really need an app here but we want everything else
+	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
 		l.Debug("not authed so can't boost status")
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "not authorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/status/statusboost_test.go
+++ b/internal/api/client/status/statusboost_test.go
@@ -51,6 +51,7 @@ func (suite *StatusBoostTestSuite) TestPostBoost() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080%s", strings.Replace(status.ReblogPath, ":id", targetStatus.ID, 1)), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 
 	// normally the router would populate these params from the path values,
 	// but because we're calling the function directly, we need to set them manually.
@@ -117,6 +118,7 @@ func (suite *StatusBoostTestSuite) TestPostUnboostable() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080%s", strings.Replace(status.ReblogPath, ":id", targetStatus.ID, 1)), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 
 	// normally the router would populate these params from the path values,
 	// but because we're calling the function directly, we need to set them manually.
@@ -155,6 +157,7 @@ func (suite *StatusBoostTestSuite) TestPostNotVisible() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_2"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_2"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080%s", strings.Replace(status.ReblogPath, ":id", targetStatus.ID, 1)), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 
 	// normally the router would populate these params from the path values,
 	// but because we're calling the function directly, we need to set them manually.

--- a/internal/api/client/status/statuscontext.go
+++ b/internal/api/client/status/statuscontext.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -77,6 +78,11 @@ func (m *Module) StatusContextGETHandler(c *gin.Context) {
 	if err != nil {
 		l.Errorf("error authing status context request: %s", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "not authed"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/status/statuscreate.go
+++ b/internal/api/client/status/statuscreate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
@@ -71,10 +72,15 @@ import (
 //      description: internal error
 func (m *Module) StatusCreatePOSTHandler(c *gin.Context) {
 	l := logrus.WithField("func", "statusCreatePOSTHandler")
-	authed, err := oauth.Authed(c, true, true, true, true) // posting a status is serious business so we want *everything*
+	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
 		l.Debugf("couldn't auth: %s", err)
 		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/status/statuscreate_test.go
+++ b/internal/api/client/status/statuscreate_test.go
@@ -65,6 +65,7 @@ func (suite *StatusCreateTestSuite) TestPostNewStatus() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", status.BasePath), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Request.Form = url.Values{
 		"status":       {"this is a brand new status! #helloworld"},
 		"spoiler_text": {"hello hello"},
@@ -119,6 +120,7 @@ func (suite *StatusCreateTestSuite) TestPostAnotherNewStatus() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", status.BasePath), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Request.Form = url.Values{
 		"status": {statusWithLinksAndTags},
 	}
@@ -154,6 +156,7 @@ func (suite *StatusCreateTestSuite) TestPostNewStatusWithEmoji() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", status.BasePath), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Request.Form = url.Values{
 		"status": {"here is a rainbow emoji a few times! :rainbow: :rainbow: :rainbow: \n here's an emoji that isn't in the db: :test_emoji: "},
 	}
@@ -195,6 +198,7 @@ func (suite *StatusCreateTestSuite) TestReplyToNonexistentStatus() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", status.BasePath), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Request.Form = url.Values{
 		"status":         {"this is a reply to a status that doesn't exist"},
 		"spoiler_text":   {"don't open cuz it won't work"},
@@ -226,6 +230,7 @@ func (suite *StatusCreateTestSuite) TestReplyToLocalStatus() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", status.BasePath), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Request.Form = url.Values{
 		"status":         {fmt.Sprintf("hello @%s this reply should work!", testrig.NewTestAccounts()["local_account_2"].Username)},
 		"in_reply_to_id": {testrig.NewTestStatuses()["local_account_2_status_1"].ID},
@@ -268,6 +273,7 @@ func (suite *StatusCreateTestSuite) TestAttachNewMediaSuccess() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", status.BasePath), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Request.Form = url.Values{
 		"status":    {"here's an image attachment"},
 		"media_ids": {attachment.ID},

--- a/internal/api/client/status/statusdelete.go
+++ b/internal/api/client/status/statusdelete.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -73,10 +74,15 @@ func (m *Module) StatusDELETEHandler(c *gin.Context) {
 	})
 	l.Debugf("entering function")
 
-	authed, err := oauth.Authed(c, true, false, true, true) // we don't really need an app here but we want everything else
+	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
 		l.Debug("not authed so can't delete status")
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "not authorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/status/statusfave.go
+++ b/internal/api/client/status/statusfave.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -70,10 +71,15 @@ func (m *Module) StatusFavePOSTHandler(c *gin.Context) {
 	})
 	l.Debugf("entering function")
 
-	authed, err := oauth.Authed(c, true, false, true, true) // we don't really need an app here but we want everything else
+	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
 		l.Debug("not authed so can't fave status")
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "not authorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/status/statusfave_test.go
+++ b/internal/api/client/status/statusfave_test.go
@@ -55,6 +55,7 @@ func (suite *StatusFaveTestSuite) TestPostFave() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080%s", strings.Replace(status.FavouritePath, ":id", targetStatus.ID, 1)), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 
 	// normally the router would populate these params from the path values,
 	// but because we're calling the function directly, we need to set them manually.
@@ -103,6 +104,7 @@ func (suite *StatusFaveTestSuite) TestPostUnfaveable() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080%s", strings.Replace(status.FavouritePath, ":id", targetStatus.ID, 1)), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 
 	// normally the router would populate these params from the path values,
 	// but because we're calling the function directly, we need to set them manually.

--- a/internal/api/client/status/statusfavedby.go
+++ b/internal/api/client/status/statusfavedby.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -71,10 +72,15 @@ func (m *Module) StatusFavedByGETHandler(c *gin.Context) {
 	})
 	l.Debugf("entering function")
 
-	authed, err := oauth.Authed(c, false, false, false, false) // we don't really need an app here but we want everything else
+	authed, err := oauth.Authed(c, true, true, true, true) // we don't really need an app here but we want everything else
 	if err != nil {
 		l.Errorf("error authing status faved by request: %s", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "not authed"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/status/statusfavedby_test.go
+++ b/internal/api/client/status/statusfavedby_test.go
@@ -53,6 +53,7 @@ func (suite *StatusFavedByTestSuite) TestGetFavedBy() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_2"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_2"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080%s", strings.Replace(status.FavouritedPath, ":id", targetStatus.ID, 1)), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 
 	// normally the router would populate these params from the path values,
 	// but because we're calling the function directly, we need to set them manually.

--- a/internal/api/client/status/statusget.go
+++ b/internal/api/client/status/statusget.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -70,10 +71,15 @@ func (m *Module) StatusGETHandler(c *gin.Context) {
 	})
 	l.Debugf("entering function")
 
-	authed, err := oauth.Authed(c, false, false, false, false) // we don't really need an app here but we want everything else
+	authed, err := oauth.Authed(c, false, false, false, false)
 	if err != nil {
 		l.Errorf("error authing status faved by request: %s", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "not authed"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/status/statusunboost.go
+++ b/internal/api/client/status/statusunboost.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -71,10 +72,15 @@ func (m *Module) StatusUnboostPOSTHandler(c *gin.Context) {
 	})
 	l.Debugf("entering function")
 
-	authed, err := oauth.Authed(c, true, false, true, true) // we don't really need an app here but we want everything else
+	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
 		l.Debug("not authed so can't unboost status")
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "not authorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/status/statusunfave.go
+++ b/internal/api/client/status/statusunfave.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -70,10 +71,15 @@ func (m *Module) StatusUnfavePOSTHandler(c *gin.Context) {
 	})
 	l.Debugf("entering function")
 
-	authed, err := oauth.Authed(c, true, false, true, true) // we don't really need an app here but we want everything else
+	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
 		l.Debug("not authed so can't unfave status")
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "not authorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/status/statusunfave_test.go
+++ b/internal/api/client/status/statusunfave_test.go
@@ -56,6 +56,7 @@ func (suite *StatusUnfaveTestSuite) TestPostUnfave() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080%s", strings.Replace(status.UnfavouritePath, ":id", targetStatus.ID, 1)), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 
 	// normally the router would populate these params from the path values,
 	// but because we're calling the function directly, we need to set them manually.
@@ -105,6 +106,7 @@ func (suite *StatusUnfaveTestSuite) TestPostAlreadyNotFaved() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080%s", strings.Replace(status.UnfavouritePath, ":id", targetStatus.ID, 1)), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 
 	// normally the router would populate these params from the path values,
 	// but because we're calling the function directly, we need to set them manually.

--- a/internal/api/client/timeline/home.go
+++ b/internal/api/client/timeline/home.go
@@ -19,11 +19,13 @@
 package timeline
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"strconv"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -109,6 +111,11 @@ func (m *Module) HomeTimelineGETHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("error authing: %s", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/timeline/public.go
+++ b/internal/api/client/timeline/public.go
@@ -19,11 +19,13 @@
 package timeline
 
 import (
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"strconv"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
@@ -109,6 +111,11 @@ func (m *Module) PublicTimelineGETHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("error authing: %s", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/user/passwordchange.go
+++ b/internal/api/client/user/passwordchange.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
@@ -68,6 +69,11 @@ func (m *Module) PasswordChangePOSTHandler(c *gin.Context) {
 	if err != nil {
 		l.Debugf("error authing: %s", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/api/client/user/passwordchange_test.go
+++ b/internal/api/client/user/passwordchange_test.go
@@ -50,6 +50,7 @@ func (suite *PasswordChangeTestSuite) TestPasswordChangePOST() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", user.PasswordChangePath), nil)
+	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Request.Form = url.Values{
 		"old_password": {"password"},
 		"new_password": {"peepeepoopoopassword"},
@@ -83,6 +84,7 @@ func (suite *PasswordChangeTestSuite) TestPasswordMissingOldPassword() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", user.PasswordChangePath), nil)
+	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Request.Form = url.Values{
 		"new_password": {"peepeepoopoopassword"},
 	}
@@ -109,6 +111,7 @@ func (suite *PasswordChangeTestSuite) TestPasswordIncorrectOldPassword() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", user.PasswordChangePath), nil)
+	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Request.Form = url.Values{
 		"old_password": {"notright"},
 		"new_password": {"peepeepoopoopassword"},
@@ -136,6 +139,7 @@ func (suite *PasswordChangeTestSuite) TestPasswordWeakNewPassword() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", user.PasswordChangePath), nil)
+	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Request.Form = url.Values{
 		"old_password": {"password"},
 		"new_password": {"peepeepoopoo"},

--- a/internal/api/model/content.go
+++ b/internal/api/model/content.go
@@ -20,6 +20,9 @@ package model
 
 // Content wraps everything needed to serve a blob of content (some kind of media) through the API.
 type Content struct {
+	// Attachment is the attachment that owns this content.
+	// Can be null when the content is an emoji or something that's not got an attachment.
+	Attachment *Attachment
 	// MIME content type
 	ContentType string
 	// ContentLength in bytes

--- a/internal/api/model/content.go
+++ b/internal/api/model/content.go
@@ -20,9 +20,6 @@ package model
 
 // Content wraps everything needed to serve a blob of content (some kind of media) through the API.
 type Content struct {
-	// Attachment is the attachment that owns this content.
-	// Can be null when the content is an emoji or something that's not got an attachment.
-	Attachment *Attachment
 	// MIME content type
 	ContentType string
 	// ContentLength in bytes

--- a/internal/api/model/well-known.go
+++ b/internal/api/model/well-known.go
@@ -22,6 +22,8 @@ package model
 // For example, it would be returned from https://example.org/.well-known/webfinger?resource=acct:some_username@example.org
 //
 // See https://webfinger.net/
+//
+// swagger:model wellKnownResponse
 type WellKnownResponse struct {
 	Subject string   `json:"subject,omitempty"`
 	Aliases []string `json:"aliases,omitempty"`
@@ -40,8 +42,11 @@ type Link struct {
 
 // Nodeinfo represents a version 2.1 or version 2.0 nodeinfo schema.
 // See: https://nodeinfo.diaspora.software/schema.html
+//
+// swagger:model nodeinfo
 type Nodeinfo struct {
 	// The schema version
+	// example: 2.0
 	Version string `json:"version"`
 	// Metadata about server software in use.
 	Software NodeInfoSoftware `json:"software"`
@@ -50,6 +55,7 @@ type Nodeinfo struct {
 	// The third party sites this server can connect to via their application API.
 	Services NodeInfoServices `json:"services"`
 	// Whether this server allows open self-registration.
+	// example: false
 	OpenRegistrations bool `json:"openRegistrations"`
 	// Usage statistics for this server.
 	Usage NodeInfoUsage `json:"usage"`
@@ -59,7 +65,9 @@ type Nodeinfo struct {
 
 // NodeInfoSoftware represents the name and version number of the software of this node.
 type NodeInfoSoftware struct {
+	// example: gotosocial
 	Name    string `json:"name"`
+	// example: 0.1.2 1234567
 	Version string `json:"version"`
 }
 

--- a/internal/api/model/well-known.go
+++ b/internal/api/model/well-known.go
@@ -66,7 +66,7 @@ type Nodeinfo struct {
 // NodeInfoSoftware represents the name and version number of the software of this node.
 type NodeInfoSoftware struct {
 	// example: gotosocial
-	Name    string `json:"name"`
+	Name string `json:"name"`
 	// example: 0.1.2 1234567
 	Version string `json:"version"`
 }

--- a/internal/api/negotiate.go
+++ b/internal/api/negotiate.go
@@ -10,27 +10,27 @@ import (
 type offer string
 
 const (
-	appJSONCharSet    offer = `application/json; charset="utf-8"`
-	appActivityJSON   offer = `application/activity+json`
-	appActivityLDJSON offer = `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`
-	textHTMLCharSet   offer = `text/html; charset="utf-8"`
+	AppJSON           offer = `application/json`                                                     // AppJSON is the mime type for 'application/json'.
+	AppActivityJSON   offer = `application/activity+json`                                            // AppActivityJSON is the mime type for 'application/activity+json'.
+	AppActivityLDJSON offer = `application/ld+json; profile="https://www.w3.org/ns/activitystreams"` // AppActivityLDJSON is the mime type for 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+	TextHTML          offer = `text/html`                                                            // TextHTML is the mime type for 'text/html'.
 )
 
 // ActivityPubAcceptHeaders represents the Accept headers mentioned here:
 // https://www.w3.org/TR/activitypub/#retrieving-objects
 var ActivityPubAcceptHeaders = []offer{
-	appActivityJSON,
-	appActivityLDJSON,
+	AppActivityJSON,
+	AppActivityLDJSON,
 }
 
 // JSONAcceptHeaders is a slice of offers that just contains application/json types.
 var JSONAcceptHeaders = []offer{
-	appJSONCharSet,
+	AppJSON,
 }
 
 // HTMLAcceptHeaders is a slice of offers that just contains text/html types.
 var HTMLAcceptHeaders = []offer{
-	textHTMLCharSet,
+	TextHTML,
 }
 
 // NegotiateAccept takes the *gin.Context from an incoming request, and a
@@ -52,8 +52,8 @@ var HTMLAcceptHeaders = []offer{
 // Callers can use the offer slices exported in this package as shortcuts for
 // often-used Accept types.
 //
-// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation
-func NegotiateAccept(c *gin.Context, offers []offer) (string, error) {
+// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation#server-driven_content_negotiation
+func NegotiateAccept(c *gin.Context, offers ...offer) (string, error) {
 	if len(offers) == 0 {
 		return "", errors.New("no format offered")
 	}

--- a/internal/api/negotiate.go
+++ b/internal/api/negotiate.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+)
+
+type Offer string
+
+const (
+	OfferAppJSON         Offer = `application/json`
+	OfferAppActivityJson Offer = `application/activity+json`
+	OfferAppLDJson       Offer = `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`
+)
+
+// ActivityPubAcceptHeaders represents the Accept headers mentioned here:
+// https://www.w3.org/TR/activitypub/#retrieving-objects
+var ActivityPubAcceptHeaders = []Offer{
+	OfferAppActivityJson,
+	OfferAppLDJson,
+}
+
+func NegotiateAccept(c *gin.Context, offers []Offer) (string, error) {
+	if len(offers) == 0 {
+		return "", errors.New("no format offered")
+	}
+
+	accepts := c.Request.Header.Values("Accept")
+	if len(accepts) == 0 {
+		return "", errors.New("no Accept header(s) set on incoming request")
+	}
+
+	strings := []string{}
+	for _, o := range offers {
+		strings = append(strings, string(o))
+	}
+
+	format := c.NegotiateFormat(strings...)
+	if format == "" {
+		return "", fmt.Errorf("no format can be offered for Accept header(s) %s; we offered %s", accepts, offers)
+	}
+
+	return format, nil
+}

--- a/internal/api/negotiate.go
+++ b/internal/api/negotiate.go
@@ -7,29 +7,60 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type Offer string
+type offer string
 
 const (
-	OfferAppJSON         Offer = `application/json`
-	OfferAppActivityJson Offer = `application/activity+json`
-	OfferAppLDJson       Offer = `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`
+	appJSONCharSet    offer = `application/json; charset="utf-8"`
+	appActivityJSON   offer = `application/activity+json`
+	appActivityLDJSON offer = `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`
+	textHTMLCharSet   offer = `text/html; charset="utf-8"`
 )
 
 // ActivityPubAcceptHeaders represents the Accept headers mentioned here:
 // https://www.w3.org/TR/activitypub/#retrieving-objects
-var ActivityPubAcceptHeaders = []Offer{
-	OfferAppActivityJson,
-	OfferAppLDJson,
+var ActivityPubAcceptHeaders = []offer{
+	appActivityJSON,
+	appActivityLDJSON,
 }
 
-func NegotiateAccept(c *gin.Context, offers []Offer) (string, error) {
+// JSONAcceptHeaders is a slice of offers that just contains application/json types.
+var JSONAcceptHeaders = []offer{
+	appJSONCharSet,
+}
+
+// HTMLAcceptHeaders is a slice of offers that just contains text/html types.
+var HTMLAcceptHeaders = []offer{
+	textHTMLCharSet,
+}
+
+// NegotiateAccept takes the *gin.Context from an incoming request, and a
+// slice of Offers, and performs content negotiation for the given request
+// with the given content-type offers. It will return a string representation
+// of the first suitable content-type, or an error if something goes wrong or
+// a suiteable content-type cannot be matched.
+//
+// For example, if the request in the *gin.Context has Accept headers of value
+// [application/json, text/html], and the provided offers are of value
+// [application/json, application/xml], then the returned string will be
+// 'application/json', which indicates the content-type that should be returned.
+//
+// If there are no Accept headers in the request, or the length of offers is 0,
+// then an error will be returned, so this function should only be called in places
+// where format negotiation is actually needed and headers are expected to be present
+// on incoming requests.
+//
+// Callers can use the offer slices exported in this package as shortcuts for
+// often-used Accept types.
+//
+// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation
+func NegotiateAccept(c *gin.Context, offers []offer) (string, error) {
 	if len(offers) == 0 {
 		return "", errors.New("no format offered")
 	}
 
 	accepts := c.Request.Header.Values("Accept")
 	if len(accepts) == 0 {
-		return "", errors.New("no Accept header(s) set on incoming request")
+		return "", fmt.Errorf("no Accept header(s) set on incoming request; this endpoint offers %s", offers)
 	}
 
 	strings := []string{}
@@ -39,7 +70,7 @@ func NegotiateAccept(c *gin.Context, offers []Offer) (string, error) {
 
 	format := c.NegotiateFormat(strings...)
 	if format == "" {
-		return "", fmt.Errorf("no format can be offered for Accept header(s) %s; we offered %s", accepts, offers)
+		return "", fmt.Errorf("no format can be offered for requested Accept header(s) %s; this endpoint offers %s", accepts, offers)
 	}
 
 	return format, nil

--- a/internal/api/negotiate.go
+++ b/internal/api/negotiate.go
@@ -1,3 +1,21 @@
+/*
+   GoToSocial
+   Copyright (C) 2021 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package api
 
 import (
@@ -7,29 +25,30 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type offer string
+// Offer represents an offered mime-type.
+type Offer string
 
 const (
-	AppJSON           offer = `application/json`                                                     // AppJSON is the mime type for 'application/json'.
-	AppActivityJSON   offer = `application/activity+json`                                            // AppActivityJSON is the mime type for 'application/activity+json'.
-	AppActivityLDJSON offer = `application/ld+json; profile="https://www.w3.org/ns/activitystreams"` // AppActivityLDJSON is the mime type for 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-	TextHTML          offer = `text/html`                                                            // TextHTML is the mime type for 'text/html'.
+	AppJSON           Offer = `application/json`                                                     // AppJSON is the mime type for 'application/json'.
+	AppActivityJSON   Offer = `application/activity+json`                                            // AppActivityJSON is the mime type for 'application/activity+json'.
+	AppActivityLDJSON Offer = `application/ld+json; profile="https://www.w3.org/ns/activitystreams"` // AppActivityLDJSON is the mime type for 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+	TextHTML          Offer = `text/html`                                                            // TextHTML is the mime type for 'text/html'.
 )
 
 // ActivityPubAcceptHeaders represents the Accept headers mentioned here:
 // https://www.w3.org/TR/activitypub/#retrieving-objects
-var ActivityPubAcceptHeaders = []offer{
+var ActivityPubAcceptHeaders = []Offer{
 	AppActivityJSON,
 	AppActivityLDJSON,
 }
 
 // JSONAcceptHeaders is a slice of offers that just contains application/json types.
-var JSONAcceptHeaders = []offer{
+var JSONAcceptHeaders = []Offer{
 	AppJSON,
 }
 
 // HTMLAcceptHeaders is a slice of offers that just contains text/html types.
-var HTMLAcceptHeaders = []offer{
+var HTMLAcceptHeaders = []Offer{
 	TextHTML,
 }
 
@@ -53,7 +72,7 @@ var HTMLAcceptHeaders = []offer{
 // often-used Accept types.
 //
 // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation#server-driven_content_negotiation
-func NegotiateAccept(c *gin.Context, offers ...offer) (string, error) {
+func NegotiateAccept(c *gin.Context, offers ...Offer) (string, error) {
 	if len(offers) == 0 {
 		return "", errors.New("no format offered")
 	}

--- a/internal/api/s2s/nodeinfo/nodeinfoget.go
+++ b/internal/api/s2s/nodeinfo/nodeinfoget.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 )
 
 // NodeInfoGETHandler swagger:operation GET /nodeinfo/2.0 accountGet
@@ -49,6 +50,11 @@ func (m *Module) NodeInfoGETHandler(c *gin.Context) {
 		"func":       "NodeInfoGETHandler",
 		"user-agent": c.Request.UserAgent(),
 	})
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
+		return
+	}
 
 	ni, err := m.processor.GetNodeInfo(c.Request.Context(), c.Request)
 	if err != nil {

--- a/internal/api/s2s/nodeinfo/nodeinfoget.go
+++ b/internal/api/s2s/nodeinfo/nodeinfoget.go
@@ -25,8 +25,25 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// NodeInfoGETHandler returns a compliant nodeinfo response to node info queries.
-// See: https://nodeinfo.diaspora.software/
+// NodeInfoGETHandler swagger:operation GET /nodeinfo/2.0 accountGet
+//
+// Returns a compliant nodeinfo response to node info queries. See: https://nodeinfo.diaspora.software/.
+//
+// ---
+// tags:
+// - nodeinfo
+//
+// produces:
+// - application/json
+//
+// security:
+// - OAuth2 Bearer:
+//   - read:accounts
+//
+// responses:
+//   '200':
+//     schema:
+//       "$ref": "#/definitions/nodeinfo"
 func (m *Module) NodeInfoGETHandler(c *gin.Context) {
 	l := logrus.WithFields(logrus.Fields{
 		"func":       "NodeInfoGETHandler",

--- a/internal/api/s2s/nodeinfo/wellknownget.go
+++ b/internal/api/s2s/nodeinfo/wellknownget.go
@@ -23,15 +23,36 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 )
 
-// NodeInfoWellKnownGETHandler returns a well known response to a query to /.well-known/nodeinfo,
-// directing (but not redirecting...) callers to the NodeInfoGETHandler.
+// NodeInfoWellKnownGETHandler swagger:operation GET /.well-known/nodeinfo nodeInfoWellKnownGet
+//
+// Directs callers to /nodeinfo/2.0.
+//
+// eg. `{"links":[{"rel":"http://nodeinfo.diaspora.software/ns/schema/2.0","href":"http://example.org/nodeinfo/2.0"}]}`
+// See: https://nodeinfo.diaspora.software/protocol.html
+//
+// ---
+// tags:
+// - nodeinfo
+//
+// produces:
+// - application/json
+//
+// responses:
+//   '200':
+//     schema:
+//       "$ref": "#/definitions/wellKnownResponse"
 func (m *Module) NodeInfoWellKnownGETHandler(c *gin.Context) {
 	l := logrus.WithFields(logrus.Fields{
-		"func":       "NodeInfoWellKnownGETHandler",
-		"user-agent": c.Request.UserAgent(),
+		"func": "NodeInfoWellKnownGETHandler",
 	})
+
+	if _, err := api.NegotiateAccept(c, api.JSONAcceptHeaders...); err != nil {
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
+		return
+	}
 
 	niRel, err := m.processor.GetNodeInfoRel(c.Request.Context(), c.Request)
 	if err != nil {

--- a/internal/api/s2s/user/common.go
+++ b/internal/api/s2s/user/common.go
@@ -20,18 +20,10 @@ package user
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gin-gonic/gin"
 	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
-
-// ActivityPubAcceptHeaders represents the Accept headers mentioned here:
-// https://www.w3.org/TR/activitypub/#retrieving-objects
-var ActivityPubAcceptHeaders = []string{
-	`application/activity+json`,
-	`application/ld+json; profile="https://www.w3.org/ns/activitystreams"`,
-}
 
 // transferContext transfers the signature verifier and signature from the gin context to the request context
 func transferContext(c *gin.Context) context.Context {
@@ -48,14 +40,6 @@ func transferContext(c *gin.Context) context.Context {
 	}
 
 	return ctx
-}
-
-func negotiateFormat(c *gin.Context) (string, error) {
-	format := c.NegotiateFormat(ActivityPubAcceptHeaders...)
-	if format == "" {
-		return "", fmt.Errorf("no format can be offered for Accept headers %s", c.Request.Header.Get("Accept"))
-	}
-	return format, nil
 }
 
 // SwaggerCollection represents an activitypub collection.

--- a/internal/api/s2s/user/followers.go
+++ b/internal/api/s2s/user/followers.go
@@ -41,7 +41,7 @@ func (m *Module) FollowersGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders)
+	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders...)
 	if err != nil {
 		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return

--- a/internal/api/s2s/user/followers.go
+++ b/internal/api/s2s/user/followers.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 )
 
 // FollowersGETHandler returns a collection of URIs for followers of the target user, formatted so that other AP servers can understand it.
@@ -40,9 +41,9 @@ func (m *Module) FollowersGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := negotiateFormat(c)
+	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders)
 	if err != nil {
-		c.JSON(http.StatusNotAcceptable, gin.H{"error": fmt.Sprintf("could not negotiate format with given Accept header(s): %s", err)})
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 	l.Tracef("negotiated format: %s", format)

--- a/internal/api/s2s/user/following.go
+++ b/internal/api/s2s/user/following.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 )
 
 // FollowingGETHandler returns a collection of URIs for accounts that the target user follows, formatted so that other AP servers can understand it.
@@ -40,9 +41,9 @@ func (m *Module) FollowingGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := negotiateFormat(c)
+	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders)
 	if err != nil {
-		c.JSON(http.StatusNotAcceptable, gin.H{"error": fmt.Sprintf("could not negotiate format with given Accept header(s): %s", err)})
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 	l.Tracef("negotiated format: %s", format)

--- a/internal/api/s2s/user/following.go
+++ b/internal/api/s2s/user/following.go
@@ -41,7 +41,7 @@ func (m *Module) FollowingGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders)
+	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders...)
 	if err != nil {
 		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return

--- a/internal/api/s2s/user/outboxget.go
+++ b/internal/api/s2s/user/outboxget.go
@@ -114,7 +114,7 @@ func (m *Module) OutboxGETHandler(c *gin.Context) {
 		maxID = maxIDString
 	}
 
-	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders)
+	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders...)
 	if err != nil {
 		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return

--- a/internal/api/s2s/user/outboxget.go
+++ b/internal/api/s2s/user/outboxget.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 )
 
 // OutboxGETHandler swagger:operation GET /users/{username}/outbox s2sOutboxGet
@@ -113,9 +114,9 @@ func (m *Module) OutboxGETHandler(c *gin.Context) {
 		maxID = maxIDString
 	}
 
-	format, err := negotiateFormat(c)
+	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders)
 	if err != nil {
-		c.JSON(http.StatusNotAcceptable, gin.H{"error": fmt.Sprintf("could not negotiate format with given Accept header(s): %s", err)})
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 	l.Tracef("negotiated format: %s", format)

--- a/internal/api/s2s/user/outboxget_test.go
+++ b/internal/api/s2s/user/outboxget_test.go
@@ -54,6 +54,7 @@ func (suite *OutboxGetTestSuite) TestGetOutbox() {
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 	ctx.Request = httptest.NewRequest(http.MethodGet, targetAccount.OutboxURI, nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/activity+json")
 	ctx.Request.Header.Set("Signature", signedRequest.SignatureHeader)
 	ctx.Request.Header.Set("Date", signedRequest.DateHeader)
 
@@ -108,6 +109,7 @@ func (suite *OutboxGetTestSuite) TestGetOutboxFirstPage() {
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 	ctx.Request = httptest.NewRequest(http.MethodGet, targetAccount.OutboxURI+"?page=true", nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/activity+json")
 	ctx.Request.Header.Set("Signature", signedRequest.SignatureHeader)
 	ctx.Request.Header.Set("Date", signedRequest.DateHeader)
 
@@ -162,6 +164,7 @@ func (suite *OutboxGetTestSuite) TestGetOutboxNextPage() {
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 	ctx.Request = httptest.NewRequest(http.MethodGet, targetAccount.OutboxURI+"?page=true&max_id=01F8MHAMCHF6Y650WCRSCP4WMY", nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/activity+json")
 	ctx.Request.Header.Set("Signature", signedRequest.SignatureHeader)
 	ctx.Request.Header.Set("Date", signedRequest.DateHeader)
 

--- a/internal/api/s2s/user/publickeyget.go
+++ b/internal/api/s2s/user/publickeyget.go
@@ -45,7 +45,7 @@ func (m *Module) PublicKeyGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders)
+	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders...)
 	if err != nil {
 		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return

--- a/internal/api/s2s/user/publickeyget.go
+++ b/internal/api/s2s/user/publickeyget.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 )
 
 // PublicKeyGETHandler should be served at eg https://example.org/users/:username/main-key.
@@ -44,9 +45,9 @@ func (m *Module) PublicKeyGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := negotiateFormat(c)
+	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders)
 	if err != nil {
-		c.JSON(http.StatusNotAcceptable, gin.H{"error": fmt.Sprintf("could not negotiate format with given Accept header(s): %s", err)})
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 	l.Tracef("negotiated format: %s", format)

--- a/internal/api/s2s/user/repliesget.go
+++ b/internal/api/s2s/user/repliesget.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 )
 
 // StatusRepliesGETHandler swagger:operation GET /users/{username}/statuses/{status}/replies s2sRepliesGet
@@ -131,9 +132,9 @@ func (m *Module) StatusRepliesGETHandler(c *gin.Context) {
 		minID = minIDString
 	}
 
-	format, err := negotiateFormat(c)
+	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders)
 	if err != nil {
-		c.JSON(http.StatusNotAcceptable, gin.H{"error": fmt.Sprintf("could not negotiate format with given Accept header(s): %s", err)})
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 	l.Tracef("negotiated format: %s", format)

--- a/internal/api/s2s/user/repliesget.go
+++ b/internal/api/s2s/user/repliesget.go
@@ -132,7 +132,7 @@ func (m *Module) StatusRepliesGETHandler(c *gin.Context) {
 		minID = minIDString
 	}
 
-	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders)
+	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders...)
 	if err != nil {
 		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return

--- a/internal/api/s2s/user/repliesget_test.go
+++ b/internal/api/s2s/user/repliesget_test.go
@@ -57,6 +57,7 @@ func (suite *RepliesGetTestSuite) TestGetReplies() {
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 	ctx.Request = httptest.NewRequest(http.MethodGet, targetStatus.URI+"/replies", nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/activity+json")
 	ctx.Request.Header.Set("Signature", signedRequest.SignatureHeader)
 	ctx.Request.Header.Set("Date", signedRequest.DateHeader)
 
@@ -117,6 +118,7 @@ func (suite *RepliesGetTestSuite) TestGetRepliesNext() {
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 	ctx.Request = httptest.NewRequest(http.MethodGet, targetStatus.URI+"/replies?only_other_accounts=false&page=true", nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/activity+json")
 	ctx.Request.Header.Set("Signature", signedRequest.SignatureHeader)
 	ctx.Request.Header.Set("Date", signedRequest.DateHeader)
 
@@ -180,6 +182,7 @@ func (suite *RepliesGetTestSuite) TestGetRepliesLast() {
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 	ctx.Request = httptest.NewRequest(http.MethodGet, targetStatus.URI+"/replies?only_other_accounts=false&page=true&min_id=01FF25D5Q0DH7CHD57CTRS6WK0", nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/activity+json")
 	ctx.Request.Header.Set("Signature", signedRequest.SignatureHeader)
 	ctx.Request.Header.Set("Date", signedRequest.DateHeader)
 

--- a/internal/api/s2s/user/statusget.go
+++ b/internal/api/s2s/user/statusget.go
@@ -47,7 +47,7 @@ func (m *Module) StatusGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders)
+	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders...)
 	if err != nil {
 		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return

--- a/internal/api/s2s/user/statusget.go
+++ b/internal/api/s2s/user/statusget.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 )
 
 // StatusGETHandler serves the target status as an activitystreams NOTE so that other AP servers can parse it.
@@ -46,9 +47,9 @@ func (m *Module) StatusGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := negotiateFormat(c)
+	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders)
 	if err != nil {
-		c.JSON(http.StatusNotAcceptable, gin.H{"error": fmt.Sprintf("could not negotiate format with given Accept header(s): %s", err)})
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 	l.Tracef("negotiated format: %s", format)

--- a/internal/api/s2s/user/userget.go
+++ b/internal/api/s2s/user/userget.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api"
 )
 
 // UsersGETHandler should be served at https://example.org/users/:username.
@@ -48,9 +49,9 @@ func (m *Module) UsersGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := negotiateFormat(c)
+	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders)
 	if err != nil {
-		c.JSON(http.StatusNotAcceptable, gin.H{"error": fmt.Sprintf("could not negotiate format with given Accept header(s): %s", err)})
+		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return
 	}
 	l.Tracef("negotiated format: %s", format)

--- a/internal/api/s2s/user/userget.go
+++ b/internal/api/s2s/user/userget.go
@@ -49,7 +49,7 @@ func (m *Module) UsersGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders)
+	format, err := api.NegotiateAccept(c, api.ActivityPubAcceptHeaders...)
 	if err != nil {
 		c.JSON(http.StatusNotAcceptable, gin.H{"error": err.Error()})
 		return

--- a/internal/api/s2s/user/userget_test.go
+++ b/internal/api/s2s/user/userget_test.go
@@ -55,6 +55,7 @@ func (suite *UserGetTestSuite) TestGetUser() {
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 	ctx.Request = httptest.NewRequest(http.MethodGet, targetAccount.URI, nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/activity+json")
 	ctx.Request.Header.Set("Signature", signedRequest.SignatureHeader)
 	ctx.Request.Header.Set("Date", signedRequest.DateHeader)
 

--- a/internal/api/s2s/webfinger/webfingerget_test.go
+++ b/internal/api/s2s/webfinger/webfingerget_test.go
@@ -50,6 +50,7 @@ func (suite *WebfingerGetTestSuite) TestFingerUser() {
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 	ctx.Request = httptest.NewRequest(http.MethodGet, requestPath, nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 
 	// trigger the function being tested
 	suite.webfingerModule.WebfingerGETRequest(ctx)
@@ -83,6 +84,7 @@ func (suite *WebfingerGetTestSuite) TestFingerUserWithDifferentAccountDomainByHo
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 	ctx.Request = httptest.NewRequest(http.MethodGet, requestPath, nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 
 	// trigger the function being tested
 	suite.webfingerModule.WebfingerGETRequest(ctx)
@@ -116,6 +118,7 @@ func (suite *WebfingerGetTestSuite) TestFingerUserWithDifferentAccountDomainByAc
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 	ctx.Request = httptest.NewRequest(http.MethodGet, requestPath, nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 
 	// trigger the function being tested
 	suite.webfingerModule.WebfingerGETRequest(ctx)
@@ -141,6 +144,7 @@ func (suite *WebfingerGetTestSuite) TestFingerUserWithoutAcct() {
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 	ctx.Request = httptest.NewRequest(http.MethodGet, requestPath, nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/json")
 
 	// trigger the function being tested
 	suite.webfingerModule.WebfingerGETRequest(ctx)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,7 @@ nav:
     - "configuration/index.md"
     - "configuration/general.md"
     - "configuration/database.md"
-    - "configuration/template.md"
+    - "configuration/web.md"
     - "configuration/accounts.md"
     - "configuration/media.md"
     - "configuration/storage.md"


### PR DESCRIPTION
This PR adds server-driven content negotiation logic to API endpoints. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation#server-driven_content_negotiation

This is done by adding a `NegotiateAccept` function in the `api` package, which can be called by handler functions that return specific content types.

In cases where the requested content-type is not available, the server will reply with code [406](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406) and an error message:

```
{
  "error": "no format can be offered for requested Accept header(s) [text/html]; this endpoint offers [application/json]"
}
```

For now, all handler functions that need to do content-negotiation call the NegotiateAccept function manually. In future, we could look at grouping these handler functions and applying [gin middleware](https://github.com/gin-gonic/gin#using-middleware) to [router groups](https://github.com/gin-gonic/gin#grouping-routes), though this will require some fiddling.

This PR also doesn't handle redirects when a requested content-type is not available, for now it just returns the 406. In future we can look at doing redirects for specific endpoints, but this should (imo) be a separate PR.

closes https://github.com/superseriousbusiness/gotosocial/issues/328