### PR TITLE
use Exec to rename media_attachments

### DIFF
--- a/internal/db/bundb/migrations/20220214175650_media_cleanup.go
+++ b/internal/db/bundb/migrations/20220214175650_media_cleanup.go
@@ -142,7 +142,7 @@ func init() {
 			}
 
 			// rename the new table to the same name as the old table was
-			if _, err := tx.QueryContext(ctx, "ALTER TABLE new_media_attachments RENAME TO media_attachments;"); err != nil {
+			if _, err := tx.ExecContext(ctx, "ALTER TABLE new_media_attachments RENAME TO media_attachments;"); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
The `database/sql` package in the Go stdlib has two methods that can run
queries against the database driver: `Query` and `Exec`. When the query
returns rows, such as "SELECT", the package expects the use of `Query`,
and returns `*sql.Rows`. When the query does not return rows, the
package expects the use of `Exec`, which returns `sql.Result`.

This changeset corrects the "media_attachments" migration to using
`ExecContext`, as "ALTER TABLE" does not return rows.