### PR TITLE
[bugfix] Fix `error extracting status content: no content found`

### DIFF
--- a/internal/ap/extract.go
+++ b/internal/ap/extract.go
@@ -349,7 +349,7 @@ func ExtractContent(i WithContent) string {
 		}
 		if iter.IsIRI() && iter.GetIRI() != nil {
 			return iter.GetIRI().String()
-		} 
+		}
 	}
 
 	return ""

--- a/internal/ap/extract.go
+++ b/internal/ap/extract.go
@@ -335,18 +335,24 @@ func ExtractPublicKeyForOwner(i WithPublicKey, forOwner *url.URL) (*rsa.PublicKe
 	return nil, nil, errors.New("couldn't find public key")
 }
 
-// ExtractContent returns a string representation of the interface's Content property.
-func ExtractContent(i WithContent) (string, error) {
+// ExtractContent returns a string representation of the interface's Content property,
+// or an empty string if no Content is found.
+func ExtractContent(i WithContent) string {
 	contentProperty := i.GetActivityStreamsContent()
 	if contentProperty == nil {
-		return "", nil
+		return ""
 	}
+
 	for iter := contentProperty.Begin(); iter != contentProperty.End(); iter = iter.Next() {
-		if iter.IsXMLSchemaString() && iter.GetXMLSchemaString() != "" {
-			return iter.GetXMLSchemaString(), nil
+		if iter.IsXMLSchemaString() {
+			return iter.GetXMLSchemaString()
 		}
+		if iter.IsIRI() && iter.GetIRI() != nil {
+			return iter.GetIRI().String()
+		} 
 	}
-	return "", errors.New("no content found")
+
+	return ""
 }
 
 // ExtractAttachments returns a slice of attachments on the interface.

--- a/internal/ap/extract_test.go
+++ b/internal/ap/extract_test.go
@@ -92,6 +92,10 @@ func noteWithMentions1() vocab.ActivityStreamsNote {
 
 	note.SetActivityStreamsTag(tags)
 
+	content := streams.NewActivityStreamsContentProperty()
+	content.AppendXMLSchemaString("hey @f0x and @dumpsterqueer")
+	note.SetActivityStreamsContent(content)
+
 	return note
 }
 

--- a/internal/ap/extractcontent_test.go
+++ b/internal/ap/extractcontent_test.go
@@ -1,0 +1,42 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package ap_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/ap"
+)
+
+type ExtractContentTestSuite struct {
+	ExtractTestSuite
+}
+
+func (suite *ExtractContentTestSuite) TestExtractContent1() {
+	note := suite.noteWithMentions1
+
+	content := ap.ExtractContent(note)
+
+	suite.Equal("hey @f0x and @dumpsterqueer", content)
+}
+
+func TestExtractContentTestSuite(t *testing.T) {
+	suite.Run(t, &ExtractContentTestSuite{})
+}

--- a/internal/typeutils/astointernal.go
+++ b/internal/typeutils/astointernal.go
@@ -191,11 +191,7 @@ func (c *converter) ASStatusToStatus(ctx context.Context, statusable ap.Statusab
 	}
 
 	// the html-formatted content of this status
-	if content, err := ap.ExtractContent(statusable); err != nil {
-		l.Infof("ASStatusToStatus: error extracting status content: %s", err)
-	} else {
-		status.Content = content
-	}
+	status.Content = ap.ExtractContent(statusable)
 
 	// attachments to dereference and fetch later on (we don't do that here)
 	if attachments, err := ap.ExtractAttachments(statusable); err != nil {


### PR DESCRIPTION
This PR closes https://github.com/superseriousbusiness/gotosocial/issues/565 by updating ExtractContent to just return an empty string if no Content is found in an Activity, since this isn't technically an error, it just means that no text content was set and most likely the post contains a poll or media or something. It also updates the extract content function to check if there's an IRI in the content field, because that's a thing that can sometimes happen.