### PR TITLE
Include password strength in error message when password strength is too low

### DIFF
--- a/internal/api/client/user/passwordchange_test.go
+++ b/internal/api/client/user/passwordchange_test.go
@@ -153,7 +153,7 @@ func (suite *PasswordChangeTestSuite) TestPasswordWeakNewPassword() {
 	defer result.Body.Close()
 	b, err := ioutil.ReadAll(result.Body)
 	suite.NoError(err)
-	suite.Equal(`{"error":"bad request: insecure password, try including more special characters, using uppercase letters, using numbers or using a longer password"}`, string(b))
+	suite.Equal(`{"error":"bad request: password is 94% strength, try including more special characters, using uppercase letters, using numbers or using a longer password"}`, string(b))
 }
 
 func TestPasswordChangeTestSuite(t *testing.T) {

--- a/internal/processing/user/changepassword_test.go
+++ b/internal/processing/user/changepassword_test.go
@@ -64,9 +64,9 @@ func (suite *ChangePasswordTestSuite) TestChangePasswordWeakNew() {
 	user := suite.testUsers["local_account_1"]
 
 	errWithCode := suite.user.ChangePassword(context.Background(), user, "password", "1234")
-	suite.EqualError(errWithCode, "insecure password, try including more special characters, using lowercase letters, using uppercase letters or using a longer password")
+	suite.EqualError(errWithCode, "password is 11% strength, try including more special characters, using lowercase letters, using uppercase letters or using a longer password")
 	suite.Equal(http.StatusBadRequest, errWithCode.Code())
-	suite.Equal("bad request: insecure password, try including more special characters, using lowercase letters, using uppercase letters or using a longer password", errWithCode.Safe())
+	suite.Equal("bad request: password is 11% strength, try including more special characters, using lowercase letters, using uppercase letters or using a longer password", errWithCode.Safe())
 }
 
 func TestChangePasswordTestSuite(t *testing.T) {

--- a/internal/validate/formvalidation.go
+++ b/internal/validate/formvalidation.go
@@ -53,7 +53,12 @@ func NewPassword(password string) error {
 		return fmt.Errorf("password should be no more than %d chars", maximumPasswordLength)
 	}
 
-	return pwv.Validate(password, minimumPasswordEntropy)
+	if err := pwv.Validate(password, minimumPasswordEntropy); err != nil {
+		percent := int(100 * pwv.GetEntropy(password) / minimumPasswordEntropy)
+		return fmt.Errorf("Password is only %d%% as strong as it should be; %s", percent, err)
+	}
+
+	return nil // pasword OK
 }
 
 // Username makes sure that a given username is valid (ie., letters, numbers, underscores, check length).

--- a/internal/validate/formvalidation.go
+++ b/internal/validate/formvalidation.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net/mail"
+	"strings"
 
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/regexes"
@@ -54,8 +55,12 @@ func NewPassword(password string) error {
 	}
 
 	if err := pwv.Validate(password, minimumPasswordEntropy); err != nil {
+		// Modify error message to include percentage requred entropy the password has
 		percent := int(100 * pwv.GetEntropy(password) / minimumPasswordEntropy)
-		return fmt.Errorf("Password is only %d%% as strong as it should be; %s", percent, err)
+		return errors.New(strings.ReplaceAll(
+			err.Error(),
+			"insecure password",
+			fmt.Sprintf("password is %d%% strength", percent)))
 	}
 
 	return nil // pasword OK

--- a/internal/validate/formvalidation_test.go
+++ b/internal/validate/formvalidation_test.go
@@ -50,22 +50,22 @@ func (suite *ValidationTestSuite) TestCheckPasswordStrength() {
 
 	err = validate.NewPassword(terriblePassword)
 	if assert.Error(suite.T(), err) {
-		assert.Equal(suite.T(), errors.New("insecure password, try including more special characters, using uppercase letters, using numbers or using a longer password"), err)
+		assert.Equal(suite.T(), errors.New("password is 62% strength, try including more special characters, using uppercase letters, using numbers or using a longer password"), err)
 	}
 
 	err = validate.NewPassword(weakPassword)
 	if assert.Error(suite.T(), err) {
-		assert.Equal(suite.T(), errors.New("insecure password, try including more special characters, using numbers or using a longer password"), err)
+		assert.Equal(suite.T(), errors.New("password is 95% strength, try including more special characters, using numbers or using a longer password"), err)
 	}
 
 	err = validate.NewPassword(shortPassword)
 	if assert.Error(suite.T(), err) {
-		assert.Equal(suite.T(), errors.New("insecure password, try including more special characters or using a longer password"), err)
+		assert.Equal(suite.T(), errors.New("password is 39% strength, try including more special characters or using a longer password"), err)
 	}
 
 	err = validate.NewPassword(specialPassword)
 	if assert.Error(suite.T(), err) {
-		assert.Equal(suite.T(), errors.New("insecure password, try including more special characters or using a longer password"), err)
+		assert.Equal(suite.T(), errors.New("password is 53% strength, try including more special characters or using a longer password"), err)
 	}
 
 	err = validate.NewPassword(longPassword)


### PR DESCRIPTION
When the password validator fails because the attempted password is not strong enough, change the error message to include the percentage strength of the attempted password.

This makes it easier for the user to judge how much they need to change the password.

Fixes #549  