### PR TITLE
[feature] allow absolute path to templates

### DIFF
--- a/internal/email/util.go
+++ b/internal/email/util.go
@@ -28,14 +28,16 @@ import (
 )
 
 func loadTemplates(templateBaseDir string) (*template.Template, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("error getting current working directory: %s", err)
+	if !filepath.IsAbs(templateBaseDir) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("error getting current working directory: %s", err)
+		}
+		templateBaseDir = filepath.Join(cwd, templateBaseDir)
 	}
 
 	// look for all templates that start with 'email_'
-	tmPath := filepath.Join(cwd, fmt.Sprintf("%semail_*", templateBaseDir))
-	return template.ParseGlob(tmPath)
+	return template.ParseGlob(filepath.Join(templateBaseDir, "email_*"))
 }
 
 // https://datatracker.ietf.org/doc/html/rfc2822


### PR DESCRIPTION
Only attempt to join the `WebTemplateBaseDir` with the current working
directory if the user has not configured an absolute path to the
template directory.

This changeset also makes a similar change to the testrig, allowing
tests to configure an alternative location for the templates directory.

Fixes #411

Signed-off-by: Terin Stock <terinjokes@gmail.com>