### PR TITLE
[documentation] put single-quotes around passwords in install docs

### DIFF
--- a/docs/installation_guide/binary.md
+++ b/docs/installation_guide/binary.md
@@ -79,7 +79,7 @@ You can use the GoToSocial binary to also create, confirm, and promote your user
 Run the following command to create a new account:
 
 ```bash
-./gotosocial --config-path ./config.yaml admin account create --username some_username --email some_email@whatever.org --password SOME_PASSWORD
+./gotosocial --config-path ./config.yaml admin account create --username some_username --email some_email@whatever.org --password 'SOME_PASSWORD'
 ```
 
 In the above command, replace `some_username` with your desired username, `some_email@whatever.org` with the email address you want to associate with your account, and `SOME_PASSWORD` with a secure password.

--- a/docs/installation_guide/docker.md
+++ b/docs/installation_guide/docker.md
@@ -123,7 +123,7 @@ Now that GoToSocial is running, you can execute commands inside the running cont
 First create a user (replace the username, email, and password with appropriate values):
 
 ```bash
-docker exec -it gotosocial /gotosocial/gotosocial admin account create --username some_username --email someone@example.org --password some_very_good_password
+docker exec -it gotosocial /gotosocial/gotosocial admin account create --username some_username --email someone@example.org --password 'some_very_good_password'
 ```
 
 Now confirm the user, replacing username with the value you used in the command above.


### PR DESCRIPTION
This should help avoid problems like https://github.com/superseriousbusiness/gotosocial/issues/518 where the command-line is interpreting special characters