### PR TITLE
[bugfix] Catch json syntax errors in the frontend + display a more helpful message

### DIFF
--- a/web/source/panels/lib/oauth.js
+++ b/web/source/panels/lib/oauth.js
@@ -184,6 +184,12 @@ module.exports = function oauthClient(config, initState) {
 			} else {
 				return json;
 			}
+		}).catch(e => {
+			if (e instanceof SyntaxError) {
+				throw new Error("Error: The GtS API returned a non-json error. This usually means an issue with your instance's reverse proxy.");
+			} else {
+				throw e;
+			}
 		});
 	}
 

--- a/web/source/panels/lib/oauth.js
+++ b/web/source/panels/lib/oauth.js
@@ -186,7 +186,7 @@ module.exports = function oauthClient(config, initState) {
 			}
 		}).catch(e => {
 			if (e instanceof SyntaxError) {
-				throw new Error("Error: The GtS API returned a non-json error. This usually means an issue with your instance's reverse proxy.");
+				throw new Error("Error: The GtS API returned a non-json error. This usually means a network problem, or an issue with your instance's reverse proxy configuration.");
 			} else {
 				throw e;
 			}

--- a/web/source/panels/lib/oauth.js
+++ b/web/source/panels/lib/oauth.js
@@ -186,7 +186,7 @@ module.exports = function oauthClient(config, initState) {
 			}
 		}).catch(e => {
 			if (e instanceof SyntaxError) {
-				throw new Error("Error: The GtS API returned a non-json error. This usually means a network problem, or an issue with your instance's reverse proxy configuration.");
+				throw new Error("Error: The GtS API returned a non-json error. This usually means a network problem, or an issue with your instance's reverse proxy configuration.", {cause: e});
 			} else {
 				throw e;
 			}


### PR DESCRIPTION
This PR just adds a bit of error checking in the panel oauth functionality to check for JSON parsing errors. Now, a human-readable error message will be displayed, which hints at possible issues, instead of a JSON parsing error.

fixes #771 