### PR TITLE
[performance] Speed up some of the slower db queries

### DIFF
--- a/internal/api/s2s/user/statusget.go
+++ b/internal/api/s2s/user/statusget.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -35,13 +36,15 @@ func (m *Module) StatusGETHandler(c *gin.Context) {
 		"url":  c.Request.RequestURI,
 	})
 
-	requestedUsername := c.Param(UsernameKey)
+	// usernames on our instance are always lowercase
+	requestedUsername := strings.ToLower(c.Param(UsernameKey))
 	if requestedUsername == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "no username specified in request"})
 		return
 	}
 
-	requestedStatusID := c.Param(StatusIDKey)
+	// status IDs on our instance are always uppercase
+	requestedStatusID := strings.ToUpper(c.Param(StatusIDKey))
 	if requestedStatusID == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "no status id specified in request"})
 		return

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -199,7 +200,7 @@ func (a *accountDB) GetLocalAccountByUsername(ctx context.Context, username stri
 	account := new(gtsmodel.Account)
 
 	q := a.newAccountQ(account).
-		Where("LOWER(?) = LOWER(?)", bun.Ident("username"), username). // ignore casing
+		Where("username = ?", strings.ToLower(username)). // usernames on our instance will always be lowercase
 		WhereGroup(" AND ", whereEmptyOrNull("domain"))
 
 	if err := q.Scan(ctx); err != nil {

--- a/internal/db/bundb/conn.go
+++ b/internal/db/bundb/conn.go
@@ -68,13 +68,12 @@ func (conn *DBConn) ProcessError(err error) db.Error {
 
 // Exists checks the results of a SelectQuery for the existence of the data in question, masking ErrNoEntries errors
 func (conn *DBConn) Exists(ctx context.Context, query *bun.SelectQuery) (bool, db.Error) {
-	// Get the select query result
-	count, err := query.Count(ctx)
+	exists, err := query.Exists(ctx)
 
 	// Process error as our own and check if it exists
 	switch err := conn.ProcessError(err); err {
 	case nil:
-		return (count != 0), nil
+		return exists, nil
 	case db.ErrNoEntries:
 		return false, nil
 	default:

--- a/internal/db/bundb/domain.go
+++ b/internal/db/bundb/domain.go
@@ -21,6 +21,7 @@ package bundb
 import (
 	"context"
 	"net/url"
+	"strings"
 
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
@@ -39,6 +40,7 @@ func (d *domainDB) IsDomainBlocked(ctx context.Context, domain string) (bool, db
 	q := d.conn.
 		NewSelect().
 		Model(&gtsmodel.DomainBlock{}).
+		ExcludeColumn("id", "created_at", "updated_at", "created_by_account_id", "private_comment", "public_comment", "obfuscate", "subscription_id").
 		Where("domain = ?", domain).
 		Limit(1)
 
@@ -50,7 +52,7 @@ func (d *domainDB) AreDomainsBlocked(ctx context.Context, domains []string) (boo
 	uniqueDomains := util.UniqueStrings(domains)
 
 	for _, domain := range uniqueDomains {
-		if blocked, err := d.IsDomainBlocked(ctx, domain); err != nil {
+		if blocked, err := d.IsDomainBlocked(ctx, strings.ToLower(domain)); err != nil {
 			return false, err
 		} else if blocked {
 			return blocked, nil

--- a/internal/db/bundb/domain.go
+++ b/internal/db/bundb/domain.go
@@ -39,7 +39,7 @@ func (d *domainDB) IsDomainBlocked(ctx context.Context, domain string) (bool, db
 	q := d.conn.
 		NewSelect().
 		Model(&gtsmodel.DomainBlock{}).
-		Where("LOWER(domain) = LOWER(?)", domain).
+		Where("domain = ?", domain).
 		Limit(1)
 
 	return d.conn.Exists(ctx, q)

--- a/internal/db/bundb/domain_test.go
+++ b/internal/db/bundb/domain_test.go
@@ -1,0 +1,57 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package bundb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+)
+
+type DomainTestSuite struct {
+	BunDBStandardTestSuite
+}
+
+func (suite *DomainTestSuite) TestIsDomainBlocked() {
+	ctx := context.Background()
+
+	domainBlock := &gtsmodel.DomainBlock{
+		ID:                 "01G204214Y9TNJEBX39C7G88SW",
+		Domain:             "some.bad.apples",
+		CreatedByAccountID: suite.testAccounts["admin_account"].ID,
+	}
+
+	// no domain block exists for the given domain yet
+	blocked, err := suite.db.IsDomainBlocked(ctx, domainBlock.Domain)
+	suite.NoError(err)
+	suite.False(blocked)
+
+	suite.db.Put(ctx, domainBlock)
+
+	// domain block now exists
+	blocked, err = suite.db.IsDomainBlocked(ctx, domainBlock.Domain)
+	suite.NoError(err)
+	suite.True(blocked)
+}
+
+func TestDomainTestSuite(t *testing.T) {
+	suite.Run(t, new(DomainTestSuite))
+}

--- a/internal/db/bundb/relationship.go
+++ b/internal/db/bundb/relationship.go
@@ -51,7 +51,9 @@ func (r *relationshipDB) newFollowQ(follow interface{}) *bun.SelectQuery {
 func (r *relationshipDB) IsBlocked(ctx context.Context, account1 string, account2 string, eitherDirection bool) (bool, db.Error) {
 	q := r.conn.
 		NewSelect().
-		Model(&gtsmodel.Block{})
+		Model(&gtsmodel.Block{}).
+		ExcludeColumn("id", "created_at", "updated_at", "uri").
+		Limit(1)
 
 	if eitherDirection {
 		q = q.

--- a/internal/db/bundb/relationship_test.go
+++ b/internal/db/bundb/relationship_test.go
@@ -33,10 +33,6 @@ type RelationshipTestSuite struct {
 }
 
 func (suite *RelationshipTestSuite) TestIsBlocked() {
-	suite.Suite.T().Skip("TODO: implement")
-}
-
-func (suite *RelationshipTestSuite) TestGetBlock() {
 	ctx := context.Background()
 
 	account1 := suite.testAccounts["local_account_1"].ID
@@ -76,6 +72,10 @@ func (suite *RelationshipTestSuite) TestGetBlock() {
 	blocked, err = suite.db.IsBlocked(ctx, account2, account1, true)
 	suite.NoError(err)
 	suite.True(blocked)
+}
+
+func (suite *RelationshipTestSuite) TestGetBlock() {
+	suite.Suite.T().Skip("TODO: implement")
 }
 
 func (suite *RelationshipTestSuite) TestGetRelationship() {

--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -70,7 +70,7 @@ func (s *statusDB) GetStatusByID(ctx context.Context, id string) (*gtsmodel.Stat
 			return s.cache.GetByID(id)
 		},
 		func(status *gtsmodel.Status) error {
-			return s.newStatusQ(status).Where("LOWER(status.id) = LOWER(?)", id).Scan(ctx)
+			return s.newStatusQ(status).Where("status.id = ?", id).Scan(ctx)
 		},
 	)
 }
@@ -82,7 +82,7 @@ func (s *statusDB) GetStatusByURI(ctx context.Context, uri string) (*gtsmodel.St
 			return s.cache.GetByURI(uri)
 		},
 		func(status *gtsmodel.Status) error {
-			return s.newStatusQ(status).Where("LOWER(status.uri) = LOWER(?)", uri).Scan(ctx)
+			return s.newStatusQ(status).Where("status.uri = ?", uri).Scan(ctx)
 		},
 	)
 }
@@ -94,7 +94,7 @@ func (s *statusDB) GetStatusByURL(ctx context.Context, url string) (*gtsmodel.St
 			return s.cache.GetByURL(url)
 		},
 		func(status *gtsmodel.Status) error {
-			return s.newStatusQ(status).Where("LOWER(status.url) = LOWER(?)", url).Scan(ctx)
+			return s.newStatusQ(status).Where("status.url = ?", url).Scan(ctx)
 		},
 	)
 }

--- a/internal/db/bundb/trace.go
+++ b/internal/db/bundb/trace.go
@@ -47,6 +47,11 @@ func (q *debugQueryHook) AfterQuery(_ context.Context, event *bun.QueryEvent) {
 		"operation": event.Operation(),
 	})
 
+	if dur > 1 * time.Second {
+		l.Warnf("SLOW DATABASE QUERY [%s] %s", dur, event.Query)
+		return
+	}
+
 	if logrus.GetLevel() == logrus.TraceLevel {
 		l.Tracef("[%s] %s", dur, event.Query)
 	} else {

--- a/internal/db/bundb/trace.go
+++ b/internal/db/bundb/trace.go
@@ -47,7 +47,7 @@ func (q *debugQueryHook) AfterQuery(_ context.Context, event *bun.QueryEvent) {
 		"operation": event.Operation(),
 	})
 
-	if dur > 1 * time.Second {
+	if dur > 1*time.Second {
 		l.Warnf("SLOW DATABASE QUERY [%s] %s", dur, event.Query)
 		return
 	}

--- a/internal/federation/federatingprotocol.go
+++ b/internal/federation/federatingprotocol.go
@@ -134,7 +134,7 @@ func (f *federator) AuthenticatePostInbox(ctx context.Context, w http.ResponseWr
 
 	// authentication has passed, so add an instance entry for this instance if it hasn't been done already
 	i := &gtsmodel.Instance{}
-	if err := f.db.GetWhere(ctx, []db.Where{{Key: "domain", Value: publicKeyOwnerURI.Host, CaseInsensitive: true}}, i); err != nil {
+	if err := f.db.GetWhere(ctx, []db.Where{{Key: "domain", Value: publicKeyOwnerURI.Host}}, i); err != nil {
 		if err != db.ErrNoEntries {
 			// there's been an actual error
 			return ctx, false, fmt.Errorf("error getting requesting account with public key id %s: %s", publicKeyOwnerURI.String(), err)

--- a/internal/processing/admin/createdomainblock.go
+++ b/internal/processing/admin/createdomainblock.go
@@ -21,6 +21,7 @@ package admin
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -35,9 +36,12 @@ import (
 )
 
 func (p *processor) DomainBlockCreate(ctx context.Context, account *gtsmodel.Account, domain string, obfuscate bool, publicComment string, privateComment string, subscriptionID string) (*apimodel.DomainBlock, gtserror.WithCode) {
+	// domain blocks will always be lowercase
+	domain = strings.ToLower(domain)
+
 	// first check if we already have a block -- if err == nil we already had a block so we can skip a whole lot of work
 	domainBlock := &gtsmodel.DomainBlock{}
-	err := p.db.GetWhere(ctx, []db.Where{{Key: "domain", Value: domain, CaseInsensitive: true}}, domainBlock)
+	err := p.db.GetWhere(ctx, []db.Where{{Key: "domain", Value: domain}}, domainBlock)
 	if err != nil {
 		if err != db.ErrNoEntries {
 			// something went wrong in the DB
@@ -95,7 +99,7 @@ func (p *processor) initiateDomainBlockSideEffects(ctx context.Context, account 
 
 	// if we have an instance entry for this domain, update it with the new block ID and clear all fields
 	instance := &gtsmodel.Instance{}
-	if err := p.db.GetWhere(ctx, []db.Where{{Key: "domain", Value: block.Domain, CaseInsensitive: true}}, instance); err == nil {
+	if err := p.db.GetWhere(ctx, []db.Where{{Key: "domain", Value: block.Domain}}, instance); err == nil {
 		instance.Title = ""
 		instance.UpdatedAt = time.Now()
 		instance.SuspendedAt = time.Now()

--- a/internal/web/thread.go
+++ b/internal/web/thread.go
@@ -36,14 +36,16 @@ func (m *Module) threadTemplateHandler(c *gin.Context) {
 
 	ctx := c.Request.Context()
 
-	username := c.Param(usernameKey)
+	// usernames on our instance will always be lowercase
+	username := strings.ToLower(c.Param(usernameKey))
 	if username == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "no account username specified"})
 		return
 	}
 
-	statusID := c.Param(statusIDKey)
-	if username == "" {
+	// status ids will always be uppercase
+	statusID := strings.ToUpper(c.Param(statusIDKey))
+	if statusID == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "no status id specified"})
 		return
 	}


### PR DESCRIPTION
This PR:

1. Removes use of the `LOWER()` db function where it wasn't necessary (this function prevented the db indexes from working properly).
2. Swaps the db exists function from using `COUNT(*)` to using `EXISTS`, which should be faster.
3. Reworks the blocked function to always present params in the order that's been indexed.
4. Adds a warning level log when db queries take longer than 1s to help debugging.

closes https://github.com/superseriousbusiness/gotosocial/issues/520