### PR TITLE
[security] Set SameSite to `strict` instead of browser default

### DIFF
--- a/internal/router/session.go
+++ b/internal/router/session.go
@@ -42,7 +42,7 @@ func SessionOptions() sessions.Options {
 		MaxAge:   120,                                              // 2 minutes
 		Secure:   viper.GetString(config.Keys.Protocol) == "https", // only use cookie over https
 		HttpOnly: true,                                             // exclude javascript from inspecting cookie
-		SameSite: http.SameSiteDefaultMode,                         // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-cookie-same-site-00#section-4.1.1
+		SameSite: http.SameSiteStrictMode,                          // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-cookie-same-site-00#section-4.1.1
 	}
 }
 


### PR DESCRIPTION
Previously we were using `http.SameSiteDefaultMode` on our session cookies, which (in firefox at least) defaults to Lax. This PR switches our session config to use `http.SameSiteStrictMode` instead, which should make us more secure against CSRF attacks (not that these were much of an issue anyway but you never know).

Tested with the testrig and goblin.technology on Pinafore, both chrome and firefox, and it seems to work fine :)