### PR TITLE
Fix subway tooter problems

### DIFF
--- a/internal/api/client/auth/token.go
+++ b/internal/api/client/auth/token.go
@@ -76,10 +76,9 @@ func (m *Module) TokenPOSTHandler(c *gin.Context) {
 		help = append(help, "client_secret was not set in the token request form")
 	}
 
+	// redirect_uri is optional
 	if form.RedirectURI != nil {
 		c.Request.Form.Set("redirect_uri", *form.RedirectURI)
-	} else {
-		help = append(help, "redirect_uri was not set in the token request form")
 	}
 
 	var code string

--- a/vendor/github.com/superseriousbusiness/oauth2/v4/manage/manager.go
+++ b/vendor/github.com/superseriousbusiness/oauth2/v4/manage/manager.go
@@ -294,6 +294,8 @@ func (m *Manager) GenerateAccessToken(ctx context.Context, gt oauth2.GrantType, 
 		if err := m.validateURI(cli.GetDomain(), tgr.RedirectURI); err != nil {
 			return nil, err
 		}
+	} else {
+		tgr.RedirectURI = cli.GetDomain()
 	}
 
 	if gt == oauth2.AuthorizationCode {


### PR DESCRIPTION
fixes #304, but in a bad way so draft PR

it seems that subway tooter doesn't send along the redirect_uri in the token request. [the RFC for oauth says this is required](https://www.rfc-editor.org/rfc/rfc6749.html#section-3.1.2:~:text=redirect_uri%0A%20%20%20%20%20%20%20%20%20REQUIRED%2C%20if%20the%20%22redirect_uri%22%20parameter%20was%20included%20in%20the%0A%20%20%20%20%20%20%20%20%20authorization%20request%20as%20described%20in%20Section%204.1.1%2C%20and%20their%0A%20%20%20%20%20%20%20%20%20values%20MUST%20be%20identical.) (optional for the /authorize request). I guess mastodon uses the redirect_uri that the application originally registered with if it's absent. this change adopts that behaviour and allows me to login to subway tooter.

kinda a bad fix because we're going against the oauth spec, but if this is what mastodon also does maybe it's necessary. the alternative is to make a PR to subway tooter