### PR TITLE
[feature] serve HEAD requests via the fileserver

### DIFF
--- a/internal/api/client/fileserver/fileserver.go
+++ b/internal/api/client/fileserver/fileserver.go
@@ -59,5 +59,6 @@ func (m *FileServer) Route(s router.Router) error {
 	// something like "/fileserver/:account_id/:media_type/:media_size/:file_name"
 	fileServePath := fmt.Sprintf("%s/:%s/:%s/:%s/:%s", FileServeBasePath, AccountIDKey, MediaTypeKey, MediaSizeKey, FileNameKey)
 	s.AttachHandler(http.MethodGet, fileServePath, m.ServeFile)
+	s.AttachHandler(http.MethodHead, fileServePath, m.ServeFile)
 	return nil
 }


### PR DESCRIPTION
This PR updates the fileserver endpoint to also serve `HEAD` requests, which is functionality supported by the mastodon API. This should allow liberapay (for example) to properly use GtS avatars as avatars for connected accounts.