### PR TITLE
Fix tusky search issue by returning empty if offset is greater than zero

### DIFF
--- a/internal/processing/search.go
+++ b/internal/processing/search.go
@@ -54,6 +54,13 @@ func (p *processor) SearchGet(ctx context.Context, authed *oauth.Auth, search *a
 		Statuses: []apimodel.Status{},
 		Hashtags: []apimodel.Tag{},
 	}
+
+	// currently the search will only ever return one result,
+	// so return nothing if the offset is greater than 0
+	if search.Offset > 0 {
+		return searchResult, nil
+	}
+
 	foundAccounts := []*gtsmodel.Account{}
 	foundStatuses := []*gtsmodel.Status{}
 


### PR DESCRIPTION
fixes #68

basically the issue is not using limit/offset, but because the code only ever returns one item, we can underhandedly-implement offset to fix this bug