### PR TITLE
[bugfix] Account self finger fix

### DIFF
--- a/internal/processing/search.go
+++ b/internal/processing/search.go
@@ -85,11 +85,17 @@ func (p *processor) SearchGet(ctx context.Context, authed *oauth.Auth, search *a
 	*/
 	if !foundOne {
 		if uri, err := url.Parse(query); err == nil && (uri.Scheme == "https" || uri.Scheme == "http") {
+			// don't attempt to resolve (ie., dereference) local accounts/statuses
+			resolve := search.Resolve
+			if uri.Host == config.GetHost() || uri.Host == config.GetAccountDomain() {
+				resolve = false
+			}
+
 			// check if it's a status or an account
-			if foundStatus, err := p.searchStatusByURI(ctx, authed, uri, search.Resolve); err == nil && foundStatus != nil {
+			if foundStatus, err := p.searchStatusByURI(ctx, authed, uri, resolve); err == nil && foundStatus != nil {
 				foundStatuses = append(foundStatuses, foundStatus)
 				l.Debug("got a status by searching by URI")
-			} else if foundAccount, err := p.searchAccountByURI(ctx, authed, uri, search.Resolve); err == nil && foundAccount != nil {
+			} else if foundAccount, err := p.searchAccountByURI(ctx, authed, uri, resolve); err == nil && foundAccount != nil {
 				foundAccounts = append(foundAccounts, foundAccount)
 				l.Debug("got an account by searching by URI")
 			}

--- a/internal/processing/search.go
+++ b/internal/processing/search.go
@@ -85,14 +85,11 @@ func (p *processor) SearchGet(ctx context.Context, authed *oauth.Auth, search *a
 	*/
 	if !foundOne {
 		if uri, err := url.Parse(query); err == nil && (uri.Scheme == "https" || uri.Scheme == "http") {
-			// 1. check if it's a status
+			// check if it's a status or an account
 			if foundStatus, err := p.searchStatusByURI(ctx, authed, uri, search.Resolve); err == nil && foundStatus != nil {
 				foundStatuses = append(foundStatuses, foundStatus)
 				l.Debug("got a status by searching by URI")
-			}
-
-			// 2. check if it's an account
-			if foundAccount, err := p.searchAccountByURI(ctx, authed, uri, search.Resolve); err == nil && foundAccount != nil {
+			} else if foundAccount, err := p.searchAccountByURI(ctx, authed, uri, search.Resolve); err == nil && foundAccount != nil {
 				foundAccounts = append(foundAccounts, foundAccount)
 				l.Debug("got an account by searching by URI")
 			}


### PR DESCRIPTION
This PR updates some of the search logic to not attempt to dereference/resolve URLs that belong to the instance the search was performed on. This caused an issue where an account ended up webfingering itself, which caused all sorts of problems since the finger ended up updating the account's domain, so it wasn't recognized as a local account anymore -_-