### PR TITLE
[bugfix] Markdown format fixes

### DIFF
--- a/internal/text/markdown.go
+++ b/internal/text/markdown.go
@@ -37,5 +37,5 @@ func (f *formatter) FromMarkdown(ctx context.Context, md string, mentions []*gts
 	// format mentions nicely
 	content = f.ReplaceMentions(ctx, content, mentions)
 
-	return postformat(content)
+	return SanitizeHTML(content)
 }

--- a/internal/text/markdown_test.go
+++ b/internal/text/markdown_test.go
@@ -44,13 +44,15 @@ that was some JSON :)
 `
 
 const (
-	simpleMarkdown         = "# Title\n\nHere's a simple text in markdown.\n\nHere's a [link](https://example.org)."
-	simpleMarkdownExpected = "<h1>Title</h1>\n\n<p>Here’s a simple text in markdown.</p>\n\n<p>Here’s a <a href=\"https://example.org\" rel=\"nofollow noreferrer noopener\" target=\"_blank\">link</a>.</p>\n"
-	withCodeBlockExpected  = "<h1>Title</h1>\n\n<p>Below is some JSON.</p>\n\n<pre><code class=\"language-json\">{\n  &#34;key&#34;: &#34;value&#34;,\n  &#34;another_key&#34;: [\n    &#34;value1&#34;,\n    &#34;value2&#34;\n  ]\n}\n</code></pre>\n\n<p>that was some JSON :)</p>\n"
-	withInlineCode         = "`Nobody tells you about the <code><del>SECRET CODE</del></code>, do they?`"
-	withInlineCodeExpected = "<p><code>Nobody tells you about the &lt;code&gt;&lt;del&gt;SECRET CODE&lt;/del&gt;&lt;/code&gt;, do they?</code></p>\n"
-	withHashtag            = "# Title\n\nhere's a simple status that uses hashtag #Hashtag!"
-	withHashtagExpected    = "<h1>Title</h1>\n\n<p>here’s a simple status that uses hashtag <a href=\"http://localhost:8080/tags/Hashtag\" class=\"mention hashtag\" rel=\"tag nofollow noreferrer noopener\" target=\"_blank\">#<span>Hashtag</span></a>!</p>\n"
+	simpleMarkdown          = "# Title\n\nHere's a simple text in markdown.\n\nHere's a [link](https://example.org)."
+	simpleMarkdownExpected  = "<h1>Title</h1>\n\n<p>Here’s a simple text in markdown.</p>\n\n<p>Here’s a <a href=\"https://example.org\" rel=\"nofollow noreferrer noopener\" target=\"_blank\">link</a>.</p>\n"
+	withCodeBlockExpected   = "<h1>Title</h1>\n\n<p>Below is some JSON.</p>\n\n<pre><code class=\"language-json\">{\n  &#34;key&#34;: &#34;value&#34;,\n  &#34;another_key&#34;: [\n    &#34;value1&#34;,\n    &#34;value2&#34;\n  ]\n}\n</code></pre>\n\n<p>that was some JSON :)</p>\n"
+	withInlineCode          = "`Nobody tells you about the <code><del>SECRET CODE</del></code>, do they?`"
+	withInlineCodeExpected  = "<p><code>Nobody tells you about the &lt;code&gt;&lt;del&gt;SECRET CODE&lt;/del&gt;&lt;/code&gt;, do they?</code></p>\n"
+	withInlineCode2         = "`Nobody tells you about the </code><del>SECRET CODE</del><code>, do they?`"
+	withInlineCode2Expected = "<p><code>Nobody tells you about the &lt;/code&gt;&lt;del&gt;SECRET CODE&lt;/del&gt;&lt;code&gt;, do they?</code></p>\n"
+	withHashtag             = "# Title\n\nhere's a simple status that uses hashtag #Hashtag!"
+	withHashtagExpected     = "<h1>Title</h1>\n\n<p>here’s a simple status that uses hashtag <a href=\"http://localhost:8080/tags/Hashtag\" class=\"mention hashtag\" rel=\"tag nofollow noreferrer noopener\" target=\"_blank\">#<span>Hashtag</span></a>!</p>\n"
 )
 
 type MarkdownTestSuite struct {
@@ -70,6 +72,11 @@ func (suite *MarkdownTestSuite) TestParseWithCodeBlock() {
 func (suite *MarkdownTestSuite) TestParseWithInlineCode() {
 	s := suite.formatter.FromMarkdown(context.Background(), withInlineCode, nil, nil)
 	suite.Equal(withInlineCodeExpected, s)
+}
+
+func (suite *MarkdownTestSuite) TestParseWithInlineCode2() {
+	s := suite.formatter.FromMarkdown(context.Background(), withInlineCode2, nil, nil)
+	suite.Equal(withInlineCode2Expected, s)
 }
 
 func (suite *MarkdownTestSuite) TestParseWithHashtag() {

--- a/internal/text/markdown_test.go
+++ b/internal/text/markdown_test.go
@@ -20,30 +20,13 @@ package text_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 )
 
-const (
-	simpleMarkdown = `# Title
-
-Here's a simple text in markdown.
-
-Here's a [link](https://example.org).`
-
-	simpleMarkdownExpected = "<h1>Title</h1><p>Here’s a simple text in markdown.</p><p>Here’s a <a href=\"https://example.org\" rel=\"nofollow noreferrer noopener\" target=\"_blank\">link</a>.</p>"
-
-	withCodeBlockExpected = "<h1>Title</h1><p>Below is some JSON.</p><pre><code class=\"language-json\">{\n  \"key\": \"value\",\n  \"another_key\": [\n    \"value1\",\n    \"value2\"\n  ]\n}\n</code></pre><p>that was some JSON :)</p>"
-
-	withHashtag         = "# Title\n\nhere's a simple status that uses hashtag #Hashtag!"
-	withHashtagExpected = "<h1>Title</h1><p>here’s a simple status that uses hashtag <a href=\"http://localhost:8080/tags/Hashtag\" class=\"mention hashtag\" rel=\"tag nofollow noreferrer noopener\" target=\"_blank\">#<span>Hashtag</span></a>!</p>"
-)
-
-var (
-	withCodeBlock = `# Title
+var withCodeBlock = `# Title
 
 Below is some JSON.
 
@@ -59,6 +42,15 @@ Below is some JSON.
 
 that was some JSON :)
 `
+
+const (
+	simpleMarkdown         = "# Title\n\nHere's a simple text in markdown.\n\nHere's a [link](https://example.org)."
+	simpleMarkdownExpected = "<h1>Title</h1>\n\n<p>Here’s a simple text in markdown.</p>\n\n<p>Here’s a <a href=\"https://example.org\" rel=\"nofollow noreferrer noopener\" target=\"_blank\">link</a>.</p>\n"
+	withCodeBlockExpected  = "<h1>Title</h1>\n\n<p>Below is some JSON.</p>\n\n<pre><code class=\"language-json\">{\n  &#34;key&#34;: &#34;value&#34;,\n  &#34;another_key&#34;: [\n    &#34;value1&#34;,\n    &#34;value2&#34;\n  ]\n}\n</code></pre>\n\n<p>that was some JSON :)</p>\n"
+	withInlineCode         = "`Nobody tells you about the <code><del>SECRET CODE</del></code>, do they?`"
+	withInlineCodeExpected = "<p><code>Nobody tells you about the &lt;code&gt;&lt;del&gt;SECRET CODE&lt;/del&gt;&lt;/code&gt;, do they?</code></p>\n"
+	withHashtag            = "# Title\n\nhere's a simple status that uses hashtag #Hashtag!"
+	withHashtagExpected    = "<h1>Title</h1>\n\n<p>here’s a simple status that uses hashtag <a href=\"http://localhost:8080/tags/Hashtag\" class=\"mention hashtag\" rel=\"tag nofollow noreferrer noopener\" target=\"_blank\">#<span>Hashtag</span></a>!</p>\n"
 )
 
 type MarkdownTestSuite struct {
@@ -71,9 +63,13 @@ func (suite *MarkdownTestSuite) TestParseSimple() {
 }
 
 func (suite *MarkdownTestSuite) TestParseWithCodeBlock() {
-	fmt.Println(withCodeBlock)
 	s := suite.formatter.FromMarkdown(context.Background(), withCodeBlock, nil, nil)
 	suite.Equal(withCodeBlockExpected, s)
+}
+
+func (suite *MarkdownTestSuite) TestParseWithInlineCode() {
+	s := suite.formatter.FromMarkdown(context.Background(), withInlineCode, nil, nil)
+	suite.Equal(withInlineCodeExpected, s)
 }
 
 func (suite *MarkdownTestSuite) TestParseWithHashtag() {


### PR DESCRIPTION
This PR updates markdown post formatting to not use the same postprocessing as plaintext posts, since this was causing issues with html being improperly escaped. Instead, it just sanitizes html in outgoing markdown, instead of escaping it + minifying it.

closes https://github.com/superseriousbusiness/gotosocial/issues/679