### PR TITLE
[chore] Re-enable source tar but name it clearly as source

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -171,4 +171,5 @@ snapshot:
   name_template: "{{ incpatch .Version }}-SNAPSHOT"
 source:
   # https://goreleaser.com/customization/source/
-  enabled: false
+  enabled: true
+  name_template: "{{ .ProjectName }}-{{ .Version }}-source-code"


### PR DESCRIPTION
closes https://github.com/superseriousbusiness/gotosocial/issues/662 -- since the source tar is being generated again now, the checksums.txt file is also complete

GoReleaser is weird