### PR TITLE
Don't double escape instance title

### DIFF
--- a/web/template/header.tmpl
+++ b/web/template/header.tmpl
@@ -13,14 +13,14 @@
 	{{range .stylesheets}}<link rel="stylesheet" href="{{.}}">
 	{{end}}
 	<link rel="shortcut icon" href="/assets/logo.png" type="image/png">
-	<title>{{.instance.Title}} - GoToSocial</title>
+	<title>{{.instance.Title | noescape}} - GoToSocial</title>
 </head>
 <body>
 	<header>
 		<img src="/assets/logo.png" alt="Instance Logo"/>
 		<div>
 			<h1>
-				{{.instance.Title}}
+				{{.instance.Title | noescape}}
 			</h1>
 		</div>
 		<div></div>


### PR DESCRIPTION
Currently the instance title is escaped when it's put in the DB and when it's displayed, leading to errors. The short description is not escaped when displayed, so this change bring the title in line with that.