### PR TITLE
[feature] Implement media v2 endpoint to accommodate Tusky 17

### DIFF
--- a/internal/api/client/media/media.go
+++ b/internal/api/client/media/media.go
@@ -26,14 +26,18 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/router"
 )
 
-// BasePath is the base API path for making media requests
-const BasePath = "/api/v1/media"
+// BasePathV1 is the base API path for making media requests through v1 of the api (for mastodon API compatibility)
+const BasePathV1 = "/api/v1/media"
+// BasePathV2 is the base API path for making media requests through v2 of the api (for mastodon API compatibility)
+const BasePathV2 = "/api/v2/media"
 
 // IDKey is the key for media attachment IDs
 const IDKey = "id"
 
-// BasePathWithID corresponds to a media attachment with the given ID
-const BasePathWithID = BasePath + "/:" + IDKey
+// BasePathWithIDV1 corresponds to a media attachment with the given ID
+const BasePathWithIDV1 = BasePathV1 + "/:" + IDKey
+// BasePathWithIDV2 corresponds to a media attachment with the given ID
+const BasePathWithIDV2 = BasePathV2 + "/:" + IDKey
 
 // Module implements the ClientAPIModule interface for media
 type Module struct {
@@ -49,8 +53,15 @@ func New(processor processing.Processor) api.ClientModule {
 
 // Route satisfies the RESTAPIModule interface
 func (m *Module) Route(s router.Router) error {
-	s.AttachHandler(http.MethodPost, BasePath, m.MediaCreatePOSTHandler)
-	s.AttachHandler(http.MethodGet, BasePathWithID, m.MediaGETHandler)
-	s.AttachHandler(http.MethodPut, BasePathWithID, m.MediaPUTHandler)
+	// v1 handlers
+	s.AttachHandler(http.MethodPost, BasePathV1, m.MediaCreatePOSTHandler)
+	s.AttachHandler(http.MethodGet, BasePathWithIDV1, m.MediaGETHandler)
+	s.AttachHandler(http.MethodPut, BasePathWithIDV1, m.MediaPUTHandler)
+	
+	// v2 handlers
+	s.AttachHandler(http.MethodPost, BasePathV2, m.MediaCreatePOSTHandler)
+	s.AttachHandler(http.MethodGet, BasePathWithIDV2, m.MediaGETHandler)
+	s.AttachHandler(http.MethodPut, BasePathWithIDV2, m.MediaPUTHandler)
+	
 	return nil
 }

--- a/internal/api/client/media/media.go
+++ b/internal/api/client/media/media.go
@@ -28,6 +28,7 @@ import (
 
 // BasePathV1 is the base API path for making media requests through v1 of the api (for mastodon API compatibility)
 const BasePathV1 = "/api/v1/media"
+
 // BasePathV2 is the base API path for making media requests through v2 of the api (for mastodon API compatibility)
 const BasePathV2 = "/api/v2/media"
 
@@ -36,6 +37,7 @@ const IDKey = "id"
 
 // BasePathWithIDV1 corresponds to a media attachment with the given ID
 const BasePathWithIDV1 = BasePathV1 + "/:" + IDKey
+
 // BasePathWithIDV2 corresponds to a media attachment with the given ID
 const BasePathWithIDV2 = BasePathV2 + "/:" + IDKey
 
@@ -57,11 +59,11 @@ func (m *Module) Route(s router.Router) error {
 	s.AttachHandler(http.MethodPost, BasePathV1, m.MediaCreatePOSTHandler)
 	s.AttachHandler(http.MethodGet, BasePathWithIDV1, m.MediaGETHandler)
 	s.AttachHandler(http.MethodPut, BasePathWithIDV1, m.MediaPUTHandler)
-	
+
 	// v2 handlers
 	s.AttachHandler(http.MethodPost, BasePathV2, m.MediaCreatePOSTHandler)
 	s.AttachHandler(http.MethodGet, BasePathWithIDV2, m.MediaGETHandler)
 	s.AttachHandler(http.MethodPut, BasePathWithIDV2, m.MediaPUTHandler)
-	
+
 	return nil
 }

--- a/internal/api/client/media/mediacreate_test.go
+++ b/internal/api/client/media/mediacreate_test.go
@@ -150,7 +150,7 @@ func (suite *MediaCreateTestSuite) TestMediaCreateSuccessful() {
 	if err != nil {
 		panic(err)
 	}
-	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", mediamodule.BasePath), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
+	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", mediamodule.BasePathV1), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
 	ctx.Request.Header.Set("Content-Type", w.FormDataContentType())
 	ctx.Request.Header.Set("accept", "application/json")
 
@@ -234,7 +234,7 @@ func (suite *MediaCreateTestSuite) TestMediaCreateLongDescription() {
 	if err != nil {
 		panic(err)
 	}
-	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", mediamodule.BasePath), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
+	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", mediamodule.BasePathV1), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
 	ctx.Request.Header.Set("Content-Type", w.FormDataContentType())
 	ctx.Request.Header.Set("accept", "application/json")
 
@@ -275,7 +275,7 @@ func (suite *MediaCreateTestSuite) TestMediaCreateTooShortDescription() {
 	if err != nil {
 		panic(err)
 	}
-	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", mediamodule.BasePath), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
+	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", mediamodule.BasePathV1), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
 	ctx.Request.Header.Set("Content-Type", w.FormDataContentType())
 	ctx.Request.Header.Set("accept", "application/json")
 

--- a/internal/api/client/media/mediaupdate_test.go
+++ b/internal/api/client/media/mediaupdate_test.go
@@ -140,7 +140,7 @@ func (suite *MediaUpdateTestSuite) TestUpdateImage() {
 	if err != nil {
 		panic(err)
 	}
-	ctx.Request = httptest.NewRequest(http.MethodPut, fmt.Sprintf("http://localhost:8080/%s/%s", mediamodule.BasePath, toUpdate.ID), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
+	ctx.Request = httptest.NewRequest(http.MethodPut, fmt.Sprintf("http://localhost:8080/%s/%s", mediamodule.BasePathV1, toUpdate.ID), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
 	ctx.Request.Header.Set("Content-Type", w.FormDataContentType())
 	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Params = gin.Params{
@@ -205,7 +205,7 @@ func (suite *MediaUpdateTestSuite) TestUpdateImageShortDescription() {
 	if err != nil {
 		panic(err)
 	}
-	ctx.Request = httptest.NewRequest(http.MethodPut, fmt.Sprintf("http://localhost:8080/%s/%s", mediamodule.BasePath, toUpdate.ID), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
+	ctx.Request = httptest.NewRequest(http.MethodPut, fmt.Sprintf("http://localhost:8080/%s/%s", mediamodule.BasePathV1, toUpdate.ID), bytes.NewReader(buf.Bytes())) // the endpoint we're hitting
 	ctx.Request.Header.Set("Content-Type", w.FormDataContentType())
 	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Params = gin.Params{


### PR DESCRIPTION
This PR 'implements' the /api/v2/media endpoints to accommodate their use by Tusky version 17 (see https://github.com/tuskyapp/Tusky/issues/2409). The implementation is really just a copy: the same handlers serve both v1 and v2 of the API because it's prettymuch identical.

Closes #462 (tested and working with tusky 17)