### PR TITLE
[performance] use cache for local account lookups

### DIFF
--- a/cmd/gotosocial/action/admin/account/account.go
+++ b/cmd/gotosocial/action/admin/account/account.go
@@ -87,7 +87,7 @@ var Confirm action.GTSAction = func(ctx context.Context) error {
 		return err
 	}
 
-	a, err := dbConn.GetLocalAccountByUsername(ctx, username)
+	a, err := dbConn.GetAccountByUsernameDomain(ctx, username, "")
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ var Promote action.GTSAction = func(ctx context.Context) error {
 		return err
 	}
 
-	a, err := dbConn.GetLocalAccountByUsername(ctx, username)
+	a, err := dbConn.GetAccountByUsernameDomain(ctx, username, "")
 	if err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ var Demote action.GTSAction = func(ctx context.Context) error {
 		return err
 	}
 
-	a, err := dbConn.GetLocalAccountByUsername(ctx, username)
+	a, err := dbConn.GetAccountByUsernameDomain(ctx, username, "")
 	if err != nil {
 		return err
 	}
@@ -197,7 +197,7 @@ var Disable action.GTSAction = func(ctx context.Context) error {
 		return err
 	}
 
-	a, err := dbConn.GetLocalAccountByUsername(ctx, username)
+	a, err := dbConn.GetAccountByUsernameDomain(ctx, username, "")
 	if err != nil {
 		return err
 	}
@@ -247,7 +247,7 @@ var Password action.GTSAction = func(ctx context.Context) error {
 		return err
 	}
 
-	a, err := dbConn.GetLocalAccountByUsername(ctx, username)
+	a, err := dbConn.GetAccountByUsernameDomain(ctx, username, "")
 	if err != nil {
 		return err
 	}

