### PR TITLE
[bugfix] Status iri summary fix

### DIFF
--- a/internal/ap/extract.go
+++ b/internal/ap/extract.go
@@ -248,7 +248,10 @@ func ExtractSummary(i WithSummary) (string, error) {
 	}
 
 	for iter := summaryProp.Begin(); iter != summaryProp.End(); iter = iter.Next() {
-		if iter.IsXMLSchemaString() && iter.GetXMLSchemaString() != "" {
+		switch {
+		case iter.IsIRI():
+			return iter.GetIRI().String(), nil
+		case iter.IsXMLSchemaString():
 			return iter.GetXMLSchemaString(), nil
 		}
 	}

--- a/internal/typeutils/astointernal_test.go
+++ b/internal/typeutils/astointernal_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/activity/streams"
 	"github.com/superseriousbusiness/activity/streams/vocab"
@@ -40,7 +39,7 @@ func (suite *ASToInternalTestSuite) TestParsePerson() {
 	testPerson := suite.testPeople["https://unknown-instance.com/users/brand_new_person"]
 
 	acct, err := suite.typeconverter.ASRepresentationToAccount(context.Background(), testPerson, false)
-	assert.NoError(suite.T(), err)
+	suite.NoError(err)
 
 	suite.Equal("https://unknown-instance.com/users/brand_new_person", acct.URI)
 	suite.Equal("https://unknown-instance.com/users/brand_new_person/following", acct.FollowingURI)
@@ -57,19 +56,37 @@ func (suite *ASToInternalTestSuite) TestParsePerson() {
 	suite.False(acct.Locked)
 }
 
+func (suite *ASToInternalTestSuite) TestParsePublicStatus() {
+	m := make(map[string]interface{})
+	err := json.Unmarshal([]byte(publicStatusActivityJson), &m)
+	suite.NoError(err)
+
+	t, err := streams.ToType(context.Background(), m)
+	suite.NoError(err)
+
+	rep, ok := t.(ap.Statusable)
+	suite.True(ok)
+
+	status, err := suite.typeconverter.ASStatusToStatus(context.Background(), rep)
+	suite.NoError(err)
+
+	suite.Equal("reading: Punishment and Reward in the Corporate University", status.ContentWarning)
+	suite.Equal(`<p>&gt; So we have to examine critical thinking as a signifier, dynamic and ambiguous.  It has a normative definition, a tacit definition, and an ideal definition.  One of the hallmarks of graduate training is learning to comprehend those definitions and applying the correct one as needed for professional success.</p>`, status.Content)
+}
+
 func (suite *ASToInternalTestSuite) TestParseGargron() {
 	m := make(map[string]interface{})
 	err := json.Unmarshal([]byte(gargronAsActivityJson), &m)
-	assert.NoError(suite.T(), err)
+	suite.NoError(err)
 
 	t, err := streams.ToType(context.Background(), m)
-	assert.NoError(suite.T(), err)
+	suite.NoError(err)
 
 	rep, ok := t.(ap.Accountable)
-	assert.True(suite.T(), ok)
+	suite.True(ok)
 
 	acct, err := suite.typeconverter.ASRepresentationToAccount(context.Background(), rep, false)
-	assert.NoError(suite.T(), err)
+	suite.NoError(err)
 
 	fmt.Printf("%+v", acct)
 	// TODO: write assertions here, rn we're just eyeballing the output
@@ -78,10 +95,10 @@ func (suite *ASToInternalTestSuite) TestParseGargron() {
 func (suite *ASToInternalTestSuite) TestParseReplyWithMention() {
 	m := make(map[string]interface{})
 	err := json.Unmarshal([]byte(statusWithMentionsActivityJson), &m)
-	assert.NoError(suite.T(), err)
+	suite.NoError(err)
 
 	t, err := streams.ToType(context.Background(), m)
-	assert.NoError(suite.T(), err)
+	suite.NoError(err)
 
 	create, ok := t.(vocab.ActivityStreamsCreate)
 	suite.True(ok)

--- a/internal/typeutils/converter_test.go
+++ b/internal/typeutils/converter_test.go
@@ -319,6 +319,54 @@ const (
 		  "url": "https://files.mastodon.social/accounts/headers/000/000/001/original/c91b871f294ea63e.png"
 		}
 	  }`
+	publicStatusActivityJson = `
+	{
+		"@context": [
+		  "https://www.w3.org/ns/activitystreams",
+		  {
+			"ostatus": "http://ostatus.org#",
+			"atomUri": "ostatus:atomUri",
+			"inReplyToAtomUri": "ostatus:inReplyToAtomUri",
+			"conversation": "ostatus:conversation",
+			"sensitive": "as:sensitive",
+			"toot": "http://joinmastodon.org/ns#",
+			"votersCount": "toot:votersCount"
+		  }
+		],
+		"id": "http://fossbros-anonymous.io/users/foss_satan/statuses/108138763199405167",
+		"type": "Note",
+		"summary": "reading: Punishment and Reward in the Corporate University",
+		"inReplyTo": "http://fossbros-anonymous.io/users/foss_satan/statuses/108138729399508469",
+		"published": "2022-04-15T23:49:37Z",
+		"url": "http://fossbros-anonymous.io/@foss_satan/108138763199405167",
+		"attributedTo": "http://fossbros-anonymous.io/users/foss_satan",
+		"to": [
+		  "https://www.w3.org/ns/activitystreams#Public"
+		],
+		"cc": [
+		  "http://fossbros-anonymous.io/users/foss_satan/followers"
+		],
+		"sensitive": true,
+		"atomUri": "http://fossbros-anonymous.io/users/foss_satan/statuses/108138763199405167",
+		"inReplyToAtomUri": "http://fossbros-anonymous.io/users/foss_satan/statuses/108138729399508469",
+		"content": "<p>&gt; So we have to examine critical thinking as a signifier, dynamic and ambiguous.  It has a normative definition, a tacit definition, and an ideal definition.  One of the hallmarks of graduate training is learning to comprehend those definitions and applying the correct one as needed for professional success.</p>",
+		"contentMap": {
+		  "en": "<p>&gt; So we have to examine critical thinking as a signifier, dynamic and ambiguous.  It has a normative definition, a tacit definition, and an ideal definition.  One of the hallmarks of graduate training is learning to comprehend those definitions and applying the correct one as needed for professional success.</p>"
+		},
+		"attachment": [],
+		"tag": [],
+		"replies": {
+		  "id": "http://fossbros-anonymous.io/users/foss_satan/statuses/108138763199405167/replies",
+		  "type": "Collection",
+		  "first": {
+			"type": "CollectionPage",
+			"next": "http://fossbros-anonymous.io/users/foss_satan/statuses/108138763199405167/replies?only_other_accounts=true&page=true",
+			"partOf": "http://fossbros-anonymous.io/users/foss_satan/statuses/108138763199405167/replies",
+			"items": []
+		  }
+		}
+	  }	  
+	`
 )
 
 type TypeUtilsTestSuite struct {


### PR DESCRIPTION
This PR fixes a bug where statuses content warnings were sometimes parsed as an IRI by the Activity library if they contain characters like `:`, but GoToSocial would only try extract them as strings. Now GoToSocial attempts to extract content warnings that are either strings or IRIs (which are then converted into plain strings anyway). A test case is added to validate the parsing.

closes https://github.com/superseriousbusiness/gotosocial/issues/456