### PR TITLE
[bugfix] Add account raw note fix

### DIFF
--- a/internal/db/bundb/migrations/20220506110822_add_account_raw_note.go
+++ b/internal/db/bundb/migrations/20220506110822_add_account_raw_note.go
@@ -27,14 +27,11 @@ import (
 
 func init() {
 	up := func(ctx context.Context, db *bun.DB) error {
-		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-			// add account raw_note column
-			_, err := tx.ExecContext(ctx, "ALTER TABLE ? ADD COLUMN ? TEXT", bun.Ident("accounts"), bun.Ident("note_raw"))
-			if strings.Contains(err.Error(), "already exists") {
-				return nil
-			}
+		_, err := db.ExecContext(ctx, "ALTER TABLE ? ADD COLUMN ? TEXT", bun.Ident("accounts"), bun.Ident("note_raw"))
+		if err != nil && !(strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "duplicate column name")) {
 			return err
-		})
+		}
+		return nil
 	}
 
 	down := func(ctx context.Context, db *bun.DB) error {

--- a/internal/db/bundb/migrations/20220506110822_add_account_raw_note.go
+++ b/internal/db/bundb/migrations/20220506110822_add_account_raw_note.go
@@ -20,8 +20,8 @@ package migrations
 
 import (
 	"context"
+	"strings"
 
-	gtsmodel "github.com/superseriousbusiness/gotosocial/internal/db/bundb/migrations/20211113114307_init"
 	"github.com/uptrace/bun"
 )
 
@@ -29,11 +29,10 @@ func init() {
 	up := func(ctx context.Context, db *bun.DB) error {
 		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 			// add account raw_note column
-			expr := tx.
-				NewAddColumn().
-				Model(&gtsmodel.Account{}).
-				ColumnExpr("note_raw")
-			_, err := expr.Exec(ctx)
+			_, err := tx.ExecContext(ctx, "ALTER TABLE ? ADD COLUMN ? TEXT", bun.Ident("accounts"), bun.Ident("note_raw"))
+			if strings.Contains(err.Error(), "already exists") {
+				return nil
+			}
 			return err
 		})
 	}

--- a/internal/db/bundb/migrations/20220511165212_add_account_raw_note_fix.go
+++ b/internal/db/bundb/migrations/20220511165212_add_account_raw_note_fix.go
@@ -1,0 +1,46 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package migrations
+
+import (
+	"context"
+	"strings"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		_, err := db.ExecContext(ctx, "ALTER TABLE ? ADD COLUMN ? TEXT", bun.Ident("accounts"), bun.Ident("note_raw"))
+		if err != nil && !(strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "duplicate column name")) {
+			return err
+		}
+		return nil
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
This PR fixes the database migration script that may have already been run by some users.

To do this, it both:

1. fixes the previous migration script
2. adds a new migration script that repeats the command, which will be run even in cases where the previous migration script already ran

The two scripts above are now identical.

To make sure the migration is idempotent, the updated/added migration script doesn't error out if the column name already exists.

To avoid panicking even when this error was checked, the migration is not run in a transaction.