### PR TITLE
[bugfix] Use 'Image' instead of unrecognized 'Gif' type for media attachments

### DIFF
--- a/internal/api/client/media/mediaupdate_test.go
+++ b/internal/api/client/media/mediaupdate_test.go
@@ -173,7 +173,7 @@ func (suite *MediaUpdateTestSuite) TestUpdateImage() {
 
 	// the reply should contain the updated fields
 	suite.Equal("new description!", *attachmentReply.Description)
-	suite.EqualValues("gif", attachmentReply.Type)
+	suite.EqualValues("image", attachmentReply.Type)
 	suite.EqualValues(model.MediaMeta{
 		Original: model.MediaDimensions{Width: 800, Height: 450, FrameRate: "", Duration: 0, Bitrate: 0, Size: "800x450", Aspect: 1.7777778},
 		Small:    model.MediaDimensions{Width: 256, Height: 144, FrameRate: "", Duration: 0, Bitrate: 0, Size: "256x144", Aspect: 1.7777778},

--- a/internal/db/bundb/migrations/20220903141016_store_gifs_as_image.go
+++ b/internal/db/bundb/migrations/20220903141016_store_gifs_as_image.go
@@ -1,0 +1,51 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			// set the Type of all gifs to Image instead of Gif
+			if _, err := tx.NewUpdate().
+				Table("media_attachments").
+				Set("type = 'Image'").
+				Where("media_attachments.type = 'Gif'").
+				Exec(ctx); err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}

--- a/internal/gtsmodel/mediaattachment.go
+++ b/internal/gtsmodel/mediaattachment.go
@@ -31,7 +31,7 @@ type MediaAttachment struct {
 	StatusID          string           `validate:"omitempty,ulid" bun:"type:CHAR(26),nullzero"`                                        // ID of the status to which this is attached
 	URL               string           `validate:"required_without=RemoteURL,omitempty,url" bun:",nullzero"`                           // Where can the attachment be retrieved on *this* server
 	RemoteURL         string           `validate:"required_without=URL,omitempty,url" bun:",nullzero"`                                 // Where can the attachment be retrieved on a remote server (empty for local media)
-	Type              FileType         `validate:"oneof=Image Gif Audio Video Unknown" bun:",nullzero,notnull"`                        // Type of file (image/gif/audio/video)
+	Type              FileType         `validate:"oneof=Image Gifv Audio Video Unknown" bun:",nullzero,notnull"`                       // Type of file (image/gifv/audio/video)
 	FileMeta          FileMeta         `validate:"required" bun:",embed:filemeta_,nullzero,notnull"`                                   // Metadata about the file
 	AccountID         string           `validate:"required,ulid" bun:"type:CHAR(26),nullzero,notnull"`                                 // To which account does this attachment belong
 	Account           *Account         `validate:"-" bun:"rel:belongs-to,join:account_id=id"`                                          // Account corresponding to accountID
@@ -80,8 +80,8 @@ type FileType string
 
 // MediaAttachment file types.
 const (
-	FileTypeImage   FileType = "Image"   // FileTypeImage is for jpegs and pngs
-	FileTypeGif     FileType = "Gif"     // FileTypeGif is for native gifs and soundless videos that have been converted to gifs
+	FileTypeImage   FileType = "Image"   // FileTypeImage is for jpegs, pngs, and standard gifs
+	FileTypeGifv    FileType = "Gifv"    // FileTypeGif is for soundless looping videos that behave like gifs
 	FileTypeAudio   FileType = "Audio"   // FileTypeAudio is for audio-only files (no video)
 	FileTypeVideo   FileType = "Video"   // FileTypeVideo is for files with audio + visual
 	FileTypeUnknown FileType = "Unknown" // FileTypeUnknown is for unknown file types (surprise surprise!)

--- a/internal/media/processingmedia.go
+++ b/internal/media/processingmedia.go
@@ -313,7 +313,7 @@ func (p *ProcessingMedia) store(ctx context.Context) error {
 	var clean io.Reader
 	switch extension {
 	case mimeGif:
-		p.attachment.Type = gtsmodel.FileTypeGif
+		p.attachment.Type = gtsmodel.FileTypeImage
 		clean = multiReader // nothing to clean from a gif
 	case mimeJpeg, mimePng:
 		p.attachment.Type = gtsmodel.FileTypeImage

--- a/testrig/testmodels.go
+++ b/testrig/testmodels.go
@@ -630,7 +630,7 @@ func NewTestAttachments() map[string]*gtsmodel.MediaAttachment {
 			RemoteURL: "",
 			CreatedAt: TimeMustParse("2022-06-09T13:12:00Z"),
 			UpdatedAt: TimeMustParse("2022-06-09T13:12:00Z"),
-			Type:      gtsmodel.FileTypeGif,
+			Type:      gtsmodel.FileTypeImage,
 			FileMeta: gtsmodel.FileMeta{
 				Original: gtsmodel.Original{
 					Width:  400,
@@ -679,7 +679,7 @@ func NewTestAttachments() map[string]*gtsmodel.MediaAttachment {
 			RemoteURL: "",
 			CreatedAt: TimeMustParse("2022-06-09T13:12:00Z"),
 			UpdatedAt: TimeMustParse("2022-06-09T13:12:00Z"),
-			Type:      gtsmodel.FileTypeGif,
+			Type:      gtsmodel.FileTypeImage,
 			FileMeta: gtsmodel.FileMeta{
 				Original: gtsmodel.Original{
 					Width:  800,


### PR DESCRIPTION
We made a mistake earlier with our implementation of the media attachment api: instead of storing gifs with type `Image` we stored them with type `Gif`, which isn't part of the Mastodon API (`Gifv` is but that's for short looping soundless video files, not gifs). This meant that frontends like Tusky always showed gifs as unrecognized file types.

This PR corrects this behavior by:

1. Storing and presenting new gifs as type Image
2. Migrating already-stored Gif types to Image.