### PR TITLE
[chore] Add Federatingactor.Send() tests

### DIFF
--- a/internal/federation/federatingactor.go
+++ b/internal/federation/federatingactor.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/sirupsen/logrus"
 	"github.com/superseriousbusiness/activity/pub"
 	"github.com/superseriousbusiness/activity/streams/vocab"
 )
@@ -55,6 +56,7 @@ func newFederatingActor(c pub.CommonBehavior, s2s pub.FederatingProtocol, db pub
 // method will guaranteed work for non-custom Actors. For custom actors,
 // care should be used to not call this method if only C2S is supported.
 func (f *federatingActor) Send(c context.Context, outbox *url.URL, t vocab.Type) (pub.Activity, error) {
+	logrus.Infof("federating actor: send activity %s via outbox %s", t.GetTypeName(), outbox)
 	return f.actor.Send(c, outbox, t)
 }
 

--- a/internal/federation/federatingactor_test.go
+++ b/internal/federation/federatingactor_test.go
@@ -1,0 +1,141 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package federation_test
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/federation"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/messages"
+	"github.com/superseriousbusiness/gotosocial/internal/worker"
+	"github.com/superseriousbusiness/gotosocial/testrig"
+)
+
+type FederatingActorTestSuite struct {
+	FederatorStandardTestSuite
+}
+
+func (suite *FederatingActorTestSuite) TestSendNoRemoteFollowers() {
+	ctx := context.Background()
+	testAccount := suite.testAccounts["local_account_1"]
+	testNote := testrig.NewAPNote(
+		testrig.URLMustParse("http://localhost:8080/users/the_mighty_zork/statuses/01G1TR6BADACCZWQMNF9X21TV5"),
+		testrig.URLMustParse("http://localhost:8080/@the_mighty_zork/statuses/01G1TR6BADACCZWQMNF9X21TV5"),
+		time.Now(),
+		"boobies",
+		"",
+		testrig.URLMustParse(testAccount.URI),
+		[]*url.URL{testrig.URLMustParse(testAccount.FollowersURI)},
+		nil,
+		false,
+		nil,
+		nil,
+	)
+	testActivity := testrig.WrapAPNoteInCreate(testrig.URLMustParse("http://localhost:8080/whatever_some_create"), testrig.URLMustParse(testAccount.URI), time.Now(), testNote)
+
+	fedWorker := worker.New[messages.FromFederator](-1, -1)
+
+	// setup transport controller with a no-op client so we don't make external calls
+	sentMessages := []*url.URL{}
+	tc := testrig.NewTestTransportController(testrig.NewMockHTTPClient(func(req *http.Request) (*http.Response, error) {
+		sentMessages = append(sentMessages, req.URL)
+		r := ioutil.NopCloser(bytes.NewReader([]byte{}))
+		return &http.Response{
+			StatusCode: 200,
+			Body:       r,
+		}, nil
+	}), suite.db, fedWorker)
+	// setup module being tested
+	federator := federation.NewFederator(suite.db, testrig.NewTestFederatingDB(suite.db, fedWorker), tc, suite.tc, testrig.NewTestMediaManager(suite.db, suite.storage))
+
+	activity, err := federator.FederatingActor().Send(ctx, testrig.URLMustParse(testAccount.OutboxURI), testActivity)
+	suite.NoError(err)
+	suite.NotNil(activity)
+
+	// because zork has no remote followers, sent messages should be empty (no messages sent to own instance)
+	suite.Empty(sentMessages)
+}
+
+func (suite *FederatingActorTestSuite) TestSendRemoteFollower() {
+	ctx := context.Background()
+	testAccount := suite.testAccounts["local_account_1"]
+	testRemoteAccount := suite.testAccounts["remote_account_1"]
+
+	err := suite.db.Put(ctx, &gtsmodel.Follow{
+		ID:              "01G1TRWV4AYCDBX5HRWT2EVBCV",
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+		AccountID:       testRemoteAccount.ID,
+		TargetAccountID: testAccount.ID,
+		ShowReblogs:     true,
+		URI:             "http://fossbros-anonymous.io/users/foss_satan/follows/01G1TRWV4AYCDBX5HRWT2EVBCV",
+		Notify:          false,
+	})
+	suite.NoError(err)
+
+	testNote := testrig.NewAPNote(
+		testrig.URLMustParse("http://localhost:8080/users/the_mighty_zork/statuses/01G1TR6BADACCZWQMNF9X21TV5"),
+		testrig.URLMustParse("http://localhost:8080/@the_mighty_zork/statuses/01G1TR6BADACCZWQMNF9X21TV5"),
+		time.Now(),
+		"boobies",
+		"",
+		testrig.URLMustParse(testAccount.URI),
+		[]*url.URL{testrig.URLMustParse(testAccount.FollowersURI)},
+		nil,
+		false,
+		nil,
+		nil,
+	)
+	testActivity := testrig.WrapAPNoteInCreate(testrig.URLMustParse("http://localhost:8080/whatever_some_create"), testrig.URLMustParse(testAccount.URI), time.Now(), testNote)
+
+	fedWorker := worker.New[messages.FromFederator](-1, -1)
+
+	// setup transport controller with a no-op client so we don't make external calls
+	sentMessages := []*url.URL{}
+	tc := testrig.NewTestTransportController(testrig.NewMockHTTPClient(func(req *http.Request) (*http.Response, error) {
+		sentMessages = append(sentMessages, req.URL)
+		r := ioutil.NopCloser(bytes.NewReader([]byte{}))
+		return &http.Response{
+			StatusCode: 200,
+			Body:       r,
+		}, nil
+	}), suite.db, fedWorker)
+	// setup module being tested
+	federator := federation.NewFederator(suite.db, testrig.NewTestFederatingDB(suite.db, fedWorker), tc, suite.tc, testrig.NewTestMediaManager(suite.db, suite.storage))
+
+	activity, err := federator.FederatingActor().Send(ctx, testrig.URLMustParse(testAccount.OutboxURI), testActivity)
+	suite.NoError(err)
+	suite.NotNil(activity)
+
+	// because we added 1 remote follower for zork, there should be a url in sentMessage
+	suite.Len(sentMessages, 1)
+	suite.Equal(testRemoteAccount.InboxURI, sentMessages[0].String())
+}
+
+func TestFederatingActorTestSuite(t *testing.T) {
+	suite.Run(t, new(FederatingActorTestSuite))
+}

