### PR TITLE
[feature] Add `created_at` and `error_description` to `/oauth/token` endpoint

### DIFF
--- a/cmd/gotosocial/action/server/server.go
+++ b/cmd/gotosocial/action/server/server.go
@@ -165,7 +165,7 @@ var Start action.GTSAction = func(ctx context.Context) error {
 	}
 
 	// build client api modules
-	authModule := auth.New(dbService, oauthServer, idp, processor)
+	authModule := auth.New(dbService, idp, processor)
 	accountModule := account.New(processor)
 	instanceModule := instance.New(processor)
 	appsModule := app.New(processor)

--- a/cmd/gotosocial/action/testrig/testrig.go
+++ b/cmd/gotosocial/action/testrig/testrig.go
@@ -108,7 +108,7 @@ var Start action.GTSAction = func(ctx context.Context) error {
 	}
 
 	// build client api modules
-	authModule := auth.New(dbService, oauthServer, idp, processor)
+	authModule := auth.New(dbService, idp, processor)
 	accountModule := account.New(processor)
 	instanceModule := instance.New(processor)
 	appsModule := app.New(processor)

--- a/internal/api/client/auth/auth.go
+++ b/internal/api/client/auth/auth.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/superseriousbusiness/gotosocial/internal/api"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
-	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 	"github.com/superseriousbusiness/gotosocial/internal/oidc"
 	"github.com/superseriousbusiness/gotosocial/internal/processing"
 	"github.com/superseriousbusiness/gotosocial/internal/router"
