### PR TITLE
Use type=email for email input

### DIFF
--- a/web/template/sign-in.tmpl
+++ b/web/template/sign-in.tmpl
@@ -4,7 +4,7 @@
         <h1>Login</h1>
         <form action="/auth/sign_in" method="POST">
             <label for="email">Email</label>
-            <input type="text" class="form-control" name="username" required placeholder="Please enter your email address">
+            <input type="email" class="form-control" name="username" required placeholder="Please enter your email address">
         
             <label for="password">Password</label>
             <input type="password" class="form-control" name="password" required placeholder="Please enter your password">


### PR DESCRIPTION
So that mobile devices with software keyboards use the email keyboard and turn off autocorrect/autocapitalization