### PR TITLE
update media manager to use internal/worker package

### DIFF
--- a/internal/media/manager.go
+++ b/internal/media/manager.go
@@ -87,16 +87,9 @@ type manager struct {
 // NewManager returns a media manager with the given db and underlying storage.
 //
 // A worker pool will also be initialized for the manager, to ensure that only
-// a limited number of media will be processed in parallel.
-//
-// The number of workers will be the number of CPUs available to the Go runtime,
-// divided by 2 (rounding down, but always at least 1).
-//
-// The length of the queue will be the number of workers multiplied by 10.
-//
-// So for an 8 core machine, the media manager will get 4 workers, and a queue of length 40.
-// For a 4 core machine, this will be 2 workers, and a queue length of 20.
-// For a single or 2-core machine, the media manager will get 1 worker, and a queue of length 10.
+// a limited number of media will be processed in parallel. The numbers of workers
+// is determined from the $GOMAXPROCS environment variable (usually no. CPU cores).
+// See internal/worker.New() documentation for further information.
 func NewManager(database db.DB, storage *kv.KVStore) (Manager, error) {
 	m := &manager{
 		db:      database,

--- a/internal/media/manager_test.go
+++ b/internal/media/manager_test.go
@@ -443,8 +443,6 @@ func (suite *ManagerTestSuite) TestSimpleJpegQueueSpamming() {
 	}
 
 	for _, processingMedia := range inProcess {
-		fmt.Printf("\n\n\nactive workers: %d, queue length: %d\n\n\n", suite.manager.ActiveWorkers(), suite.manager.JobsQueued())
-
 		// fetch the attachment id from the processing media
 		attachmentID := processingMedia.AttachmentID()
 

--- a/internal/worker/workers.go
+++ b/internal/worker/workers.go
@@ -93,7 +93,7 @@ func (w *Worker[MsgType]) SetProcessor(fn func(context.Context, MsgType) error) 
 
 // Queue will queue provided message to be processed with there's a free worker.
 func (w *Worker[MsgType]) Queue(msg MsgType) {
-	logrus.Tracef("%q queueing message (workers=%d queue=%q): %+v",
+	logrus.Tracef("%s queueing message (workers=%d queue=%d): %+v",
 		w.prefix, w.workers.Workers(), w.workers.Queue(), msg,
 	)
 	w.workers.Enqueue(func(ctx context.Context) {


### PR DESCRIPTION
By updating the media manager to use the internal/worker package it allows us to neaten up the enqueuing mechanism. I also added some improved logging to the worker pool so when trace is enabled we get an idea of workers state on each queued message.