### PR TITLE
Fix some bugs when viewing a user's posts: include their self-replies (threads) even when excludeReplies is set, and use in_reply_to_uri instead of in_reply_to_id to filter out replies

### DIFF
--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -270,7 +270,14 @@ func (a *accountDB) GetAccountStatuses(ctx context.Context, accountID string, li
 	}
 
 	if excludeReplies {
-		q = q.WhereGroup(" AND ", whereEmptyOrNull("in_reply_to_id"))
+		// include self-replies (threads)
+		whereGroup := func(*bun.SelectQuery) *bun.SelectQuery {
+			return q.
+				WhereOr("in_reply_to_account_id = ?", accountID).
+				WhereGroup(" OR ", whereEmptyOrNull("in_reply_to_uri"))
+		}
+
+		q = q.WhereGroup(" AND ", whereGroup)
 	}
 
 	if excludeReblogs {
@@ -332,7 +339,7 @@ func (a *accountDB) GetAccountWebStatuses(ctx context.Context, accountID string,
 		Table("statuses").
 		Column("id").
 		Where("account_id = ?", accountID).
-		WhereGroup(" AND ", whereEmptyOrNull("in_reply_to_id")).
+		WhereGroup(" AND ", whereEmptyOrNull("in_reply_to_uri")).
 		WhereGroup(" AND ", whereEmptyOrNull("boost_of_id")).
 		Where("visibility = ?", gtsmodel.VisibilityPublic).
 		Where("federated = ?", true)

--- a/internal/db/bundb/migrations/20220827085121_assign_missing_in_reply_to_uris.go
+++ b/internal/db/bundb/migrations/20220827085121_assign_missing_in_reply_to_uris.go
@@ -1,0 +1,66 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			// set in_reply_to_uri to the uri of the status pointed to by in_reply_to_id
+			if _, err := tx.NewUpdate().
+				Table("statuses").
+				TableExpr("statuses AS secondary").
+				SetColumn("in_reply_to_uri", "secondary.uri").
+				Where("statuses.in_reply_to_id = secondary.id").
+				Where("statuses.in_reply_to_id IS NOT null").
+				Where("statuses.in_reply_to_uri IS null").
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			// add index to in_reply_to_uri
+			if _, err := tx.
+				NewCreateIndex().
+				Model(&gtsmodel.Status{}).
+				Index("statuses_in_reply_to_uri_idx").
+				Column("in_reply_to_uri").
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}

--- a/internal/processing/status/util.go
+++ b/internal/processing/status/util.go
@@ -151,6 +151,7 @@ func (p *processor) ProcessReplyToID(ctx context.Context, form *apimodel.Advance
 	}
 
 	status.InReplyToID = repliedStatus.ID
+	status.InReplyToURI = repliedStatus.URI
 	status.InReplyToAccountID = repliedAccount.ID
 
 	return nil


### PR DESCRIPTION
This makes the behaviour more like mastodon: excludeReplies=true will still show replies that the user made with themselves (i.e. a long thread)

also fixes a bug where a post that is a response to another post can accidentally appear when excludeReplies=true, since the in_reply_to_id is unset because the post it was replying to isn't in the instance's DB.