### PR TITLE
postgres locale: fix accounts.note_raw migration

### DIFF
--- a/internal/db/bundb/migrations/20220506110822_add_account_raw_note.go
+++ b/internal/db/bundb/migrations/20220506110822_add_account_raw_note.go
@@ -28,7 +28,7 @@ import (
 func init() {
 	up := func(ctx context.Context, db *bun.DB) error {
 		_, err := db.ExecContext(ctx, "ALTER TABLE ? ADD COLUMN ? TEXT", bun.Ident("accounts"), bun.Ident("note_raw"))
-		if err != nil && !(strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "duplicate column name")) {
+		if err != nil && !(strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "duplicate column name") || strings.Contains(err.Error(), "SQLSTATE 42701")) {
 			return err
 		}
 		return nil


### PR DESCRIPTION
Database migration `20220506110822_add_account_raw_note.go` has [some error
handling code](https://github.com/superseriousbusiness/gotosocial/blob/13e4bbdbfa104a2384834b634285dce2f4dafe2e/internal/db/bundb/migrations/20220506110822_add_account_raw_note.go#L31) to detect some error messages as "ok", but only done for english error messages.

This adds a check for the specific error code, which should be locale agnostic.