### PR TITLE
[bugfix] Fix thumbnail image type

### DIFF
--- a/internal/media/manager_test.go
+++ b/internal/media/manager_test.go
@@ -77,6 +77,7 @@ func (suite *ManagerTestSuite) TestSimpleJpegProcessBlocking() {
 		Width: 512, Height: 288, Size: 147456, Aspect: 1.7777777777777777,
 	}, attachment.FileMeta.Small)
 	suite.Equal("image/jpeg", attachment.File.ContentType)
+	suite.Equal("image/jpeg", attachment.Thumbnail.ContentType)
 	suite.Equal(269739, attachment.File.FileSize)
 	suite.Equal("LjBzUo#6RQR._NvzRjWF?urqV@a$", attachment.Blurhash)
 
@@ -155,6 +156,7 @@ func (suite *ManagerTestSuite) TestSimpleJpegProcessAsync() {
 		Width: 512, Height: 288, Size: 147456, Aspect: 1.7777777777777777,
 	}, attachment.FileMeta.Small)
 	suite.Equal("image/jpeg", attachment.File.ContentType)
+	suite.Equal("image/jpeg", attachment.Thumbnail.ContentType)
 	suite.Equal(269739, attachment.File.FileSize)
 	suite.Equal("LjBzUo#6RQR._NvzRjWF?urqV@a$", attachment.Blurhash)
 
@@ -237,6 +239,7 @@ func (suite *ManagerTestSuite) TestSimpleJpegQueueSpamming() {
 			Width: 512, Height: 288, Size: 147456, Aspect: 1.7777777777777777,
 		}, attachment.FileMeta.Small)
 		suite.Equal("image/jpeg", attachment.File.ContentType)
+		suite.Equal("image/jpeg", attachment.Thumbnail.ContentType)
 		suite.Equal(269739, attachment.File.FileSize)
 		suite.Equal("LjBzUo#6RQR._NvzRjWF?urqV@a$", attachment.Blurhash)
 
@@ -325,6 +328,7 @@ func (suite *ManagerTestSuite) TestSimpleJpegProcessBlockingWithDiskStorage() {
 		Width: 512, Height: 288, Size: 147456, Aspect: 1.7777777777777777,
 	}, attachment.FileMeta.Small)
 	suite.Equal("image/jpeg", attachment.File.ContentType)
+	suite.Equal("image/jpeg", attachment.Thumbnail.ContentType)
 	suite.Equal(269739, attachment.File.FileSize)
 	suite.Equal("LjBzUo#6RQR._NvzRjWF?urqV@a$", attachment.Blurhash)
 

--- a/internal/media/processingmedia.go
+++ b/internal/media/processingmedia.go
@@ -331,7 +331,7 @@ func (m *manager) preProcessMedia(ctx context.Context, data DataFunc, accountID 
 	thumbnail := gtsmodel.Thumbnail{
 		URL:         uris.GenerateURIForAttachment(accountID, string(TypeAttachment), string(SizeSmall), id, mimeJpeg), // all thumbnails are encoded as jpeg,
 		Path:        fmt.Sprintf("%s/%s/%s/%s.%s", accountID, TypeAttachment, SizeSmall, id, mimeJpeg),                 // all thumbnails are encoded as jpeg,
-		ContentType: mimeJpeg,
+		ContentType: mimeImageJpeg,
 		UpdatedAt:   time.Now(),
 	}
 


### PR DESCRIPTION
We were incorrectly setting the image type of thumbnails to `jpeg` instead of `image/jpeg`, which resulted in the wrong content-type being served to callers when retrieving files. This PR fixes that + adds a test for it.