### PR TITLE
Log when listening

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -79,8 +79,9 @@ func (r *router) Start() {
 		// serve the http handler on the selected letsencrypt port, for receiving letsencrypt requests and solving their devious riddles
 		go func() {
 			listen := fmt.Sprintf("%s:%d", bindAddress, lePort)
+			logrus.Infof("letsencrypt listening on %s", listen)
 			if err := http.ListenAndServe(listen, r.certManager.HTTPHandler(http.HandlerFunc(httpsRedirect))); err != nil && err != http.ErrServerClosed {
-				logrus.Fatalf("listen: %s", err)
+				logrus.Fatalf("letsencrypt: listen: %s", err)
 			}
 		}()
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -87,6 +87,7 @@ func (r *router) Start() {
 
 		// and serve the actual TLS handler
 		go func() {
+			logrus.Infof("listening on %s", r.srv.Addr)
 			if err := r.srv.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
 				logrus.Fatalf("listen: %s", err)
 			}
@@ -94,6 +95,7 @@ func (r *router) Start() {
 	} else {
 		// no tls required
 		go func() {
+			logrus.Infof("listening on %s", r.srv.Addr)
 			if err := r.srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 				logrus.Fatalf("listen: %s", err)
 			}


### PR DESCRIPTION
I got a bit confused when trying to start `gotosocial server`, because it was failing to bind to `:80`, when I was asking it to bind to `:8080`. Turns out that's the let's encrypt port!

Since this will fail when running as non-root (without `CAP_NET_ADMIN`, at least), or if something like nginx is already hogging that port, we should probably make the error a bit more obvious, and add some logging for good measure.

(Maybe it's just me, but I like it when software tells me when it's opening ports and stuff.)