### PR TITLE
[bugfix] Add `accept: application/activity+json` to dereferencer

### DIFF
--- a/internal/transport/dereference.go
+++ b/internal/transport/dereference.go
@@ -54,6 +54,7 @@ func (t *transport) Dereference(ctx context.Context, iri *url.URL) ([]byte, erro
 		return nil, err
 	}
 	req.Header.Add("Accept", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
+	req.Header.Add("Accept", "application/activity+json")
 	req.Header.Add("Accept-Charset", "utf-8")
 	req.Header.Add("User-Agent", t.controller.userAgent)
 	req.Header.Set("Host", iri.Host)

--- a/internal/transport/dereference.go
+++ b/internal/transport/dereference.go
@@ -53,8 +53,7 @@ func (t *transport) Dereference(ctx context.Context, iri *url.URL) ([]byte, erro
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Accept", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"")
-	req.Header.Add("Accept", "application/activity+json")
+	req.Header.Add("Accept", "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\",application/activity+json")
 	req.Header.Add("Accept-Charset", "utf-8")
 	req.Header.Add("User-Agent", t.controller.userAgent)
 	req.Header.Set("Host", iri.Host)


### PR DESCRIPTION
This PR adds `application/activity+json` to the Accept header on dereference requests, in addition to the `application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"` value that we already had.

This is a workaround for servers that don't understand `application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"` (like the most recent version of Owncast).

closes https://github.com/superseriousbusiness/gotosocial/issues/610 , since with this fix it's possible now to lookup an Owncast account. 