### PR TITLE
[bugfix] Close ReadClosers properly in the media package

### DIFF
--- a/internal/processing/media/util.go
+++ b/internal/processing/media/util.go
@@ -20,6 +20,7 @@ package media
 
 import (
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 )
@@ -60,4 +61,17 @@ func parseFocus(focus string) (focusx, focusy float32, err error) {
 	}
 	focusy = float32(fy)
 	return
+}
+
+type teeReadCloser struct {
+	teeReader io.Reader
+	close     func() error
+}
+
+func (t teeReadCloser) Read(p []byte) (n int, err error) {
+	return t.teeReader.Read(p)
+}
+
+func (t teeReadCloser) Close() error {
+	return t.close()
 }


### PR DESCRIPTION
This PR makes some small changes in the media package to make sure that we're properly closing Readers wherever possible. This *might* help with #420, it's running on goblin.technology for testing.

Update: haven't seen any more issues on goblin.technology. However, it's only been running for two days. Still I'm going to merge this in as it can't hurt having these fixes in main anyway, even if they don't end up resolving the issue.