### PR TITLE
[bug] Fix sqlite empty address issue

### DIFF
--- a/docs/configuration/database.md
+++ b/docs/configuration/database.md
@@ -8,7 +8,7 @@ By default, GoToSocial will use Postgres, but this is easy to change.
 
 SQLite, as the name implies, is the lightest database type that GoToSocial can use. It stores entries in a simple file format, usually in the same directory as the GoToSocial binary itself. SQLite is great for small instances and lower-powered machines like Raspberry Pi, where a dedicated database would be overkill.
 
-To configure GoToSocial to use SQLite, change `db-type` to `sqlite`. The `address` setting will then be a filename instead of an address, so you might want to change it to `sqlite.db` or something similar.
+To configure GoToSocial to use SQLite, change `db-type` to `sqlite`. The `address` setting will then be a filename instead of an address, so you will want to change it to `sqlite.db` or something similar.
 
 Note that the `:memory:` setting will use an *in-memory database* which will be wiped when your GoToSocial instance stops running. This is for testing only and is absolutely not suitable for running a proper instance, so *don't do this*.
 
@@ -57,7 +57,17 @@ grant all privileges on database gotosocial to gotosocial;
 db-type: "postgres"
 
 # String. Database address or parameters.
-# Examples: ["localhost","my.db.host","127.0.0.1","192.111.39.110",":memory:"]
+#
+# For Postgres, this should be the address or socket at which the database can be reached.
+#
+# For Sqlite, this should be the path to your sqlite database file. Eg., /opt/gotosocial/sqlite.db.
+# If the file doesn't exist at the specified path, it will be created.
+# If just a filename is provided (no directory) then the database will be created in the same directory
+# as the GoToSocial binary.
+# If address is set to :memory: then an in-memory database will be used (no file).
+# WARNING: :memory: should NOT BE USED except for testing purposes.
+#
+# Examples: ["localhost","my.db.host","127.0.0.1","192.111.39.110",":memory:", "sqlite.db"]
 # Default: ""
 db-address: ""
 

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -93,7 +93,17 @@ trusted-proxies:
 db-type: "postgres"
 
 # String. Database address or parameters.
-# Examples: ["localhost","my.db.host","127.0.0.1","192.111.39.110",":memory:"]
+#
+# For Postgres, this should be the address or socket at which the database can be reached.
+#
+# For Sqlite, this should be the path to your sqlite database file. Eg., /opt/gotosocial/sqlite.db.
+# If the file doesn't exist at the specified path, it will be created.
+# If just a filename is provided (no directory) then the database will be created in the same directory
+# as the GoToSocial binary.
+# If address is set to :memory: then an in-memory database will be used (no file).
+# WARNING: :memory: should NOT BE USED except for testing purposes.
+#
+# Examples: ["localhost","my.db.host","127.0.0.1","192.111.39.110",":memory:", "sqlite.db"]
 # Default: ""
 db-address: ""
 

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -204,7 +204,11 @@ func NewBunDBService(ctx context.Context) (db.DB, error) {
 }
 
 func sqliteConn(ctx context.Context) (*DBConn, error) {
+	// validate db address has actually been set
 	dbAddress := viper.GetString(config.Keys.DbAddress)
+	if dbAddress == "" {
+		return nil, fmt.Errorf("'%s' was not set when attempting to start sqlite", config.Keys.DbAddress)
+	}
 
 	// Drop anything fancy from DB address
 	dbAddress = strings.Split(dbAddress, "?")[0]

--- a/internal/db/bundb/bundbnew_test.go
+++ b/internal/db/bundb/bundbnew_test.go
@@ -1,0 +1,52 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package bundb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/db/bundb"
+)
+
+type BundbNewTestSuite struct {
+	BunDBStandardTestSuite
+}
+
+func (suite *BundbNewTestSuite) TestCreateNewDB() {
+	// create a new db with standard test settings
+	db, err := bundb.NewBunDBService(context.Background())
+	suite.NoError(err)
+	suite.NotNil(db)
+}
+
+func (suite *BundbNewTestSuite) TestCreateNewSqliteDBNoAddress() {
+	// create a new db with no address specified
+	viper.Set(config.Keys.DbAddress, "")
+	db, err := bundb.NewBunDBService(context.Background())
+	suite.EqualError(err, "'db-address' was not set when attempting to start sqlite")
+	suite.Nil(db)
+}
+
+func TestBundbNewTestSuite(t *testing.T) {
+	suite.Run(t, new(BundbNewTestSuite))
+}


### PR DESCRIPTION
This PR updates the docs to better explain what `db-address` means for sqlite, and also adds a check in bun that will fail if no `db-address` has been set, when creating an sqlite connection. This should avoid weird scenarios where it looks like a db has been created, but GoToSocial fails trying to access it.

Closes https://github.com/superseriousbusiness/gotosocial/issues/363
