### PR TITLE
[bugfix] Fix emojis, attachments, and mentions not being serialized correctly sometimes via AP

### DIFF
--- a/internal/typeutils/internaltoas.go
+++ b/internal/typeutils/internaltoas.go
@@ -430,7 +430,18 @@ func (c *converter) StatusToAS(ctx context.Context, s *gtsmodel.Status) (vocab.A
 	tagProp := streams.NewActivityStreamsTagProperty()
 
 	// tag -- mentions
-	for _, m := range s.Mentions {
+	mentions := s.Mentions
+	if len(s.MentionIDs) > len(mentions) {
+		mentions = []*gtsmodel.Mention{}
+		for _, mentionID := range s.MentionIDs {
+			mention, err := c.db.GetMention(ctx, mentionID)
+			if err != nil {
+				return nil, fmt.Errorf("StatusToAS: error getting mention %s from database: %s", mentionID, err)
+			}
+			mentions = append(mentions, mention)
+		}
+	}
+	for _, m := range mentions {
 		asMention, err := c.MentionToAS(ctx, m)
 		if err != nil {
 			return nil, fmt.Errorf("StatusToAS: error converting mention to AS mention: %s", err)
@@ -439,7 +450,18 @@ func (c *converter) StatusToAS(ctx context.Context, s *gtsmodel.Status) (vocab.A
 	}
 
 	// tag -- emojis
-	for _, emoji := range s.Emojis {
+	emojis := s.Emojis
+	if len(s.EmojiIDs) > len(emojis) {
+		emojis = []*gtsmodel.Emoji{}
+		for _, emojiID := range s.EmojiIDs {
+			emoji, err := c.db.GetEmojiByID(ctx, emojiID)
+			if err != nil {
+				return nil, fmt.Errorf("StatusToAS: error getting emoji %s from database: %s", emojiID, err)
+			}
+			emojis = append(emojis, emoji)
+		}
+	}
+	for _, emoji := range emojis {
 		asMention, err := c.EmojiToAS(ctx, emoji)
 		if err != nil {
 			return nil, fmt.Errorf("StatusToAS: error converting emoji to AS emoji: %s", err)
@@ -522,9 +544,20 @@ func (c *converter) StatusToAS(ctx context.Context, s *gtsmodel.Status) (vocab.A
 	contentProp.AppendXMLSchemaString(s.Content)
 	status.SetActivityStreamsContent(contentProp)
 
-	// attachment
+	// attachments
 	attachmentProp := streams.NewActivityStreamsAttachmentProperty()
-	for _, a := range s.Attachments {
+	attachments := s.Attachments
+	if len(s.AttachmentIDs) > len(attachments) {
+		attachments = []*gtsmodel.MediaAttachment{}
+		for _, attachmentID := range s.AttachmentIDs {
+			attachment, err := c.db.GetAttachmentByID(ctx, attachmentID)
+			if err != nil {
+				return nil, fmt.Errorf("StatusToAS: error getting attachment %s from database: %s", attachmentID, err)
+			}
+			attachments = append(attachments, attachment)
+		}
+	}
+	for _, a := range attachments {
 		doc, err := c.AttachmentToAS(ctx, a)
 		if err != nil {
 			return nil, fmt.Errorf("StatusToAS: error converting attachment: %s", err)

--- a/internal/typeutils/internaltoas_test.go
+++ b/internal/typeutils/internaltoas_test.go
@@ -94,9 +94,30 @@ func (suite *InternalToASTestSuite) TestStatusToAS() {
 	suite.Equal(`{"@context":"https://www.w3.org/ns/activitystreams","attachment":[],"attributedTo":"http://localhost:8080/users/the_mighty_zork","cc":"http://localhost:8080/users/the_mighty_zork/followers","content":"hello everyone!","id":"http://localhost:8080/users/the_mighty_zork/statuses/01F8MHAMCHF6Y650WCRSCP4WMY","published":"2021-10-20T12:40:37+02:00","replies":{"first":{"id":"http://localhost:8080/users/the_mighty_zork/statuses/01F8MHAMCHF6Y650WCRSCP4WMY/replies?page=true","next":"http://localhost:8080/users/the_mighty_zork/statuses/01F8MHAMCHF6Y650WCRSCP4WMY/replies?only_other_accounts=false\u0026page=true","partOf":"http://localhost:8080/users/the_mighty_zork/statuses/01F8MHAMCHF6Y650WCRSCP4WMY/replies","type":"CollectionPage"},"id":"http://localhost:8080/users/the_mighty_zork/statuses/01F8MHAMCHF6Y650WCRSCP4WMY/replies","type":"Collection"},"sensitive":true,"summary":"introduction post","tag":[],"to":"https://www.w3.org/ns/activitystreams#Public","type":"Note","url":"http://localhost:8080/@the_mighty_zork/statuses/01F8MHAMCHF6Y650WCRSCP4WMY"}`, string(bytes))
 }
 
-func (suite *InternalToASTestSuite) TestStatusWithTagsToAS() {
+func (suite *InternalToASTestSuite) TestStatusWithTagsToASWithIDs() {
+	// use the status with just IDs of attachments and emojis pinned on it
+	testStatus := suite.testStatuses["admin_account_status_1"]
 	ctx := context.Background()
-	//get the entire status with all tags
+
+	asStatus, err := suite.typeconverter.StatusToAS(ctx, testStatus)
+	suite.NoError(err)
+
+	ser, err := streams.Serialize(asStatus)
+	suite.NoError(err)
+
+	bytes, err := json.Marshal(ser)
+	suite.NoError(err)
+
+	// we can't be sure in what order the two context entries --
+	// http://joinmastodon.org/ns, https://www.w3.org/ns/activitystreams --
+	// will appear, so trim them out of the string for consistency
+	trimmed := strings.SplitAfter(string(bytes), `"attachment":`)[1]
+	suite.Equal(`{"blurhash":"LNJRdVM{00Rj%Mayt7j[4nWBofRj","mediaType":"image/jpeg","name":"Black and white image of some 50's style text saying: Welcome On Board","type":"Document","url":"http://localhost:8080/fileserver/01F8MH17FWEB39HZJ76B6VXSKF/attachment/original/01F8MH6NEM8D7527KZAECTCR76.jpeg"},"attributedTo":"http://localhost:8080/users/admin","cc":"http://localhost:8080/users/admin/followers","content":"hello world! #welcome ! first post on the instance :rainbow: !","id":"http://localhost:8080/users/admin/statuses/01F8MH75CBF9JFX4ZAD54N0W0R","published":"2021-10-20T11:36:45Z","replies":{"first":{"id":"http://localhost:8080/users/admin/statuses/01F8MH75CBF9JFX4ZAD54N0W0R/replies?page=true","next":"http://localhost:8080/users/admin/statuses/01F8MH75CBF9JFX4ZAD54N0W0R/replies?only_other_accounts=false\u0026page=true","partOf":"http://localhost:8080/users/admin/statuses/01F8MH75CBF9JFX4ZAD54N0W0R/replies","type":"CollectionPage"},"id":"http://localhost:8080/users/admin/statuses/01F8MH75CBF9JFX4ZAD54N0W0R/replies","type":"Collection"},"sensitive":false,"summary":"","tag":{"icon":{"mediaType":"image/png","type":"Image","url":"http://localhost:8080/fileserver/01F8MH17FWEB39HZJ76B6VXSKF/emoji/original/01F8MH9H8E4VG3KDYJR9EGPXCQ.png"},"id":"http://localhost:8080/emoji/01F8MH9H8E4VG3KDYJR9EGPXCQ","name":":rainbow:","type":"Emoji"},"to":"https://www.w3.org/ns/activitystreams#Public","type":"Note","url":"http://localhost:8080/@admin/statuses/01F8MH75CBF9JFX4ZAD54N0W0R"}`, trimmed)
+}
+
+func (suite *InternalToASTestSuite) TestStatusWithTagsToASFromDB() {
+	ctx := context.Background()
+	// get the entire status with all tags
 	testStatus, err := suite.db.GetStatusByID(ctx, suite.testStatuses["admin_account_status_1"].ID)
 	suite.NoError(err)
 
@@ -133,23 +154,6 @@ func (suite *InternalToASTestSuite) TestStatusToASWithMentions() {
 	suite.NoError(err)
 
 	suite.Equal(`{"@context":"https://www.w3.org/ns/activitystreams","attachment":[],"attributedTo":"http://localhost:8080/users/admin","cc":["http://localhost:8080/users/admin/followers","http://localhost:8080/users/the_mighty_zork"],"content":"hi @the_mighty_zork welcome to the instance!","id":"http://localhost:8080/users/admin/statuses/01FF25D5Q0DH7CHD57CTRS6WK0","inReplyTo":"http://localhost:8080/users/the_mighty_zork/statuses/01F8MHAMCHF6Y650WCRSCP4WMY","published":"2021-11-20T13:32:16Z","replies":{"first":{"id":"http://localhost:8080/users/admin/statuses/01FF25D5Q0DH7CHD57CTRS6WK0/replies?page=true","next":"http://localhost:8080/users/admin/statuses/01FF25D5Q0DH7CHD57CTRS6WK0/replies?only_other_accounts=false\u0026page=true","partOf":"http://localhost:8080/users/admin/statuses/01FF25D5Q0DH7CHD57CTRS6WK0/replies","type":"CollectionPage"},"id":"http://localhost:8080/users/admin/statuses/01FF25D5Q0DH7CHD57CTRS6WK0/replies","type":"Collection"},"sensitive":false,"summary":"","tag":{"href":"http://localhost:8080/users/the_mighty_zork","name":"@the_mighty_zork@localhost:8080","type":"Mention"},"to":"https://www.w3.org/ns/activitystreams#Public","type":"Note","url":"http://localhost:8080/@admin/statuses/01FF25D5Q0DH7CHD57CTRS6WK0"}`, string(bytes))
-}
-
-func (suite *InternalToASTestSuite) TestStatusToASNotSensitive() {
-	testStatus := suite.testStatuses["admin_account_status_1"]
-
-	ctx := context.Background()
-
-	asStatus, err := suite.typeconverter.StatusToAS(ctx, testStatus)
-	suite.NoError(err)
-
-	ser, err := streams.Serialize(asStatus)
-	suite.NoError(err)
-
-	bytes, err := json.Marshal(ser)
-	suite.NoError(err)
-
-	suite.Equal(`{"@context":"https://www.w3.org/ns/activitystreams","attachment":[],"attributedTo":"http://localhost:8080/users/admin","cc":"http://localhost:8080/users/admin/followers","content":"hello world! #welcome ! first post on the instance :rainbow: !","id":"http://localhost:8080/users/admin/statuses/01F8MH75CBF9JFX4ZAD54N0W0R","published":"2021-10-20T11:36:45Z","replies":{"first":{"id":"http://localhost:8080/users/admin/statuses/01F8MH75CBF9JFX4ZAD54N0W0R/replies?page=true","next":"http://localhost:8080/users/admin/statuses/01F8MH75CBF9JFX4ZAD54N0W0R/replies?only_other_accounts=false\u0026page=true","partOf":"http://localhost:8080/users/admin/statuses/01F8MH75CBF9JFX4ZAD54N0W0R/replies","type":"CollectionPage"},"id":"http://localhost:8080/users/admin/statuses/01F8MH75CBF9JFX4ZAD54N0W0R/replies","type":"Collection"},"sensitive":false,"summary":"","tag":[],"to":"https://www.w3.org/ns/activitystreams#Public","type":"Note","url":"http://localhost:8080/@admin/statuses/01F8MH75CBF9JFX4ZAD54N0W0R"}`, string(bytes))
 }
 
 func (suite *InternalToASTestSuite) TestStatusesToASOutboxPage() {


### PR DESCRIPTION
There were a couple cases where we weren't selecting attachments, emojis, and mentions properly from the database on statuses serialized via the activitypub API. This PR fixes that. Should resolve an issue where emojis sometimes weren't being seen correctly on remote instances.