### PR TITLE
[bugfix] Fix server trying to listen twice on same address when LE enabled

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -91,10 +91,6 @@ func (r *router) Start() {
 			http.Redirect(rw, r, target, http.StatusTemporaryRedirect)
 		})
 
-		// Clone HTTP server but with autocert handler
-		srv := r.srv
-		srv.Handler = r.certManager.HTTPHandler(redirect)
-
 		// Start the LetsEncrypt autocert manager HTTP server.
 		go func() {
 			addr := fmt.Sprintf("%s:%d",
@@ -103,8 +99,7 @@ func (r *router) Start() {
 			)
 
 			logrus.Infof("letsencrypt listening on %s", addr)
-
-			if err := srv.ListenAndServe(); err != nil &&
+			if err := http.ListenAndServe(addr, r.certManager.HTTPHandler(redirect)); err != nil &&
 				err != http.ErrServerClosed {
 				logrus.Fatalf("letsencrypt: listen: %s", err)
 			}


### PR DESCRIPTION
This PR fixes a bug where we weren't setting the listen address on the letsencrypt server properly, so that it was trying to listen on whatever port was configured for the main server. This was causing the main listener to then fail because the port was already in use.

This fix tested and working both in nginx with certs handled by nginx, and with a raw binary with certs handled by the built in le