### PR TITLE
[feature] Admin account actions

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -2336,6 +2336,43 @@ paths:
       summary: Verify a token by returning account details pertaining to it.
       tags:
       - accounts
+  /api/v1/admin/accounts/{id}/action:
+    post:
+      consumes:
+      - multipart/form-data
+      operationId: adminAccountAction
+      parameters:
+      - description: ID of the account.
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: 'Type of action to be taken. One of: disable, silence, suspend.'
+        in: formData
+        name: type
+        required: true
+        type: string
+      - description: Optional text describing why this action was taken.
+        in: formData
+        name: text
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: bad request
+        "401":
+          description: unauthorized
+        "403":
+          description: forbidden
+      security:
+      - OAuth2 Bearer:
+        - admin
+      summary: Perform an admin action on an account.
+      tags:
+      - admin
   /api/v1/admin/custom_emojis:
     post:
       consumes:

--- a/internal/api/client/admin/accountaction.go
+++ b/internal/api/client/admin/accountaction.go
@@ -50,7 +50,8 @@ import (
 //   type: string
 // - name: type
 //   in: formData
-//   description: Type of action to be taken. One of: disable, silence, suspend.
+//   description: |-
+//     Type of action to be taken. One of: disable, silence, suspend.
 //   type: string
 //   required: true
 // - name: text

--- a/internal/api/client/admin/accountaction.go
+++ b/internal/api/client/admin/accountaction.go
@@ -1,0 +1,125 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package admin
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+	"github.com/superseriousbusiness/gotosocial/internal/api/model"
+	"github.com/superseriousbusiness/gotosocial/internal/oauth"
+)
+
+// AccountActionPOSTHandler swagger:operation POST /api/v1/admin/accounts/{id}/action adminAccountAction
+//
+// Perform an admin action on an account.
+//
+// ---
+// tags:
+// - admin
+//
+// consumes:
+// - multipart/form-data
+//
+// produces:
+// - application/json
+//
+// parameters:
+// - name: id
+//   required: true
+//   in: path
+//   description: ID of the account.
+//   type: string
+// - name: type
+//   in: formData
+//   description: Type of action to be taken. One of: disable, silence, suspend.
+//   type: string
+//   required: true
+// - name: text
+//   in: formData
+//   description: Optional text describing why this action was taken.
+//   type: string
+//
+// security:
+// - OAuth2 Bearer:
+//   - admin
+//
+// responses:
+//   '200':
+//     description: OK
+//   '400':
+//      description: bad request
+//   '401':
+//      description: unauthorized
+//   '403':
+//      description: forbidden
+func (m *Module) AccountActionPOSTHandler(c *gin.Context) {
+	l := logrus.WithFields(logrus.Fields{
+		"func":        "AccountActionPOSTHandler",
+		"request_uri": c.Request.RequestURI,
+		"user_agent":  c.Request.UserAgent(),
+		"origin_ip":   c.ClientIP(),
+	})
+
+	// make sure we're authed...
+	authed, err := oauth.Authed(c, true, true, true, true)
+	if err != nil {
+		l.Debugf("couldn't auth: %s", err)
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+
+	// with an admin account
+	if !authed.User.Admin {
+		l.Debugf("user %s not an admin", authed.User.ID)
+		c.JSON(http.StatusForbidden, gin.H{"error": "not an admin"})
+		return
+	}
+
+	// extract the form from the request context
+	l.Tracef("parsing request form: %+v", c.Request.Form)
+	form := &model.AdminAccountActionRequest{}
+	if err := c.ShouldBind(form); err != nil {
+		l.Debugf("error parsing form %+v: %s", c.Request.Form, err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("could not parse form: %s", err)})
+		return
+	}
+
+	if form.Type == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no type specified"})
+		return
+	}
+
+	targetAcctID := c.Param(IDKey)
+	if targetAcctID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no account id specified"})
+		return
+	}
+	form.TargetAccountID = targetAcctID
+
+	if errWithCode := m.processor.AdminAccountAction(c.Request.Context(), authed, form); errWithCode != nil {
+		l.Debugf("error performing account action: %s", errWithCode.Error())
+		c.JSON(errWithCode.Code(), gin.H{"error": errWithCode.Safe()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "OK"})
+}

