### PR TITLE
[bugfix] Fix bug where admin panel could not be accessed at `/admin`

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -47,7 +47,7 @@ type Router interface {
 	AttachMiddleware(handler gin.HandlerFunc)
 	// Attach 404 NoRoute handler
 	AttachNoRouteHandler(handler gin.HandlerFunc)
-	// Add Gin StaticFile handler
+	// Add Gin StaticFS handler
 	AttachStaticFS(relativePath string, fs http.FileSystem)
 	// Start the router
 	Start()
@@ -62,7 +62,7 @@ type router struct {
 	certManager *autocert.Manager
 }
 
-// Add Gin StaticFile handler
+// Add Gin StaticFS handler
 func (r *router) AttachStaticFS(relativePath string, fs http.FileSystem) {
 	r.engine.StaticFS(relativePath, fs)
 }


### PR DESCRIPTION
This PR fixes a bug where the admin panel was not accessible at `/admin` but was accessible at `/admin/`. The fix just adds a 301 redirect from `/admin` to `/admin/`, in a similar style to how admin panel access already worked at `/assets/admin`.

Also tidy up some of the serving logic by using absolute paths where appropriate.

Closes https://github.com/superseriousbusiness/gotosocial/issues/377