--- a/internal/db/account.go
+++ b/internal/db/account.go
@@ -42,9 +42,6 @@ type Account interface {
 	// UpdateAccount updates one account by ID.
 	UpdateAccount(ctx context.Context, account *gtsmodel.Account) (*gtsmodel.Account, Error)
 
-	// GetLocalAccountByUsername returns an account on this instance by its username.
-	GetLocalAccountByUsername(ctx context.Context, username string) (*gtsmodel.Account, Error)
-
 	// GetAccountFaves fetches faves/likes created by the target accountID.
 	GetAccountFaves(ctx context.Context, accountID string) ([]*gtsmodel.StatusFave, Error)
 

--- a/internal/federation/dereferencing/account.go
+++ b/internal/federation/dereferencing/account.go
@@ -127,7 +127,7 @@ func (d *deref) GetRemoteAccount(ctx context.Context, params GetRemoteAccountPar
 		// to be a local account, so don't resolve
 		skipResolve = true
 
-		if a, dbErr := d.db.GetLocalAccountByUsername(ctx, params.RemoteAccountUsername); dbErr == nil {
+		if a, dbErr := d.db.GetAccountByUsernameDomain(ctx, params.RemoteAccountUsername, ""); dbErr == nil {
 			foundAccount = a
 		} else if dbErr != db.ErrNoEntries {
 			err = fmt.Errorf("GetRemoteAccount: database error looking for local account with username %s: %s", params.RemoteAccountUsername, err)

--- a/internal/federation/federatingdb/inbox.go
+++ b/internal/federation/federatingdb/inbox.go
@@ -85,7 +85,7 @@ func (f *federatingDB) InboxesForIRI(c context.Context, iri *url.URL) (inboxIRIs
 			return nil, fmt.Errorf("couldn't extract local account username from uri %s: %s", iri, err)
 		}
 
-		account, err := f.db.GetLocalAccountByUsername(c, localAccountUsername)
+		account, err := f.db.GetAccountByUsernameDomain(c, localAccountUsername, "")
 		if err != nil {
 			return nil, fmt.Errorf("couldn't find local account with username %s: %s", localAccountUsername, err)
 		}

--- a/internal/federation/federatingdb/owns.go
+++ b/internal/federation/federatingdb/owns.go
@@ -70,7 +70,7 @@ func (f *federatingDB) Owns(ctx context.Context, id *url.URL) (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("error parsing statuses path for url %s: %s", id.String(), err)
 		}
-		if _, err := f.db.GetLocalAccountByUsername(ctx, username); err != nil {
+		if _, err := f.db.GetAccountByUsernameDomain(ctx, username, ""); err != nil {
 			if err == db.ErrNoEntries {
 				// there are no entries for this username
 				return false, nil
@@ -87,7 +87,7 @@ func (f *federatingDB) Owns(ctx context.Context, id *url.URL) (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("error parsing statuses path for url %s: %s", id.String(), err)
 		}
-		if _, err := f.db.GetLocalAccountByUsername(ctx, username); err != nil {
+		if _, err := f.db.GetAccountByUsernameDomain(ctx, username, ""); err != nil {
 			if err == db.ErrNoEntries {
 				// there are no entries for this username
 				return false, nil
@@ -104,7 +104,7 @@ func (f *federatingDB) Owns(ctx context.Context, id *url.URL) (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("error parsing statuses path for url %s: %s", id.String(), err)
 		}
-		if _, err := f.db.GetLocalAccountByUsername(ctx, username); err != nil {
+		if _, err := f.db.GetAccountByUsernameDomain(ctx, username, ""); err != nil {
 			if err == db.ErrNoEntries {
 				// there are no entries for this username
 				return false, nil
@@ -121,7 +121,7 @@ func (f *federatingDB) Owns(ctx context.Context, id *url.URL) (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("error parsing like path for url %s: %s", id.String(), err)
 		}
-		if _, err := f.db.GetLocalAccountByUsername(ctx, username); err != nil {
+		if _, err := f.db.GetAccountByUsernameDomain(ctx, username, ""); err != nil {
 			if err == db.ErrNoEntries {
 				// there are no entries for this username
 				return false, nil
@@ -146,7 +146,7 @@ func (f *federatingDB) Owns(ctx context.Context, id *url.URL) (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("error parsing block path for url %s: %s", id.String(), err)
 		}
-		if _, err := f.db.GetLocalAccountByUsername(ctx, username); err != nil {
+		if _, err := f.db.GetAccountByUsernameDomain(ctx, username, ""); err != nil {
 			if err == db.ErrNoEntries {
 				// there are no entries for this username
 				return false, nil

--- a/internal/federation/federatingprotocol.go
+++ b/internal/federation/federatingprotocol.go
@@ -157,7 +157,7 @@ func (f *federator) AuthenticatePostInbox(ctx context.Context, w http.ResponseWr
 		return nil, false, errors.New("username was empty")
 	}
 
-	receivingAccount, err := f.db.GetLocalAccountByUsername(ctx, username)
+	receivingAccount, err := f.db.GetAccountByUsernameDomain(ctx, username, "")
 	if err != nil {
 		return nil, false, fmt.Errorf("could not fetch receiving account with username %s: %s", username, err)
 	}

--- a/internal/processing/account/get.go
+++ b/internal/processing/account/get.go
@@ -44,7 +44,7 @@ func (p *processor) Get(ctx context.Context, requestingAccount *gtsmodel.Account
 }
 
 func (p *processor) GetLocalByUsername(ctx context.Context, requestingAccount *gtsmodel.Account, username string) (*apimodel.Account, gtserror.WithCode) {
-	targetAccount, err := p.db.GetLocalAccountByUsername(ctx, username)
+	targetAccount, err := p.db.GetAccountByUsernameDomain(ctx, username, "")
 	if err != nil {
 		if err == db.ErrNoEntries {
 			return nil, gtserror.NewErrorNotFound(errors.New("account not found"))

--- a/internal/processing/federation/getfollowers.go
+++ b/internal/processing/federation/getfollowers.go
@@ -30,7 +30,7 @@ import (
 
 func (p *processor) GetFollowers(ctx context.Context, requestedUsername string, requestURL *url.URL) (interface{}, gtserror.WithCode) {
 	// get the account the request is referring to
-	requestedAccount, err := p.db.GetLocalAccountByUsername(ctx, requestedUsername)
+	requestedAccount, err := p.db.GetAccountByUsernameDomain(ctx, requestedUsername, "")
 	if err != nil {
 		return nil, gtserror.NewErrorNotFound(fmt.Errorf("database error getting account with username %s: %s", requestedUsername, err))
 	}

--- a/internal/processing/federation/getfollowing.go
+++ b/internal/processing/federation/getfollowing.go
@@ -30,7 +30,7 @@ import (
 
 func (p *processor) GetFollowing(ctx context.Context, requestedUsername string, requestURL *url.URL) (interface{}, gtserror.WithCode) {
 	// get the account the request is referring to
-	requestedAccount, err := p.db.GetLocalAccountByUsername(ctx, requestedUsername)
+	requestedAccount, err := p.db.GetAccountByUsernameDomain(ctx, requestedUsername, "")
 	if err != nil {
 		return nil, gtserror.NewErrorNotFound(fmt.Errorf("database error getting account with username %s: %s", requestedUsername, err))
 	}

--- a/internal/processing/federation/getoutbox.go
+++ b/internal/processing/federation/getoutbox.go
@@ -31,7 +31,7 @@ import (
 
 func (p *processor) GetOutbox(ctx context.Context, requestedUsername string, page bool, maxID string, minID string, requestURL *url.URL) (interface{}, gtserror.WithCode) {
 	// get the account the request is referring to
-	requestedAccount, err := p.db.GetLocalAccountByUsername(ctx, requestedUsername)
+	requestedAccount, err := p.db.GetAccountByUsernameDomain(ctx, requestedUsername, "")
 	if err != nil {
 		return nil, gtserror.NewErrorNotFound(fmt.Errorf("database error getting account with username %s: %s", requestedUsername, err))
 	}

--- a/internal/processing/federation/getstatus.go
+++ b/internal/processing/federation/getstatus.go
@@ -30,7 +30,7 @@ import (
 
 func (p *processor) GetStatus(ctx context.Context, requestedUsername string, requestedStatusID string, requestURL *url.URL) (interface{}, gtserror.WithCode) {
 	// get the account the request is referring to
-	requestedAccount, err := p.db.GetLocalAccountByUsername(ctx, requestedUsername)
+	requestedAccount, err := p.db.GetAccountByUsernameDomain(ctx, requestedUsername, "")
 	if err != nil {
 		return nil, gtserror.NewErrorNotFound(fmt.Errorf("database error getting account with username %s: %s", requestedUsername, err))
 	}

--- a/internal/processing/federation/getstatusreplies.go
+++ b/internal/processing/federation/getstatusreplies.go
@@ -32,7 +32,7 @@ import (
 
 func (p *processor) GetStatusReplies(ctx context.Context, requestedUsername string, requestedStatusID string, page bool, onlyOtherAccounts bool, minID string, requestURL *url.URL) (interface{}, gtserror.WithCode) {
 	// get the account the request is referring to
-	requestedAccount, err := p.db.GetLocalAccountByUsername(ctx, requestedUsername)
+	requestedAccount, err := p.db.GetAccountByUsernameDomain(ctx, requestedUsername, "")
 	if err != nil {
 		return nil, gtserror.NewErrorNotFound(fmt.Errorf("database error getting account with username %s: %s", requestedUsername, err))
 	}

--- a/internal/processing/federation/getuser.go
+++ b/internal/processing/federation/getuser.go
@@ -32,7 +32,7 @@ import (
 
 func (p *processor) GetUser(ctx context.Context, requestedUsername string, requestURL *url.URL) (interface{}, gtserror.WithCode) {
 	// get the account the request is referring to
-	requestedAccount, err := p.db.GetLocalAccountByUsername(ctx, requestedUsername)
+	requestedAccount, err := p.db.GetAccountByUsernameDomain(ctx, requestedUsername, "")
 	if err != nil {
 		return nil, gtserror.NewErrorNotFound(fmt.Errorf("database error getting account with username %s: %s", requestedUsername, err))
 	}

--- a/internal/processing/federation/getwebfinger.go
+++ b/internal/processing/federation/getwebfinger.go
@@ -37,7 +37,7 @@ const (
 
 func (p *processor) GetWebfingerAccount(ctx context.Context, requestedUsername string) (*apimodel.WellKnownResponse, gtserror.WithCode) {
 	// get the account the request is referring to
-	requestedAccount, err := p.db.GetLocalAccountByUsername(ctx, requestedUsername)
+	requestedAccount, err := p.db.GetAccountByUsernameDomain(ctx, requestedUsername, "")
 	if err != nil {
 		return nil, gtserror.NewErrorNotFound(fmt.Errorf("database error getting account with username %s: %s", requestedUsername, err))
 	}

--- a/internal/processing/instance.go
+++ b/internal/processing/instance.go
@@ -137,7 +137,7 @@ func (p *processor) InstancePatch(ctx context.Context, form *apimodel.InstanceSe
 	// validate & update site contact account if it's set on the form
 	if form.ContactUsername != nil {
 		// make sure the account with the given username exists in the db
-		contactAccount, err := p.db.GetLocalAccountByUsername(ctx, *form.ContactUsername)
+		contactAccount, err := p.db.GetAccountByUsernameDomain(ctx, *form.ContactUsername, "")
 		if err != nil {
 			return nil, gtserror.NewErrorBadRequest(err, fmt.Sprintf("account with username %s not retrievable", *form.ContactUsername))
 		}

--- a/internal/processing/search.go
+++ b/internal/processing/search.go
@@ -193,7 +193,7 @@ func (p *processor) searchAccountByURI(ctx context.Context, authed *oauth.Auth, 
 func (p *processor) searchAccountByMention(ctx context.Context, authed *oauth.Auth, username string, domain string, resolve bool) (*gtsmodel.Account, error) {
 	// if it's a local account we can skip a whole bunch of stuff
 	if domain == config.GetHost() || domain == config.GetAccountDomain() || domain == "" {
-		maybeAcct, err := p.db.GetLocalAccountByUsername(ctx, username)
+		maybeAcct, err := p.db.GetAccountByUsernameDomain(ctx, username, "")
 		if err == nil || err == db.ErrNoEntries {
 			return maybeAcct, nil
 		}

--- a/internal/processing/util.go
+++ b/internal/processing/util.go
@@ -46,7 +46,7 @@ func GetParseMentionFunc(dbConn db.DB, federator federation.Federator) gtsmodel.
 
 		var mentionedAccount *gtsmodel.Account
 		if domain == "" || domain == config.GetHost() || domain == config.GetAccountDomain() {
-			localAccount, err := dbConn.GetLocalAccountByUsername(ctx, username)
+			localAccount, err := dbConn.GetAccountByUsernameDomain(ctx, username, "")
 			if err != nil {
 				return nil, err
 			}

--- a/internal/transport/controller.go
+++ b/internal/transport/controller.go
@@ -129,7 +129,7 @@ func (c *controller) NewTransportForUsername(ctx context.Context, username strin
 		u = username
 	}
 
-	ourAccount, err := c.db.GetLocalAccountByUsername(ctx, u)
+	ourAccount, err := c.db.GetAccountByUsernameDomain(ctx, u, "")
 	if err != nil {
 		return nil, fmt.Errorf("error getting account %s from db: %s", username, err)
 	}
@@ -138,6 +138,7 @@ func (c *controller) NewTransportForUsername(ctx context.Context, username strin
 	if err != nil {
 		return nil, fmt.Errorf("error creating transport for user %s: %s", username, err)
 	}
+
 	return transport, nil
 }
 


### PR DESCRIPTION
Removes GetLocalAccountByUsername() to instead rely on GetAccountByUsernameDomain()