### PR TITLE
[feature] add 'state' oauth2 param to /oauth/authorize

### DIFF
--- a/internal/api/client/auth/auth.go
+++ b/internal/api/client/auth/auth.go
@@ -55,13 +55,14 @@ const (
 	callbackStateParam = "state"
 	callbackCodeParam  = "code"
 
-	sessionUserID       = "userid"
-	sessionClientID     = "client_id"
-	sessionRedirectURI  = "redirect_uri"
-	sessionForceLogin   = "force_login"
-	sessionResponseType = "response_type"
-	sessionScope        = "scope"
-	sessionState        = "state"
+	sessionUserID        = "userid"
+	sessionClientID      = "client_id"
+	sessionRedirectURI   = "redirect_uri"
+	sessionForceLogin    = "force_login"
+	sessionResponseType  = "response_type"
+	sessionScope         = "scope"
+	sessionInternalState = "internal_state"
+	sessionClientState   = "client_state"
 )
 
 // Module implements the ClientAPIModule interface for

--- a/internal/api/client/auth/callback.go
+++ b/internal/api/client/auth/callback.go
@@ -45,26 +45,26 @@ func (m *Module) CallbackGETHandler(c *gin.Context) {
 	// check the query vs session state parameter to mitigate csrf
 	// https://auth0.com/docs/secure/attack-protection/state-parameters
 
-	state := c.Query(callbackStateParam)
-	if state == "" {
+	returnedInternalState := c.Query(callbackStateParam)
+	if returnedInternalState == "" {
 		m.clearSession(s)
 		err := fmt.Errorf("%s parameter not found on callback query", callbackStateParam)
 		api.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
 		return
 	}
 
-	savedStateI := s.Get(sessionState)
-	savedState, ok := savedStateI.(string)
+	savedInternalStateI := s.Get(sessionInternalState)
+	savedInternalState, ok := savedInternalStateI.(string)
 	if !ok {
 		m.clearSession(s)
-		err := fmt.Errorf("key %s was not found in session", sessionState)
+		err := fmt.Errorf("key %s was not found in session", sessionInternalState)
 		api.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
 		return
 	}
 
-	if state != savedState {
+	if returnedInternalState != savedInternalState {
 		m.clearSession(s)
-		err := errors.New("mismatch between query state and session state")
+		err := errors.New("mismatch between callback state and saved state")
 		api.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
 		return
 	}

--- a/internal/api/client/auth/signin.go
+++ b/internal/api/client/auth/signin.go
@@ -58,16 +58,16 @@ func (m *Module) SignInGETHandler(c *gin.Context) {
 	// idp provider is in use, so redirect to it
 	s := sessions.Default(c)
 
-	stateI := s.Get(sessionState)
-	state, ok := stateI.(string)
+	internalStateI := s.Get(sessionInternalState)
+	internalState, ok := internalStateI.(string)
 	if !ok {
 		m.clearSession(s)
-		err := fmt.Errorf("key %s was not found in session", sessionState)
+		err := fmt.Errorf("key %s was not found in session", sessionInternalState)
 		api.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
 		return
 	}
 
-	c.Redirect(http.StatusSeeOther, m.idp.AuthCodeURL(state))
+	c.Redirect(http.StatusSeeOther, m.idp.AuthCodeURL(internalState))
 }
 
 // SignInPOSTHandler should be served at https://example.org/auth/sign_in.

--- a/internal/api/client/status/statuscreate_test.go
+++ b/internal/api/client/status/statuscreate_test.go
@@ -312,7 +312,7 @@ func (suite *StatusCreateTestSuite) TestAttachNewMediaSuccess() {
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", status.BasePath), nil) // the endpoint we're hitting
 	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Request.Form = url.Values{
-		"status":    {"here's an image attachment"},
+		"status":      {"here's an image attachment"},
 		"media_ids[]": {attachment.ID},
 	}
 	suite.statusModule.StatusCreatePOSTHandler(ctx)

--- a/internal/api/model/oauth.go
+++ b/internal/api/model/oauth.go
@@ -33,4 +33,8 @@ type OAuthAuthorize struct {
 	// List of requested OAuth scopes, separated by spaces (or by pluses, if using query parameters).
 	// Must be a subset of scopes declared during app registration. If not provided, defaults to read.
 	Scope string `form:"scope" json:"scope"`
+	// State is used by the application to store request-specific data and/or prevent CSRF attacks.
+	// The authorization server must return the unmodified state value back to the application.
+	// See https://www.oauth.com/oauth2-servers/authorization/the-authorization-request/
+	State string `form:"state" json:"state"`
 }


### PR DESCRIPTION
This PR adds support for the optional oauth2 'state' request parameter, which was missing before.

See https://www.oauth.com/oauth2-servers/authorization/the-authorization-request/

This also introduces a differentiation between 'internal' state during the flow, and 'client' state.

Internal state is generated by the server for every request, and sent along to oidc providers as necessary.

Client state on the other hand is only set by an incoming client request, and the state param is returned to the client at the end of the flow, just like it was submitted.

This should allow GtS to work properly with clients that submit state to mitigate csrf attacks :)