### PR TITLE
[bug] Fix status API / status web API being case sensitive

### DIFF
--- a/internal/api/s2s/user/statusget_test.go
+++ b/internal/api/s2s/user/statusget_test.go
@@ -1,0 +1,174 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package user_test
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/activity/streams"
+	"github.com/superseriousbusiness/activity/streams/vocab"
+	"github.com/superseriousbusiness/gotosocial/internal/api/s2s/user"
+	"github.com/superseriousbusiness/gotosocial/testrig"
+)
+
+type StatusGetTestSuite struct {
+	UserStandardTestSuite
+}
+
+func (suite *StatusGetTestSuite) TestGetStatus() {
+	// the dereference we're gonna use
+	derefRequests := testrig.NewTestDereferenceRequests(suite.testAccounts)
+	signedRequest := derefRequests["foss_satan_dereference_local_account_1_status_1"]
+	targetAccount := suite.testAccounts["local_account_1"]
+	targetStatus := suite.testStatuses["local_account_1_status_1"]
+
+	tc := testrig.NewTestTransportController(testrig.NewMockHTTPClient(nil), suite.db)
+	federator := testrig.NewTestFederator(suite.db, tc, suite.storage, suite.mediaManager)
+	emailSender := testrig.NewEmailSender("../../../../web/template/", nil)
+	processor := testrig.NewTestProcessor(suite.db, suite.storage, federator, emailSender, suite.mediaManager)
+	userModule := user.New(processor).(*user.Module)
+
+	// setup request
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodGet, targetStatus.URI, nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/activity+json")
+	ctx.Request.Header.Set("Signature", signedRequest.SignatureHeader)
+	ctx.Request.Header.Set("Date", signedRequest.DateHeader)
+
+	// we need to pass the context through signature check first to set appropriate values on it
+	suite.securityModule.SignatureCheck(ctx)
+
+	// normally the router would populate these params from the path values,
+	// but because we're calling the function directly, we need to set them manually.
+	ctx.Params = gin.Params{
+		gin.Param{
+			Key:   user.UsernameKey,
+			Value: targetAccount.Username,
+		},
+		gin.Param{
+			Key:   user.StatusIDKey,
+			Value: targetStatus.ID,
+		},
+	}
+
+	// trigger the function being tested
+	userModule.StatusGETHandler(ctx)
+
+	// check response
+	suite.EqualValues(http.StatusOK, recorder.Code)
+
+	result := recorder.Result()
+	defer result.Body.Close()
+	b, err := ioutil.ReadAll(result.Body)
+	suite.NoError(err)
+
+	// should be a Note
+	m := make(map[string]interface{})
+	err = json.Unmarshal(b, &m)
+	suite.NoError(err)
+
+	t, err := streams.ToType(context.Background(), m)
+	suite.NoError(err)
+
+	note, ok := t.(vocab.ActivityStreamsNote)
+	suite.True(ok)
+
+	// convert note to status
+	a, err := suite.tc.ASStatusToStatus(context.Background(), note)
+	suite.NoError(err)
+	suite.EqualValues(targetStatus.Content, a.Content)
+}
+
+func (suite *StatusGetTestSuite) TestGetStatusLowercase() {
+	// the dereference we're gonna use
+	derefRequests := testrig.NewTestDereferenceRequests(suite.testAccounts)
+	signedRequest := derefRequests["foss_satan_dereference_local_account_1_status_1_lowercase"]
+	targetAccount := suite.testAccounts["local_account_1"]
+	targetStatus := suite.testStatuses["local_account_1_status_1"]
+
+	tc := testrig.NewTestTransportController(testrig.NewMockHTTPClient(nil), suite.db)
+	federator := testrig.NewTestFederator(suite.db, tc, suite.storage, suite.mediaManager)
+	emailSender := testrig.NewEmailSender("../../../../web/template/", nil)
+	processor := testrig.NewTestProcessor(suite.db, suite.storage, federator, emailSender, suite.mediaManager)
+	userModule := user.New(processor).(*user.Module)
+
+	// setup request
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodGet, strings.ToLower(targetStatus.URI), nil) // the endpoint we're hitting
+	ctx.Request.Header.Set("accept", "application/activity+json")
+	ctx.Request.Header.Set("Signature", signedRequest.SignatureHeader)
+	ctx.Request.Header.Set("Date", signedRequest.DateHeader)
+
+	// we need to pass the context through signature check first to set appropriate values on it
+	suite.securityModule.SignatureCheck(ctx)
+
+	// normally the router would populate these params from the path values,
+	// but because we're calling the function directly, we need to set them manually.
+	ctx.Params = gin.Params{
+		gin.Param{
+			Key:   user.UsernameKey,
+			Value: strings.ToLower(targetAccount.Username),
+		},
+		gin.Param{
+			Key:   user.StatusIDKey,
+			Value: strings.ToLower(targetStatus.ID),
+		},
+	}
+
+	// trigger the function being tested
+	userModule.StatusGETHandler(ctx)
+
+	// check response
+	suite.EqualValues(http.StatusOK, recorder.Code)
+
+	result := recorder.Result()
+	defer result.Body.Close()
+	b, err := ioutil.ReadAll(result.Body)
+	suite.NoError(err)
+
+	// should be a Note
+	m := make(map[string]interface{})
+	err = json.Unmarshal(b, &m)
+	suite.NoError(err)
+
+	t, err := streams.ToType(context.Background(), m)
+	suite.NoError(err)
+
+	note, ok := t.(vocab.ActivityStreamsNote)
+	suite.True(ok)
+
+	// convert note to status
+	a, err := suite.tc.ASStatusToStatus(context.Background(), note)
+	suite.NoError(err)
+	suite.EqualValues(targetStatus.Content, a.Content)
+}
+
+func TestStatusGetTestSuite(t *testing.T) {
+	suite.Run(t, new(StatusGetTestSuite))
+}

