### PR TITLE
[feature] Add back/next buttons to profiles for paging through statuses

### DIFF
--- a/internal/api/model/timeline.go
+++ b/internal/api/model/timeline.go
@@ -25,4 +25,6 @@ import "github.com/superseriousbusiness/gotosocial/internal/timeline"
 type TimelineResponse struct {
 	Items      []timeline.Timelineable
 	LinkHeader string
+	NextLink   string
+	PrevLink   string
 }

--- a/internal/db/account.go
+++ b/internal/db/account.go
@@ -57,7 +57,7 @@ type Account interface {
 	// GetAccountWebStatuses is similar to GetAccountStatuses, but it's specifically for returning statuses that
 	// should be visible via the web view of an account. So, only public, federated statuses that aren't boosts
 	// or replies.
-	GetAccountWebStatuses(ctx context.Context, accountID string, limit int, maxID string, minID string) ([]*gtsmodel.Status, Error)
+	GetAccountWebStatuses(ctx context.Context, accountID string, limit int, maxID string) ([]*gtsmodel.Status, Error)
 
 	GetAccountBlocks(ctx context.Context, accountID string, maxID string, sinceID string, limit int) ([]*gtsmodel.Account, string, string, Error)
 

--- a/internal/db/account.go
+++ b/internal/db/account.go
@@ -54,6 +54,11 @@ type Account interface {
 	// In case of no entries, a 'no entries' error will be returned
 	GetAccountStatuses(ctx context.Context, accountID string, limit int, excludeReplies bool, excludeReblogs bool, maxID string, minID string, pinnedOnly bool, mediaOnly bool, publicOnly bool) ([]*gtsmodel.Status, Error)
 
+	// GetAccountWebStatuses is similar to GetAccountStatuses, but it's specifically for returning statuses that
+	// should be visible via the web view of an account. So, only public, federated statuses that aren't boosts
+	// or replies.
+	GetAccountWebStatuses(ctx context.Context, accountID string, limit int, maxID string, minID string) ([]*gtsmodel.Status, Error)
+
 	GetAccountBlocks(ctx context.Context, accountID string, maxID string, sinceID string, limit int) ([]*gtsmodel.Account, string, string, Error)
 
 	// GetAccountLastPosted simply gets the timestamp of the most recent post by the account.

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -304,7 +304,7 @@ func (a *accountDB) GetAccountStatuses(ctx context.Context, accountID string, li
 	return a.statusesFromIDs(ctx, statusIDs)
 }
 
-func (a *accountDB) GetAccountWebStatuses(ctx context.Context, accountID string, limit int, maxID string, minID string) ([]*gtsmodel.Status, db.Error) {
+func (a *accountDB) GetAccountWebStatuses(ctx context.Context, accountID string, limit int, maxID string) ([]*gtsmodel.Status, db.Error) {
 	statusIDs := []string{}
 
 	q := a.conn.
@@ -319,10 +319,6 @@ func (a *accountDB) GetAccountWebStatuses(ctx context.Context, accountID string,
 
 	if maxID != "" {
 		q = q.Where("id < ?", maxID)
-	}
-
-	if minID != "" {
-		q = q.Where("id > ?", minID)
 	}
 
 	q = q.Limit(limit).Order("id DESC")

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -301,27 +301,37 @@ func (a *accountDB) GetAccountStatuses(ctx context.Context, accountID string, li
 		return nil, a.conn.ProcessError(err)
 	}
 
-	// Catch case of no statuses early
-	if len(statusIDs) == 0 {
-		return nil, db.ErrNoEntries
+	return a.statusesFromIDs(ctx, statusIDs)
+}
+
+func (a *accountDB) GetAccountWebStatuses(ctx context.Context, accountID string, limit int, maxID string, minID string) ([]*gtsmodel.Status, db.Error) {
+	statusIDs := []string{}
+
+	q := a.conn.
+		NewSelect().
+		Table("statuses").
+		Column("id").
+		Where("account_id = ?", accountID).
+		WhereGroup(" AND ", whereEmptyOrNull("in_reply_to_id")).
+		WhereGroup(" AND ", whereEmptyOrNull("boost_of_id")).
+		Where("visibility = ?", gtsmodel.VisibilityPublic).
+		Where("federated = ?", true)
+
+	if maxID != "" {
+		q = q.Where("id < ?", maxID)
 	}
 
-	// Allocate return slice (will be at most len statusIDS)
-	statuses := make([]*gtsmodel.Status, 0, len(statusIDs))
-
-	for _, id := range statusIDs {
-		// Fetch from status from database by ID
-		status, err := a.status.GetStatusByID(ctx, id)
-		if err != nil {
-			logrus.Errorf("GetAccountStatuses: error getting status %q: %v", id, err)
-			continue
-		}
-
-		// Append to return slice
-		statuses = append(statuses, status)
+	if minID != "" {
+		q = q.Where("id > ?", minID)
 	}
 
-	return statuses, nil
+	q = q.Limit(limit).Order("id DESC")
+
+	if err := q.Scan(ctx, &statusIDs); err != nil {
+		return nil, a.conn.ProcessError(err)
+	}
+
+	return a.statusesFromIDs(ctx, statusIDs)
 }
 
 func (a *accountDB) GetAccountBlocks(ctx context.Context, accountID string, maxID string, sinceID string, limit int) ([]*gtsmodel.Account, string, string, db.Error) {
@@ -362,4 +372,28 @@ func (a *accountDB) GetAccountBlocks(ctx context.Context, accountID string, maxI
 	nextMaxID := blocks[len(blocks)-1].ID
 	prevMinID := blocks[0].ID
 	return accounts, nextMaxID, prevMinID, nil
+}
+
+func (a *accountDB) statusesFromIDs(ctx context.Context, statusIDs []string) ([]*gtsmodel.Status, db.Error) {
+	// Catch case of no statuses early
+	if len(statusIDs) == 0 {
+		return nil, db.ErrNoEntries
+	}
+
+	// Allocate return slice (will be at most len statusIDS)
+	statuses := make([]*gtsmodel.Status, 0, len(statusIDs))
+
+	for _, id := range statusIDs {
+		// Fetch from status from database by ID
+		status, err := a.status.GetStatusByID(ctx, id)
+		if err != nil {
+			logrus.Errorf("statusesFromIDs: error getting status %q: %v", id, err)
+			continue
+		}
+
+		// Append to return slice
+		statuses = append(statuses, status)
+	}
+
+	return statuses, nil
 }

--- a/internal/processing/account.go
+++ b/internal/processing/account.go
@@ -50,6 +50,10 @@ func (p *processor) AccountStatusesGet(ctx context.Context, authed *oauth.Auth, 
 	return p.accountProcessor.StatusesGet(ctx, authed.Account, targetAccountID, limit, excludeReplies, excludeReblogs, maxID, minID, pinnedOnly, mediaOnly, publicOnly)
 }
 
+func (p *processor) AccountWebStatusesGet(ctx context.Context, targetAccountID string, maxID string, minID string)(*apimodel.TimelineResponse, gtserror.WithCode) {
+	return p.accountProcessor.WebStatusesGet(ctx, targetAccountID, maxID, minID)
+}
+
 func (p *processor) AccountFollowersGet(ctx context.Context, authed *oauth.Auth, targetAccountID string) ([]apimodel.Account, gtserror.WithCode) {
 	return p.accountProcessor.FollowersGet(ctx, authed.Account, targetAccountID)
 }

--- a/internal/processing/account.go
+++ b/internal/processing/account.go
@@ -50,7 +50,7 @@ func (p *processor) AccountStatusesGet(ctx context.Context, authed *oauth.Auth, 
 	return p.accountProcessor.StatusesGet(ctx, authed.Account, targetAccountID, limit, excludeReplies, excludeReblogs, maxID, minID, pinnedOnly, mediaOnly, publicOnly)
 }
 
-func (p *processor) AccountWebStatusesGet(ctx context.Context, targetAccountID string, maxID string)(*apimodel.TimelineResponse, gtserror.WithCode) {
+func (p *processor) AccountWebStatusesGet(ctx context.Context, targetAccountID string, maxID string) (*apimodel.TimelineResponse, gtserror.WithCode) {
 	return p.accountProcessor.WebStatusesGet(ctx, targetAccountID, maxID)
 }
 

--- a/internal/processing/account.go
+++ b/internal/processing/account.go
@@ -50,8 +50,8 @@ func (p *processor) AccountStatusesGet(ctx context.Context, authed *oauth.Auth, 
 	return p.accountProcessor.StatusesGet(ctx, authed.Account, targetAccountID, limit, excludeReplies, excludeReblogs, maxID, minID, pinnedOnly, mediaOnly, publicOnly)
 }
 
-func (p *processor) AccountWebStatusesGet(ctx context.Context, targetAccountID string, maxID string, minID string)(*apimodel.TimelineResponse, gtserror.WithCode) {
-	return p.accountProcessor.WebStatusesGet(ctx, targetAccountID, maxID, minID)
+func (p *processor) AccountWebStatusesGet(ctx context.Context, targetAccountID string, maxID string)(*apimodel.TimelineResponse, gtserror.WithCode) {
+	return p.accountProcessor.WebStatusesGet(ctx, targetAccountID, maxID)
 }
 
 func (p *processor) AccountFollowersGet(ctx context.Context, authed *oauth.Auth, targetAccountID string) ([]apimodel.Account, gtserror.WithCode) {

--- a/internal/processing/account/account.go
+++ b/internal/processing/account/account.go
@@ -58,7 +58,7 @@ type Processor interface {
 	StatusesGet(ctx context.Context, requestingAccount *gtsmodel.Account, targetAccountID string, limit int, excludeReplies bool, excludeReblogs bool, maxID string, minID string, pinned bool, mediaOnly bool, publicOnly bool) (*apimodel.TimelineResponse, gtserror.WithCode)
 	// WebStatusesGet fetches a number of statuses (in descending order) from the given account. It selects only
 	// statuses which are suitable for showing on the public web profile of an account.
-	WebStatusesGet(ctx context.Context, targetAccountID string, maxID string, minID string) (*apimodel.TimelineResponse, gtserror.WithCode)
+	WebStatusesGet(ctx context.Context, targetAccountID string, maxID string) (*apimodel.TimelineResponse, gtserror.WithCode)
 	// FollowersGet fetches a list of the target account's followers.
 	FollowersGet(ctx context.Context, requestingAccount *gtsmodel.Account, targetAccountID string) ([]apimodel.Account, gtserror.WithCode)
 	// FollowingGet fetches a list of the accounts that target account is following.

--- a/internal/processing/account/account.go
+++ b/internal/processing/account/account.go
@@ -56,6 +56,9 @@ type Processor interface {
 	// StatusesGet fetches a number of statuses (in time descending order) from the given account, filtered by visibility for
 	// the account given in authed.
 	StatusesGet(ctx context.Context, requestingAccount *gtsmodel.Account, targetAccountID string, limit int, excludeReplies bool, excludeReblogs bool, maxID string, minID string, pinned bool, mediaOnly bool, publicOnly bool) (*apimodel.TimelineResponse, gtserror.WithCode)
+	// WebStatusesGet fetches a number of statuses (in descending order) from the given account. It selects only
+	// statuses which are suitable for showing on the public web profile of an account.
+	WebStatusesGet(ctx context.Context, targetAccountID string, maxID string, minID string) (*apimodel.TimelineResponse, gtserror.WithCode)
 	// FollowersGet fetches a list of the target account's followers.
 	FollowersGet(ctx context.Context, requestingAccount *gtsmodel.Account, targetAccountID string) ([]apimodel.Account, gtserror.WithCode)
 	// FollowingGet fetches a list of the accounts that target account is following.

--- a/internal/processing/account/getstatuses.go
+++ b/internal/processing/account/getstatuses.go
@@ -85,7 +85,7 @@ func (p *processor) StatusesGet(ctx context.Context, requestingAccount *gtsmodel
 	})
 }
 
-func (p *processor) WebStatusesGet(ctx context.Context, targetAccountID string, maxID string, minID string) (*apimodel.TimelineResponse, gtserror.WithCode) {
+func (p *processor) WebStatusesGet(ctx context.Context, targetAccountID string, maxID string) (*apimodel.TimelineResponse, gtserror.WithCode) {
 	acct, err := p.db.GetAccountByID(ctx, targetAccountID)
 	if err != nil {
 		if err == db.ErrNoEntries {
@@ -100,7 +100,7 @@ func (p *processor) WebStatusesGet(ctx context.Context, targetAccountID string, 
 		return nil, gtserror.NewErrorNotFound(err)
 	}
 
-	statuses, err := p.db.GetAccountWebStatuses(ctx, targetAccountID, 10, maxID, minID)
+	statuses, err := p.db.GetAccountWebStatuses(ctx, targetAccountID, 10, maxID)
 	if err != nil {
 		if err == db.ErrNoEntries {
 			return util.EmptyTimelineResponse(), nil

--- a/internal/processing/processor.go
+++ b/internal/processing/processor.go
@@ -86,7 +86,7 @@ type Processor interface {
 	AccountStatusesGet(ctx context.Context, authed *oauth.Auth, targetAccountID string, limit int, excludeReplies bool, excludeReblogs bool, maxID string, minID string, pinned bool, mediaOnly bool, publicOnly bool) (*apimodel.TimelineResponse, gtserror.WithCode)
 	// AccountWebStatusesGet fetches a number of statuses (in descending order) from the given account. It selects only
 	// statuses which are suitable for showing on the public web profile of an account.
-	AccountWebStatusesGet(ctx context.Context, targetAccountID string, maxID string, minID string) (*apimodel.TimelineResponse, gtserror.WithCode)
+	AccountWebStatusesGet(ctx context.Context, targetAccountID string, maxID string) (*apimodel.TimelineResponse, gtserror.WithCode)
 	// AccountFollowersGet fetches a list of the target account's followers.
 	AccountFollowersGet(ctx context.Context, authed *oauth.Auth, targetAccountID string) ([]apimodel.Account, gtserror.WithCode)
 	// AccountFollowingGet fetches a list of the accounts that target account is following.

--- a/internal/processing/processor.go
+++ b/internal/processing/processor.go
@@ -84,6 +84,9 @@ type Processor interface {
 	// AccountStatusesGet fetches a number of statuses (in time descending order) from the given account, filtered by visibility for
 	// the account given in authed.
 	AccountStatusesGet(ctx context.Context, authed *oauth.Auth, targetAccountID string, limit int, excludeReplies bool, excludeReblogs bool, maxID string, minID string, pinned bool, mediaOnly bool, publicOnly bool) (*apimodel.TimelineResponse, gtserror.WithCode)
+	// AccountWebStatusesGet fetches a number of statuses (in descending order) from the given account. It selects only
+	// statuses which are suitable for showing on the public web profile of an account.
+	AccountWebStatusesGet(ctx context.Context, targetAccountID string, maxID string, minID string) (*apimodel.TimelineResponse, gtserror.WithCode)
 	// AccountFollowersGet fetches a list of the target account's followers.
 	AccountFollowersGet(ctx context.Context, authed *oauth.Auth, targetAccountID string) ([]apimodel.Account, gtserror.WithCode)
 	// AccountFollowingGet fetches a list of the accounts that target account is following.

--- a/internal/util/timeline.go
+++ b/internal/util/timeline.go
@@ -61,11 +61,11 @@ func PackageTimelineableResponse(params TimelineableResponseParams) (*apimodel.T
 		Items: params.Items,
 	}
 
-	// prepare the next and previous links
 	if len(params.Items) != 0 {
 		protocol := config.GetProtocol()
 		host := config.GetHost()
 
+		// next
 		nextRaw := params.NextMaxIDKey + "=" + params.NextMaxIDValue
 		if params.Limit != 0 {
 			nextRaw = fmt.Sprintf("limit=%d&", params.Limit) + nextRaw
@@ -79,8 +79,10 @@ func PackageTimelineableResponse(params TimelineableResponseParams) (*apimodel.T
 			Path:     params.Path,
 			RawQuery: nextRaw,
 		}
-		next := fmt.Sprintf("<%s>; rel=\"next\"", nextLink.String())
+		nextLinkString := nextLink.String()
+		timelineResponse.NextLink = nextLinkString
 
+		// prev
 		prevRaw := params.PrevMinIDKey + "=" + params.PrevMinIDValue
 		if params.Limit != 0 {
 			prevRaw = fmt.Sprintf("limit=%d&", params.Limit) + prevRaw
@@ -94,7 +96,12 @@ func PackageTimelineableResponse(params TimelineableResponseParams) (*apimodel.T
 			Path:     params.Path,
 			RawQuery: prevRaw,
 		}
-		prev := fmt.Sprintf("<%s>; rel=\"prev\"", prevLink.String())
+		prevLinkString := prevLink.String()
+		timelineResponse.PrevLink = prevLinkString
+
+		// link header
+		next := fmt.Sprintf("<%s>; rel=\"next\"", nextLinkString)
+		prev := fmt.Sprintf("<%s>; rel=\"prev\"", prevLinkString)
 		timelineResponse.LinkHeader = next + ", " + prev
 	}
 

--- a/internal/util/timeline.go
+++ b/internal/util/timeline.go
@@ -66,7 +66,10 @@ func PackageTimelineableResponse(params TimelineableResponseParams) (*apimodel.T
 		protocol := config.GetProtocol()
 		host := config.GetHost()
 
-		nextRaw := fmt.Sprintf("limit=%d&%s=%s", params.Limit, params.NextMaxIDKey, params.NextMaxIDValue)
+		nextRaw := params.NextMaxIDKey + "=" + params.NextMaxIDValue
+		if params.Limit != 0 {
+			nextRaw = fmt.Sprintf("limit=%d&", params.Limit) + nextRaw
+		}
 		for _, p := range params.ExtraQueryParams {
 			nextRaw = nextRaw + "&" + p
 		}
@@ -78,7 +81,10 @@ func PackageTimelineableResponse(params TimelineableResponseParams) (*apimodel.T
 		}
 		next := fmt.Sprintf("<%s>; rel=\"next\"", nextLink.String())
 
-		prevRaw := fmt.Sprintf("limit=%d&%s=%s", params.Limit, params.PrevMinIDKey, params.PrevMinIDValue)
+		prevRaw := params.PrevMinIDKey + "=" + params.PrevMinIDValue
+		if params.Limit != 0 {
+			prevRaw = fmt.Sprintf("limit=%d&", params.Limit) + prevRaw
+		}
 		for _, p := range params.ExtraQueryParams {
 			prevRaw = prevRaw + "&" + p
 		}

--- a/web/source/css/profile.css
+++ b/web/source/css/profile.css
@@ -160,6 +160,10 @@ main {
 	}
 }
 
+.nothinghere {
+	margin-left: 1rem;
+}
+
 .toot, .toot:last-child {
 	box-shadow: $boxshadow;
 }

--- a/web/source/css/profile.css
+++ b/web/source/css/profile.css
@@ -164,6 +164,20 @@ main {
 	margin-left: 1rem;
 }
 
+.backnextlinks {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+
+	a {
+		padding: 1rem;
+	}
+
+	.next {
+		margin-left: auto;
+	}
+}
+
 .toot, .toot:last-child {
 	box-shadow: $boxshadow;
 }

--- a/web/template/profile.tmpl
+++ b/web/template/profile.tmpl
@@ -27,7 +27,7 @@
             <div class="entry">Posted <b>{{.account.StatusesCount}}</b></div>
         </div>
     </div>
-    <h2 id="recent">Recent public toots</h2>
+    <h2 id="recent">Latest public toots</h2>
 	    {{ if not .statuses }}
         <div class="nothinghere">Nothing here!</div>
         {{ else }}

--- a/web/template/profile.tmpl
+++ b/web/template/profile.tmpl
@@ -39,5 +39,13 @@
             {{ end }}
         </div>
         {{ end }}
+    <div class="backnextlinks">
+        {{ if .show_back_to_top }}
+        <a href="/@{{ .account.Username }}">Back to top</a>
+        {{ end }}
+        {{ if .statuses_next }}
+        <a href="{{ .statuses_next }}" class="next">Show older</a>
+        {{ end }}
+    </div>
 </main>
 {{ template "footer.tmpl" .}}

--- a/web/template/profile.tmpl
+++ b/web/template/profile.tmpl
@@ -28,12 +28,16 @@
         </div>
     </div>
     <h2 id="recent">Recent public toots</h2>
-	<div class="thread">
-		{{range .statuses}}
-		<div class="toot expanded">
-			{{ template "status.tmpl" .}}
-		</div>
-		{{end}}
-	</div>
+	    {{ if not .statuses }}
+        <div class="nothinghere">Nothing here!</div>
+        {{ else }}
+        <div class="thread">
+            {{ range .statuses }}
+            <div class="toot expanded">
+                {{ template "status.tmpl" .}}
+            </div>
+            {{ end }}
+        </div>
+        {{ end }}
 </main>
 {{ template "footer.tmpl" .}}


### PR DESCRIPTION
This PR adds 'back to top' and 'next page' links to local account profiles, to allow visitors to the profile to page through more than just the most recent 10 public statuses.

![Screenshot from 2022-07-12 15-08-45](https://user-images.githubusercontent.com/31960611/178498552-70dfd163-de47-4a29-a9f7-e166e4224cc3.png)

The 'back to top' link is not shown on the first page of profiles (since the user is then already at the 'top').

![Screenshot from 2022-07-12 15-09-05](https://user-images.githubusercontent.com/31960611/178498668-1c29af85-c860-431a-aed5-ed72a7982728.png)

To support this functionality, a new function has been added to the database that *just* selects statuses that are candidates for viewing on a user's profile (public, non-reply, non-boost, federated statuses).

Closes #https://github.com/superseriousbusiness/gotosocial/issues/583