### PR TITLE
[chore] Normalize domain blocks to punycode

### DIFF
--- a/internal/db/bundb/domain.go
+++ b/internal/db/bundb/domain.go
@@ -28,6 +28,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"golang.org/x/net/idna"
 )
 
 type domainDB struct {
@@ -35,15 +36,27 @@ type domainDB struct {
 	cache *cache.DomainBlockCache
 }
 
+// normalize converts the given domain to lowercase
+// then to punycode (for international domain names).
+// Returns the resulting domain or an error if the
+// punycode conversion fails.
+func (d *domainDB) normalize(domain string) (out string, err error) {
+	out = strings.ToLower(domain)
+	out, err = idna.ToASCII(out)
+	return out, err
+}
+
 func (d *domainDB) CreateDomainBlock(ctx context.Context, block gtsmodel.DomainBlock) db.Error {
-	// Normalize to lowercase
-	block.Domain = strings.ToLower(block.Domain)
+	domain, err := d.normalize(block.Domain)
+	if err != nil {
+		return err
+	}
+	block.Domain = domain
 
 	// Attempt to insert new domain block
-	_, err := d.conn.NewInsert().
+	if _, err := d.conn.NewInsert().
 		Model(&block).
-		Exec(ctx, &block)
-	if err != nil {
+		Exec(ctx, &block); err != nil {
 		return d.conn.ProcessError(err)
 	}
 
@@ -54,8 +67,11 @@ func (d *domainDB) CreateDomainBlock(ctx context.Context, block gtsmodel.DomainB
 }
 
 func (d *domainDB) GetDomainBlock(ctx context.Context, domain string) (*gtsmodel.DomainBlock, db.Error) {
-	// Normalize to lowercase
-	domain = strings.ToLower(domain)
+	var err error
+	domain, err = d.normalize(domain)
+	if err != nil {
+		return nil, err
+	}
 
 	// Check for easy case, domain referencing *us*
 	if domain == "" || domain == config.GetAccountDomain() {
@@ -100,15 +116,17 @@ func (d *domainDB) GetDomainBlock(ctx context.Context, domain string) (*gtsmodel
 }
 
 func (d *domainDB) DeleteDomainBlock(ctx context.Context, domain string) db.Error {
-	// Normalize to lowercase
-	domain = strings.ToLower(domain)
+	var err error
+	domain, err = d.normalize(domain)
+	if err != nil {
+		return err
+	}
 
 	// Attempt to delete domain block
-	_, err := d.conn.NewDelete().
+	if _, err := d.conn.NewDelete().
 		Model((*gtsmodel.DomainBlock)(nil)).
 		Where("domain = ?", domain).
-		Exec(ctx)
-	if err != nil {
+		Exec(ctx); err != nil {
 		return d.conn.ProcessError(err)
 	}
 

--- a/internal/db/bundb/domain.go
+++ b/internal/db/bundb/domain.go
@@ -36,18 +36,19 @@ type domainDB struct {
 	cache *cache.DomainBlockCache
 }
 
-// normalize converts the given domain to lowercase
+// normalizeDomain converts the given domain to lowercase
 // then to punycode (for international domain names).
+//
 // Returns the resulting domain or an error if the
 // punycode conversion fails.
-func (d *domainDB) normalize(domain string) (out string, err error) {
+func normalizeDomain(domain string) (out string, err error) {
 	out = strings.ToLower(domain)
 	out, err = idna.ToASCII(out)
 	return out, err
 }
 
 func (d *domainDB) CreateDomainBlock(ctx context.Context, block gtsmodel.DomainBlock) db.Error {
-	domain, err := d.normalize(block.Domain)
+	domain, err := normalizeDomain(block.Domain)
 	if err != nil {
 		return err
 	}
@@ -68,7 +69,7 @@ func (d *domainDB) CreateDomainBlock(ctx context.Context, block gtsmodel.DomainB
 
 func (d *domainDB) GetDomainBlock(ctx context.Context, domain string) (*gtsmodel.DomainBlock, db.Error) {
 	var err error
-	domain, err = d.normalize(domain)
+	domain, err = normalizeDomain(domain)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +118,7 @@ func (d *domainDB) GetDomainBlock(ctx context.Context, domain string) (*gtsmodel
 
 func (d *domainDB) DeleteDomainBlock(ctx context.Context, domain string) db.Error {
 	var err error
-	domain, err = d.normalize(domain)
+	domain, err = normalizeDomain(domain)
 	if err != nil {
 		return err
 	}

--- a/internal/db/bundb/domain_test.go
+++ b/internal/db/bundb/domain_test.go
@@ -59,6 +59,78 @@ func (suite *DomainTestSuite) TestIsDomainBlocked() {
 	suite.True(blocked)
 }
 
+func (suite *DomainTestSuite) TestIsDomainBlockedNonASCII() {
+	ctx := context.Background()
+
+	now := time.Now()
+
+	domainBlock := &gtsmodel.DomainBlock{
+		ID:                 "01G204214Y9TNJEBX39C7G88SW",
+		Domain:             "xn--80aaa1bbb1h.com",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+		CreatedByAccountID: suite.testAccounts["admin_account"].ID,
+		CreatedByAccount:   suite.testAccounts["admin_account"],
+	}
+
+	// no domain block exists for the given domain yet
+	blocked, err := suite.db.IsDomainBlocked(ctx, "какашка.com")
+	suite.NoError(err)
+	suite.False(blocked)
+
+	blocked, err = suite.db.IsDomainBlocked(ctx, "xn--80aaa1bbb1h.com")
+	suite.NoError(err)
+	suite.False(blocked)
+
+	err = suite.db.CreateDomainBlock(ctx, *domainBlock)
+	suite.NoError(err)
+
+	// domain block now exists
+	blocked, err = suite.db.IsDomainBlocked(ctx, "какашка.com")
+	suite.NoError(err)
+	suite.True(blocked)
+
+	blocked, err = suite.db.IsDomainBlocked(ctx, "xn--80aaa1bbb1h.com")
+	suite.NoError(err)
+	suite.True(blocked)
+}
+
+func (suite *DomainTestSuite) TestIsDomainBlockedNonASCII2() {
+	ctx := context.Background()
+
+	now := time.Now()
+
+	domainBlock := &gtsmodel.DomainBlock{
+		ID:                 "01G204214Y9TNJEBX39C7G88SW",
+		Domain:             "какашка.com",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+		CreatedByAccountID: suite.testAccounts["admin_account"].ID,
+		CreatedByAccount:   suite.testAccounts["admin_account"],
+	}
+
+	// no domain block exists for the given domain yet
+	blocked, err := suite.db.IsDomainBlocked(ctx, "какашка.com")
+	suite.NoError(err)
+	suite.False(blocked)
+
+	blocked, err = suite.db.IsDomainBlocked(ctx, "xn--80aaa1bbb1h.com")
+	suite.NoError(err)
+	suite.False(blocked)
+
+	err = suite.db.CreateDomainBlock(ctx, *domainBlock)
+	suite.NoError(err)
+
+	// domain block now exists
+	blocked, err = suite.db.IsDomainBlocked(ctx, "какашка.com")
+	suite.NoError(err)
+	suite.True(blocked)
+
+	blocked, err = suite.db.IsDomainBlocked(ctx, "xn--80aaa1bbb1h.com")
+	suite.NoError(err)
+	suite.True(blocked)
+}
+
 func TestDomainTestSuite(t *testing.T) {
 	suite.Run(t, new(DomainTestSuite))
 }


### PR DESCRIPTION
This PR makes it so that domain blocks are always normalized to punycode no matter how you create or check the domain block.

This should make life a bit easier for admins, since now they don't need to worry about whether to block the punycode domain or the unicode domain, both will work.