### PR TITLE
Fix start command invocation

### DIFF
--- a/docs/installation_guide/binary.md
+++ b/docs/installation_guide/binary.md
@@ -63,7 +63,7 @@ You can now run the binary.
 Start the GoToSocial server with the following command:
 
 ```bash
-./gotosocial server start --config-path ./config.yaml
+./gotosocial --config-path ./config.yaml server start
 ```
 
 The server should now start up and you should be able to access the splash page by navigating to your domain in the browser. Note that it might take up to a minute or so for your LetsEncrypt certificates to be created for the first time, so refresh a few times if necessary.


### PR DESCRIPTION
When I tried to start the server using the command `./gotosocial server start --config-file ./config.yaml`, I got the following error:

```
root@gotosocial-experiment:/gotosocial# ./gotosocial server start --config-file ./config.yaml
Incorrect Usage: flag provided but not defined: -config-file

NAME:
   gotosocial server start - start the gotosocial server

USAGE:
   gotosocial server start [command options] [arguments...]

OPTIONS:
   --help, -h  show help (default: false)

FATA[0000] flag provided but not defined: -config-file
```

Putting the flag after the `./gotosocial` but before the `server start` seems to work properly