### PR TITLE
[bugfix] Don't remove jpeg orientation metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/jackc/pgconn v1.11.0
 	github.com/jackc/pgx/v4 v4.15.0
 	github.com/microcosm-cc/bluemonday v1.0.18
+	github.com/miekg/dns v1.1.49
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/oklog/ulid v1.3.1
@@ -35,7 +36,7 @@ require (
 	github.com/spf13/viper v1.11.0
 	github.com/stretchr/testify v1.7.1
 	github.com/superseriousbusiness/activity v1.1.0-gts
-	github.com/superseriousbusiness/exif-terminator v0.2.0
+	github.com/superseriousbusiness/exif-terminator v0.3.0
 	github.com/superseriousbusiness/oauth2/v4 v4.3.2-SSB
 	github.com/tdewolff/minify/v2 v2.11.2
 	github.com/uptrace/bun v1.1.3
@@ -94,7 +95,6 @@ require (
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/miekg/dns v1.1.49 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -482,8 +482,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/superseriousbusiness/activity v1.1.0-gts h1:BSnMzs/84s0Zme7BngE9iJAHV7g1Bv1nhLCP0aJtU3I=
 github.com/superseriousbusiness/activity v1.1.0-gts/go.mod h1:AZw0Xb4Oju8rmaJCZ21gc5CPg47MmNgyac+Hx5jo8VM=
-github.com/superseriousbusiness/exif-terminator v0.2.0 h1:C21KOUr54E37qTqYS7WJX0J83sNzzCwBEy0KXyDprqU=
-github.com/superseriousbusiness/exif-terminator v0.2.0/go.mod h1:DHJuKguXqyOVqB/oyOylutEDIZCbkYsn2GZFNSUDT9E=
+github.com/superseriousbusiness/exif-terminator v0.3.0 h1:ej7YePEB2UnAGPal5s7CnoN8eMFmDFESEAEJmbFoHh0=
+github.com/superseriousbusiness/exif-terminator v0.3.0/go.mod h1:OPfOSEDWjXaW3BILJBN89j0VLD8bglmHwHHwwwSLb5A=
 github.com/superseriousbusiness/go-jpeg-image-structure/v2 v2.0.0-20220321154430-d89a106fdabe h1:ksl2oCx/Qo8sNDc3Grb8WGKBM9nkvhCm25uvlT86azE=
 github.com/superseriousbusiness/go-jpeg-image-structure/v2 v2.0.0-20220321154430-d89a106fdabe/go.mod h1:gH4P6gN1V+wmIw5o97KGaa1RgXB/tVpC2UNzijhg3E4=
 github.com/superseriousbusiness/oauth2/v4 v4.3.2-SSB h1:PtW2w6budTvRV2J5QAoSvThTHBuvh8t/+BXIZFAaBSc=
@@ -693,6 +693,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/vendor/github.com/superseriousbusiness/exif-terminator/README.md
+++ b/vendor/github.com/superseriousbusiness/exif-terminator/README.md
@@ -53,10 +53,14 @@ Exif removal is a pain in the arse. Most other libraries seem to parse the whole
 
 `exif-terminator` differs in that it removes exif data *while scanning through the image bytes*, and it doesn't do any reencoding of the image. Bytes of exif data are simply all set to 0, and the image data is piped back out again into the returned reader.
 
+The only exception is orientation data: if an image contains orientation data, this and only this data will be preserved since it's *actually useful*.
+
 ## Example
 
+You can run the following example with `go run ./example/main.go`:
+
 ```go
-package test
+package main
 
 import (
   "io"
@@ -71,6 +75,7 @@ func main() {
   if err != nil {
     panic(err)
   }
+  defer sloth.Close()
 
   // get the length of the file
   stat, err := sloth.Stat()
@@ -103,6 +108,7 @@ func main() {
 
 `exif-terminator` borrows heavily from the two [`dsoprea`](https://github.com/dsoprea) libraries credited below. In fact, it's basically a hack on top of those libraries. Thanks `dsoprea`!
 
+- [dsoprea/go-exif](https://github.com/dsoprea/go-exif): exif header reconstruction. [MIT License](https://spdx.org/licenses/MIT.html).
 - [dsoprea/go-jpeg-image-structure](https://github.com/dsoprea/go-jpeg-image-structure): jpeg structure parsing. [MIT License](https://spdx.org/licenses/MIT.html).
 - [dsoprea/go-png-image-structure](https://github.com/dsoprea/go-png-image-structure): png structure parsing. [MIT License](https://spdx.org/licenses/MIT.html).
 - [stretchr/testify](https://github.com/stretchr/testify); test framework. [MIT License](https://spdx.org/licenses/MIT.html).

--- a/vendor/github.com/superseriousbusiness/exif-terminator/jpeg.go
+++ b/vendor/github.com/superseriousbusiness/exif-terminator/jpeg.go
@@ -19,10 +19,12 @@
 package terminator
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
 
+	exif "github.com/dsoprea/go-exif/v3"
 	jpegstructure "github.com/superseriousbusiness/go-jpeg-image-structure/v2"
 )
 
@@ -121,17 +123,128 @@ func (v *jpegVisitor) writeSegment(s *jpegstructure.Segment) error {
 		}
 	}
 
-	if s.IsExif() {
-		// if this segment is exif data, write blank bytes
-		blank := make([]byte, len(s.Data))
-		if _, err := w.Write(blank); err != nil {
+	if !s.IsExif() {
+		// if this isn't exif data just copy it over and bail
+		_, err := w.Write(s.Data)
+		return err
+	}
+
+	ifd, _, err := s.Exif()
+	if err != nil {
+		return err
+	}
+
+	// amount of bytes we've written into the exif body
+	var written int
+
+	if orientationEntries, err := ifd.FindTagWithName("Orientation"); err == nil && len(orientationEntries) == 1 {
+		// If we have an orientation entry, we don't want to completely obliterate the exif data.
+		// Instead, we want to surgically obliterate everything *except* the orientation tag, so
+		// that the image will still be rotated correctly when shown in client applications etc.
+		//
+		// To accomplish this, we're going to extract just the bytes that we need and write them
+		// in according to the exif specification, then fill in the rest of the space with empty
+		// bytes.
+		//
+		// First we need to write the exif prefix for this segment.
+		//
+		// Then we write the exif header which contains the byte order and offset of the first ifd.
+		//
+		// Then we write the ifd0 entry which contains the orientation data.
+		//
+		// After that we just fill fill fill.
+
+		newData := &bytes.Buffer{}
+
+		// 1. Write exif prefix.
+		// https://www.ozhiker.com/electronics/pjmt/jpeg_info/app_segments.html
+		prefix := []byte{'E', 'x', 'i', 'f', 0, 0}
+		if err := binary.Write(newData, ifd.ByteOrder(), &prefix); err != nil {
 			return err
 		}
-	} else {
-		// otherwise write the data
-		if _, err := w.Write(s.Data); err != nil {
+		written += 6
+
+		// 2. Write exif header, taking the existing byte order.
+		exifHeader, err := exif.BuildExifHeader(ifd.ByteOrder(), exif.ExifDefaultFirstIfdOffset)
+		if err != nil {
 			return err
 		}
+		hWritten, err := newData.Write(exifHeader)
+		if err != nil {
+			return err
+		}
+		written += hWritten
+
+		// https://web.archive.org/web/20190624045241if_/http://www.cipa.jp:80/std/documents/e/DC-008-Translation-2019-E.pdf
+		//
+		// An ifd with one orientation entry is structured like this:
+		// 		2 bytes: the number of entries in the ifd	uint16(1)
+		// 		2 bytes: the tag id							uint16(274)
+		// 		2 bytes: the tag type						uint16(3)
+		//      4 bytes: the tag count						uint32(1)
+		// 		4 bytes: the tag value offset:				uint32(one of the below with padding on the end)
+		// 			1 = Horizontal (normal)
+		// 			2 = Mirror horizontal
+		// 			3 = Rotate 180
+		// 			4 = Mirror vertical
+		// 			5 = Mirror horizontal and rotate 270 CW
+		// 			6 = Rotate 90 CW
+		// 			7 = Mirror horizontal and rotate 90 CW
+		// 			8 = Rotate 270 CW
+		orientationEntry := orientationEntries[0]
+
+		ifdCount := uint16(1) // we're only adding one entry into the ifd
+		if err := binary.Write(newData, ifd.ByteOrder(), &ifdCount); err != nil {
+			return err
+		}
+		written += 2
+
+		tagID := orientationEntry.TagId()
+		if err := binary.Write(newData, ifd.ByteOrder(), &tagID); err != nil {
+			return err
+		}
+		written += 2
+
+		tagType := orientationEntry.TagType()
+		if err := binary.Write(newData, ifd.ByteOrder(), &tagType); err != nil {
+			return err
+		}
+		written += 2
+
+		tagCount := orientationEntry.UnitCount()
+		if err := binary.Write(newData, ifd.ByteOrder(), &tagCount); err != nil {
+			return err
+		}
+		written += 4
+
+		valueOffset, err := orientationEntry.GetRawBytes()
+		if err != nil {
+			return err
+		}
+
+		vWritten, err := newData.Write(valueOffset)
+		if err != nil {
+			return err
+		}
+		written += vWritten
+
+		valuePad := make([]byte, 4-vWritten)
+		pWritten, err := newData.Write(valuePad)
+		if err != nil {
+			return err
+		}
+		written += pWritten
+
+		// write everything in
+		if _, err := io.Copy(w, newData); err != nil {
+			return err
+		}
+	}
+
+	// fill in the (remaining) exif body with blank bytes
+	blank := make([]byte, len(s.Data)-written)
+	if _, err := w.Write(blank); err != nil {
+		return err
 	}
 
 	return nil

--- a/vendor/github.com/superseriousbusiness/exif-terminator/terminator.go
+++ b/vendor/github.com/superseriousbusiness/exif-terminator/terminator.go
@@ -25,8 +25,8 @@ import (
 	"fmt"
 	"io"
 
-	jpegstructure "github.com/superseriousbusiness/go-jpeg-image-structure/v2"
 	pngstructure "github.com/dsoprea/go-png-image-structure/v2"
+	jpegstructure "github.com/superseriousbusiness/go-jpeg-image-structure/v2"
 )
 
 func Terminate(in io.Reader, fileSize int, mediaType string) (io.Reader, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -487,7 +487,7 @@ github.com/superseriousbusiness/activity/streams/values/rfc2045
 github.com/superseriousbusiness/activity/streams/values/rfc5988
 github.com/superseriousbusiness/activity/streams/values/string
 github.com/superseriousbusiness/activity/streams/vocab
-# github.com/superseriousbusiness/exif-terminator v0.2.0
+# github.com/superseriousbusiness/exif-terminator v0.3.0
 ## explicit; go 1.17
 github.com/superseriousbusiness/exif-terminator
 # github.com/superseriousbusiness/go-jpeg-image-structure/v2 v2.0.0-20220321154430-d89a106fdabe


### PR DESCRIPTION
This PR closes #618 by bumping exif-terminator to a version that preserves orientation data for jpegs.

This doesn't yet apply to PNGs, but it's a start :)