### PR TITLE
[bugfix] Fix loss of account info on export/import, add tests

### DIFF
--- a/internal/trans/import_test.go
+++ b/internal/trans/import_test.go
@@ -58,9 +58,7 @@ func (suite *ImportMinimalTestSuite) TestImportMinimalOK() {
 	fmt.Println(string(b))
 
 	// create a new database with just the tables created, no entries
-	testrig.StandardDBTeardown(suite.db)
 	newDB := testrig.NewTestDB()
-	testrig.CreateTestTables(newDB)
 
 	importer := trans.NewImporter(newDB)
 	err = importer.Import(ctx, tempFilePath)

--- a/internal/trans/import_test.go
+++ b/internal/trans/import_test.go
@@ -38,12 +38,17 @@ type ImportMinimalTestSuite struct {
 func (suite *ImportMinimalTestSuite) TestImportMinimalOK() {
 	ctx := context.Background()
 
+	testAccountBefore, err := suite.db.GetAccountByID(ctx, suite.testAccounts["local_account_1"].ID)
+	if err != nil {
+		suite.FailNow("couldn't get testAccountBefore")
+	}
+
 	// use a temporary file path
 	tempFilePath := fmt.Sprintf("%s/%s", suite.T().TempDir(), uuid.NewString())
 
 	// export to the tempFilePath
 	exporter := trans.NewExporter(suite.db)
-	err := exporter.ExportMinimal(ctx, tempFilePath)
+	err = exporter.ExportMinimal(ctx, tempFilePath)
 	suite.NoError(err)
 
 	// we should have some bytes in that file now
@@ -84,6 +89,41 @@ func (suite *ImportMinimalTestSuite) TestImportMinimalOK() {
 	err = newDB.GetAll(ctx, &domainBlocks)
 	suite.NoError(err)
 	suite.NotEmpty(domainBlocks)
+
+	// compare test account before + after
+	testAccountAfter, err := newDB.GetAccountByID(ctx, suite.testAccounts["local_account_1"].ID)
+	if err != nil {
+		suite.FailNow("couldn't get testAccountAfter")
+	}
+
+	suite.Equal(testAccountBefore.ID, testAccountAfter.ID)
+	suite.Equal(testAccountBefore.Username, testAccountAfter.Username)
+	suite.Equal(testAccountBefore.Domain, testAccountAfter.Domain)
+	suite.Equal(testAccountBefore.DisplayName, testAccountAfter.DisplayName)
+	suite.Equal(testAccountBefore.Note, testAccountAfter.Note)
+	suite.Equal(testAccountBefore.NoteRaw, testAccountAfter.NoteRaw)
+	suite.Equal(testAccountBefore.Memorial, testAccountAfter.Memorial)
+	suite.Equal(testAccountBefore.Bot, testAccountAfter.Bot)
+	suite.Equal(testAccountBefore.Locked, testAccountAfter.Locked)
+	suite.Equal(testAccountBefore.Reason, testAccountAfter.Reason)
+	suite.Equal(testAccountBefore.Privacy, testAccountAfter.Privacy)
+	suite.Equal(testAccountBefore.Sensitive, testAccountAfter.Sensitive)
+	suite.Equal(testAccountBefore.Language, testAccountAfter.Language)
+	suite.Equal(testAccountBefore.StatusFormat, testAccountAfter.StatusFormat)
+	suite.Equal(testAccountBefore.URI, testAccountAfter.URI)
+	suite.Equal(testAccountBefore.URL, testAccountAfter.URL)
+	suite.Equal(testAccountBefore.InboxURI, testAccountAfter.InboxURI)
+	suite.Equal(testAccountBefore.OutboxURI, testAccountAfter.OutboxURI)
+	suite.Equal(testAccountBefore.FollowingURI, testAccountAfter.FollowingURI)
+	suite.Equal(testAccountBefore.FollowersURI, testAccountAfter.FollowersURI)
+	suite.Equal(testAccountBefore.FeaturedCollectionURI, testAccountAfter.FeaturedCollectionURI)
+	suite.Equal(testAccountBefore.ActorType, testAccountAfter.ActorType)
+	suite.Equal(testAccountBefore.PrivateKey, testAccountAfter.PrivateKey)
+	suite.Equal(testAccountBefore.PublicKey, testAccountAfter.PublicKey)
+	suite.Equal(testAccountBefore.PublicKeyURI, testAccountAfter.PublicKeyURI)
+	suite.Equal(testAccountBefore.SuspendedAt, testAccountAfter.SuspendedAt)
+	suite.Equal(testAccountBefore.HideCollections, testAccountAfter.HideCollections)
+	suite.Equal(testAccountBefore.SuspensionOrigin, testAccountAfter.SuspensionOrigin)
 }
 
 func TestImportMinimalTestSuite(t *testing.T) {

--- a/internal/trans/model/account.go
+++ b/internal/trans/model/account.go
@@ -29,15 +29,24 @@ type Account struct {
 	ID                    string          `json:"id" bun:",nullzero"`
 	CreatedAt             *time.Time      `json:"createdAt" bun:",nullzero"`
 	Username              string          `json:"username" bun:",nullzero"`
-	DisplayName           string          `json:"displayName,omitempty" bun:",nullzero"`
-	Note                  string          `json:"note,omitempty" bun:",nullzero"`
 	Domain                string          `json:"domain,omitempty" bun:",nullzero"`
 	HeaderRemoteURL       string          `json:"headerRemoteURL,omitempty" bun:",nullzero"`
 	AvatarRemoteURL       string          `json:"avatarRemoteURL,omitempty" bun:",nullzero"`
-	Locked                *bool           `json:"locked" bun:",nullzero,notnull,default:true"`
+	DisplayName           string          `json:"displayName,omitempty" bun:",nullzero"`
+	Note                  string          `json:"note,omitempty" bun:",nullzero"`
+	NoteRaw               string          `json:"noteRaw,omitempty" bun:",nullzero"`
+	Memorial              *bool           `json:"memorial"`
+	Bot                   *bool           `json:"bot"`
+	Reason                string          `json:"reason,omitempty" bun:",nullzero"`
+	Locked                *bool           `json:"locked"`
+	Discoverable          *bool           `json:"discoverable"`
+	Privacy               string          `json:"privacy,omitempty" bun:",nullzero"`
+	Sensitive             *bool           `json:"sensitive"`
 	Language              string          `json:"language,omitempty" bun:",nullzero"`
+	StatusFormat          string          `json:"statusFormat,omitempty" bun:",nullzero"`
 	URI                   string          `json:"uri" bun:",nullzero"`
 	URL                   string          `json:"url" bun:",nullzero"`
+	LastWebfingeredAt     *time.Time      `json:"lastWebfingeredAt,omitempty" bun:",nullzero"`
 	InboxURI              string          `json:"inboxURI" bun:",nullzero"`
 	OutboxURI             string          `json:"outboxURI" bun:",nullzero"`
 	FollowingURI          string          `json:"followingUri" bun:",nullzero"`
@@ -49,6 +58,9 @@ type Account struct {
 	PublicKey             *rsa.PublicKey  `json:"-" mapstructure:"-"`
 	PublicKeyString       string          `json:"publicKey,omitempty" mapstructure:"publicKey" bun:"-"`
 	PublicKeyURI          string          `json:"publicKeyUri" bun:",nullzero"`
+	SensitizedAt          *time.Time      `json:"sensitizedAt,omitempty" bun:",nullzero"`
+	SilencedAt            *time.Time      `json:"silencedAt,omitempty" bun:",nullzero"`
 	SuspendedAt           *time.Time      `json:"suspendedAt,omitempty" bun:",nullzero"`
+	HideCollections       *bool           `json:"hideCollections"`
 	SuspensionOrigin      string          `json:"suspensionOrigin,omitempty" bun:",nullzero"`
 }

--- a/internal/trans/trans_test.go
+++ b/internal/trans/trans_test.go
@@ -21,17 +21,22 @@ package trans_test
 import (
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
 type TransTestSuite struct {
 	suite.Suite
-	db db.DB
+	db           db.DB
+	testAccounts map[string]*gtsmodel.Account
 }
 
 func (suite *TransTestSuite) SetupTest() {
-	testrig.InitTestLog()
 	testrig.InitTestConfig()
+   testrig.InitTestLog()
+
+   suite.testAccounts = testrig.NewTestAccounts()
+
 	suite.db = testrig.NewTestDB()
 	testrig.StandardDBSetup(suite.db, nil)
 }


### PR DESCRIPTION
This PR updates some of the export/import logic to export more fields from accounts, and adds tests to ensure that account data matches across export/import. To support this, the PR updates the sqlite in-memory implementation to use a different random address per in-memory database, to allow easier testing/comparison of multiple databases.