### PR TITLE
[bugfix] If status URL is empty, use URI instead and don't log unnecessary error

### DIFF
--- a/internal/typeutils/astointernal.go
+++ b/internal/typeutils/astointernal.go
@@ -184,10 +184,11 @@ func (c *converter) ASStatusToStatus(ctx context.Context, statusable ap.Statusab
 	l := logrus.WithField("statusURI", status.URI)
 
 	// web url for viewing this status
-	if statusURL, err := ap.ExtractURL(statusable); err != nil {
-		l.Infof("ASStatusToStatus: error extracting status URL: %s", err)
-	} else {
+	if statusURL, err := ap.ExtractURL(statusable); err == nil {
 		status.URL = statusURL.String()
+	} else {
+		// if no URL was set, just take the URI
+		status.URL = status.URI
 	}
 
 	// the html-formatted content of this status

--- a/internal/typeutils/astointernal_test.go
+++ b/internal/typeutils/astointernal_test.go
@@ -74,6 +74,27 @@ func (suite *ASToInternalTestSuite) TestParsePublicStatus() {
 	suite.Equal(`<p>&gt; So we have to examine critical thinking as a signifier, dynamic and ambiguous.  It has a normative definition, a tacit definition, and an ideal definition.  One of the hallmarks of graduate training is learning to comprehend those definitions and applying the correct one as needed for professional success.</p>`, status.Content)
 }
 
+func (suite *ASToInternalTestSuite) TestParsePublicStatusNoURL() {
+	m := make(map[string]interface{})
+	err := json.Unmarshal([]byte(publicStatusActivityJsonNoURL), &m)
+	suite.NoError(err)
+
+	t, err := streams.ToType(context.Background(), m)
+	suite.NoError(err)
+
+	rep, ok := t.(ap.Statusable)
+	suite.True(ok)
+
+	status, err := suite.typeconverter.ASStatusToStatus(context.Background(), rep)
+	suite.NoError(err)
+
+	suite.Equal("reading: Punishment and Reward in the Corporate University", status.ContentWarning)
+	suite.Equal(`<p>&gt; So we have to examine critical thinking as a signifier, dynamic and ambiguous.  It has a normative definition, a tacit definition, and an ideal definition.  One of the hallmarks of graduate training is learning to comprehend those definitions and applying the correct one as needed for professional success.</p>`, status.Content)
+
+	// on statuses with no URL in them (like ones we get from pleroma sometimes) we should use the AP URI of the status as URL
+	suite.Equal("http://fossbros-anonymous.io/users/foss_satan/statuses/108138763199405167", status.URL)
+}
+
 func (suite *ASToInternalTestSuite) TestParseGargron() {
 	m := make(map[string]interface{})
 	err := json.Unmarshal([]byte(gargronAsActivityJson), &m)

--- a/internal/typeutils/converter_test.go
+++ b/internal/typeutils/converter_test.go
@@ -367,6 +367,53 @@ const (
 		}
 	  }	  
 	`
+	publicStatusActivityJsonNoURL = `
+	{
+		"@context": [
+		  "https://www.w3.org/ns/activitystreams",
+		  {
+			"ostatus": "http://ostatus.org#",
+			"atomUri": "ostatus:atomUri",
+			"inReplyToAtomUri": "ostatus:inReplyToAtomUri",
+			"conversation": "ostatus:conversation",
+			"sensitive": "as:sensitive",
+			"toot": "http://joinmastodon.org/ns#",
+			"votersCount": "toot:votersCount"
+		  }
+		],
+		"id": "http://fossbros-anonymous.io/users/foss_satan/statuses/108138763199405167",
+		"type": "Note",
+		"summary": "reading: Punishment and Reward in the Corporate University",
+		"inReplyTo": "http://fossbros-anonymous.io/users/foss_satan/statuses/108138729399508469",
+		"published": "2022-04-15T23:49:37Z",
+		"attributedTo": "http://fossbros-anonymous.io/users/foss_satan",
+		"to": [
+		  "https://www.w3.org/ns/activitystreams#Public"
+		],
+		"cc": [
+		  "http://fossbros-anonymous.io/users/foss_satan/followers"
+		],
+		"sensitive": true,
+		"atomUri": "http://fossbros-anonymous.io/users/foss_satan/statuses/108138763199405167",
+		"inReplyToAtomUri": "http://fossbros-anonymous.io/users/foss_satan/statuses/108138729399508469",
+		"content": "<p>&gt; So we have to examine critical thinking as a signifier, dynamic and ambiguous.  It has a normative definition, a tacit definition, and an ideal definition.  One of the hallmarks of graduate training is learning to comprehend those definitions and applying the correct one as needed for professional success.</p>",
+		"contentMap": {
+		  "en": "<p>&gt; So we have to examine critical thinking as a signifier, dynamic and ambiguous.  It has a normative definition, a tacit definition, and an ideal definition.  One of the hallmarks of graduate training is learning to comprehend those definitions and applying the correct one as needed for professional success.</p>"
+		},
+		"attachment": [],
+		"tag": [],
+		"replies": {
+		  "id": "http://fossbros-anonymous.io/users/foss_satan/statuses/108138763199405167/replies",
+		  "type": "Collection",
+		  "first": {
+			"type": "CollectionPage",
+			"next": "http://fossbros-anonymous.io/users/foss_satan/statuses/108138763199405167/replies?only_other_accounts=true&page=true",
+			"partOf": "http://fossbros-anonymous.io/users/foss_satan/statuses/108138763199405167/replies",
+			"items": []
+		  }
+		}
+	  }	  
+	`
 )
 
 type TypeUtilsTestSuite struct {


### PR DESCRIPTION
This PR fixes an issue where if no URL was set on the Note Activity, we were logging an error and not setting a URL. This led to instances where in the UI you go to click on a status to see the web representation, but the link is empty. Now, we take the status URI and save it as the URL for the webview when no URL is available, so the user at least has something to click :)

closes #590 