### PR TITLE
update syslog tests to listen/connect specifically to ipv4 loopback

### DIFF
--- a/internal/log/syslog_test.go
+++ b/internal/log/syslog_test.go
@@ -47,7 +47,7 @@ func (suite *SyslogTestSuite) SetupTest() {
 
 	viper.Set(config.Keys.SyslogEnabled, true)
 	viper.Set(config.Keys.SyslogProtocol, "udp")
-	viper.Set(config.Keys.SyslogAddress, "localhost:42069")
+	viper.Set(config.Keys.SyslogAddress, "127.0.0.1:42069")
 	server, channel, err := testrig.InitTestSyslog()
 	if err != nil {
 		panic(err)

--- a/testrig/log.go
+++ b/testrig/log.go
@@ -43,7 +43,7 @@ func InitTestSyslog() (*syslog.Server, chan format.LogParts, error) {
 	server.SetFormat(syslog.Automatic)
 	server.SetHandler(handler)
 
-	if err := server.ListenUDP("localhost:42069"); err != nil {
+	if err := server.ListenUDP("127.0.0.1:42069"); err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
On some systems these tests will simply hang, this fixes that.