### PR TITLE
Emojify spoiler and content in web templates

### DIFF
--- a/web/source/css/base.css
+++ b/web/source/css/base.css
@@ -323,3 +323,11 @@ footer {
 		grid-template-columns: 1fr;
 	}
 }
+
+.emoji {
+	width: 2.5ex;
+	height: 2.5ex;
+	margin: -0.5ex 0 0;
+	object-fit: contain;
+	vertical-align: middle;
+}

--- a/web/template/status.tmpl
+++ b/web/template/status.tmpl
@@ -6,12 +6,12 @@
 		{{if .SpoilerText}}
 		<input class="spoiler" id="hideSpoiler-{{.ID}}" type="checkbox" style="display: none" aria-hidden="true" checked="true" />
 		<div class="spoiler">
-			<span class="spoiler-text">{{.SpoilerText}}</span>
+			<span class="spoiler-text">{{emojify .Emojis (escape .SpoilerText)}}</span>
 			<label class="button spoiler-label" for="hideSpoiler-{{.ID}}" tabindex="0">Toggle visibility</label>
 		</div>
 		{{end}}
 		<div class="content">
-			{{.Content |noescape}}
+			{{emojify .Emojis (noescape .Content)}}
 		</div>
 	</div>
 	{{with .MediaAttachments}}


### PR DESCRIPTION
fixes #648

funny enough, emojification bugs were one of the first things I worked on for mastodon 5 years ago

probably my most complicated commit so far, the creation of the regex and template can maybe be optimized?

emojify takes a template.HTML parameter for the text because it assumes that everything is already escaped, and its output can't be escaped again or it will destroy the img tags. I noticed that .Content gets sent through noescape, but not .SpoilerText. Should SpoilerText be html escaped?

the "emoji" css class still needs to be made, not sure where to put it