@@ -68,16 +67,14 @@ const (
 // Module implements the ClientAPIModule interface for
 type Module struct {
 	db        db.DB
-	server    oauth.Server
 	idp       oidc.IDP
 	processor processing.Processor
 }
 
 // New returns a new auth module
-func New(db db.DB, server oauth.Server, idp oidc.IDP, processor processing.Processor) api.ClientModule {
+func New(db db.DB, idp oidc.IDP, processor processing.Processor) api.ClientModule {
 	return &Module{
 		db:        db,
-		server:    server,
 		idp:       idp,
 		processor: processor,
 	}

--- a/internal/api/client/auth/auth_test.go
+++ b/internal/api/client/auth/auth_test.go
@@ -121,7 +121,7 @@ func (suite *AuthStandardTestSuite) newContext(requestMethod string, requestPath
 	host := config.GetHost()
 	baseURI := fmt.Sprintf("%s://%s", protocol, host)
 	requestURI := fmt.Sprintf("%s/%s", baseURI, requestPath)
-	
+
 	ctx.Request = httptest.NewRequest(requestMethod, requestURI, bytes.NewReader(requestBody)) // the endpoint we're hitting
 	ctx.Request.Header.Set("accept", "text/html")
 

--- a/internal/api/client/auth/auth_test.go
+++ b/internal/api/client/auth/auth_test.go
@@ -99,7 +99,7 @@ func (suite *AuthStandardTestSuite) SetupTest() {
 	if err != nil {
 		panic(err)
 	}
-	suite.authModule = auth.New(suite.db, suite.oauthServer, suite.idp, suite.processor).(*auth.Module)
+	suite.authModule = auth.New(suite.db, suite.idp, suite.processor).(*auth.Module)
 	testrig.StandardDBSetup(suite.db, suite.testAccounts)
 }
 

--- a/internal/api/client/auth/authorize.go
+++ b/internal/api/client/auth/authorize.go
@@ -246,7 +246,7 @@ func (m *Module) AuthorizePOSTHandler(c *gin.Context) {
 		sessionUserID:       {userID},
 	}
 
-	if err := m.server.HandleAuthorizeRequest(c.Writer, c.Request); err != nil {
+	if err := m.processor.OAuthHandleAuthorizeRequest(c.Writer, c.Request); err != nil {
 		api.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error(), helpfulAdvice), m.processor.InstanceGet)
 	}
 }

--- a/internal/api/client/auth/authorize_test.go
+++ b/internal/api/client/auth/authorize_test.go
@@ -69,7 +69,7 @@ func (suite *AuthAuthorizeTestSuite) TestAccountAuthorizeHandler() {
 	}
 
 	doTest := func(testCase authorizeHandlerTestCase) {
-		ctx, recorder := suite.newContext(http.MethodGet, auth.OauthAuthorizePath)
+		ctx, recorder := suite.newContext(http.MethodGet, auth.OauthAuthorizePath, nil, "")
 
 		user := suite.testUsers["unconfirmed_account"]
 		account := suite.testAccounts["unconfirmed_account"]

--- a/internal/api/client/auth/token.go
+++ b/internal/api/client/auth/token.go
@@ -72,7 +72,7 @@ func (m *Module) TokenPOSTHandler(c *gin.Context) {
 
 	// pass the writer and request into the oauth server handler, which will
 	// take care of writing the oauth token into the response etc
-	if err := m.server.HandleTokenRequest(c.Writer, c.Request); err != nil {
+	if err := m.processor.OAuthHandleTokenRequest(c.Writer, c.Request); err != nil {
 		api.ErrorHandler(c, gtserror.NewErrorInternalError(err, helpfulAdvice), m.processor.InstanceGet)
 	}
 }

--- a/internal/api/client/auth/token_test.go
+++ b/internal/api/client/auth/token_test.go
@@ -1,0 +1,68 @@
+package auth_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/testrig"
+)
+
+type TokenTestSuite struct {
+	AuthStandardTestSuite
+}
+
+func (suite *TokenTestSuite) TestPOSTTokenEmptyForm() {
+	ctx, recorder := suite.newContext(http.MethodPost, "oauth/token", []byte{}, "")
+	ctx.Request.Header.Set("accept", "application/json")
+
+	suite.authModule.TokenPOSTHandler(ctx)
+
+	suite.Equal(http.StatusBadRequest, recorder.Code)
+
+	result := recorder.Result()
+	defer result.Body.Close()
+
+	b, err := ioutil.ReadAll(result.Body)
+	suite.NoError(err)
+
+	suite.Equal(`{"error":"invalid_request","error_description":"Bad Request: grant_type was not set in the token request, but must be set to authorization_code or client_credentials: code was not set in the token request body: redirect_uri was not set in the token request body: client_id was not set in the token request body"}`, string(b))
+}
+
+func (suite *TokenTestSuite) TestRetrieveApplicationToken() {
+	testClient := suite.testClients["local_account_1"]
+	// testApplication := suite.testApplications["application_1"]
+
+	requestBody, w, err := testrig.CreateMultipartFormData(
+		"", "",
+		map[string]string{
+			"grant_type":    "client_credentials",
+			"client_id":     testClient.ID,
+			"client_secret": testClient.Secret,
+			"redirect_uri":  "http://localhost:8080",
+		})
+	if err != nil {
+		panic(err)
+	}
+	bodyBytes := requestBody.Bytes()
+
+	ctx, recorder := suite.newContext(http.MethodPost, "oauth/token", bodyBytes, w.FormDataContentType())
+	ctx.Request.Header.Set("accept", "application/json")
+
+	suite.authModule.TokenPOSTHandler(ctx)
+
+	suite.Equal(http.StatusBadRequest, recorder.Code)
+
+	result := recorder.Result()
+	defer result.Body.Close()
+
+	b, err := ioutil.ReadAll(result.Body)
+	suite.NoError(err)
+
+	suite.Equal(`{"error":"invalid_request","error_description":"Bad Request: could not validate token request: invalid_request"}`, string(b))
+}
+
+func TestTokenTestSuite(t *testing.T) {
+	suite.Run(t, &TokenTestSuite{})
+}

--- a/internal/api/client/auth/token_test.go
+++ b/internal/api/client/auth/token_test.go
@@ -1,3 +1,21 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package auth_test
 
 import (

--- a/internal/api/client/auth/token_test.go
+++ b/internal/api/client/auth/token_test.go
@@ -1,11 +1,17 @@
 package auth_test
 
 import (
+	"context"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
+	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
@@ -27,17 +33,107 @@ func (suite *TokenTestSuite) TestPOSTTokenEmptyForm() {
 	b, err := ioutil.ReadAll(result.Body)
 	suite.NoError(err)
 
-	suite.Equal(`{"error":"invalid_request","error_description":"Bad Request: grant_type was not set in the token request, but must be set to authorization_code or client_credentials: code was not set in the token request body: redirect_uri was not set in the token request body: client_id was not set in the token request body"}`, string(b))
+	suite.Equal(`{"error":"invalid_request","error_description":"Bad Request: grant_type was not set in the token request form, but must be set to authorization_code or client_credentials: client_id was not set in the token request form: client_secret was not set in the token request form: redirect_uri was not set in the token request form"}`, string(b))
 }
 
-func (suite *TokenTestSuite) TestRetrieveApplicationToken() {
+func (suite *TokenTestSuite) TestRetrieveClientCredentialsOK() {
 	testClient := suite.testClients["local_account_1"]
-	// testApplication := suite.testApplications["application_1"]
 
 	requestBody, w, err := testrig.CreateMultipartFormData(
 		"", "",
 		map[string]string{
 			"grant_type":    "client_credentials",
+			"client_id":     testClient.ID,
+			"client_secret": testClient.Secret,
+			"redirect_uri":  "http://localhost:8080",
+		})
+	if err != nil {
+		panic(err)
+	}
+	bodyBytes := requestBody.Bytes()
+
+	ctx, recorder := suite.newContext(http.MethodPost, "oauth/token", bodyBytes, w.FormDataContentType())
+	ctx.Request.Header.Set("accept", "application/json")
+
+	suite.authModule.TokenPOSTHandler(ctx)
+
+	suite.Equal(http.StatusOK, recorder.Code)
+
+	result := recorder.Result()
+	defer result.Body.Close()
+
+	b, err := ioutil.ReadAll(result.Body)
+	suite.NoError(err)
+
+	t := &apimodel.Token{}
+	err = json.Unmarshal(b, t)
+	suite.NoError(err)
+
+	suite.Equal("Bearer", t.TokenType)
+	suite.NotEmpty(t.AccessToken)
+	suite.NotEmpty(t.CreatedAt)
+	suite.WithinDuration(time.Now(), time.Unix(t.CreatedAt, 0), 1*time.Minute)
+
+	// there should be a token in the database now too
+	dbToken := &gtsmodel.Token{}
+	err = suite.db.GetWhere(context.Background(), []db.Where{{Key: "access", Value: t.AccessToken}}, dbToken)
+	suite.NoError(err)
+	suite.NotNil(dbToken)
+}
+
+func (suite *TokenTestSuite) TestRetrieveAuthorizationCodeOK() {
+	testClient := suite.testClients["local_account_1"]
+	testUserAuthorizationToken := suite.testTokens["local_account_1_user_authorization_token"]
+
+	requestBody, w, err := testrig.CreateMultipartFormData(
+		"", "",
+		map[string]string{
+			"grant_type":    "authorization_code",
+			"client_id":     testClient.ID,
+			"client_secret": testClient.Secret,
+			"redirect_uri":  "http://localhost:8080",
+			"code":          testUserAuthorizationToken.Code,
+		})
+	if err != nil {
+		panic(err)
+	}
+	bodyBytes := requestBody.Bytes()
+
+	ctx, recorder := suite.newContext(http.MethodPost, "oauth/token", bodyBytes, w.FormDataContentType())
+	ctx.Request.Header.Set("accept", "application/json")
+
+	suite.authModule.TokenPOSTHandler(ctx)
+
+	suite.Equal(http.StatusOK, recorder.Code)
+
+	result := recorder.Result()
+	defer result.Body.Close()
+
+	b, err := ioutil.ReadAll(result.Body)
+	suite.NoError(err)
+
+	t := &apimodel.Token{}
+	err = json.Unmarshal(b, t)
+	suite.NoError(err)
+
+	suite.Equal("Bearer", t.TokenType)
+	suite.NotEmpty(t.AccessToken)
+	suite.NotEmpty(t.CreatedAt)
+	suite.WithinDuration(time.Now(), time.Unix(t.CreatedAt, 0), 1*time.Minute)
+
+	dbToken := &gtsmodel.Token{}
+	err = suite.db.GetWhere(context.Background(), []db.Where{{Key: "access", Value: t.AccessToken}}, dbToken)
+	suite.NoError(err)
+	suite.NotNil(dbToken)
+}
+
+func (suite *TokenTestSuite) TestRetrieveAuthorizationCodeNoCode() {
+	testClient := suite.testClients["local_account_1"]
+
+	requestBody, w, err := testrig.CreateMultipartFormData(
+		"", "",
+		map[string]string{
+			"grant_type":    "authorization_code",
 			"client_id":     testClient.ID,
 			"client_secret": testClient.Secret,
 			"redirect_uri":  "http://localhost:8080",
@@ -60,7 +156,40 @@ func (suite *TokenTestSuite) TestRetrieveApplicationToken() {
 	b, err := ioutil.ReadAll(result.Body)
 	suite.NoError(err)
 
-	suite.Equal(`{"error":"invalid_request","error_description":"Bad Request: could not validate token request: invalid_request"}`, string(b))
+	suite.Equal(`{"error":"invalid_request","error_description":"Bad Request: code was not set in the token request form, but must be set since grant_type is authorization_code"}`, string(b))
+}
+
+func (suite *TokenTestSuite) TestRetrieveAuthorizationCodeWrongGrantType() {
+	testClient := suite.testClients["local_account_1"]
+
+	requestBody, w, err := testrig.CreateMultipartFormData(
+		"", "",
+		map[string]string{
+			"grant_type":    "client_credentials",
+			"client_id":     testClient.ID,
+			"client_secret": testClient.Secret,
+			"redirect_uri":  "http://localhost:8080",
+			"code":          "peepeepoopoo",
+		})
+	if err != nil {
+		panic(err)
+	}
+	bodyBytes := requestBody.Bytes()
+
+	ctx, recorder := suite.newContext(http.MethodPost, "oauth/token", bodyBytes, w.FormDataContentType())
+	ctx.Request.Header.Set("accept", "application/json")
+
+	suite.authModule.TokenPOSTHandler(ctx)
+
+	suite.Equal(http.StatusBadRequest, recorder.Code)
+
+	result := recorder.Result()
+	defer result.Body.Close()
+
+	b, err := ioutil.ReadAll(result.Body)
+	suite.NoError(err)
+
+	suite.Equal(`{"error":"invalid_request","error_description":"Bad Request: a code was provided in the token request form, but grant_type was not set to authorization_code"}`, string(b))
 }
 
 func TestTokenTestSuite(t *testing.T) {

--- a/internal/oauth/errors.go
+++ b/internal/oauth/errors.go
@@ -16,20 +16,11 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package processing
+package oauth
 
-import (
-	"net/http"
+import "github.com/superseriousbusiness/oauth2/v4/errors"
 
-	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
-)
-
-func (p *processor) OAuthHandleAuthorizeRequest(w http.ResponseWriter, r *http.Request) error {
-	// todo: some kind of metrics stuff here
-	return p.oauthServer.HandleAuthorizeRequest(w, r)
-}
-
-func (p *processor) OAuthHandleTokenRequest(r *http.Request) (map[string]interface{}, gtserror.WithCode) {
-	// todo: some kind of metrics stuff here
-	return p.oauthServer.HandleTokenRequest(r)
+// InvalidRequest returns an oauth spec compliant 'invalid_request' error.
+func InvalidRequest() error {
+	return errors.New("invalid_request")
 }

--- a/internal/processing/oauth.go
+++ b/internal/processing/oauth.go
@@ -1,0 +1,33 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package processing
+
+import (
+	"net/http"
+
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+)
+
+func (p *processor) OAuthHandleAuthorizeRequest(w http.ResponseWriter, r *http.Request) gtserror.WithCode {
+	return p.oauthServer.HandleAuthorizeRequest(w, r)
+}
+
+func (p *processor) OAuthHandleTokenRequest(w http.ResponseWriter, r *http.Request) gtserror.WithCode {
+	return p.oauthServer.HandleTokenRequest(w, r)
+}

--- a/internal/processing/processor.go
+++ b/internal/processing/processor.go
@@ -152,6 +152,9 @@ type Processor interface {
 	// NotificationsGet
 	NotificationsGet(ctx context.Context, authed *oauth.Auth, limit int, maxID string, sinceID string) (*apimodel.TimelineResponse, gtserror.WithCode)
 
+	OAuthHandleTokenRequest(w http.ResponseWriter, r *http.Request) gtserror.WithCode
+	OAuthHandleAuthorizeRequest(w http.ResponseWriter, r *http.Request) gtserror.WithCode
+
 	// SearchGet performs a search with the given params, resolving/dereferencing remotely as desired
 	SearchGet(ctx context.Context, authed *oauth.Auth, searchQuery *apimodel.SearchQuery) (*apimodel.SearchResult, gtserror.WithCode)
 

--- a/internal/processing/processor.go
+++ b/internal/processing/processor.go
@@ -152,8 +152,8 @@ type Processor interface {
 	// NotificationsGet
 	NotificationsGet(ctx context.Context, authed *oauth.Auth, limit int, maxID string, sinceID string) (*apimodel.TimelineResponse, gtserror.WithCode)
 
-	OAuthHandleTokenRequest(w http.ResponseWriter, r *http.Request) gtserror.WithCode
-	OAuthHandleAuthorizeRequest(w http.ResponseWriter, r *http.Request) gtserror.WithCode
+	OAuthHandleTokenRequest(r *http.Request) (map[string]interface{}, gtserror.WithCode)
+	OAuthHandleAuthorizeRequest(w http.ResponseWriter, r *http.Request) error
 
 	// SearchGet performs a search with the given params, resolving/dereferencing remotely as desired
 	SearchGet(ctx context.Context, authed *oauth.Auth, searchQuery *apimodel.SearchQuery) (*apimodel.SearchResult, gtserror.WithCode)

--- a/testrig/testmodels.go
+++ b/testrig/testmodels.go
@@ -56,6 +56,23 @@ func NewTestTokens() map[string]*gtsmodel.Token {
 			AccessCreateAt:  time.Now(),
 			AccessExpiresAt: time.Now().Add(72 * time.Hour),
 		},
+		"local_account_1_client_application_token": {
+			ID:              "01P9SVWS9J3SPHZQ3KCMBEN70N",
+			ClientID:        "01F8MGV8AC3NGSJW0FE8W1BV70",
+			RedirectURI:     "http://localhost:8080",
+			Access:          "ZTK1MWMWZDGTMGMXOS0ZY2UXLWI5ZWETMWEZYZZIYTLHMZI4",
+			AccessCreateAt:  TimeMustParse("2022-06-10T15:22:08Z"),
+			AccessExpiresAt: TimeMustParse("2050-01-01T15:22:08Z"),
+		},
+		"local_account_1_user_authorization_token": {
+			ID:            "01G574M2VTV66YZBC9AZ7HY3FV",
+			ClientID:      "01F8MGV8AC3NGSJW0FE8W1BV70",
+			UserID:        "01F8MGVGPHQ2D3P3X0454H54Z5",
+			RedirectURI:   "http://localhost:8080",
+			Code:          "ZJYYMZQ0MTQTZTU1NC0ZNJK4LWE2ZWITYTM1MDHHOTAXNJHL",
+			CodeCreateAt:  TimeMustParse("2022-06-10T15:22:08Z"),
+			CodeExpiresAt: TimeMustParse("2050-01-01T15:22:08Z"),
+		},
 		"local_account_2": {
 			ID:              "01F8MGVVM1EDVYET710J27XY5R",
 			ClientID:        "01F8MGW47HN8ZXNHNZ7E47CDMQ",


### PR DESCRIPTION
This PR adds a 'created_at' unix timestamp to tokens returned by the `oauth/token` endpoint, to ensure mastodon API compatibility (closes #644).

It also does better validation of input to that endpoint, and returns helpful error messages in the `error_description` field, while remaining oauth compliant by only returning one of the mandated oauth errors in the `error` field. This should make life a little easier for users who are trying to fetch a token, and wondering why it's not working.

This is also relevant to https://github.com/superseriousbusiness/gotosocial/issues/83