### PR TITLE
[feature] Stream files via reader

### DIFF
--- a/internal/api/client/fileserver/servefile.go
+++ b/internal/api/client/fileserver/servefile.go
@@ -89,6 +89,11 @@ func (m *FileServer) ServeFile(c *gin.Context) {
 		c.String(http.StatusNotFound, "404 page not found")
 		return
 	}
+	defer func() {
+		if err := content.Content.Close(); err != nil {
+			l.Errorf("error closing readcloser: %s", err)
+		}
+	}()
 
 	// TODO: if the requester only accepts text/html we should try to serve them *something*.
 	// This is mostly needed because when sharing a link to a gts-hosted file on something like mastodon, the masto servers will

--- a/internal/api/client/fileserver/servefile.go
+++ b/internal/api/client/fileserver/servefile.go
@@ -19,7 +19,6 @@
 package fileserver
 
 import (
-	"bytes"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -100,5 +99,5 @@ func (m *FileServer) ServeFile(c *gin.Context) {
 		return
 	}
 
-	c.DataFromReader(http.StatusOK, content.ContentLength, format, bytes.NewReader(content.Content), nil)
+	c.DataFromReader(http.StatusOK, content.ContentLength, format, content.Content, nil)
 }

--- a/internal/api/client/fileserver/servefile.go
+++ b/internal/api/client/fileserver/servefile.go
@@ -19,6 +19,7 @@
 package fileserver
 
 import (
+	"io"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -89,9 +90,13 @@ func (m *FileServer) ServeFile(c *gin.Context) {
 		c.String(http.StatusNotFound, "404 page not found")
 		return
 	}
+
 	defer func() {
-		if err := content.Content.Close(); err != nil {
-			l.Errorf("error closing readcloser: %s", err)
+		// if the content is a ReadCloser, close it when we're done
+		if closer, ok := content.Content.(io.ReadCloser); ok {
+			if err := closer.Close(); err != nil {
+				l.Errorf("error closing readcloser: %s", err)
+			}
 		}
 	}()
 

--- a/internal/api/model/content.go
+++ b/internal/api/model/content.go
@@ -27,7 +27,7 @@ type Content struct {
 	// ContentLength in bytes
 	ContentLength int64
 	// Actual content
-	Content io.Reader
+	Content io.ReadCloser
 }
 
 // GetContentRequestForm describes a piece of content desired by the caller of the fileserver API.

--- a/internal/api/model/content.go
+++ b/internal/api/model/content.go
@@ -18,14 +18,16 @@
 
 package model
 
+import "io"
+
 // Content wraps everything needed to serve a blob of content (some kind of media) through the API.
 type Content struct {
 	// MIME content type
 	ContentType string
 	// ContentLength in bytes
 	ContentLength int64
-	// Actual content blob
-	Content []byte
+	// Actual content
+	Content io.Reader
 }
 
 // GetContentRequestForm describes a piece of content desired by the caller of the fileserver API.

--- a/internal/api/model/content.go
+++ b/internal/api/model/content.go
@@ -27,7 +27,7 @@ type Content struct {
 	// ContentLength in bytes
 	ContentLength int64
 	// Actual content
-	Content io.ReadCloser
+	Content io.Reader
 }
 
 // GetContentRequestForm describes a piece of content desired by the caller of the fileserver API.


### PR DESCRIPTION
This PR switches the fileserver to use an io.reader to stream files directly from storage, rather than getting files as a byte blob, holding them in memory, and converting them into a reader. This should make fileserving less memory intensive.

closes #402 