### PR TITLE
Fix issue where the 'favourited' field of a notification's status is always false

### DIFF
--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -736,7 +736,7 @@ func (c *converter) NotificationToAPINotification(ctx context.Context, n *gtsmod
 		}
 
 		var err error
-		apiStatus, err = c.StatusToAPIStatus(ctx, n.Status, nil)
+		apiStatus, err = c.StatusToAPIStatus(ctx, n.Status, n.TargetAccount)
 		if err != nil {
 			return nil, fmt.Errorf("NotificationToapi: error converting status to api: %s", err)
 		}


### PR DESCRIPTION
since the requesting account was nil in the call to StatusToAPIStatus, it couldn't set the favourited flag correctly. so if you favourite a post from a notification then reload notifications, the favourite disappears (even though the favourite was successful)