### PR TITLE
[bugfix] remove <= 0 `expires_in` from oauth token response

### DIFF
--- a/internal/api/client/status/statuscreate_test.go
+++ b/internal/api/client/status/statuscreate_test.go
@@ -312,7 +312,7 @@ func (suite *StatusCreateTestSuite) TestAttachNewMediaSuccess() {
 	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:8080/%s", status.BasePath), nil) // the endpoint we're hitting
 	ctx.Request.Header.Set("accept", "application/json")
 	ctx.Request.Form = url.Values{
-		"status":    {"here's an image attachment"},
+		"status":      {"here's an image attachment"},
 		"media_ids[]": {attachment.ID},
 	}
 	suite.statusModule.StatusCreatePOSTHandler(ctx)


### PR DESCRIPTION
This PR updates the oauth token response to remove the `expires_in` field completely from the response if the value is less than or equal to 0. According to oauth:

> expires_in (recommended) If the access token expires, the server should reply with the duration of time the access token is granted for.

Since we use 0 to indicate a token that doesn't expire, we should not set this in the response in case clients interpret this to mean that the token is *already expired* as soon as they receive it.

Along with https://github.com/superseriousbusiness/gotosocial/pull/730, this should allow liberapay to work with GoToSocial