### PR TITLE
[chore] Use shorter timestamps in frontend for replies

### DIFF
--- a/internal/router/template.go
+++ b/internal/router/template.go
@@ -36,8 +36,10 @@ import (
 
 const (
 	justTime     = "15:04"
-	dateAndTime  = "Jan 02, 15:04"
-	yearDateTime = "Jan 02, 2006, 15:04"
+	dateYear     = "Jan 02, 2006"
+	dateTime     = "Jan 02, 15:04"
+	dateYearTime = "Jan 02, 2006, 15:04"
+	monthYear    = "Jan, 2006"
 )
 
 // LoadTemplates loads html templates for use by the given engine
@@ -92,17 +94,22 @@ func timestamp(stamp string) string {
 
 	switch {
 	case tYear == currentYear && tMonth == currentMonth && tDay == currentDay:
-		return "Today, " + t.Format("15:04")
+		return "Today, " + t.Format(justTime)
 	case tYear == currentYear:
-		return t.Format("Jan 02, 15:04")
+		return t.Format(dateTime)
 	default:
-		return t.Format("Jan 02, 2006, 15:04")
+		return t.Format(dateYear)
 	}
+}
+
+func timestampPrecise(stamp string) string {
+	t, _ := util.ParseISO8601(stamp)
+	return t.Local().Format(dateYearTime)
 }
 
 func timestampVague(stamp string) string {
 	t, _ := util.ParseISO8601(stamp)
-	return t.Format("January, 2006")
+	return t.Format(monthYear)
 }
 
 type iconWithLabel struct {
@@ -174,13 +181,14 @@ func emojify(emojis []model.Emoji, text template.HTML) template.HTML {
 
 func LoadTemplateFunctions(engine *gin.Engine) {
 	engine.SetFuncMap(template.FuncMap{
-		"escape":         escape,
-		"noescape":       noescape,
-		"noescapeAttr":   noescapeAttr,
-		"oddOrEven":      oddOrEven,
-		"visibilityIcon": visibilityIcon,
-		"timestamp":      timestamp,
-		"timestampVague": timestampVague,
-		"emojify":        emojify,
+		"escape":           escape,
+		"noescape":         noescape,
+		"noescapeAttr":     noescapeAttr,
+		"oddOrEven":        oddOrEven,
+		"visibilityIcon":   visibilityIcon,
+		"timestamp":        timestamp,
+		"timestampVague":   timestampVague,
+		"timestampPrecise": timestampPrecise,
+		"emojify":          emojify,
 	})
 }

--- a/internal/router/template.go
+++ b/internal/router/template.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/regexes"
 	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
@@ -40,6 +41,7 @@ const (
 	dateTime     = "Jan 02, 15:04"
 	dateYearTime = "Jan 02, 2006, 15:04"
 	monthYear    = "Jan, 2006"
+	badTimestamp = "bad timestamp"
 )
 
 // LoadTemplates loads html templates for use by the given engine
@@ -85,7 +87,12 @@ func noescapeAttr(str string) template.HTMLAttr {
 }
 
 func timestamp(stamp string) string {
-	t, _ := util.ParseISO8601(stamp)
+	t, err := util.ParseISO8601(stamp)
+	if err != nil {
+		log.Errorf("error parsing timestamp %s: %s", stamp, err)
+		return badTimestamp
+	}
+
 	t = t.Local()
 
 	tYear, tMonth, tDay := t.Date()
@@ -103,12 +110,20 @@ func timestamp(stamp string) string {
 }
 
 func timestampPrecise(stamp string) string {
-	t, _ := util.ParseISO8601(stamp)
+	t, err := util.ParseISO8601(stamp)
+	if err != nil {
+		log.Errorf("error parsing timestamp %s: %s", stamp, err)
+		return badTimestamp
+	}
 	return t.Local().Format(dateYearTime)
 }
 
 func timestampVague(stamp string) string {
-	t, _ := util.ParseISO8601(stamp)
+	t, err := util.ParseISO8601(stamp)
+	if err != nil {
+		log.Errorf("error parsing timestamp %s: %s", stamp, err)
+		return badTimestamp
+	}
 	return t.Format(monthYear)
 }
 

--- a/internal/router/template.go
+++ b/internal/router/template.go
@@ -76,8 +76,7 @@ func noescapeAttr(str string) template.HTMLAttr {
 }
 
 func timestamp(stamp string) string {
-	t, _ := time.Parse(time.RFC3339, stamp)
-	return t.Format("January 2, 2006, 15:04:05")
+	t, _ := util.ParseISO8601(stamp)
 }
 
 func timestampVague(stamp string) string {

--- a/internal/router/template.go
+++ b/internal/router/template.go
@@ -31,6 +31,13 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/regexes"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
+)
+
+const (
+	justTime     = "15:04"
+	dateAndTime  = "Jan 02, 15:04"
+	yearDateTime = "Jan 02, 2006, 15:04"
 )
 
 // LoadTemplates loads html templates for use by the given engine
@@ -77,6 +84,20 @@ func noescapeAttr(str string) template.HTMLAttr {
 
 func timestamp(stamp string) string {
 	t, _ := util.ParseISO8601(stamp)
+	t = t.Local()
+
+	tYear, tMonth, tDay := t.Date()
+	now := time.Now()
+	currentYear, currentMonth, currentDay := now.Date()
+
+	switch {
+	case tYear == currentYear && tMonth == currentMonth && tDay == currentDay:
+		return "Today, " + t.Format("15:04")
+	case tYear == currentYear:
+		return t.Format("Jan 02, 15:04")
+	default:
+		return t.Format("Jan 02, 2006, 15:04")
+	}
 }
 
 func timestampVague(stamp string) string {

--- a/internal/router/template.go
+++ b/internal/router/template.go
@@ -80,8 +80,8 @@ func timestamp(stamp string) string {
 	return t.Format("January 2, 2006, 15:04:05")
 }
 
-func timestampShort(stamp string) string {
-	t, _ := time.Parse(time.RFC3339, stamp)
+func timestampVague(stamp string) string {
+	t, _ := util.ParseISO8601(stamp)
 	return t.Format("January, 2006")
 }
 
@@ -160,7 +160,7 @@ func LoadTemplateFunctions(engine *gin.Engine) {
 		"oddOrEven":      oddOrEven,
 		"visibilityIcon": visibilityIcon,
 		"timestamp":      timestamp,
-		"timestampShort": timestampShort,
+		"timestampVague": timestampVague,
 		"emojify":        emojify,
 	})
 }

--- a/internal/util/time.go
+++ b/internal/util/time.go
@@ -28,3 +28,8 @@ const ISO8601 = "2006-01-02T15:04:05.000Z"
 func FormatISO8601(t time.Time) string {
 	return t.UTC().Format(ISO8601)
 }
+
+// ParseISO8601 parses the given time string according to the ISO8601 const.
+func ParseISO8601(in string) (time.Time, error) {
+	return time.Parse(ISO8601, in)
+}

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -75,28 +75,27 @@ main {
 			background: $bg;
 		}
 	}
+
+	.displayname, .username {
+		justify-self: start;
+		align-self: start;
+		
+		max-width: 100%;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+
+		/* margin-top: -0.5rem; */
+		line-height: 2rem;
+	}
 	
 	.displayname {
 		font-weight: bold;
 		font-size: 1.2rem;
-		line-height: 2rem;
-		margin-top: -0.5rem;
-		align-self: start;
-
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
 	}
-	
+
 	.username {
 		color: $link-fg;
-		line-height: 2rem;
-		margin-top: -0.5rem;
-		align-self: start;
-		
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
 	}
 
 	input.spoiler:checked ~ .content {

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -180,7 +180,7 @@ main {
 	}
 
 	.media {
-		margin-top: 0.6rem;
+		margin-top: 0.5rem;
 		border-radius: $br;
 		grid-column: span 3;
 		display: grid;
@@ -362,6 +362,7 @@ main {
 
 			.text {
 				grid-column: 1 / span 3;
+				padding-top: 0.5rem;
 			}
 
 			.not-expanded {
@@ -371,6 +372,10 @@ main {
 
 		.info {
 			display: flex;
+		}
+
+		.media {
+			margin-bottom: 0.5rem;
 		}
 	}
 }

--- a/web/template/profile.tmpl
+++ b/web/template/profile.tmpl
@@ -21,7 +21,7 @@
             </div>
         </div>
         <div class="accountstats">
-            <div class="entry">Joined <b>{{.account.CreatedAt | timestampShort}}</b></div>
+            <div class="entry">Joined <b>{{.account.CreatedAt | timestampVague}}</b></div>
             <div class="entry">Followed by <b>{{.account.FollowersCount}}</b></div>
             <div class="entry">Following <b>{{.account.FollowingCount}}</b></div>
             <div class="entry">Posted <b>{{.account.StatusesCount}}</b></div>

--- a/web/template/status.tmpl
+++ b/web/template/status.tmpl
@@ -3,7 +3,6 @@
 	<a href="{{.Account.URL}}" class="displayname">{{if .Account.DisplayName}}{{emojify .Account.Emojis (escape .Account.DisplayName)}}{{else}}{{.Account.Username}}{{end}}</a>
 	<a href="{{.Account.URL}}" class="username">@{{.Account.Acct}}</a>
 	<div class="not-expanded">
-		<span class="visibility">{{.Visibility | visibilityIcon}}</span>
 		<span class="date">{{.CreatedAt | timestamp}}</span>
 	</div>
 	<div class="text">
@@ -45,7 +44,7 @@
 	{{end}}
 </div>
 <div class="info">
-	<div id="date">{{.CreatedAt | timestamp}}</div>
+	<div id="date">{{.CreatedAt | timestampPrecise}}</div>
 	<div class="stats">
 		<div id="replies"><i aria-label="Replies" class="fa fa-reply-all"></i> {{.RepliesCount}}</div>
 		<div id="boosts"><i aria-label="Boosts" class="fa fa-retweet"></i> {{.ReblogsCount}}</div>


### PR DESCRIPTION
This PR updates some of the timestamp string generation logic in web templates. Now, replies use timestamp strings that are shorter, to avoid obscuring the display name + username as much. These timestamps become more vague the longer ago the status was created. A status created today gets `Today, 15:04`; a status created this year gets `Jan 02, 15:04`, and a status created longer ago than this year gets `Jan 02, 2006`.

examples:

![Screenshot from 2022-10-02 11-10-33](https://user-images.githubusercontent.com/31960611/193446854-9fcd0856-ec51-4bda-aecf-7ab0426e72a9.png)

![Screenshot from 2022-10-02 11-03-55](https://user-images.githubusercontent.com/31960611/193446856-3fcdfcb7-4627-4c26-b973-fb4e6024a133.png)

![Screenshot from 2022-10-02 11-03-38](https://user-images.githubusercontent.com/31960611/193446860-2b4451df-6d9d-4e58-be28-aea67722a4ea.png)
