### PR TITLE
goreleaser multi Architecture Images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,15 +54,55 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
-    - "superseriousbusiness/gotosocial:latest"
-    - "superseriousbusiness/gotosocial:{{ .Version }}"
+    # - "superseriousbusiness/{{ .ProjectName }}:latest"
+    - "superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-amd64"
     build_flag_templates:
+    - --platform=linux/amd64
     - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
     extra_files:
     - web
+  -
+    goos: linux
+    goarch: arm64
+    image_templates:
+    # - "superseriousbusiness/{{ .ProjectName }}:latest"
+    - "superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+    build_flag_templates:
+    - --platform=linux/arm64/v8
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    extra_files:
+    - web
+  -
+    goos: linux
+    goarch: arm
+    image_templates:
+    # - "superseriousbusiness/{{ .ProjectName }}:latest"
+    - "superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-armv7"
+    build_flag_templates:
+    - --platform=linux/arm/v7
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    extra_files:
+    - web
+docker_manifests:
+  - name_template: superseriousbusiness/{{ .ProjectName }}:{{ .Version }}
+    image_templates:
+    - superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-amd64
+    - superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-arm64v8
+    - superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-armv7
+  - name_template: superseriousbusiness/{{ .ProjectName }}:latest
+    image_templates:
+    - superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-amd64
+    - superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-arm64v8
+    - superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-armv7
 archives:
   # https://goreleaser.com/customization/archive/
   -


### PR DESCRIPTION
This should build the containers for Linux (amd64, arm64 & arm), I commented out latest here because I added another step here (docker_manifests), this step wants to push the images into dockerhub and build a manifest from it. So you can just do a docker pull from your architecture and the right version will be selected.

Unfortunately I couldn't test the last step properly locally, so in any case the changes need to be tested again before the merge.

But if you don't want goreleaser to push this manifest, you can simply delete the step "docker_manifests" edit the latest tags to `:latest`, `:latest-arm64` & `:latest-arm` or something like that and uncomment the lines.

EDIT:
Sources:
 - https://goreleaser.com/customization/docker/?h=docker
 - https://goreleaser.com/customization/docker_manifest/