### PR TITLE
[frontend] Fix up status 'show more' and z-index

### DIFF
--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -87,6 +87,11 @@ main {
 	}
 
 	.spoiler {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+
 		label {
 			padding: 0.2rem 0.3rem;
 			margin-left: 0.4rem;

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -94,9 +94,6 @@ main {
 
 		label {
 			padding: 0.2rem 0.3rem;
-			margin-left: 0.4rem;
-			position: relative;
-			z-index: 2;
 			cursor: pointer;
 			font-size: 1rem;
 		}
@@ -108,6 +105,9 @@ main {
 		margin: 0;
 		margin-top: 0.5rem;
 		grid-column: span 2;
+
+		position: relative;
+		z-index: 2;
 
 		a {
 			color: $link_fg;

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -92,6 +92,10 @@ main {
 		flex-wrap: wrap;
 		gap: 0.4rem;
 
+		.spoiler-text {
+			word-break: break-word;
+		}
+
 		label {
 			padding: 0.2rem 0.3rem;
 			cursor: pointer;

--- a/web/template/status.tmpl
+++ b/web/template/status.tmpl
@@ -6,7 +6,8 @@
 		{{if .SpoilerText}}
 		<input class="spoiler" id="hideSpoiler-{{.ID}}" type="checkbox" style="display: none" aria-hidden="true" checked="true" />
 		<div class="spoiler">
-			<span>{{.SpoilerText}}</span><label class="button spoiler-label" for="hideSpoiler-{{.ID}}">Toggle visibility</label>
+			<span class="spoiler-text">{{.SpoilerText}}</span>
+			<label class="button spoiler-label" for="hideSpoiler-{{.ID}}">Toggle visibility</label>
 		</div>
 		{{end}}
 		<div class="content">


### PR DESCRIPTION
This PR:

- updates the spoiler text / button div to make it a flexbox so items can wrap without splitting the 'show more' button in half
- allows spoiler text to break so that long one-word spoiler texts won't break the display
- sets the z-index of all status text (spoiler text + show more button + content) higher, so that text can be selected/copy pasted, while still allowing the rest of the status to be clickable