### PR TITLE
Fix link to open collective

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Thanks to everyone who has used GtS, opened an issue, suggested something, given
 
 ![open collective Standard Sloth badge](https://opencollective.com/gotosocial/tiers/standard-sloth/badge.svg?label=Standard%20Sloth&color=brightgreen) ![open collective Stable Sloth badge](https://opencollective.com/gotosocial/tiers/stable-sloth/badge.svg?label=Stable%20Sloth&color=green) ![open collective Special Sloth badge](https://opencollective.com/gotosocial/tiers/special-sloth/badge.svg?label=Special%20Sloth&color=yellowgreen) ![open collective Sugar Sloth badge](https://opencollective.com/gotosocial/tiers/sugar-sloth/badge.svg?label=Sugar%20Sloth&color=blue)
 
-Currently, work on GoToSocial is funded through donations to our [OpenCollective](https://opencollective.com/) page.
+Currently, work on GoToSocial is funded through donations to our [OpenCollective](https://opencollective.com/gotosocial) page.
 
 If you would like to donate to GoToSocial to keep the lights on during development, [you can do so here](https://opencollective.com/gotosocial#support)! 💕 🦥 💕 Thank you!
 


### PR DESCRIPTION
I presumed that you want to link directly to your actual collective and not to the open collective homepage, hence this PR. Please disregard if I was mistaken.