### PR TITLE
[bug] Fix malformed webfinger response

### DIFF
--- a/internal/processing/federation/getwebfinger.go
+++ b/internal/processing/federation/getwebfinger.go
@@ -44,6 +44,9 @@ func (p *processor) GetWebfingerAccount(ctx context.Context, requestedUsername s
 	}
 
 	accountDomain := viper.GetString(config.Keys.AccountDomain)
+	if accountDomain == "" {
+		accountDomain = viper.GetString(config.Keys.Host)
+	}
 
 	// return the webfinger representation
 	return &apimodel.WellKnownResponse{

--- a/internal/typeutils/internaltoas.go
+++ b/internal/typeutils/internaltoas.go
@@ -623,6 +623,9 @@ func (c *converter) MentionToAS(ctx context.Context, m *gtsmodel.Mention) (vocab
 	var domain string
 	if m.TargetAccount.Domain == "" {
 		accountDomain := viper.GetString(config.Keys.AccountDomain)
+		if accountDomain == "" {
+			accountDomain = viper.GetString(config.Keys.Host)
+		}
 		domain = accountDomain
 	} else {
 		domain = m.TargetAccount.Domain


### PR DESCRIPTION
Due to the config changes introduced a while back, GtS was returning malformed webfinger responses if account-domain wasn't set, causing federation problems with Mastodon. This PR should fix this, by using the value for `host` if the value for `account-domain` is an empty string.