### PR TITLE
[feature] add vscode workspace config for linting + debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ web/assets/swagger.yaml
 
 # exludes docker-volume from exemple/docker-compose
 example/docker-compose/docker-volume
+
+# excludes debug build
+cmd/gotosocial/__debug_bin

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Launch Package",
+			"type": "go",
+			"request": "launch",
+			"mode": "auto",
+			"program": "${workspaceFolder}/cmd/gotosocial",
+			"args": [
+				"testrig", "start"
+			],
+			"cwd": "${workspaceFolder}"
+		}
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"go.lintTool":"golangci-lint",
+	"go.lintFlags": [
+	  "--fast"
+	]
+}


### PR DESCRIPTION
Having this in the repository will allow any dev using vscode (or forks etc) to automatically get the correct linter and debug run target set up.