### PR TITLE
[frontend] Tweak border radius for header + avatar

### DIFF
--- a/web/source/css/base.css
+++ b/web/source/css/base.css
@@ -28,7 +28,11 @@
 	src: url(../NotoSans-Bold.ttf) format('truetype');
 }
 
+// standard border radius for nice squircles
 $br: 0.4rem;
+// border radius for items that are framed/bordered
+// inside something with $br, eg avatar, header img
+$br_inner: 0.2rem; 
 
 html, body {
 	padding: 0;

--- a/web/source/css/profile.css
+++ b/web/source/css/profile.css
@@ -50,7 +50,7 @@ main {
 			width: 100%;
 			height: 100%;
 			object-fit: cover;
-			border-radius: $br $br 0 0;
+			border-radius: $br_inner $br_inner 0 0;
 		}
 	}
 
@@ -87,7 +87,7 @@ main {
 			box-shadow: $boxshadow;
 			img {
 				object-fit: cover;
-				border-radius: $br;
+				border-radius: $br_inner;
 				width: 100%;
 				height: 100%;
 			}


### PR DESCRIPTION
This PR fixes the gaps that were appearing in the corner of avatar images and (less noticeably) headers.

Before (500% zoom):

![Screenshot from 2022-07-17 16-49-45](https://user-images.githubusercontent.com/31960611/179404100-198c9a54-53f7-4868-ba81-3e6f007a0810.png)

After (500% zoom):

![Screenshot from 2022-07-17 16-49-26](https://user-images.githubusercontent.com/31960611/179404109-3e439a92-23e4-4422-8edd-677993cfcbe7.png)

