### PR TITLE
[bug] Fix minimum description length check

### DIFF
--- a/internal/api/client/media/mediacreate.go
+++ b/internal/api/client/media/mediacreate.go
@@ -149,11 +149,9 @@ func validateCreateMedia(form *model.AttachmentRequest) error {
 		return fmt.Errorf("file size limit exceeded: limit is %d bytes but attachment was %d bytes", maxSize, form.File.Size)
 	}
 
-	if len(form.Description) < minDescriptionChars || len(form.Description) > maxDescriptionChars {
+	if len(form.Description) > maxDescriptionChars {
 		return fmt.Errorf("image description length must be between %d and %d characters (inclusive), but provided image description was %d chars", minDescriptionChars, maxDescriptionChars, len(form.Description))
 	}
-
-	// TODO: validate focus here
 
 	return nil
 }

--- a/internal/api/client/media/mediaupdate_test.go
+++ b/internal/api/client/media/mediaupdate_test.go
@@ -21,8 +21,6 @@ package media_test
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -49,7 +47,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
-type MediaCreateTestSuite struct {
+type MediaUpdateTestSuite struct {
 	// standard suite interfaces
 	suite.Suite
 	db           db.DB
@@ -77,7 +75,7 @@ type MediaCreateTestSuite struct {
 	TEST INFRASTRUCTURE
 */
 
-func (suite *MediaCreateTestSuite) SetupSuite() {
+func (suite *MediaUpdateTestSuite) SetupSuite() {
 	// setup standard items
 	testrig.InitTestConfig()
 	testrig.InitTestLog()
@@ -94,13 +92,13 @@ func (suite *MediaCreateTestSuite) SetupSuite() {
 	suite.mediaModule = mediamodule.New(suite.processor).(*mediamodule.Module)
 }
 
-func (suite *MediaCreateTestSuite) TearDownSuite() {
+func (suite *MediaUpdateTestSuite) TearDownSuite() {
 	if err := suite.db.Stop(context.Background()); err != nil {
 		logrus.Panicf("error closing db connection: %s", err)
 	}
 }
 
-func (suite *MediaCreateTestSuite) SetupTest() {
+func (suite *MediaUpdateTestSuite) SetupTest() {
 	testrig.StandardDBSetup(suite.db, nil)
 	testrig.StandardStorageSetup(suite.storage, "../../../../testrig/media")
 	suite.testTokens = testrig.NewTestTokens()
@@ -111,7 +109,7 @@ func (suite *MediaCreateTestSuite) SetupTest() {
 	suite.testAttachments = testrig.NewTestAttachments()
 }
 
-func (suite *MediaCreateTestSuite) TearDownTest() {
+func (suite *MediaUpdateTestSuite) TearDownTest() {
 	testrig.StandardDBTeardown(suite.db)
 	testrig.StandardStorageTeardown(suite.storage)
 }
@@ -120,7 +118,9 @@ func (suite *MediaCreateTestSuite) TearDownTest() {
 	ACTUAL TESTS
 */
 
-func (suite *MediaCreateTestSuite) TestMediaCreateSuccessful() {
+func (suite *MediaUpdateTestSuite) TestUpdateImage() {
+	toUpdate := suite.testAttachments["local_account_1_unattached_1"]
+
 	// set up the context for the request
 	t := suite.testTokens["local_account_1"]
 	oauthToken := oauth.DBTokenToToken(t)
@@ -131,42 +131,27 @@ func (suite *MediaCreateTestSuite) TestMediaCreateSuccessful() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 
-	// see what's in storage *before* the request
-	storageKeysBeforeRequest := []string{}
-	iter, err := suite.storage.Iterator(nil)
-	if err != nil {
-		panic(err)
-	}
-	for iter.Next() {
-		storageKeysBeforeRequest = append(storageKeysBeforeRequest, iter.Key())
-	}
-	iter.Release()
-
 	// create the request
-	buf, w, err := testrig.CreateMultipartFormData("file", "../../../../testrig/media/test-jpeg.jpg", map[string]string{
-		"description": "this is a test image -- a cool background from somewhere",
-		"focus":       "-0.5,0.5",
+	buf, w, err := testrig.CreateMultipartFormData("", "", map[string]string{
+		"id":          toUpdate.ID,
+		"description": "new description!",
+		"focus":       "-0.1,0.3",
 	})
 	if err != nil {
 		panic(err)
 	}
-	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", mediamodule.BasePath), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
+	ctx.Request = httptest.NewRequest(http.MethodPut, fmt.Sprintf("http://localhost:8080/%s/%s", mediamodule.BasePath, toUpdate.ID), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
 	ctx.Request.Header.Set("Content-Type", w.FormDataContentType())
 	ctx.Request.Header.Set("accept", "application/json")
+	ctx.Params = gin.Params{
+		gin.Param{
+			Key:   mediamodule.IDKey,
+			Value: toUpdate.ID,
+		},
+	}
 
 	// do the actual request
-	suite.mediaModule.MediaCreatePOSTHandler(ctx)
-
-	// check what's in storage *after* the request
-	storageKeysAfterRequest := []string{}
-	iter, err = suite.storage.Iterator(nil)
-	if err != nil {
-		panic(err)
-	}
-	for iter.Next() {
-		storageKeysAfterRequest = append(storageKeysAfterRequest, iter.Key())
-	}
-	iter.Release()
+	suite.mediaModule.MediaPUTHandler(ctx)
 
 	// check response
 	suite.EqualValues(http.StatusOK, recorder.Code)
@@ -175,40 +160,32 @@ func (suite *MediaCreateTestSuite) TestMediaCreateSuccessful() {
 	defer result.Body.Close()
 	b, err := ioutil.ReadAll(result.Body)
 	suite.NoError(err)
-	fmt.Println(string(b))
 
+	// reply should be an attachment
 	attachmentReply := &model.Attachment{}
 	err = json.Unmarshal(b, attachmentReply)
 	suite.NoError(err)
 
-	suite.Equal("this is a test image -- a cool background from somewhere", attachmentReply.Description)
-	suite.Equal("image", attachmentReply.Type)
+	// the reply should contain the updated fields
+	suite.Equal("new description!", attachmentReply.Description)
+	suite.EqualValues("gif", attachmentReply.Type)
 	suite.EqualValues(model.MediaMeta{
-		Original: model.MediaDimensions{
-			Width:  1920,
-			Height: 1080,
-			Size:   "1920x1080",
-			Aspect: 1.7777778,
-		},
-		Small: model.MediaDimensions{
-			Width:  512,
-			Height: 288,
-			Size:   "512x288",
-			Aspect: 1.7777778,
-		},
-		Focus: model.MediaFocus{
-			X: -0.5,
-			Y: 0.5,
-		},
+		Original: model.MediaDimensions{Width: 800, Height: 450, FrameRate: "", Duration: 0, Bitrate: 0, Size: "800x450", Aspect: 1.7777778},
+		Small:    model.MediaDimensions{Width: 256, Height: 144, FrameRate: "", Duration: 0, Bitrate: 0, Size: "256x144", Aspect: 1.7777778},
+		Focus:    model.MediaFocus{X: -0.1, Y: 0.3},
 	}, attachmentReply.Meta)
-	suite.Equal("LjBzUo#6RQR._NvzRjWF?urqV@a$", attachmentReply.Blurhash)
-	suite.NotEmpty(attachmentReply.ID)
-	suite.NotEmpty(attachmentReply.URL)
-	suite.NotEmpty(attachmentReply.PreviewURL)
-	suite.Equal(len(storageKeysBeforeRequest)+2, len(storageKeysAfterRequest)) // 2 images should be added to storage: the original and the thumbnail
+	suite.Equal(toUpdate.Blurhash, attachmentReply.Blurhash)
+	suite.Equal(toUpdate.ID, attachmentReply.ID)
+	suite.Equal(toUpdate.URL, attachmentReply.URL)
+	suite.NotEmpty(toUpdate.Thumbnail.URL, attachmentReply.PreviewURL)
 }
 
-func (suite *MediaCreateTestSuite) TestMediaCreateLongDescription() {
+func (suite *MediaUpdateTestSuite) TestUpdateImageShortDescription() {
+	// set the min description length
+	viper.Set(config.Keys.MediaDescriptionMinChars, 50)
+
+	toUpdate := suite.testAttachments["local_account_1_unattached_1"]
+
 	// set up the context for the request
 	t := suite.testTokens["local_account_1"]
 	oauthToken := oauth.DBTokenToToken(t)
@@ -219,73 +196,40 @@ func (suite *MediaCreateTestSuite) TestMediaCreateLongDescription() {
 	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 
-	// read a random string of a really long description
-	descriptionBytes := make([]byte, 5000)
-	if _, err := rand.Read(descriptionBytes); err != nil {
-		panic(err)
-	}
-	description := base64.RawStdEncoding.EncodeToString(descriptionBytes)
-
 	// create the request
-	buf, w, err := testrig.CreateMultipartFormData("file", "../../../../testrig/media/test-jpeg.jpg", map[string]string{
-		"description": description,
-		"focus":       "-0.5,0.5",
+	buf, w, err := testrig.CreateMultipartFormData("", "", map[string]string{
+		"id":          toUpdate.ID,
+		"description": "new description!",
+		"focus":       "-0.1,0.3",
 	})
 	if err != nil {
 		panic(err)
 	}
-	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", mediamodule.BasePath), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
+	ctx.Request = httptest.NewRequest(http.MethodPut, fmt.Sprintf("http://localhost:8080/%s/%s", mediamodule.BasePath, toUpdate.ID), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
 	ctx.Request.Header.Set("Content-Type", w.FormDataContentType())
 	ctx.Request.Header.Set("accept", "application/json")
+	ctx.Params = gin.Params{
+		gin.Param{
+			Key:   mediamodule.IDKey,
+			Value: toUpdate.ID,
+		},
+	}
 
 	// do the actual request
-	suite.mediaModule.MediaCreatePOSTHandler(ctx)
+	suite.mediaModule.MediaPUTHandler(ctx)
 
 	// check response
-	suite.EqualValues(http.StatusUnprocessableEntity, recorder.Code)
+	suite.EqualValues(http.StatusBadRequest, recorder.Code)
 
 	result := recorder.Result()
 	defer result.Body.Close()
 	b, err := ioutil.ReadAll(result.Body)
 	suite.NoError(err)
 
-	expectedErr := fmt.Sprintf(`{"error":"image description length must be between 0 and 500 characters (inclusive), but provided image description was %d chars"}`, len(description))
-	suite.Equal(expectedErr, string(b))
+	// reply should be an error message
+	suite.Equal(`{"error":"image description length must be between 50 and 500 characters (inclusive), but provided image description was 16 chars"}`, string(b))
 }
 
-func (suite *MediaCreateTestSuite) TestMediaCreateTooShortDescription() {
-	// set the min description length
-	viper.Set(config.Keys.MediaDescriptionMinChars, 500)
-
-	// set up the context for the request
-	t := suite.testTokens["local_account_1"]
-	oauthToken := oauth.DBTokenToToken(t)
-	recorder := httptest.NewRecorder()
-	ctx, _ := gin.CreateTestContext(recorder)
-	ctx.Set(oauth.SessionAuthorizedApplication, suite.testApplications["application_1"])
-	ctx.Set(oauth.SessionAuthorizedToken, oauthToken)
-	ctx.Set(oauth.SessionAuthorizedUser, suite.testUsers["local_account_1"])
-	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
-
-	// create the request
-	buf, w, err := testrig.CreateMultipartFormData("file", "../../../../testrig/media/test-jpeg.jpg", map[string]string{
-		"description": "", // provide an empty description
-		"focus":       "-0.5,0.5",
-	})
-	if err != nil {
-		panic(err)
-	}
-	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", mediamodule.BasePath), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
-	ctx.Request.Header.Set("Content-Type", w.FormDataContentType())
-	ctx.Request.Header.Set("accept", "application/json")
-
-	// do the actual request
-	suite.mediaModule.MediaCreatePOSTHandler(ctx)
-
-	// check response -- there should be no error because minimum description length is checked on *UPDATE*, not initial upload
-	suite.EqualValues(http.StatusOK, recorder.Code)
-}
-
-func TestMediaCreateTestSuite(t *testing.T) {
-	suite.Run(t, new(MediaCreateTestSuite))
+func TestMediaUpdateTestSuite(t *testing.T) {
+	suite.Run(t, new(MediaUpdateTestSuite))
 }


### PR DESCRIPTION
This PR adjusts the checks when first creating POSTing new media to remove the minimum description check.

The description length check when updating media still exists.

This gives users the chance to edit their description before the server gets arsey at them for the description not being long enough.

closes https://github.com/superseriousbusiness/gotosocial/issues/338