--- a/internal/api/s2s/user/user_test.go
+++ b/internal/api/s2s/user/user_test.go
@@ -73,8 +73,8 @@ func (suite *UserStandardTestSuite) SetupSuite() {
 }
 
 func (suite *UserStandardTestSuite) SetupTest() {
-	testrig.InitTestLog()
 	testrig.InitTestConfig()
+	testrig.InitTestLog()
 
 	suite.db = testrig.NewTestDB()
 	suite.tc = testrig.NewTestTypeConverter(suite.db)

--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -70,7 +70,7 @@ func (s *statusDB) GetStatusByID(ctx context.Context, id string) (*gtsmodel.Stat
 			return s.cache.GetByID(id)
 		},
 		func(status *gtsmodel.Status) error {
-			return s.newStatusQ(status).Where("status.id = ?", id).Scan(ctx)
+			return s.newStatusQ(status).Where("LOWER(status.id) = LOWER(?)", id).Scan(ctx)
 		},
 	)
 }

--- a/internal/processing/federation/getstatus.go
+++ b/internal/processing/federation/getstatus.go
@@ -62,8 +62,8 @@ func (p *processor) GetStatus(ctx context.Context, requestedUsername string, req
 	// get the status out of the database here
 	s := &gtsmodel.Status{}
 	if err := p.db.GetWhere(ctx, []db.Where{
-		{Key: "id", Value: requestedStatusID},
-		{Key: "account_id", Value: requestedAccount.ID},
+		{Key: "id", Value: requestedStatusID, CaseInsensitive: true},
+		{Key: "account_id", Value: requestedAccount.ID, CaseInsensitive: true},
 	}, s); err != nil {
 		return nil, gtserror.NewErrorNotFound(fmt.Errorf("database error getting status with id %s and account id %s: %s", requestedStatusID, requestedAccount.ID, err))
 	}

--- a/testrig/testmodels.go
+++ b/testrig/testmodels.go
@@ -34,6 +34,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/superseriousbusiness/activity/pub"
@@ -1727,6 +1728,22 @@ func NewTestDereferenceRequests(accounts map[string]*gtsmodel.Account) map[strin
 		DateHeader:      date,
 	}
 
+	target = URLMustParse(statuses["local_account_1_status_1"].URI)
+	sig, digest, date = GetSignatureForDereference(accounts["remote_account_1"].PublicKeyURI, accounts["remote_account_1"].PrivateKey, target)
+	fossSatanDereferenceLocalAccount1Status1 := ActivityWithSignature{
+		SignatureHeader: sig,
+		DigestHeader:    digest,
+		DateHeader:      date,
+	}
+
+	target = URLMustParse(strings.ToLower(statuses["local_account_1_status_1"].URI))
+	sig, digest, date = GetSignatureForDereference(accounts["remote_account_1"].PublicKeyURI, accounts["remote_account_1"].PrivateKey, target)
+	fossSatanDereferenceLocalAccount1Status1Lowercase := ActivityWithSignature{
+		SignatureHeader: sig,
+		DigestHeader:    digest,
+		DateHeader:      date,
+	}
+
 	target = URLMustParse(statuses["local_account_1_status_1"].URI + "/replies")
 	sig, digest, date = GetSignatureForDereference(accounts["remote_account_1"].PublicKeyURI, accounts["remote_account_1"].PrivateKey, target)
 	fossSatanDereferenceLocalAccount1Status1Replies := ActivityWithSignature{
@@ -1778,6 +1795,8 @@ func NewTestDereferenceRequests(accounts map[string]*gtsmodel.Account) map[strin
 	return map[string]ActivityWithSignature{
 		"foss_satan_dereference_zork":                                  fossSatanDereferenceZork,
 		"foss_satan_dereference_zork_public_key":                       fossSatanDereferenceZorkPublicKey,
+		"foss_satan_dereference_local_account_1_status_1":              fossSatanDereferenceLocalAccount1Status1,
+		"foss_satan_dereference_local_account_1_status_1_lowercase":    fossSatanDereferenceLocalAccount1Status1Lowercase,
 		"foss_satan_dereference_local_account_1_status_1_replies":      fossSatanDereferenceLocalAccount1Status1Replies,
 		"foss_satan_dereference_local_account_1_status_1_replies_next": fossSatanDereferenceLocalAccount1Status1RepliesNext,
 		"foss_satan_dereference_local_account_1_status_1_replies_last": fossSatanDereferenceLocalAccount1Status1RepliesLast,


### PR DESCRIPTION
This PR makes the status ID case insensitive when fetching statuses out of the database, which means that the web url for statuses is no longer case sensitive. This also means the federating api can also serve statuses in a case-insensitive manner (however it still requires the case of the dereference signature and the request target to match).

closes https://github.com/superseriousbusiness/gotosocial/issues/469