--- a/internal/federation/federatingprotocol_test.go
+++ b/internal/federation/federatingprotocol_test.go
@@ -42,7 +42,7 @@ type FederatingProtocolTestSuite struct {
 // make sure PostInboxRequestBodyHook properly sets the inbox username and activity on the context
 func (suite *FederatingProtocolTestSuite) TestPostInboxRequestBodyHook() {
 	// the activity we're gonna use
-	activity := suite.activities["dm_for_zork"]
+	activity := suite.testActivities["dm_for_zork"]
 
 	fedWorker := worker.New[messages.FromFederator](-1, -1)
 
@@ -51,7 +51,7 @@ func (suite *FederatingProtocolTestSuite) TestPostInboxRequestBodyHook() {
 		return nil, nil
 	}), suite.db, fedWorker)
 	// setup module being tested
-	federator := federation.NewFederator(suite.db, testrig.NewTestFederatingDB(suite.db, fedWorker), tc, suite.typeConverter, testrig.NewTestMediaManager(suite.db, suite.storage))
+	federator := federation.NewFederator(suite.db, testrig.NewTestFederatingDB(suite.db, fedWorker), tc, suite.tc, testrig.NewTestMediaManager(suite.db, suite.storage))
 
 	// setup request
 	ctx := context.Background()
