### PR TITLE
[frontend] style blockquote nicely within content

### DIFF
--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -127,6 +127,13 @@ main {
 
 		.content {
 			word-break: break-word;
+
+			blockquote {
+				padding: 0.5rem 0 0.5rem 1.5rem;
+				border-left: 0.2rem solid $sloth_orange1;
+				margin-left: 1rem;
+				font-style: italic;
+			}
 		}
 	}
 


### PR DESCRIPTION
![blockquote styling is now indented and italicized with an orange border left](https://user-images.githubusercontent.com/31960611/183288710-e667719b-5e7f-43df-8691-2f7d1467e85e.png)
