### PR TITLE
[frontend] Add Accept header to oauthed api requests

### DIFF
--- a/web/source/lib/oauth.js
+++ b/web/source/lib/oauth.js
@@ -149,7 +149,7 @@ module.exports = function oauthClient(config, initState) {
 		return (state.access_token != undefined);
 	}
 
-	function apiRequest(path, method, data, type="json") {
+	function apiRequest(path, method, data, type="json", accept="json") {
 		if (!isAuthorized()) {
 			throw new Error("Not Authenticated");
 		}
@@ -160,7 +160,8 @@ module.exports = function oauthClient(config, initState) {
 			url.search = s;
 		}
 		let headers = {
-			"Authorization": `Bearer ${state.access_token}`
+			"Authorization": `Bearer ${state.access_token}`,
+			"Accept": accept == "json" ? "application/json" : "*/*"
 		};
 		let body = data;
 		if (type == "json" && body != undefined) {


### PR DESCRIPTION
This PR adds `Accept: application/json` by default to oauth api requests by the admin panel. If any other value than "json" is provided in the apiRequest call, accept will instead be `*/*`.