### PR TITLE
[documentation] Recommend users take latest *stable* release in installation guides

### DIFF
--- a/docs/installation_guide/binary.md
+++ b/docs/installation_guide/binary.md
@@ -22,16 +22,18 @@ cd /gotosocial
 
 Now, download the latest GoToSocial release archive corresponding to the operating system and architecture you're running on.
 
-For example, for version 0.1.0 running on 64-bit Linux:
+(You can find the list of releases [right here](https://github.com/superseriousbusiness/gotosocial/releases), arranged with the newest release at the top.)
+
+For example, to download version 0.3.1 for running on 64-bit Linux:
 
 ```bash
-wget https://github.com/superseriousbusiness/gotosocial/releases/download/v0.1.0/gotosocial_0.1.0_linux_amd64.tar.gz
+wget https://github.com/superseriousbusiness/gotosocial/releases/download/v0.3.1/gotosocial_0.3.1_linux_amd64.tar.gz
 ```
 
 Then extract it:
 
 ```bash
-tar -xzf gotosocial_0.1.0_linux_amd64.tar.gz
+tar -xzf gotosocial_0.3.1_linux_amd64.tar.gz
 ```
 
 This will put the `gotosocial` binary in your current directory, in addition to the `web` folder, which contains assets for the web frontend, and an `example` folder, which contains a sample configuration file.

--- a/docs/installation_guide/docker.md
+++ b/docs/installation_guide/docker.md
@@ -60,7 +60,23 @@ nano docker-compose.yaml
 
 Now, you should change the `GTS_HOST` environment variable to the domain you are running GoToSocial on.
 
-If you want to use [LetsEncrypt](../configuration/letsencrypt.md) for ssl certificates (https), you should:
+You should also update the GoToSocial version number to use the latest stable release.
+
+The list of releases can be found [right here](https://github.com/superseriousbusiness/gotosocial/releases), with the newest release at the top.
+
+Replace `latest` in the docker-compose.yaml with the number of the release (without the leading `v` or trailing version name). So for example if you want to run [v0.3.1 Sleepy Sloth](https://github.com/superseriousbusiness/gotosocial/releases/tag/v0.3.1) you should replace:
+
+```text
+image: superseriousbusiness/gotosocial:latest
+```
+
+with:
+
+```text
+image: superseriousbusiness/gotosocial:0.3.1
+```
+
+If you want to use [LetsEncrypt](../configuration/letsencrypt.md) for ssl certificates (https), you should also:
 
 1. Change the value of `GTS_LETSENCRYPT_ENABLED` to `"true"`.
 2. Remove the `#` before `- "80:80"` in the `ports` section.


### PR DESCRIPTION
This PR updates the binary + docker installation guides to recommend that users take the latest stable release of GoToSocial when they're doing their deploys.

This should avoid issues where something has been broken on main and we haven't fixed it yet, and users are deploying with `latest` and running into issues (https://github.com/superseriousbusiness/gotosocial/issues/511)