### PR TITLE
Adjust the notifications endpoint slightly so the status object of a reblog notification is the original, reblogged post

### DIFF
--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -742,6 +742,11 @@ func (c *converter) NotificationToAPINotification(ctx context.Context, n *gtsmod
 		}
 	}
 
+	if apiStatus != nil && apiStatus.Reblog != nil {
+		// use the actual reblog status for the notifications endpoint
+		apiStatus = apiStatus.Reblog.Status
+	}
+
 	return &model.Notification{
 		ID:        n.ID,
 		Type:      string(n.NotificationType),


### PR DESCRIPTION
pretty minor change to bring the endpoint more in line with mastodon behaviour. the mastodon implementation of this endpoint puts the original, reblogged status in the "status" field of the "reblog" notification, instead of the reblogging user's status that includes the original status in the "reblog" field. to explain better, here's a "reblog" notification from a mastodon instance:

<details>
  <summary>long json snippet</summary>
<pre>
{
    &quot;id&quot;: &quot;8977162&quot;,
    &quot;type&quot;: &quot;reblog&quot;,
    &quot;created_at&quot;: &quot;2022-08-29T03:26:10.907Z&quot;,
    &quot;account&quot;: {
        &quot;id&quot;: &quot;263434&quot;,
        &quot;username&quot;: &quot;aphyr&quot;,
        &quot;acct&quot;: &quot;aphyr@woof.group&quot;,
        &quot;display_name&quot;: &quot;Bear Traffic Control&quot;,
        &quot;locked&quot;: false,
        &quot;bot&quot;: false,
        &quot;discoverable&quot;: true,
        &quot;group&quot;: false,
        &quot;created_at&quot;: &quot;2019-12-17T17:55:50.913Z&quot;,
        &quot;note&quot;: &quot;&lt;p&gt;Switchy leatherman into bad puns, thick boys, and distributed systems. &lt;span class=\&quot;h-card\&quot;&gt;&lt;a href=\&quot;https://woof.group/@Daddy\&quot; class=\&quot;u-url mention\&quot; rel=\&quot;nofollow noopener noreferrer\&quot; target=\&quot;_blank\&quot;&gt;@&lt;span&gt;Daddy&lt;/span&gt;&lt;/a&gt;&lt;/span&gt;'s boy. Purveyor of fine jockstrap selfies.&lt;/p&gt;&lt;p&gt;Jim Starkey: \&quot;Of interest only to third-rate academics a few papers short of a tenure package.\&quot;&lt;/p&gt;&lt;p&gt;Reddit: \&quot;would never ever ever hire this degenerate holy shit\&quot;&lt;/p&gt;&lt;p&gt;Peter Watts: \&quot;The most innovative fanfic I've ever read.\&quot;&lt;/p&gt;&quot;,
        &quot;url&quot;: &quot;https://woof.group/@aphyr&quot;,
        &quot;avatar&quot;: &quot;https://cybre.ams3.digitaloceanspaces.com/accounts/avatars/000/263/434/original/1c3368137fe4cd2e.jpeg&quot;,
        &quot;avatar_static&quot;: &quot;https://cybre.ams3.digitaloceanspaces.com/accounts/avatars/000/263/434/original/1c3368137fe4cd2e.jpeg&quot;,
        &quot;header&quot;: &quot;https://cybre.ams3.digitaloceanspaces.com/accounts/headers/000/263/434/original/42a2e82f8e6f89cd.jpeg&quot;,
        &quot;header_static&quot;: &quot;https://cybre.ams3.digitaloceanspaces.com/accounts/headers/000/263/434/original/42a2e82f8e6f89cd.jpeg&quot;,
        &quot;followers_count&quot;: 1466,
        &quot;following_count&quot;: 767,
        &quot;statuses_count&quot;: 8389,
        &quot;last_status_at&quot;: &quot;2022-08-29&quot;,
        &quot;emojis&quot;: [],
        &quot;fields&quot;: [
            {
                &quot;name&quot;: &quot;Blog&quot;,
                &quot;value&quot;: &quot;&lt;a href=\&quot;https://aphyr.com\&quot; rel=\&quot;nofollow noopener noreferrer\&quot; target=\&quot;_blank\&quot;&gt;&lt;span class=\&quot;invisible\&quot;&gt;https://&lt;/span&gt;&lt;span class=\&quot;\&quot;&gt;aphyr.com&lt;/span&gt;&lt;span class=\&quot;invisible\&quot;&gt;&lt;/span&gt;&lt;/a&gt;&quot;,
                &quot;verified_at&quot;: null
            },
            {
                &quot;name&quot;: &quot;Leather Blog&quot;,
                &quot;value&quot;: &quot;&lt;a href=\&quot;https://blog.woof.group/aphyr\&quot; rel=\&quot;nofollow noopener noreferrer\&quot; target=\&quot;_blank\&quot;&gt;&lt;span class=\&quot;invisible\&quot;&gt;https://&lt;/span&gt;&lt;span class=\&quot;\&quot;&gt;blog.woof.group/aphyr&lt;/span&gt;&lt;span class=\&quot;invisible\&quot;&gt;&lt;/span&gt;&lt;/a&gt;&quot;,
                &quot;verified_at&quot;: null
            },
            {
                &quot;name&quot;: &quot;Work&quot;,
                &quot;value&quot;: &quot;&lt;a href=\&quot;https://jepsen.io\&quot; rel=\&quot;nofollow noopener noreferrer\&quot; target=\&quot;_blank\&quot;&gt;&lt;span class=\&quot;invisible\&quot;&gt;https://&lt;/span&gt;&lt;span class=\&quot;\&quot;&gt;jepsen.io&lt;/span&gt;&lt;span class=\&quot;invisible\&quot;&gt;&lt;/span&gt;&lt;/a&gt;&quot;,
                &quot;verified_at&quot;: null
            },
            {
                &quot;name&quot;: &quot;Pronouns&quot;,
                &quot;value&quot;: &quot;He/Him&quot;,
                &quot;verified_at&quot;: null
            }
        ]
    },
    &quot;status&quot;: {
        &quot;id&quot;: &quot;108902977987723865&quot;,
        &quot;created_at&quot;: &quot;2022-08-28T22:59:29.525Z&quot;,
        &quot;in_reply_to_id&quot;: null,
        &quot;in_reply_to_account_id&quot;: null,
        &quot;sensitive&quot;: false,
        &quot;spoiler_text&quot;: &quot;&quot;,
        &quot;visibility&quot;: &quot;public&quot;,
        &quot;language&quot;: &quot;en&quot;,
        &quot;uri&quot;: &quot;https://cybre.space/users/SuricrasiaOnline/statuses/108902977987723865&quot;,
        &quot;url&quot;: &quot;https://cybre.space/@SuricrasiaOnline/108902977987723865&quot;,
        &quot;replies_count&quot;: 20,
        &quot;reblogs_count&quot;: 5,
        &quot;favourites_count&quot;: 5,
        &quot;favourited&quot;: false,
        &quot;reblogged&quot;: false,
        &quot;muted&quot;: false,
        &quot;bookmarked&quot;: false,
        &quot;pinned&quot;: false,
        &quot;content&quot;: &quot;&lt;p&gt;anyone know of any novel ways to produce a pseudo random sequence with nothing but your brain and a pen and paper? (potentially with other paper with a reusable cypher or something)&lt;/p&gt;&lt;p&gt;methods that avoid needing to do math in your head are a plus&lt;/p&gt;&quot;,
        &quot;reblog&quot;: null,
        &quot;application&quot;: {
            &quot;name&quot;: &quot;Pinafore&quot;,
            &quot;website&quot;: &quot;https://pinafore.social&quot;
        },
        &quot;account&quot;: {
            &quot;id&quot;: &quot;125507&quot;,
            &quot;username&quot;: &quot;SuricrasiaOnline&quot;,
            &quot;acct&quot;: &quot;SuricrasiaOnline&quot;,
            &quot;display_name&quot;: &quot;Shark Blackle&quot;,
            &quot;locked&quot;: false,
            &quot;bot&quot;: false,
            &quot;discoverable&quot;: true,
            &quot;group&quot;: false,
            &quot;created_at&quot;: &quot;2018-08-19T06:42:08.033Z&quot;,
            &quot;note&quot;: &quot;&lt;p&gt;I do lots of random stuff because my brain has too many chemicals inside of it. 1994 ⚧&lt;/p&gt;&quot;,
            &quot;url&quot;: &quot;https://cybre.space/@SuricrasiaOnline&quot;,
            &quot;avatar&quot;: &quot;https://cybre.ams3.digitaloceanspaces.com/accounts/avatars/000/125/507/original/75a79b617c9c564a.jpg&quot;,
            &quot;avatar_static&quot;: &quot;https://cybre.ams3.digitaloceanspaces.com/accounts/avatars/000/125/507/original/75a79b617c9c564a.jpg&quot;,
            &quot;header&quot;: &quot;https://cybre.ams3.digitaloceanspaces.com/accounts/headers/000/125/507/original/180716f637e7e459.png&quot;,
            &quot;header_static&quot;: &quot;https://cybre.ams3.digitaloceanspaces.com/accounts/headers/000/125/507/original/180716f637e7e459.png&quot;,
            &quot;followers_count&quot;: 2425,
            &quot;following_count&quot;: 2188,
            &quot;statuses_count&quot;: 18189,
            &quot;last_status_at&quot;: &quot;2022-08-29&quot;,
            &quot;emojis&quot;: [],
            &quot;fields&quot;: [
                {
                    &quot;name&quot;: &quot;website&quot;,
                    &quot;value&quot;: &quot;&lt;a href=\&quot;https://suricrasia.online/\&quot; rel=\&quot;me nofollow noopener noreferrer\&quot; target=\&quot;_blank\&quot;&gt;&lt;span class=\&quot;invisible\&quot;&gt;https://&lt;/span&gt;&lt;span class=\&quot;\&quot;&gt;suricrasia.online/&lt;/span&gt;&lt;span class=\&quot;invisible\&quot;&gt;&lt;/span&gt;&lt;/a&gt;&quot;,
                    &quot;verified_at&quot;: &quot;2018-12-06T20:00:13.225+00:00&quot;
                },
                {
                    &quot;name&quot;: &quot;location&quot;,
                    &quot;value&quot;: &quot;toronto&quot;,
                    &quot;verified_at&quot;: null
                },
                {
                    &quot;name&quot;: &quot;pronunciation&quot;,
                    &quot;value&quot;: &quot;&lt;a href=\&quot;https://www.youtube.com/watch?v=wWubxZ-fSxU\&quot; rel=\&quot;me nofollow noopener noreferrer\&quot; target=\&quot;_blank\&quot;&gt;&lt;span class=\&quot;invisible\&quot;&gt;https://www.&lt;/span&gt;&lt;span class=\&quot;ellipsis\&quot;&gt;youtube.com/watch?v=wWubxZ-fSx&lt;/span&gt;&lt;span class=\&quot;invisible\&quot;&gt;U&lt;/span&gt;&lt;/a&gt;&quot;,
                    &quot;verified_at&quot;: null
                },
                {
                    &quot;name&quot;: &quot;pronouns&quot;,
                    &quot;value&quot;: &quot;it/its&quot;,
                    &quot;verified_at&quot;: null
                }
            ]
        },
        &quot;media_attachments&quot;: [],
        &quot;mentions&quot;: [],
        &quot;tags&quot;: [],
        &quot;emojis&quot;: [],
        &quot;card&quot;: null,
        &quot;poll&quot;: null
    }
}
<pre>
</details>

note that status.reblog == null.

the only real effect of this api difference was pinafore would show reblogs with the same font colour as replies, instead of being greyed out. this PR fixes that