@@ -74,15 +74,15 @@ func (suite *FederatingProtocolTestSuite) TestPostInboxRequestBodyHook() {
 
 func (suite *FederatingProtocolTestSuite) TestAuthenticatePostInbox() {
 	// the activity we're gonna use
-	activity := suite.activities["dm_for_zork"]
-	sendingAccount := suite.accounts["remote_account_1"]
-	inboxAccount := suite.accounts["local_account_1"]
+	activity := suite.testActivities["dm_for_zork"]
+	sendingAccount := suite.testAccounts["remote_account_1"]
+	inboxAccount := suite.testAccounts["local_account_1"]
 
 	fedWorker := worker.New[messages.FromFederator](-1, -1)
 
 	tc := testrig.NewTestTransportController(testrig.NewMockHTTPClient(nil), suite.db, fedWorker)
 	// now setup module being tested, with the mock transport controller
-	federator := federation.NewFederator(suite.db, testrig.NewTestFederatingDB(suite.db, fedWorker), tc, suite.typeConverter, testrig.NewTestMediaManager(suite.db, suite.storage))
+	federator := federation.NewFederator(suite.db, testrig.NewTestFederatingDB(suite.db, fedWorker), tc, suite.tc, testrig.NewTestMediaManager(suite.db, suite.storage))
 
 	request := httptest.NewRequest(http.MethodPost, "http://localhost:8080/users/the_mighty_zork/inbox", nil)
 	// we need these headers for the request to be validated

--- a/internal/federation/federator_test.go
+++ b/internal/federation/federator_test.go
@@ -30,27 +30,27 @@ import (
 
 type FederatorStandardTestSuite struct {
 	suite.Suite
-	db            db.DB
-	storage       *kv.KVStore
-	typeConverter typeutils.TypeConverter
-	accounts      map[string]*gtsmodel.Account
-	activities    map[string]testrig.ActivityWithSignature
+	db             db.DB
+	storage        *kv.KVStore
+	tc             typeutils.TypeConverter
+	testAccounts   map[string]*gtsmodel.Account
+	testActivities map[string]testrig.ActivityWithSignature
 }
 
 // SetupSuite sets some variables on the suite that we can use as consts (more or less) throughout
 func (suite *FederatorStandardTestSuite) SetupSuite() {
 	// setup standard items
 	suite.storage = testrig.NewTestStorage()
-	suite.typeConverter = testrig.NewTestTypeConverter(suite.db)
-	suite.accounts = testrig.NewTestAccounts()
+	suite.tc = testrig.NewTestTypeConverter(suite.db)
+	suite.testAccounts = testrig.NewTestAccounts()
 }
 
 func (suite *FederatorStandardTestSuite) SetupTest() {
 	testrig.InitTestConfig()
 	testrig.InitTestLog()
 	suite.db = testrig.NewTestDB()
-	suite.activities = testrig.NewTestActivities(suite.accounts)
-	testrig.StandardDBSetup(suite.db, suite.accounts)
+	suite.testActivities = testrig.NewTestActivities(suite.testAccounts)
+	testrig.StandardDBSetup(suite.db, suite.testAccounts)
 }
 
 // TearDownTest drops tables to make sure there's no data in the db

--- a/testrig/testmodels.go
+++ b/testrig/testmodels.go
@@ -1483,7 +1483,7 @@ type ActivityWithSignature struct {
 // A struct of accounts needs to be passed in because the activities will also be bundled along with
 // their requesting signatures.
 func NewTestActivities(accounts map[string]*gtsmodel.Account) map[string]ActivityWithSignature {
-	dmForZork := newAPNote(
+	dmForZork := NewAPNote(
 		URLMustParse("http://fossbros-anonymous.io/users/foss_satan/statuses/5424b153-4553-4f30-9358-7b92f7cd42f6"),
 		URLMustParse("http://fossbros-anonymous.io/@foss_satan/5424b153-4553-4f30-9358-7b92f7cd42f6"),
 		time.Now(),
@@ -1496,14 +1496,14 @@ func NewTestActivities(accounts map[string]*gtsmodel.Account) map[string]Activit
 		[]vocab.ActivityStreamsMention{},
 		nil,
 	)
-	createDmForZork := wrapAPNoteInCreate(
+	createDmForZork := WrapAPNoteInCreate(
 		URLMustParse("http://fossbros-anonymous.io/users/foss_satan/statuses/5424b153-4553-4f30-9358-7b92f7cd42f6/activity"),
 		URLMustParse("http://fossbros-anonymous.io/users/foss_satan"),
 		time.Now(),
 		dmForZork)
 	createDmForZorkSig, createDmForZorkDigest, creatDmForZorkDate := GetSignatureForActivity(createDmForZork, accounts["remote_account_1"].PublicKeyURI, accounts["remote_account_1"].PrivateKey, URLMustParse(accounts["local_account_1"].InboxURI))
 
-	forwardedMessage := newAPNote(
+	forwardedMessage := NewAPNote(
 		URLMustParse("http://example.org/users/some_user/statuses/afaba698-5740-4e32-a702-af61aa543bc1"),
 		URLMustParse("http://example.org/@some_user/afaba698-5740-4e32-a702-af61aa543bc1"),
 		time.Now(),
@@ -1516,7 +1516,7 @@ func NewTestActivities(accounts map[string]*gtsmodel.Account) map[string]Activit
 		[]vocab.ActivityStreamsMention{},
 		nil,
 	)
-	createForwardedMessage := wrapAPNoteInCreate(
+	createForwardedMessage := WrapAPNoteInCreate(
 		URLMustParse("http://example.org/users/some_user/statuses/afaba698-5740-4e32-a702-af61aa543bc1/activity"),
 		URLMustParse("http://example.org/users/some_user"),
 		time.Now(),
@@ -1668,7 +1668,7 @@ func NewTestFediAttachments(relativePath string) map[string]RemoteAttachmentFile
 
 func NewTestFediStatuses() map[string]vocab.ActivityStreamsNote {
 	return map[string]vocab.ActivityStreamsNote{
-		"https://unknown-instance.com/users/brand_new_person/statuses/01FE4NTHKWW7THT67EF10EB839": newAPNote(
+		"https://unknown-instance.com/users/brand_new_person/statuses/01FE4NTHKWW7THT67EF10EB839": NewAPNote(
 			URLMustParse("https://unknown-instance.com/users/brand_new_person/statuses/01FE4NTHKWW7THT67EF10EB839"),
 			URLMustParse("https://unknown-instance.com/users/@brand_new_person/01FE4NTHKWW7THT67EF10EB839"),
 			time.Now(),
@@ -1683,7 +1683,7 @@ func NewTestFediStatuses() map[string]vocab.ActivityStreamsNote {
 			nil,
 			nil,
 		),
-		"https://unknown-instance.com/users/brand_new_person/statuses/01FE5Y30E3W4P7TRE0R98KAYQV": newAPNote(
+		"https://unknown-instance.com/users/brand_new_person/statuses/01FE5Y30E3W4P7TRE0R98KAYQV": NewAPNote(
 			URLMustParse("https://unknown-instance.com/users/brand_new_person/statuses/01FE5Y30E3W4P7TRE0R98KAYQV"),
 			URLMustParse("https://unknown-instance.com/users/@brand_new_person/01FE5Y30E3W4P7TRE0R98KAYQV"),
 			time.Now(),
@@ -1703,7 +1703,7 @@ func NewTestFediStatuses() map[string]vocab.ActivityStreamsNote {
 			},
 			nil,
 		),
-		"https://turnip.farm/users/turniplover6969/statuses/70c53e54-3146-42d5-a630-83c8b6c7c042": newAPNote(
+		"https://turnip.farm/users/turniplover6969/statuses/70c53e54-3146-42d5-a630-83c8b6c7c042": NewAPNote(
 			URLMustParse("https://turnip.farm/users/turniplover6969/statuses/70c53e54-3146-42d5-a630-83c8b6c7c042"),
 			URLMustParse("https://turnip.farm/@turniplover6969/70c53e54-3146-42d5-a630-83c8b6c7c042"),
 			time.Now(),
@@ -2325,8 +2325,8 @@ func newAPImage(url *url.URL, mediaType string, imageDescription string, blurhas
 	return image
 }
 
-// newAPNote returns a new activity streams note for the given parameters
-func newAPNote(
+// NewAPNote returns a new activity streams note for the given parameters
+func NewAPNote(
 	noteID *url.URL,
 	noteURL *url.URL,
 	noteCreatedAt time.Time,
@@ -2421,8 +2421,8 @@ func newAPNote(
 	return note
 }
 
-// wrapAPNoteInCreate wraps the given activity streams note in a Create activity streams action
-func wrapAPNoteInCreate(createID *url.URL, createActor *url.URL, createPublished time.Time, createNote vocab.ActivityStreamsNote) vocab.ActivityStreamsCreate {
+// WrapAPNoteInCreate wraps the given activity streams note in a Create activity streams action
+func WrapAPNoteInCreate(createID *url.URL, createActor *url.URL, createPublished time.Time, createNote vocab.ActivityStreamsNote) vocab.ActivityStreamsCreate {
 	// create the.... create
 	create := streams.NewActivityStreamsCreate()
 


### PR DESCRIPTION
This PR adds a couple of tests for the FederatingActor's Send() function.

It also adds a logrus.Infof() call when a federating activity is being sent out.