### PR TITLE
Dereference shortcuts

### DIFF
--- a/cmd/gotosocial/action/server/server.go
+++ b/cmd/gotosocial/action/server/server.go
@@ -117,7 +117,7 @@ var Start action.GTSAction = func(ctx context.Context) error {
 		return fmt.Errorf("error creating media manager: %s", err)
 	}
 	oauthServer := oauth.New(ctx, dbService)
-	transportController := transport.NewController(dbService, &federation.Clock{}, http.DefaultClient)
+	transportController := transport.NewController(dbService, federatingDB, &federation.Clock{}, http.DefaultClient)
 	federator := federation.NewFederator(dbService, federatingDB, transportController, typeConverter, mediaManager)
 
 	// decide whether to create a noop email sender (won't send emails) or a real one

--- a/internal/transport/deliver.go
+++ b/internal/transport/deliver.go
@@ -23,6 +23,8 @@ import (
 	"net/url"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
 )
 
 func (t *transport) BatchDeliver(ctx context.Context, b []byte, recipients []*url.URL) error {
@@ -30,6 +32,11 @@ func (t *transport) BatchDeliver(ctx context.Context, b []byte, recipients []*ur
 }
 
 func (t *transport) Deliver(ctx context.Context, b []byte, to *url.URL) error {
+	// if the 'to' host is our own, just skip this delivery since we by definition already have the message!
+	if to.Host == viper.GetString(config.Keys.Host) {
+		return nil
+	}
+
 	l := logrus.WithField("func", "Deliver")
 	l.Debugf("performing POST to %s", to.String())
 	return t.sigTransport.Deliver(ctx, b, to)

--- a/internal/transport/dereference.go
+++ b/internal/transport/dereference.go
@@ -39,13 +39,13 @@ func (t *transport) Dereference(ctx context.Context, iri *url.URL) ([]byte, erro
 			return t.dereferenceFollowersShortcut(ctx, iri)
 		}
 
-      if uris.IsUserPath(iri) {
-         // the request is for one of our accounts, which we can shortcut
-         return t.dereferenceUserShortcut(ctx, iri)
-      }
+		if uris.IsUserPath(iri) {
+			// the request is for one of our accounts, which we can shortcut
+			return t.dereferenceUserShortcut(ctx, iri)
+		}
 	}
 
-   // the request is either for a remote host or for us but we don't have a shortcut, so continue as normal
+	// the request is either for a remote host or for us but we don't have a shortcut, so continue as normal
 	l.Debugf("performing GET to %s", iri.String())
 	return t.sigTransport.Dereference(ctx, iri)
 }

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -43,6 +43,8 @@ type Transport interface {
 	DereferenceInstance(ctx context.Context, iri *url.URL) (*gtsmodel.Instance, error)
 	// Finger performs a webfinger request with the given username and domain, and returns the bytes from the response body.
 	Finger(ctx context.Context, targetUsername string, targetDomains string) ([]byte, error)
+	// SigTransport returns the underlying http signature transport wrapped by the GoToSocial transport.
+	SigTransport() pub.Transport
 }
 
 // transport implements the Transport interface
@@ -61,4 +63,8 @@ type transport struct {
 
 	dereferenceFollowersShortcut func(ctx context.Context, iri *url.URL) ([]byte, error)
 	dereferenceUserShortcut      func(ctx context.Context, iri *url.URL) ([]byte, error)
+}
+
+func (t *transport) SigTransport() pub.Transport {
+	return t.sigTransport
 }

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -30,8 +30,11 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 )
 
-// Transport wraps the pub.Transport interface with some additional
-// functionality for fetching remote media.
+// Transport wraps the pub.Transport interface with some additional functionality for fetching remote media.
+//
+// Since the transport has the concept of 'shortcuts' for fetching data locally rather than remotely, it is
+// not *always* the case that calling a Transport function does an http call, but it usually will for remote
+// hosts or resources for which a shortcut isn't provided by the transport controller (also in this package).
 type Transport interface {
 	pub.Transport
 	// DereferenceMedia fetches the given media attachment IRI, returning the reader and filesize.
@@ -53,4 +56,9 @@ type transport struct {
 	sigTransport *pub.HttpSigTransport
 	getSigner    httpsig.Signer
 	getSignerMu  *sync.Mutex
+
+	// shortcuts for dereferencing things that exist on our instance without making an http call to ourself
+
+	dereferenceFollowersShortcut func(ctx context.Context, iri *url.URL) ([]byte, error)
+	dereferenceUserShortcut      func(ctx context.Context, iri *url.URL) ([]byte, error)
 }

--- a/testrig/testmodels.go
+++ b/testrig/testmodels.go
@@ -1749,8 +1749,8 @@ func GetSignatureForActivity(activity pub.Activity, pubKeyID string, privkey cry
 		panic(err)
 	}
 
-	// trigger the delivery function, which will trigger the 'do' function of the recorder above
-	if err := tp.Deliver(context.Background(), bytes, destination); err != nil {
+	// trigger the delivery function for the underlying signature transport, which will trigger the 'do' function of the recorder above
+	if err := tp.SigTransport().Deliver(context.Background(), bytes, destination); err != nil {
 		panic(err)
 	}
 
@@ -1781,8 +1781,8 @@ func GetSignatureForDereference(pubKeyID string, privkey crypto.PrivateKey, dest
 		panic(err)
 	}
 
-	// trigger the delivery function, which will trigger the 'do' function of the recorder above
-	if _, err := tp.Dereference(context.Background(), destination); err != nil {
+	// trigger the dereference function for the underlying signature transport, which will trigger the 'do' function of the recorder above
+	if _, err := tp.SigTransport().Dereference(context.Background(), destination); err != nil {
 		panic(err)
 	}
 

--- a/testrig/transportcontroller.go
+++ b/testrig/transportcontroller.go
@@ -39,7 +39,7 @@ import (
 // PER TEST rather than per suite, so that the do function can be set on a test by test (or even more granular)
 // basis.
 func NewTestTransportController(client pub.HttpClient, db db.DB) transport.Controller {
-	return transport.NewController(db, &federation.Clock{}, client)
+	return transport.NewController(db, NewTestFederatingDB(db), &federation.Clock{}, client)
 }
 
 // NewMockHTTPClient returns a client that conforms to the pub.HttpClient interface,


### PR DESCRIPTION
This PR adds logic within the transport controller + transports to skip 'remote' dereferencing of resources that already exist on our instance, and fetch them from the database instead. It also adds logic to skip delivering messages to inboxes owned by our instance, since by definition we're already aware of whatever message is being sent.