### PR TITLE
[feature] Implement `cache-control` and etags for static assets

### DIFF
--- a/internal/router/cache.go
+++ b/internal/router/cache.go
@@ -1,0 +1,114 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package router
+
+import (
+	// nolint:gosec
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// generateEtag generates a weak etag for the given byte slice.
+func generateEtag(in []byte) string {
+	// nolint:gosec
+	sum := sha1.Sum(in)
+	etag := fmt.Sprintf(`/W"%d-%x"`, len(in), sum)
+	return etag
+}
+
+func cacheMiddleware(fs http.FileSystem) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// We set the cache-control header in this middleware to avoid clients using
+		// default cacheing or heuristic caching.
+		//
+		// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+		c.Header("Cache-Control", "no-cache")
+
+		// pull some variables out of the request
+		urlString := c.Request.URL.String()
+		reqEtag := c.Request.Header.Get("If-None-Match")
+		sinceString := c.Request.Header.Get("If-Modified-Since")
+
+		// First check if the file has been modified using If-None-Match etag, if present.
+		// If the file hasn't been modified, bail with a 304.
+		//
+		// Then, check if the file has been modified using If-Modified-Since, if present.
+		// If the file hasn't been modified since the given date, bail with a 304.
+		// We only do this second check if If-None-Match wasn't set.
+		//
+		// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since
+		// and: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match
+
+		file, err := fs.Open(strings.TrimPrefix(urlString, "/assets"))
+		if err != nil {
+			logrus.Errorf("error opening asset: %s", err)
+			return
+		}
+		defer file.Close()
+
+		b, err := io.ReadAll(file)
+		if err != nil {
+			logrus.Errorf("error reading file: %s", err)
+			return
+		}
+
+		etag := generateEtag(b)
+
+		// Regardless of what happens further down, set the etag header
+		// so that the client has the up-to-date version.
+		c.Header("Etag", etag)
+
+		// If the client already has the latest version, we can bail early.
+		if reqEtag == etag {
+			c.AbortWithStatus(http.StatusNotModified)
+			return
+		}
+
+		// only fall back to using If-Modifed-Since if If-None-Match wasn't set.
+		if reqEtag == "" && sinceString != "" {
+			ifModifiedSince, err := http.ParseTime(sinceString)
+			if err != nil {
+				logrus.Debugf("If-Modifed-Since header could not be parsed: %s", err)
+				return
+			}
+
+			fileInfo, err := file.Stat()
+			if err != nil {
+				logrus.Errorf("error statting asset: %s", err)
+				return
+			}
+
+			lastModified := fileInfo.ModTime()
+			if !lastModified.After(ifModifiedSince) {
+				c.AbortWithStatus(http.StatusNotModified)
+				return
+			}
+		}
+
+		// if we reach this point, either the file has been modified, or we don't have
+		// enough information from the caller to determine caching; either way, let the
+		// request proceed as normal
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -68,12 +68,9 @@ func (r *router) AttachStaticFS(relativePath string, fs http.FileSystem) {
 	// group will consiste of endpoints under relativePath, so
 	// something like "/assets"
 	group := r.engine.Group(relativePath)
-	group.Use(func(c *gin.Context) {
-		// file system will already set 'last-modified' headers,
-		// but we want to set cache-control too to make sure callers
-		// understand they can cache static assets
-		c.Header("Cache-Control", "max-age=604800")
-	})
+
+	// use the cache middleware on all handlers in this group
+	group.Use(cacheMiddleware(fs))
 
 	// serve static file system in the root of this group,
 	// will end up being something like "/assets/"

--- a/internal/web/base.go
+++ b/internal/web/base.go
@@ -48,7 +48,6 @@ const (
 type Module struct {
 	processor      processing.Processor
 	assetsPath     string
-	assetsEtags    map[string]string
 	adminPath      string
 	defaultAvatars []string
 }

--- a/internal/web/base.go
+++ b/internal/web/base.go
@@ -19,13 +19,10 @@
 package web
 
 import (
-	"crypto/sha1"
 	"errors"
 	"fmt"
-	"io/fs"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -67,29 +64,6 @@ func New(processor processing.Processor) (api.ClientModule, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting absolute path of %s: %s", assetsBaseDir, err)
 	}
-
-	assetsEtags := make(map[string]string)
-	walk := func(path string, info fs.FileInfo, err error) error {
-		if !info.IsDir() {
-			b, err := os.ReadFile(path)
-			if err != nil {
-				return fmt.Errorf("err reading assets file %s: %s", path, err)
-			}
-
-			// filepath.Split()
-
-			// nolint:gosec
-			sum := sha1.Sum(b)
-			etag := fmt.Sprintf("%d-%x", len(b), sum)
-			assetsEtags[path] = etag
-		}
-		return nil
-	}
-
-	if err := filepath.Walk(assetsPath, walk); err != nil {
-		return nil, fmt.Errorf("error walking assets path %s: %s", assetsPath, err)
-	}
-	fmt.Printf("\n\n\n %+v \n\n\n", assetsEtags)
 
 	defaultAvatarsPath := filepath.Join(assetsPath, "default_avatars")
 	defaultAvatarFiles, err := ioutil.ReadDir(defaultAvatarsPath)


### PR DESCRIPTION
This PR adds a new middleware used specifically on the static file server at `/assets`.

The middleware adds smarter use of the `cache-control` header to prevent clients from having to refetch assets over and over, or indeed to never fetch assets again (heuristic caching).

Each asset now has an etag generated for it, and the client's If-None-Match header is properly checked against the etag.

This means that when frontend styling stuff changes, clients will intelligently fetch the changed versions, but if nothing changes then they will receive a 304.