--- a/internal/api/client/admin/admin.go
+++ b/internal/api/client/admin/admin.go
@@ -36,7 +36,7 @@ const (
 	// DomainBlocksPathWithID is used for interacting with a single domain block.
 	DomainBlocksPathWithID = DomainBlocksPath + "/:" + IDKey
 	// AccountsPath is used for listing + acting on accounts.
-	AccountsPath = BasePath + "accounts"
+	AccountsPath = BasePath + "/accounts"
 	// AccountsPathWithID is used for interacting with a single account.
 	AccountsPathWithID = AccountsPath + "/:" + IDKey
 	// AccountsActionPath is used for taking action on a single account.

--- a/internal/api/client/admin/admin.go
+++ b/internal/api/client/admin/admin.go
@@ -35,6 +35,12 @@ const (
 	DomainBlocksPath = BasePath + "/domain_blocks"
 	// DomainBlocksPathWithID is used for interacting with a single domain block.
 	DomainBlocksPathWithID = DomainBlocksPath + "/:" + IDKey
+	// AccountsPath is used for listing + acting on accounts.
+	AccountsPath = BasePath + "accounts"
+	// AccountsPathWithID is used for interacting with a single account.
+	AccountsPathWithID = AccountsPath + "/:" + IDKey
+	// AccountsActionPath is used for taking action on a single account.
+	AccountsActionPath = AccountsPathWithID + "/action"
 
 	// ExportQueryKey is for requesting a public export of some data.
 	ExportQueryKey = "export"
@@ -63,5 +69,6 @@ func (m *Module) Route(r router.Router) error {
 	r.AttachHandler(http.MethodGet, DomainBlocksPath, m.DomainBlocksGETHandler)
 	r.AttachHandler(http.MethodGet, DomainBlocksPathWithID, m.DomainBlockGETHandler)
 	r.AttachHandler(http.MethodDelete, DomainBlocksPathWithID, m.DomainBlockDELETEHandler)
+	r.AttachHandler(http.MethodPost, AccountsActionPath, m.AccountActionPOSTHandler)
 	return nil
 }

--- a/internal/api/client/admin/admin_test.go
+++ b/internal/api/client/admin/admin_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/media"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 	"github.com/superseriousbusiness/gotosocial/internal/processing"
-	"github.com/superseriousbusiness/gotosocial/internal/typeutils"
 	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
@@ -45,7 +44,6 @@ type AdminStandardTestSuite struct {
 	// standard suite interfaces
 	suite.Suite
 	db           db.DB
-	tc           typeutils.TypeConverter
 	storage      *kv.KVStore
 	mediaManager media.Manager
 	federator    federation.Federator

--- a/internal/api/model/admin.go
+++ b/internal/api/model/admin.go
@@ -79,3 +79,15 @@ type AdminReportInfo struct {
 	// Statuses attached to the report, for context.
 	Statuses []Status `json:"statuses"`
 }
+
+// AdminAccountActionRequest models the admin view of an account's details.
+//
+// swagger:ignore
+type AdminAccountActionRequest struct {
+	// Type of the account action. One of disable, silence, suspend.
+	Type string `form:"type" json:"type" xml:"type"`
+	// Text describing why an action was taken.
+	Text string `form:"text" json:"text" xml:"text"`
+	// ID of the account to be acted on.
+	TargetAccountID string `form:"-" json:"-" xml:"-"`
+}

--- a/internal/db/bundb/migrations/20220315160814_admin_account_actions.go
+++ b/internal/db/bundb/migrations/20220315160814_admin_account_actions.go
@@ -1,0 +1,77 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package migrations
+
+import (
+	"context"
+
+	gtsmodel "github.com/superseriousbusiness/gotosocial/internal/db/bundb/migrations/20220315160814_admin_account_actions"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			// create table for the new admin action struct
+			if _, err := db.NewCreateTable().Model(&gtsmodel.AdminAccountAction{}).IfNotExists().Exec(ctx); err != nil {
+				return err
+			}
+
+			// create indexes for the new admin action struct for things we will select on
+			if _, err := tx.
+				NewCreateIndex().
+				Model(&gtsmodel.AdminAccountAction{}).
+				Index("admin_account_actions_account_id_idx").
+				Column("account_id").
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			if _, err := tx.
+				NewCreateIndex().
+				Model(&gtsmodel.AdminAccountAction{}).
+				Index("admin_account_actions_target_account_id_idx").
+				Column("target_account_id").
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			if _, err := tx.
+				NewCreateIndex().
+				Model(&gtsmodel.AdminAccountAction{}).
+				Index("admin_account_actions_type_idx").
+				Column("type").
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}

--- a/internal/db/bundb/migrations/20220315160814_admin_account_actions/account.go
+++ b/internal/db/bundb/migrations/20220315160814_admin_account_actions/account.go
@@ -1,0 +1,117 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Package gtsmodel contains types used *internally* by GoToSocial and added/removed/selected from the database.
+// These types should never be serialized and/or sent out via public APIs, as they contain sensitive information.
+// The annotation used on these structs is for handling them via the bun-db ORM.
+// See here for more info on bun model annotations: https://bun.uptrace.dev/guide/models.html
+package gtsmodel
+
+import (
+	"crypto/rsa"
+	"time"
+)
+
+// Account represents either a local or a remote fediverse account, gotosocial or otherwise (mastodon, pleroma, etc).
+type Account struct {
+	ID                      string           `validate:"required,ulid" bun:"type:CHAR(26),pk,nullzero,notnull,unique"`                                               // id of this item in the database
+	CreatedAt               time.Time        `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"`                                        // when was item created
+	UpdatedAt               time.Time        `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"`                                        // when was item last updated
+	Username                string           `validate:"required" bun:",nullzero,notnull,unique:userdomain"`                                                         // Username of the account, should just be a string of [a-zA-Z0-9_]. Can be added to domain to create the full username in the form ``[username]@[domain]`` eg., ``user_96@example.org``. Username and domain should be unique *with* each other
+	Domain                  string           `validate:"omitempty,fqdn" bun:",nullzero,unique:userdomain"`                                                           // Domain of the account, will be null if this is a local account, otherwise something like ``example.org``. Should be unique with username.
+	AvatarMediaAttachmentID string           `validate:"omitempty,ulid" bun:"type:CHAR(26),nullzero"`                                                                // Database ID of the media attachment, if present
+	AvatarMediaAttachment   *MediaAttachment `validate:"-" bun:"rel:belongs-to"`                                                                                     // MediaAttachment corresponding to avatarMediaAttachmentID
+	AvatarRemoteURL         string           `validate:"omitempty,url" bun:",nullzero"`                                                                              // For a non-local account, where can the header be fetched?
+	HeaderMediaAttachmentID string           `validate:"omitempty,ulid" bun:"type:CHAR(26),nullzero"`                                                                // Database ID of the media attachment, if present
+	HeaderMediaAttachment   *MediaAttachment `validate:"-" bun:"rel:belongs-to"`                                                                                     // MediaAttachment corresponding to headerMediaAttachmentID
+	HeaderRemoteURL         string           `validate:"omitempty,url" bun:",nullzero"`                                                                              // For a non-local account, where can the header be fetched?
+	DisplayName             string           `validate:"-" bun:""`                                                                                                   // DisplayName for this account. Can be empty, then just the Username will be used for display purposes.
+	Fields                  []Field          `validate:"-"`                                                                                                          // a key/value map of fields that this account has added to their profile
+	Note                    string           `validate:"-" bun:""`                                                                                                   // A note that this account has on their profile (ie., the account's bio/description of themselves)
+	Memorial                bool             `validate:"-" bun:",default:false"`                                                                                     // Is this a memorial account, ie., has the user passed away?
+	AlsoKnownAs             string           `validate:"omitempty,ulid" bun:"type:CHAR(26),nullzero"`                                                                // This account is associated with x account id (TODO: migrate to be AlsoKnownAsID)
+	MovedToAccountID        string           `validate:"omitempty,ulid" bun:"type:CHAR(26),nullzero"`                                                                // This account has moved this account id in the database
+	Bot                     bool             `validate:"-" bun:",default:false"`                                                                                     // Does this account identify itself as a bot?
+	Reason                  string           `validate:"-" bun:""`                                                                                                   // What reason was given for signing up when this account was created?
+	Locked                  bool             `validate:"-" bun:",default:true"`                                                                                      // Does this account need an approval for new followers?
+	Discoverable            bool             `validate:"-" bun:",default:false"`                                                                                     // Should this account be shown in the instance's profile directory?
+	Privacy                 Visibility       `validate:"required_without=Domain,omitempty,oneof=public unlocked followers_only mutuals_only direct" bun:",nullzero"` // Default post privacy for this account
+	Sensitive               bool             `validate:"-" bun:",default:false"`                                                                                     // Set posts from this account to sensitive by default?
+	Language                string           `validate:"omitempty,bcp47_language_tag" bun:",nullzero,notnull,default:'en'"`                                          // What language does this account post in?
+	URI                     string           `validate:"required,url" bun:",nullzero,notnull,unique"`                                                                // ActivityPub URI for this account.
+	URL                     string           `validate:"required_without=Domain,omitempty,url" bun:",nullzero,unique"`                                               // Web URL for this account's profile
+	LastWebfingeredAt       time.Time        `validate:"required_with=Domain" bun:"type:timestamptz,nullzero"`                                                       // Last time this account was refreshed/located with webfinger.
+	InboxURI                string           `validate:"required_without=Domain,omitempty,url" bun:",nullzero,unique"`                                               // Address of this account's ActivityPub inbox, for sending activity to
+	OutboxURI               string           `validate:"required_without=Domain,omitempty,url" bun:",nullzero,unique"`                                               // Address of this account's activitypub outbox
+	FollowingURI            string           `validate:"required_without=Domain,omitempty,url" bun:",nullzero,unique"`                                               // URI for getting the following list of this account
+	FollowersURI            string           `validate:"required_without=Domain,omitempty,url" bun:",nullzero,unique"`                                               // URI for getting the followers list of this account
+	FeaturedCollectionURI   string           `validate:"required_without=Domain,omitempty,url" bun:",nullzero,unique"`                                               // URL for getting the featured collection list of this account
+	ActorType               string           `validate:"oneof=Application Group Organization Person Service" bun:",nullzero,notnull"`                                // What type of activitypub actor is this account?
+	PrivateKey              *rsa.PrivateKey  `validate:"required_without=Domain"`                                                                                    // Privatekey for validating activitypub requests, will only be defined for local accounts
+	PublicKey               *rsa.PublicKey   `validate:"required"`                                                                                                   // Publickey for encoding activitypub requests, will be defined for both local and remote accounts
+	PublicKeyURI            string           `validate:"required,url" bun:",nullzero,notnull,unique"`                                                                // Web-reachable location of this account's public key
+	SensitizedAt            time.Time        `validate:"-" bun:"type:timestamptz,nullzero"`                                                                          // When was this account set to have all its media shown as sensitive?
+	SilencedAt              time.Time        `validate:"-" bun:"type:timestamptz,nullzero"`                                                                          // When was this account silenced (eg., statuses only visible to followers, not public)?
+	SuspendedAt             time.Time        `validate:"-" bun:"type:timestamptz,nullzero"`                                                                          // When was this account suspended (eg., don't allow it to log in/post, don't accept media/posts from this account)
+	HideCollections         bool             `validate:"-" bun:",default:false"`                                                                                     // Hide this account's collections
+	SuspensionOrigin        string           `validate:"omitempty,ulid" bun:"type:CHAR(26),nullzero"`                                                                // id of the database entry that caused this account to become suspended -- can be an account ID or a domain block ID
+}
+
+// Field represents a key value field on an account, for things like pronouns, website, etc.
+// VerifiedAt is optional, to be used only if Value is a URL to a webpage that contains the
+// username of the user.
+type Field struct {
+	Name       string    `validate:"required"`          // Name of this field.
+	Value      string    `validate:"required"`          // Value of this field.
+	VerifiedAt time.Time `validate:"-" bun:",nullzero"` // This field was verified at (optional).
+}
+
+// Relationship describes a requester's relationship with another account.
+type Relationship struct {
+	ID                  string // The account id.
+	Following           bool   // Are you following this user?
+	ShowingReblogs      bool   // Are you receiving this user's boosts in your home timeline?
+	Notifying           bool   // Have you enabled notifications for this user?
+	FollowedBy          bool   // Are you followed by this user?
+	Blocking            bool   // Are you blocking this user?
+	BlockedBy           bool   // Is this user blocking you?
+	Muting              bool   // Are you muting this user?
+	MutingNotifications bool   // Are you muting notifications from this user?
+	Requested           bool   // Do you have a pending follow request for this user?
+	DomainBlocking      bool   // Are you blocking this user's domain?
+	Endorsed            bool   // Are you featuring this user on your profile?
+	Note                string // Your note on this account.
+}
+
+// Visibility represents the visibility granularity of a status.
+type Visibility string
+
+const (
+	// VisibilityPublic means this status will be visible to everyone on all timelines.
+	VisibilityPublic Visibility = "public"
+	// VisibilityUnlocked means this status will be visible to everyone, but will only show on home timeline to followers, and in lists.
+	VisibilityUnlocked Visibility = "unlocked"
+	// VisibilityFollowersOnly means this status is viewable to followers only.
+	VisibilityFollowersOnly Visibility = "followers_only"
+	// VisibilityMutualsOnly means this status is visible to mutual followers only.
+	VisibilityMutualsOnly Visibility = "mutuals_only"
+	// VisibilityDirect means this status is visible only to mentioned recipients.
+	VisibilityDirect Visibility = "direct"
+	// VisibilityDefault is used when no other setting can be found.
+	VisibilityDefault Visibility = VisibilityUnlocked
+)

--- a/internal/db/bundb/migrations/20220315160814_admin_account_actions/admin.go
+++ b/internal/db/bundb/migrations/20220315160814_admin_account_actions/admin.go
@@ -1,0 +1,48 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package gtsmodel
+
+import "time"
+
+// AdminAccountAction models an action taken by an instance administrator on an account.
+type AdminAccountAction struct {
+	ID              string          `validate:"required,ulid" bun:"type:CHAR(26),pk,nullzero,notnull,unique"`        // id of this item in the database
+	CreatedAt       time.Time       `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"` // when was item created
+	UpdatedAt       time.Time       `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"` // when was item last updated
+	AccountID       string          `validate:"required,ulid" bun:"type:CHAR(26),notnull,nullzero"`                  // Who performed this admin action.
+	Account         *Account        `validate:"-" bun:"rel:has-one"`                                                 // Account corresponding to accountID
+	TargetAccountID string          `validate:"required,ulid" bun:"type:CHAR(26),notnull,nullzero"`                  // Who is the target of this action
+	TargetAccount   *Account        `validate:"-" bun:"rel:has-one"`                                                 // Account corresponding to targetAccountID
+	Text            string          `validate:"-" bun:""`                                                            // text explaining why this action was taken
+	Type            AdminActionType `validate:"oneof=disable silence suspend" bun:",nullzero,notnull"`               // type of action that was taken
+	SendEmail       bool            `validate:"-" bun:""`                                                            // should an email be sent to the account owner to explain what happened
+	ReportID        string          `validate:",omitempty,ulid" bun:"type:CHAR(26),nullzero"`                        // id of a report connected to this action, if it exists
+}
+
+// AdminActionType describes a type of action taken on an entity by an admin
+type AdminActionType string
+
+const (
+	// AdminActionDisable -- the account or application etc has been disabled but not deleted.
+	AdminActionDisable AdminActionType = "disable"
+	// AdminActionSilence -- the account or application etc has been silenced.
+	AdminActionSilence AdminActionType = "silence"
+	// AdminActionSuspend -- the account or application etc has been deleted.
+	AdminActionSuspend AdminActionType = "suspend"
+)

--- a/internal/db/bundb/migrations/20220315160814_admin_account_actions/mediaattachment.go
+++ b/internal/db/bundb/migrations/20220315160814_admin_account_actions/mediaattachment.go
@@ -1,0 +1,118 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package gtsmodel
+
+import (
+	"time"
+)
+
+// MediaAttachment represents a user-uploaded media attachment: an image/video/audio/gif that is
+// somewhere in storage and that can be retrieved and served by the router.
+type MediaAttachment struct {
+	ID                string           `validate:"required,ulid" bun:"type:CHAR(26),pk,nullzero,notnull,unique"`                       // id of this item in the database
+	CreatedAt         time.Time        `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"`                // when was item created
+	UpdatedAt         time.Time        `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"`                // when was item last updated
+	StatusID          string           `validate:"omitempty,ulid" bun:"type:CHAR(26),nullzero"`                                        // ID of the status to which this is attached
+	URL               string           `validate:"required_without=RemoteURL,omitempty,url" bun:",nullzero"`                           // Where can the attachment be retrieved on *this* server
+	RemoteURL         string           `validate:"required_without=URL,omitempty,url" bun:",nullzero"`                                 // Where can the attachment be retrieved on a remote server (empty for local media)
+	Type              FileType         `validate:"oneof=Image Gif Audio Video Unknown" bun:",nullzero,notnull"`                        // Type of file (image/gif/audio/video)
+	FileMeta          FileMeta         `validate:"required" bun:",embed:filemeta_,nullzero,notnull"`                                   // Metadata about the file
+	AccountID         string           `validate:"required,ulid" bun:"type:CHAR(26),nullzero,notnull"`                                 // To which account does this attachment belong
+	Account           *Account         `validate:"-" bun:"rel:has-one"`                                                                // Account corresponding to accountID
+	Description       string           `validate:"-" bun:""`                                                                           // Description of the attachment (for screenreaders)
+	ScheduledStatusID string           `validate:"omitempty,ulid" bun:"type:CHAR(26),nullzero"`                                        // To which scheduled status does this attachment belong
+	Blurhash          string           `validate:"required_if=Type Image,required_if=Type Gif,required_if=Type Video" bun:",nullzero"` // What is the generated blurhash of this attachment
+	Processing        ProcessingStatus `validate:"oneof=0 1 2 666" bun:",notnull,default:2"`                                           // What is the processing status of this attachment
+	File              File             `validate:"required" bun:",embed:file_,notnull,nullzero"`                                       // metadata for the whole file
+	Thumbnail         Thumbnail        `validate:"required" bun:",embed:thumbnail_,notnull,nullzero"`                                  // small image thumbnail derived from a larger image, video, or audio file.
+	Avatar            bool             `validate:"-" bun:",notnull,default:false"`                                                     // Is this attachment being used as an avatar?
+	Header            bool             `validate:"-" bun:",notnull,default:false"`                                                     // Is this attachment being used as a header?
+	Cached            bool             `validate:"-" bun:",notnull"`                                                                   // Is this attachment currently cached by our instance?
+}
+
+// File refers to the metadata for the whole file
+type File struct {
+	Path        string    `validate:"required,file" bun:",nullzero,notnull"`                               // Path of the file in storage.
+	ContentType string    `validate:"required" bun:",nullzero,notnull"`                                    // MIME content type of the file.
+	FileSize    int       `validate:"required" bun:",notnull"`                                             // File size in bytes
+	UpdatedAt   time.Time `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"` // When was the file last updated.
+}
+
+// Thumbnail refers to a small image thumbnail derived from a larger image, video, or audio file.
+type Thumbnail struct {
+	Path        string    `validate:"required,file" bun:",nullzero,notnull"`                               // Path of the file in storage.
+	ContentType string    `validate:"required" bun:",nullzero,notnull"`                                    // MIME content type of the file.
+	FileSize    int       `validate:"required" bun:",notnull"`                                             // File size in bytes
+	UpdatedAt   time.Time `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"` // When was the file last updated.
+	URL         string    `validate:"required_without=RemoteURL,omitempty,url" bun:",nullzero"`            // What is the URL of the thumbnail on the local server
+	RemoteURL   string    `validate:"required_without=URL,omitempty,url" bun:",nullzero"`                  // What is the remote URL of the thumbnail (empty for local media)
+}
+
+// ProcessingStatus refers to how far along in the processing stage the attachment is.
+type ProcessingStatus int
+
+// MediaAttachment processing states.
+const (
+	ProcessingStatusReceived   ProcessingStatus = 0   // ProcessingStatusReceived indicates the attachment has been received and is awaiting processing. No thumbnail available yet.
+	ProcessingStatusProcessing ProcessingStatus = 1   // ProcessingStatusProcessing indicates the attachment is currently being processed. Thumbnail is available but full media is not.
+	ProcessingStatusProcessed  ProcessingStatus = 2   // ProcessingStatusProcessed indicates the attachment has been fully processed and is ready to be served.
+	ProcessingStatusError      ProcessingStatus = 666 // ProcessingStatusError indicates something went wrong processing the attachment and it won't be tried again--these can be deleted.
+)
+
+// FileType refers to the file type of the media attaachment.
+type FileType string
+
+// MediaAttachment file types.
+const (
+	FileTypeImage   FileType = "Image"   // FileTypeImage is for jpegs and pngs
+	FileTypeGif     FileType = "Gif"     // FileTypeGif is for native gifs and soundless videos that have been converted to gifs
+	FileTypeAudio   FileType = "Audio"   // FileTypeAudio is for audio-only files (no video)
+	FileTypeVideo   FileType = "Video"   // FileTypeVideo is for files with audio + visual
+	FileTypeUnknown FileType = "Unknown" // FileTypeUnknown is for unknown file types (surprise surprise!)
+)
+
+// FileMeta describes metadata about the actual contents of the file.
+type FileMeta struct {
+	Original Original `validate:"required" bun:"embed:original_"`
+	Small    Small    `bun:"embed:small_"`
+	Focus    Focus    `bun:"embed:focus_"`
+}
+
+// Small can be used for a thumbnail of any media type
+type Small struct {
+	Width  int     `validate:"required_with=Height Size Aspect"`  // width in pixels
+	Height int     `validate:"required_with=Width Size Aspect"`   // height in pixels
+	Size   int     `validate:"required_with=Width Height Aspect"` // size in pixels (width * height)
+	Aspect float64 `validate:"required_with=Widhth Height Size"`  // aspect ratio (width / height)
+}
+
+// Original can be used for original metadata for any media type
+type Original struct {
+	Width  int     `validate:"required_with=Height Size Aspect"`  // width in pixels
+	Height int     `validate:"required_with=Width Size Aspect"`   // height in pixels
+	Size   int     `validate:"required_with=Width Height Aspect"` // size in pixels (width * height)
+	Aspect float64 `validate:"required_with=Widhth Height Size"`  // aspect ratio (width / height)
+}
+
+// Focus describes the 'center' of the image for display purposes.
+// X and Y should each be between -1 and 1
+type Focus struct {
+	X float32 `validate:"omitempty,max=1,min=-1"`
+	Y float32 `validate:"omitempty,max=1,min=-1"`
+}

--- a/internal/gtsmodel/admin.go
+++ b/internal/gtsmodel/admin.go
@@ -1,0 +1,48 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package gtsmodel
+
+import "time"
+
+// AdminAccountAction models an action taken by an instance administrator on an account.
+type AdminAccountAction struct {
+	ID              string          `validate:"required,ulid" bun:"type:CHAR(26),pk,nullzero,notnull,unique"`        // id of this item in the database
+	CreatedAt       time.Time       `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"` // when was item created
+	UpdatedAt       time.Time       `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"` // when was item last updated
+	AccountID       string          `validate:"required,ulid" bun:"type:CHAR(26),notnull,nullzero"`                  // Who performed this admin action.
+	Account         *Account        `validate:"-" bun:"rel:has-one"`                                                 // Account corresponding to accountID
+	TargetAccountID string          `validate:"required,ulid" bun:"type:CHAR(26),notnull,nullzero"`                  // Who is the target of this action
+	TargetAccount   *Account        `validate:"-" bun:"rel:has-one"`                                                 // Account corresponding to targetAccountID
+	Text            string          `validate:"-" bun:""`                                                            // text explaining why this action was taken
+	Type            AdminActionType `validate:"oneof=disable silence suspend" bun:",nullzero,notnull"`               // type of action that was taken
+	SendEmail       bool            `validate:"-" bun:""`                                                            // should an email be sent to the account owner to explain what happened
+	ReportID        string          `validate:",omitempty,ulid" bun:"type:CHAR(26),nullzero"`                        // id of a report connected to this action, if it exists
+}
+
+// AdminActionType describes a type of action taken on an entity by an admin
+type AdminActionType string
+
+const (
+	// AdminActionDisable -- the account or application etc has been disabled but not deleted.
+	AdminActionDisable AdminActionType = "disable"
+	// AdminActionSilence -- the account or application etc has been silenced.
+	AdminActionSilence AdminActionType = "silence"
+	// AdminActionSuspend -- the account or application etc has been deleted.
+	AdminActionSuspend AdminActionType = "suspend"
+)

--- a/internal/processing/admin.go
+++ b/internal/processing/admin.go
@@ -26,6 +26,10 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
+func (p *processor) AdminAccountAction(ctx context.Context, authed *oauth.Auth, form *apimodel.AdminAccountActionRequest) gtserror.WithCode {
+	return p.adminProcessor.AccountAction(ctx, authed.Account, form)
+}
+
 func (p *processor) AdminEmojiCreate(ctx context.Context, authed *oauth.Auth, form *apimodel.EmojiCreateRequest) (*apimodel.Emoji, gtserror.WithCode) {
 	return p.adminProcessor.EmojiCreate(ctx, authed.Account, authed.User, form)
 }

--- a/internal/processing/admin/accountaction.go
+++ b/internal/processing/admin/accountaction.go
@@ -1,0 +1,52 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/superseriousbusiness/gotosocial/internal/ap"
+	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/id"
+	"github.com/superseriousbusiness/gotosocial/internal/messages"
+)
+
+func (p *processor) AccountAction(ctx context.Context, account *gtsmodel.Account, form *apimodel.AdminAccountActionRequest) gtserror.WithCode {
+	targetAccount, err := p.db.GetAccountByID(ctx, form.TargetAccountID)
+	if err != nil {
+		return gtserror.NewErrorInternalError(err)
+	}
+
+	adminActionID, err := id.NewULID()
+	if err != nil {
+		return gtserror.NewErrorInternalError(err)
+	}
+
+	adminAction := &gtsmodel.AdminAccountAction{
+		ID:              adminActionID,
+		AccountID:       account.ID,
+		TargetAccountID: targetAccount.ID,
+		Text:            form.Text,
+	}
+
+	switch form.Type {
+	case string(gtsmodel.AdminActionSuspend):
+		adminAction.Type = gtsmodel.AdminActionSuspend
+		// pass the account delete through the client api channel for processing
+		p.fromClientAPI <- messages.FromClientAPI{
+			APObjectType:   ap.ActorPerson,
+			APActivityType: ap.ActivityDelete,
+			OriginAccount:  account,
+			TargetAccount:  targetAccount,
+		}
+	default:
+		return gtserror.NewErrorBadRequest(fmt.Errorf("admin action type %s is not supported for this endpoint", form.Type))
+	}
+
+	if err := p.db.Put(ctx, adminAction); err != nil {
+		return gtserror.NewErrorInternalError(err)
+	}
+
+	return nil
+}

--- a/internal/processing/admin/admin.go
+++ b/internal/processing/admin/admin.go
@@ -38,6 +38,7 @@ type Processor interface {
 	DomainBlocksGet(ctx context.Context, account *gtsmodel.Account, export bool) ([]*apimodel.DomainBlock, gtserror.WithCode)
 	DomainBlockGet(ctx context.Context, account *gtsmodel.Account, id string, export bool) (*apimodel.DomainBlock, gtserror.WithCode)
 	DomainBlockDelete(ctx context.Context, account *gtsmodel.Account, id string) (*apimodel.DomainBlock, gtserror.WithCode)
+	AccountAction(ctx context.Context, account *gtsmodel.Account, form *apimodel.AdminAccountActionRequest) gtserror.WithCode
 	EmojiCreate(ctx context.Context, account *gtsmodel.Account, user *gtsmodel.User, form *apimodel.EmojiCreateRequest) (*apimodel.Emoji, gtserror.WithCode)
 }
 

--- a/internal/processing/processor.go
+++ b/internal/processing/processor.go
@@ -97,6 +97,8 @@ type Processor interface {
 	// AccountBlockRemove handles the removal of a block from authed account to target account, either remote or local.
 	AccountBlockRemove(ctx context.Context, authed *oauth.Auth, targetAccountID string) (*apimodel.Relationship, gtserror.WithCode)
 
+	// AdminAccountAction handles the creation/execution of an action on an account.
+	AdminAccountAction(ctx context.Context, authed *oauth.Auth, form *apimodel.AdminAccountActionRequest) gtserror.WithCode
 	// AdminEmojiCreate handles the creation of a new instance emoji by an admin, using the given form.
 	AdminEmojiCreate(ctx context.Context, authed *oauth.Auth, form *apimodel.EmojiCreateRequest) (*apimodel.Emoji, gtserror.WithCode)
 	// AdminDomainBlockCreate handles the creation of a new domain block by an admin, using the given form.


### PR DESCRIPTION
This PR adds an endpoint for admins to take actions on accounts (`/api/v1/admin/accounts/:id/action`). Currently only the 'suspend' action is available, which will delete/suspend an account.

If a local account is deleted in this way, the action will be propagated out to other instances (To: the account's followers and CC: public).

This allows instance admins to delete accounts on their instances that aren't being used anymore, and also allows them to do targeted suspensions of accounts from other instances that they don't want their instance to be able to interact with anymore, without blocking the entire domain.

This PR includes a database migration which adds a new table to the database: admin_account_actions. This keeps track of which admin has taken action against which account, and why. It's currently not used for anything but in future we can display this via the admin panel so admins can review prior actions taken.