### PR TITLE
[feature] Add postDataCallbackFunc to allow cleanup

### DIFF
--- a/internal/federation/dereferencing/account.go
+++ b/internal/federation/dereferencing/account.go
@@ -285,7 +285,7 @@ func (d *deref) fetchRemoteAccountMedia(ctx context.Context, targetAccount *gtsm
 			}
 
 			avatar := true
-			newProcessing, err := d.mediaManager.ProcessMedia(ctx, data, targetAccount.ID, &media.AdditionalMediaInfo{
+			newProcessing, err := d.mediaManager.ProcessMedia(ctx, data, nil, targetAccount.ID, &media.AdditionalMediaInfo{
 				RemoteURL: &targetAccount.AvatarRemoteURL,
 				Avatar:    &avatar,
 			})
@@ -343,7 +343,7 @@ func (d *deref) fetchRemoteAccountMedia(ctx context.Context, targetAccount *gtsm
 			}
 
 			header := true
-			newProcessing, err := d.mediaManager.ProcessMedia(ctx, data, targetAccount.ID, &media.AdditionalMediaInfo{
+			newProcessing, err := d.mediaManager.ProcessMedia(ctx, data, nil, targetAccount.ID, &media.AdditionalMediaInfo{
 				RemoteURL: &targetAccount.HeaderRemoteURL,
 				Header:    &header,
 			})

--- a/internal/federation/dereferencing/media.go
+++ b/internal/federation/dereferencing/media.go
@@ -46,7 +46,7 @@ func (d *deref) GetRemoteMedia(ctx context.Context, requestingUsername string, a
 		return t.DereferenceMedia(innerCtx, derefURI)
 	}
 
-	processingMedia, err := d.mediaManager.ProcessMedia(ctx, dataFunc, accountID, ai)
+	processingMedia, err := d.mediaManager.ProcessMedia(ctx, dataFunc, nil, accountID, ai)
 	if err != nil {
 		return nil, fmt.Errorf("GetRemoteMedia: error processing attachment: %s", err)
 	}

--- a/internal/media/processingmedia.go
+++ b/internal/media/processingmedia.go
@@ -48,6 +48,7 @@ type ProcessingMedia struct {
 
 	attachment *gtsmodel.MediaAttachment
 	data       DataFunc
+	postData   PostDataCallbackFunc
 	read       bool // bool indicating that data function has been triggered already
 
 	thumbState    int32 // the processing state of the media thumbnail
@@ -313,10 +314,15 @@ func (p *ProcessingMedia) store(ctx context.Context) error {
 	}
 
 	p.read = true
+
+	if p.postData != nil {
+		return p.postData(ctx)
+	}
+
 	return nil
 }
 
-func (m *manager) preProcessMedia(ctx context.Context, data DataFunc, accountID string, ai *AdditionalMediaInfo) (*ProcessingMedia, error) {
+func (m *manager) preProcessMedia(ctx context.Context, data DataFunc, postData PostDataCallbackFunc, accountID string, ai *AdditionalMediaInfo) (*ProcessingMedia, error) {
 	id, err := id.NewRandomULID()
 	if err != nil {
 		return nil, err
@@ -403,6 +409,7 @@ func (m *manager) preProcessMedia(ctx context.Context, data DataFunc, accountID 
 	processingMedia := &ProcessingMedia{
 		attachment:    attachment,
 		data:          data,
+		postData:      postData,
 		thumbState:    int32(received),
 		fullSizeState: int32(received),
 		database:      m.db,

--- a/internal/media/types.go
+++ b/internal/media/types.go
@@ -119,3 +119,9 @@ type AdditionalEmojiInfo struct {
 
 // DataFunc represents a function used to retrieve the raw bytes of a piece of media.
 type DataFunc func(ctx context.Context) (reader io.Reader, fileSize int, err error)
+
+// PostDataCallbackFunc represents a function executed after the DataFunc has been executed,
+// and the returned reader has been read. It can be used to clean up any remaining resources.
+//
+// This can be set to nil, and will then not be executed.
+type PostDataCallbackFunc func(ctx context.Context) error

--- a/internal/processing/account/update.go
+++ b/internal/processing/account/update.go
@@ -150,7 +150,7 @@ func (p *processor) UpdateAvatar(ctx context.Context, avatar *multipart.FileHead
 		Avatar: &isAvatar,
 	}
 
-	processingMedia, err := p.mediaManager.ProcessMedia(ctx, dataFunc, accountID, ai)
+	processingMedia, err := p.mediaManager.ProcessMedia(ctx, dataFunc, nil, accountID, ai)
 	if err != nil {
 		return nil, fmt.Errorf("UpdateAvatar: error processing avatar: %s", err)
 	}
@@ -177,7 +177,7 @@ func (p *processor) UpdateHeader(ctx context.Context, header *multipart.FileHead
 		Header: &isHeader,
 	}
 
-	processingMedia, err := p.mediaManager.ProcessMedia(ctx, dataFunc, accountID, ai)
+	processingMedia, err := p.mediaManager.ProcessMedia(ctx, dataFunc, nil, accountID, ai)
 	if err != nil {
 		return nil, fmt.Errorf("UpdateHeader: error processing header: %s", err)
 	}

--- a/internal/processing/admin/emoji.go
+++ b/internal/processing/admin/emoji.go
@@ -49,7 +49,7 @@ func (p *processor) EmojiCreate(ctx context.Context, account *gtsmodel.Account, 
 
 	emojiURI := uris.GenerateURIForEmoji(emojiID)
 
-	processingEmoji, err := p.mediaManager.ProcessEmoji(ctx, data, form.Shortcode, emojiID, emojiURI, nil)
+	processingEmoji, err := p.mediaManager.ProcessEmoji(ctx, data, nil, form.Shortcode, emojiID, emojiURI, nil)
 	if err != nil {
 		return nil, gtserror.NewErrorInternalError(fmt.Errorf("error processing emoji: %s", err), "error processing emoji")
 	}

--- a/internal/processing/media/create.go
+++ b/internal/processing/media/create.go
@@ -40,7 +40,7 @@ func (p *processor) Create(ctx context.Context, account *gtsmodel.Account, form 
 	}
 
 	// process the media attachment and load it immediately
-	media, err := p.mediaManager.ProcessMedia(ctx, data, account.ID, &media.AdditionalMediaInfo{
+	media, err := p.mediaManager.ProcessMedia(ctx, data, nil, account.ID, &media.AdditionalMediaInfo{
 		Description: &form.Description,
 		FocusX:      &focusX,
 		FocusY:      &focusY,


### PR DESCRIPTION
This PR adds a callback to the media manager that will be executed after the data function has been called. This will allow callers to perform additional cleanup of resources etc.