### PR TITLE
[packaging] Use buildx for multi-arch Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.github
+cmd
+docs
+example
+internal
+scripts
+test
+testrig
+vendor

--- a/.drone.yml
+++ b/.drone.yml
@@ -57,7 +57,12 @@ steps:
       - git fetch --tags
       - /go/dockerlogin.sh
       - goreleaser release --rm-dist --snapshot
-      - docker push superseriousbusiness/gotosocial:latest
+      - docker push superseriousbusiness/gotosocial:latest-armv6 && 
+      - docker push superseriousbusiness/gotosocial:latest-armv7
+      - docker push superseriousbusiness/gotosocial:latest-arm64v8
+      - docker push superseriousbusiness/gotosocial:latest-amd64
+      - docker manifest create superseriousbusiness/gotosocial:latest superseriousbusiness/gotosocial:latest-armv6 superseriousbusiness/gotosocial:latest-armv7 superseriousbusiness/gotosocial:latest-amd64 superseriousbusiness/gotosocial:latest-arm64v8
+      - docker manifest push superseriousbusiness/gotosocial:latest
     when:
       event:
         include:
@@ -144,6 +149,6 @@ steps:
 
 ---
 kind: signature
-hmac: 0487be0a2c9224c20cf067f94b3a458227e8b5465198b2245266d17156355b98
+hmac: ea1a9c8fc0a872f43146651caeae4f724ca6a45c780456af5a1cbd093d9c51c5
 
 ...

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,9 @@ builds:
       - amd64
       - arm
       - arm64
+    goarm:
+      - 6
+      - 7
     ignore:
       # build freebsd only for amd64
       - goos: freebsd
@@ -51,13 +54,14 @@ builds:
 dockers:
   # https://goreleaser.com/customization/docker/
   -
+    use: buildx
     goos: linux
     goarch: amd64
     image_templates:
-    # - "superseriousbusiness/{{ .ProjectName }}:latest"
     - "superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-amd64"
+    - "superseriousbusiness/{{ .ProjectName }}:latest-amd64"
     build_flag_templates:
-    - --platform=linux/amd64
+    - "--platform=linux/amd64"
     - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -65,13 +69,14 @@ dockers:
     extra_files:
     - web
   -
+    use: buildx
     goos: linux
     goarch: arm64
     image_templates:
-    # - "superseriousbusiness/{{ .ProjectName }}:latest"
     - "superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+    - "superseriousbusiness/{{ .ProjectName }}:latest-arm64v8"
     build_flag_templates:
-    - --platform=linux/arm64/v8
+    - "--platform=linux/arm64/v8"
     - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -79,13 +84,31 @@ dockers:
     extra_files:
     - web
   -
+    use: buildx
     goos: linux
     goarch: arm
+    goarm: 6
     image_templates:
-    # - "superseriousbusiness/{{ .ProjectName }}:latest"
-    - "superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-armv7"
+    - "superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-armv6"
+    - "superseriousbusiness/{{ .ProjectName }}:latest-armv6"
     build_flag_templates:
-    - --platform=linux/arm/v7
+    - "--platform=linux/arm/v6"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    extra_files:
+    - web
+  -
+    use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 7
+    image_templates:
+    - "superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-armv7"
+    - "superseriousbusiness/{{ .ProjectName }}:latest-armv7"
+    build_flag_templates:
+    - "--platform=linux/arm/v7"
     - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -97,12 +120,14 @@ docker_manifests:
     image_templates:
     - superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-amd64
     - superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-arm64v8
+    - superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-armv6
     - superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-armv7
   - name_template: superseriousbusiness/{{ .ProjectName }}:latest
     image_templates:
-    - superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-amd64
-    - superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-arm64v8
-    - superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-armv7
+    - superseriousbusiness/{{ .ProjectName }}:latest-amd64
+    - superseriousbusiness/{{ .ProjectName }}:latest-arm64v8
+    - superseriousbusiness/{{ .ProjectName }}:latest-armv6
+    - superseriousbusiness/{{ .ProjectName }}:latest-armv7
 archives:
   # https://goreleaser.com/customization/archive/
   -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
+# syntax=docker/dockerfile:1.3
+
 # bundle the admin webapp
-FROM node:16.9.0-alpine3.14 AS admin_builder
+FROM --platform=${BUILDPLATFORM} node:16.9.0-alpine3.14 AS admin_builder
 RUN apk update && apk upgrade --no-cache
 RUN apk add git
 
@@ -9,28 +11,20 @@ WORKDIR /gotosocial-admin
 RUN npm install
 RUN node index.js
 
-FROM alpine:3.14.2 AS executor
-RUN apk update && apk upgrade --no-cache
+# build the executor container
+FROM --platform=${TARGETPLATFORM} alpine:3.14.2 AS executor
+
+USER 1000:1000
+VOLUME ["/gotosocial/storage"]
 
 # copy over the binary from the first stage
-RUN mkdir -p /gotosocial/storage
-COPY gotosocial /gotosocial/gotosocial
+COPY --chown=1000:1000 gotosocial /gotosocial/gotosocial
 
 # copy over the web directory with templates etc
-COPY web /gotosocial/web
+COPY --chown=1000:1000 web /gotosocial/web
 
 # copy over the admin directory
-COPY --from=admin_builder /gotosocial-admin/public /gotosocial/web/assets/admin
+COPY --chown=1000:1000 --from=admin_builder /gotosocial-admin/public /gotosocial/web/assets/admin
 
-# make the gotosocial group and user
-RUN addgroup -g 1000 gotosocial
-RUN adduser -HD -u 1000 -G gotosocial gotosocial
-
-# give ownership of the gotosocial dir to the new user
-RUN chown -R gotosocial gotosocial /gotosocial
-
-# become the user
-USER gotosocial
-
-WORKDIR /gotosocial
+WORKDIR "/gotosocial"
 ENTRYPOINT [ "/gotosocial/gotosocial", "server", "start" ]


### PR DESCRIPTION
This PR enables [buildx](https://docs.docker.com/buildx/working-with-buildx/) to ease multi-arch builds, and adds separate v6 and v7 ARM builds, as well as changing the drone file to build a manifest of `latest` for all architectures instead of just amd64. 

Credit to @0hlov3 