### PR TITLE
[bugfix] Fix Toot CLI media attachments not working properly

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -161,6 +161,10 @@ definitions:
         description: |-
           Array of Attachment ids to be attached as media.
           If provided, status becomes optional, and poll cannot be used.
+
+          If the status is being submitted as a form, the key is 'media_ids[]',
+          but if it's json or xml, the key is 'media_ids'.
+
           in: formData
         items:
           type: string
@@ -422,6 +426,10 @@ definitions:
         description: |-
           Array of Attachment ids to be attached as media.
           If provided, status becomes optional, and poll cannot be used.
+
+          If the status is being submitted as a form, the key is 'media_ids[]',
+          but if it's json or xml, the key is 'media_ids'.
+
           in: formData
         items:
           type: string
@@ -3518,6 +3526,9 @@ paths:
       - description: |-
           Array of Attachment ids to be attached as media.
           If provided, status becomes optional, and poll cannot be used.
+
+          If the status is being submitted as a form, the key is 'media_ids[]',
+          but if it's json or xml, the key is 'media_ids'.
         in: formData
         items:
           type: string

--- a/internal/api/client/status/statuscreate_test.go
+++ b/internal/api/client/status/statuscreate_test.go
@@ -313,7 +313,7 @@ func (suite *StatusCreateTestSuite) TestAttachNewMediaSuccess() {
 	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Request.Form = url.Values{
 		"status":    {"here's an image attachment"},
-		"media_ids": {attachment.ID},
+		"media_ids[]": {attachment.ID},
 	}
 	suite.statusModule.StatusCreatePOSTHandler(ctx)
 

--- a/internal/api/model/status.go
+++ b/internal/api/model/status.go
@@ -144,8 +144,12 @@ type StatusCreateRequest struct {
 	Status string `form:"status" json:"status" xml:"status"`
 	// Array of Attachment ids to be attached as media.
 	// If provided, status becomes optional, and poll cannot be used.
+	//
+	// If the status is being submitted as a form, the key is 'media_ids[]',
+	// but if it's json or xml, the key is 'media_ids'.
+	//
 	// in: formData
-	MediaIDs []string `form:"media_ids" json:"media_ids" xml:"media_ids"`
+	MediaIDs []string `form:"media_ids[]" json:"media_ids" xml:"media_ids"`
 	// Poll to include with this status.
 	// swagger:ignore
 	Poll *PollRequest `form:"poll" json:"poll" xml:"poll"`


### PR DESCRIPTION
This PR fixes the issue of the Toot cli not attaching media correctly to new statuses.

The problem was that when it comes to POST form data, the Mastodon API expects clients to use the key `media_ids[]` for their list of media attachment IDs. However, GtS was just accepting `media_ids`, which works great for json, but not so much for clients that use POST forms like Toot does.

This PR implements a simple fix for this by parsing `media_ids[]` in forms, but still using `media_ids` for json and xml. Tested and working with Toot, and therefore should work for other mastodon clients as well.

closes https://github.com/superseriousbusiness/gotosocial/issues/686