### PR TITLE
validateCreateStatus: Check the presence of form.MediaIDs more thoroughly, instead of just checking for null

### DIFF
--- a/internal/api/client/status/statuscreate.go
+++ b/internal/api/client/status/statuscreate.go
@@ -105,11 +105,15 @@ func (m *Module) StatusCreatePOSTHandler(c *gin.Context) {
 }
 
 func validateCreateStatus(form *model.AdvancedStatusCreateForm) error {
-	if form.Status == "" && form.MediaIDs == nil && form.Poll == nil {
+	hasStatus := form.Status != ""
+	hasMedia := len(form.MediaIDs) != 0
+	hasPoll := form.Poll != nil
+
+	if !hasStatus && !hasMedia && !hasPoll {
 		return errors.New("no status, media, or poll provided")
 	}
 
-	if form.MediaIDs != nil && form.Poll != nil {
+	if hasMedia && hasPoll {
 		return errors.New("can't post media + poll in same status")
 	}
 


### PR DESCRIPTION
awesome software! just set up a test instance tonight and ran into this snag. It seems that polls aren't really supported yet, but to get it to work eventually this change will probably be necessary.

When sending a post on tusky, it appears that "form.MediaIDs" isn't nil but instead an empty array. If you try to attach a poll, the post is rejected because this code thinks there's both a poll and media on the status.

On pinafore, this doesn't occur (though the post is still rejected because the expires_in field of the payload is a string and not an int. different problem that probably needs to be fixed in pinafore)