### PR TITLE
Add Caddy instructions to the documentation

### DIFF
--- a/docs/installation_guide/caddy.md
+++ b/docs/installation_guide/caddy.md
@@ -33,6 +33,10 @@ dnf install caddy
 pacman -Syu caddy
 ```
 
+### FreeBSD
+```bash
+sudo pkg install caddy
+```
 
 ## Configure GoToSocial
 
@@ -41,9 +45,6 @@ If GoToSocial is already running, stop it.
 ```bash
 sudo systemctl stop gotosocial
 ```
-
-Or if you don't have a systemd service just stop it manually.
-
 In your GoToSocial config turn off Lets Encrypt by setting `letsencrypt-enabled` to `false`.
 
 If you we running GoToSocial on port 443, change the `port` value back to the default `8080`.
@@ -90,7 +91,7 @@ Now check for configuration errors.
 sudo caddy validate
 ```
 
-If everything is fine, you should get some info lines as output. Unless there are lines marked with [err] in front of them, you are all set.
+If everything is fine, you should get some info lines as output. Unless there are lines marked with *[err]* in front of them, you are all set.
 
 Everything working? Great! Then restart caddy to load your new config file.
 

--- a/docs/installation_guide/caddy.md
+++ b/docs/installation_guide/caddy.md
@@ -1,0 +1,119 @@
+# Reverse proxy with Caddy 2
+
+## Requirements
+
+For this guide you will need [Caddy 2](https://caddyserver.com/), there are no other dependencies. Caddy manages Lets Encrypt certificates and renewal for them.
+
+Caddy is in the most popular package managers, or you can get a static binary. For all latest installation guides, refer to [https://caddyserver.com/docs/install](their manual).
+
+### Debian, Ubuntu, Raspbian
+
+```bash
+# Add the keyring for their custom repository.
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+
+# Update packages and install it
+sudo apt update
+sudo apt install caddy
+```
+
+### Fedora, Redhat, Centos
+
+```bash
+dnf install 'dnf-command(copr)'
+dnf copr enable @caddy/caddy
+dnf install caddy
+```
+
+### Arch
+
+```bash
+pacman -Syu caddy
+```
+
+
+## Configure GoToSocial
+
+If GoToSocial is already running, stop it.
+
+```bash
+sudo systemctl stop gotosocial
+```
+
+Or if you don't have a systemd service just stop it manually.
+
+In your GoToSocial config turn off Lets Encrypt by setting `letsencrypt-enabled` to `false`.
+
+If you we running GoToSocial on port 443, change the `port` value back to the default `8080`.
+
+## Set up Caddy
+
+We will configure Caddy 2 to use GoToSocial on our main domain example.org. Since Caddy takes care of obtaining the Lets Encrypt certificate, we only need to configure it properly once.
+
+In most simple use cases Caddy defaults to a file called Caddyfile. It can reload on changes, or can be configured through an HTTP API for zero downtime, but this is out of our current scope.
+
+```bash
+sudo mkdir -p /etc/caddy
+sudo vim /etc/caddy/Caddyfile
+```
+
+While editing the file above, you should replace 'example.org' with your domain. Your domain should occur twice in the current configuration. If you have chosen another port number for GoToSocial other than port 8080, change the port number on the reverse proxy line to match that.
+
+The file you're about to create should look like this:
+
+```Caddyfile
+# Because we use a reverse proxy, Caddy won't redirect port 80 to 443 by default unless we tell it to.
+example.org:80 {
+	redir https://example.org/{uri}
+}
+
+# The actual host configuration
+example.org:443 {
+	# Optional, but recommended, compress the traffic using proper protocols
+	encode zstd gzip
+
+	# The actual proxy configuration to port 8080 (unless you've chosen another port number)
+	reverse_proxy * http://127.0.0.1:8080 {
+		# Flush immediatly (important)
+		flush_interval -1
+
+		# Set the proper headers for information for HTTP signatures etc.
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-For {remote_host}
+		header_up X-Forwarded-Proto {scheme}
+		header_up X-Forwarded-Host {host}
+
+		# Tell the world what origin and methods we allow
+		header_down Access-Control-Allow-Origin *
+		header_down Access-Control-Allow-Methods "GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE"
+	}
+}
+```
+
+**Note**: `header_up X-Forwarded-Host {host}` is essential. It guarantees that the proxy and GoToSocial use the same server name. If not, GoToSocial will build the wrong authentication headers, and all attempts at federation will be rejected with 401.
+
+Now check for configuration errors.
+
+```bash
+sudo caddy validate
+```
+
+If everything is fine, you should get some info lines as output. Unless there are lines marked with [err] in front of them, you are all set.
+
+Everything working? Great! Then restart caddy to load your new config file.
+
+```bash
+sudo systemctl restart caddy
+```
+
+If everything went right, you're now all set to enjoy your GoToSocial instance, so we are going to start it again.
+
+```bash
+sudo systemctl start gotosocial
+```
+
+## Results
+
+You should now be able to open the splash page for your instance in your web browser, and will see that it runs under HTTPS!

--- a/docs/installation_guide/caddy.md
+++ b/docs/installation_guide/caddy.md
@@ -76,23 +76,13 @@ example.org:443 {
 
 	# The actual proxy configuration to port 8080 (unless you've chosen another port number)
 	reverse_proxy * http://127.0.0.1:8080 {
-		# Flush immediatly (important)
+		# Flush immediatly, to prevent buffered response to the client
 		flush_interval -1
-
-		# Set the proper headers for information for HTTP signatures etc.
-		header_up X-Real-IP {remote_host}
-		header_up X-Forwarded-For {remote_host}
-		header_up X-Forwarded-Proto {scheme}
-		header_up X-Forwarded-Host {host}
-
-		# Tell the world what origin and methods we allow
-		header_down Access-Control-Allow-Origin *
-		header_down Access-Control-Allow-Methods "GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE"
 	}
 }
 ```
 
-**Note**: `header_up X-Forwarded-Host {host}` is essential. It guarantees that the proxy and GoToSocial use the same server name. If not, GoToSocial will build the wrong authentication headers, and all attempts at federation will be rejected with 401.
+For advanced configuration check the [reverse_proxy directive](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy) at the Caddy documentation.
 
 Now check for configuration errors.
 

--- a/docs/installation_guide/caddy.md
+++ b/docs/installation_guide/caddy.md
@@ -4,7 +4,7 @@
 
 For this guide you will need [Caddy 2](https://caddyserver.com/), there are no other dependencies. Caddy manages Lets Encrypt certificates and renewal for them.
 
-Caddy is in the most popular package managers, or you can get a static binary. For all latest installation guides, refer to [https://caddyserver.com/docs/install](their manual).
+Caddy is in the most popular package managers, or you can get a static binary. For all latest installation guides, refer to [their manual](https://caddyserver.com/docs/install).
 
 ### Debian, Ubuntu, Raspbian
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
     - "installation_guide/docker.md"
     - "installation_guide/nginx.md"
     - "installation_guide/apache-httpd.md"
+    - "installation_guide/caddy.md"
     - "installation_guide/third_party.md"
     - "installation_guide/websocket.md"
   - "Configuration":


### PR DESCRIPTION
This PR adds Caddy instructions to the documentation. It borrows some text from the NGINX document for the configuration of GoToSocial. It doesn't require much configuration, so the installation instruction is actually a little bit easier.