### PR TITLE
[chore] Old browser fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -34,6 +34,15 @@ body:
     validations:
       required: false
 
+  - type: input
+    id: Browser-Version
+    attributes:
+      label: Browser version
+      description: If this is a frontend bug, what browser(s) and versions are you using that show this bug?
+      placeholder: Firefox 103.0b9 (64-bit)
+    validations:
+      required: false
+
   - type: textarea
     id: what-happened
     attributes:

--- a/web/source/css/base.css
+++ b/web/source/css/base.css
@@ -61,6 +61,7 @@ body {
 	min-height: 100%;
 	min-width: 100%;
 
+	grid-template-columns: auto minmax(auto, 90ch) auto;
 	grid-template-columns: auto min(92%, 90ch) auto;
 	grid-template-rows: auto 1fr auto;
 }

--- a/web/source/css/profile.css
+++ b/web/source/css/profile.css
@@ -43,6 +43,7 @@ main {
 	.headerimage {
 		width: 100%;
 		aspect-ratio: 3 / 1;
+		max-height: 30ch;
 		overflow: hidden;
 		box-shadow: $boxshadow;
 


### PR DESCRIPTION
Adds fallback css rules for browsers that don't support `min()` and `aspect-ratio`. Not equivalent styling but close enough

fixes https://github.com/superseriousbusiness/gotosocial/issues/803, https://github.com/superseriousbusiness/gotosocial/issues/800