### PR TITLE
[packaging] Packaging updates

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,7 +28,7 @@ steps:
           - pull_request
 
   - name: test
-    image: golang:1.18-alpine
+    image: golang:1.18.3-alpine
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -45,7 +45,7 @@ steps:
           - pull_request
 
   - name: snapshot
-    image: superseriousbusiness/gotosocial-drone-build:0.0.4 # https://github.com/superseriousbusiness/gotosocial-drone-build
+    image: superseriousbusiness/gotosocial-drone-build:0.0.5 # https://github.com/superseriousbusiness/gotosocial-drone-build
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -74,7 +74,7 @@ steps:
           - main
 
   - name: release
-    image: superseriousbusiness/gotosocial-drone-build:0.0.4 # https://github.com/superseriousbusiness/gotosocial-drone-build
+    image: superseriousbusiness/gotosocial-drone-build:0.0.5 # https://github.com/superseriousbusiness/gotosocial-drone-build
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -133,7 +133,7 @@ clone:
 
 steps:
   - name: mirror
-    image: superseriousbusiness/gotosocial-drone-build:0.0.4
+    image: superseriousbusiness/gotosocial-drone-build:0.0.5
     environment:
       ORIGIN_REPO: https://github.com/superseriousbusiness/gotosocial
       TARGET_REPO: https://codeberg.org/superseriousbusiness/gotosocial
@@ -146,6 +146,6 @@ steps:
 
 ---
 kind: signature
-hmac: adfcc11559717e4e371e714f3ac19ab528208f678961436f316f491bf82de8ad
+hmac: d696d93f3d1583b9815488fcd2ff1ade53a5d7512abac63f16bd8cd0079f03a5
 
 ...

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -161,4 +161,4 @@ snapshot:
   name_template: "{{ incpatch .Version }}-SNAPSHOT"
 source:
   # https://goreleaser.com/customization/source/
-  enabled: true
+  enabled: false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -142,17 +142,27 @@ docker_manifests:
 archives:
   # https://goreleaser.com/customization/archive/
   -
+    id: binary-release
     files:
     # standard release files
     - LICENSE
     - README.md
     - CHANGELOG*
-    # web assets
+    # web stuff minus source
     - web/assets
     - web/template
     # example config files
     - example/config.yaml
     - example/gotosocial.service
+  -
+    id: web-assets
+    files:
+    - LICENSE
+    # just the web stuff minus source
+    - web/assets
+    - web/template
+    meta: true
+    name_template: "{{ .ProjectName }}_{{ .Version }}_web-assets"
 checksum:
   # https://goreleaser.com/customization/checksum/
   name_template: 'checksums.txt'


### PR DESCRIPTION
This PR updates some of our packaging in the following ways:

1. Bump version of golang to 1.18.3.
2. Bump gotosocial-drone-build to 0.0.5 (which includes bumps to GoReleaser and Docker buildx).
3. Remove the bundled source tarball from releases, since it was misleading and unhelpful.
4. Add a release archive that just contains the bundled web/assets and web/templates folders, to make life easier for people doing ports.

Should close https://github.com/superseriousbusiness/gotosocial/issues/654

However, it doesn't really address the 'tarbomb' point raised in that issue, because while you can instruct goreleaser to embed a root directory inside a tar, it would cause our installation instructions to change, and people would have to run different installation commands for different releases. This is not something that I like the idea of doing, so I left it out of this PR. However, if there's enough impetus and interest in changing this, we can still do this in another PR.