### PR TITLE
[chore] Signature check updates

### DIFF
--- a/internal/federation/authenticate.go
+++ b/internal/federation/authenticate.go
@@ -234,8 +234,8 @@ func (f *federator) AuthenticateFederatedRequest(ctx context.Context, requestedU
 
 	// do the actual authentication here!
 	algos := []httpsig.Algorithm{
-		httpsig.RSA_SHA512,
 		httpsig.RSA_SHA256,
+		httpsig.RSA_SHA512,
 		httpsig.ED25519,
 	}
 

--- a/internal/federation/federatingprotocol.go
+++ b/internal/federation/federatingprotocol.go
@@ -119,15 +119,17 @@ func (f *federator) AuthenticatePostInbox(ctx context.Context, w http.ResponseWr
 		return nil, false, fmt.Errorf("could not fetch receiving account with username %s: %s", username, err)
 	}
 
-	publicKeyOwnerURI, authenticated, err := f.AuthenticateFederatedRequest(ctx, receivingAccount.Username)
-	if err != nil {
-		l.Debugf("request not authenticated: %s", err)
-		return ctx, false, err
-	}
-
-	if !authenticated {
-		w.WriteHeader(http.StatusForbidden)
-		return ctx, false, nil
+	publicKeyOwnerURI, errWithCode := f.AuthenticateFederatedRequest(ctx, receivingAccount.Username)
+	if errWithCode != nil {
+		switch errWithCode.Code() {
+		case http.StatusUnauthorized, http.StatusForbidden, http.StatusBadRequest:
+			// if 400, 401, or 403, obey the interface by writing the header and bailing
+			w.WriteHeader(errWithCode.Code())
+			return ctx, false, nil
+		default:
+			// if not, there's been a proper error
+			return ctx, false, err
+		}
 	}
 
 	// authentication has passed, so add an instance entry for this instance if it hasn't been done already

--- a/internal/federation/federator.go
+++ b/internal/federation/federator.go
@@ -27,6 +27,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/federation/dereferencing"
 	"github.com/superseriousbusiness/gotosocial/internal/federation/federatingdb"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/media"
 	"github.com/superseriousbusiness/gotosocial/internal/transport"
@@ -50,7 +51,7 @@ type Federator interface {
 	// If the request does not pass authentication, or there's a domain block, nil, false, nil will be returned.
 	//
 	// If something goes wrong during authentication, nil, false, and an error will be returned.
-	AuthenticateFederatedRequest(ctx context.Context, username string) (*url.URL, bool, error)
+	AuthenticateFederatedRequest(ctx context.Context, username string) (*url.URL, gtserror.WithCode)
 
 	// FingerRemoteAccount performs a webfinger lookup for a remote account, using the .well-known path. It will return the ActivityPub URI for that
 	// account, or an error if it doesn't exist or can't be retrieved.

--- a/internal/processing/federation/getfollowers.go
+++ b/internal/processing/federation/getfollowers.go
@@ -20,7 +20,6 @@ package federation
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 
@@ -36,9 +35,9 @@ func (p *processor) GetFollowers(ctx context.Context, requestedUsername string, 
 	}
 
 	// authenticate the request
-	requestingAccountURI, authenticated, err := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
-	if err != nil || !authenticated {
-		return nil, gtserror.NewErrorNotAuthorized(errors.New("not authorized"), "not authorized")
+	requestingAccountURI, errWithCode := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
+	if errWithCode != nil {
+		return nil, errWithCode
 	}
 
 	requestingAccount, err := p.federator.GetRemoteAccount(ctx, requestedUsername, requestingAccountURI, false, false)

--- a/internal/processing/federation/getfollowing.go
+++ b/internal/processing/federation/getfollowing.go
@@ -20,7 +20,6 @@ package federation
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 
@@ -36,9 +35,9 @@ func (p *processor) GetFollowing(ctx context.Context, requestedUsername string, 
 	}
 
 	// authenticate the request
-	requestingAccountURI, authenticated, err := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
-	if err != nil || !authenticated {
-		return nil, gtserror.NewErrorNotAuthorized(errors.New("not authorized"), "not authorized")
+	requestingAccountURI, errWithCode := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
+	if errWithCode != nil {
+		return nil, errWithCode
 	}
 
 	requestingAccount, err := p.federator.GetRemoteAccount(ctx, requestedUsername, requestingAccountURI, false, false)

--- a/internal/processing/federation/getoutbox.go
+++ b/internal/processing/federation/getoutbox.go
@@ -20,7 +20,6 @@ package federation
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 
@@ -37,9 +36,9 @@ func (p *processor) GetOutbox(ctx context.Context, requestedUsername string, pag
 	}
 
 	// authenticate the request
-	requestingAccountURI, authenticated, err := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
-	if err != nil || !authenticated {
-		return nil, gtserror.NewErrorNotAuthorized(errors.New("not authorized"), "not authorized")
+	requestingAccountURI, errWithCode := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
+	if errWithCode != nil {
+		return nil, errWithCode
 	}
 
 	requestingAccount, err := p.federator.GetRemoteAccount(ctx, requestedUsername, requestingAccountURI, false, false)

--- a/internal/processing/federation/getstatus.go
+++ b/internal/processing/federation/getstatus.go
@@ -20,7 +20,6 @@ package federation
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 
@@ -38,9 +37,9 @@ func (p *processor) GetStatus(ctx context.Context, requestedUsername string, req
 	}
 
 	// authenticate the request
-	requestingAccountURI, authenticated, err := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
-	if err != nil || !authenticated {
-		return nil, gtserror.NewErrorNotAuthorized(errors.New("not authorized"), "not authorized")
+	requestingAccountURI, errWithCode := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
+	if errWithCode != nil {
+		return nil, errWithCode
 	}
 
 	requestingAccount, err := p.federator.GetRemoteAccount(ctx, requestedUsername, requestingAccountURI, false, false)

--- a/internal/processing/federation/getstatusreplies.go
+++ b/internal/processing/federation/getstatusreplies.go
@@ -20,7 +20,6 @@ package federation
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 
@@ -38,9 +37,9 @@ func (p *processor) GetStatusReplies(ctx context.Context, requestedUsername stri
 	}
 
 	// authenticate the request
-	requestingAccountURI, authenticated, err := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
-	if err != nil || !authenticated {
-		return nil, gtserror.NewErrorNotAuthorized(errors.New("not authorized"), "not authorized")
+	requestingAccountURI, errWithCode := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
+	if errWithCode != nil {
+		return nil, errWithCode
 	}
 
 	requestingAccount, err := p.federator.GetRemoteAccount(ctx, requestedUsername, requestingAccountURI, false, false)

--- a/internal/processing/federation/getuser.go
+++ b/internal/processing/federation/getuser.go
@@ -20,7 +20,6 @@ package federation
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 
@@ -46,13 +45,9 @@ func (p *processor) GetUser(ctx context.Context, requestedUsername string, reque
 		}
 	} else {
 		// if it's any other path, we want to fully authenticate the request before we serve any data, and then we can serve a more complete profile
-		requestingAccountURI, authenticated, err := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
-		if err != nil {
-			return nil, gtserror.NewErrorNotAuthorized(err, "not authorized")
-		}
-
-		if !authenticated {
-			return nil, gtserror.NewErrorNotAuthorized(errors.New("not authorized"), "not authorized")
+		requestingAccountURI, errWithCode := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
+		if errWithCode != nil {
+			return nil, errWithCode
 		}
 
 		// if we're not already handshaking/dereferencing a remote account, dereference it now


### PR DESCRIPTION
This PR updates some of the signature checking/authentication functionality in two ways:

1. Make the signature for the authorization function simpler (drop the bool), and have it return an error with code instead so that codes logged and returned to callers are more informative.
2. Change the order in which http signature algorithms are checked, to put the most common -- rsa_sha256 -- first. This should same some time/cpu since it's more likely to pass first without having to check more than one algorithm :muscle: 