### PR TITLE
[frontend] Status styling tweaks

### DIFF
--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -129,6 +129,9 @@ main {
 		}
 
 		.content {
+			padding-top: 1rem;
+			padding-bottom: 1rem;
+
 			word-break: break-word;
 
 			blockquote {

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -156,16 +156,14 @@ main {
 			}
 
 			pre {
-				padding: 1rem 1rem 0 1rem;
+				display: flex;
 				border-radius: $br;
+				padding: 0.5rem;
 
 				code {	
-					display: block;				
-					width: 100%;
+					padding: 0.5rem;
 					white-space: pre;
-					padding: 0 0 1rem 0;
-					border-radius: initial;
-
+					border-radius: 0;
 					overflow-x: auto;
 					-webkit-overflow-scrolling: touch;
 					scrollbar-color: $sloth_orange1 $sloth_gray2_darker3;

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -137,6 +137,10 @@ main {
 				margin-left: 1rem;
 				font-style: italic;
 			}
+
+			hr {
+				border: 1px dashed $sloth_orange1;
+			} 
 		}
 	}
 

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -129,8 +129,8 @@ main {
 		}
 
 		.content {
-			padding-top: 1rem;
-			padding-bottom: 1rem;
+			padding-top: 0.5rem;
+			padding-bottom: 0.5rem;
 
 			word-break: break-word;
 

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -151,6 +151,7 @@ main {
 
 			code {
 				padding: 0.25rem;
+				border-radius: $br_inner;
 			}
 
 			pre {
@@ -163,6 +164,8 @@ main {
 				code {	
 					display: block;				
 					padding: initial;
+					border-radius: initial;
+
 					max-width: 100%;
 					min-width: 100px;
 					overflow-x: scroll;

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -141,6 +141,32 @@ main {
 			hr {
 				border: 1px dashed $sloth_orange1;
 			} 
+
+			pre, code {
+				background-color: $sloth_gray2_darker7;
+			}
+
+			code {
+				padding: 0.25rem;
+			}
+
+			pre {
+				display: block;
+				padding: 1rem;
+				border-radius: $br;
+				word-break: normal;
+				overflow: hidden;
+
+				code {	
+					display: block;				
+					padding: initial;
+					max-width: 100%;
+					min-width: 100px;
+					overflow-x: scroll;
+					-webkit-overflow-scrolling: touch;
+					white-space: pre;
+				}
+			}
 		}
 	}
 

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -119,6 +119,7 @@ main {
 		margin: 0;
 		margin-top: 0.5rem;
 		grid-column: span 2;
+		overflow: hidden;
 
 		position: relative;
 		z-index: 2;
@@ -155,22 +156,21 @@ main {
 			}
 
 			pre {
-				display: block;
-				padding: 1rem;
+				padding: 1rem 1rem 0 1rem;
 				border-radius: $br;
-				word-break: normal;
-				overflow: hidden;
 
 				code {	
 					display: block;				
+					white-space: pre;
 					padding: initial;
+					padding-bottom: 1rem;
 					border-radius: initial;
 
 					max-width: 100%;
 					min-width: 100px;
 					overflow-x: scroll;
 					-webkit-overflow-scrolling: touch;
-					white-space: pre;
+					scrollbar-color: $sloth_orange1 $sloth_gray2_darker3;
 				}
 			}
 		}

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -161,14 +161,12 @@ main {
 
 				code {	
 					display: block;				
+					width: 100%;
 					white-space: pre;
-					padding: initial;
-					padding-bottom: 1rem;
+					padding: 0 0 1rem 0;
 					border-radius: initial;
 
-					max-width: 100%;
-					min-width: 100px;
-					overflow-x: scroll;
+					overflow-x: auto;
 					-webkit-overflow-scrolling: touch;
 					scrollbar-color: $sloth_orange1 $sloth_gray2_darker3;
 				}


### PR DESCRIPTION
- Pad top and bottom of statuses a bit so they're more visually separated from the content warning or avatar at top, and stats at bottom.
- Format `hr` as a dotted orange line.
- Format code a bit nicer, make code blocks horizontally scrollable.

![Screenshot from 2022-08-11 17-17-07](https://user-images.githubusercontent.com/31960611/184168633-b5806596-84bc-4585-948c-31ab09f4b0ce.png)

