### PR TITLE
[bugfix] Use background context instead of request context

### DIFF
--- a/internal/processing/admin/createdomainblock.go
+++ b/internal/processing/admin/createdomainblock.go
@@ -75,7 +75,9 @@ func (p *processor) DomainBlockCreate(ctx context.Context, account *gtsmodel.Acc
 		block = &newBlock
 
 		// Process the side effects of the domain block asynchronously since it might take a while
-		go p.initiateDomainBlockSideEffects(ctx, account, block)
+		go func() {
+			p.initiateDomainBlockSideEffects(context.Background(), account, block)
+		}()
 	}
 
 	// Convert our gts model domain block into an API model

--- a/internal/processing/admin/mediaprune.go
+++ b/internal/processing/admin/mediaprune.go
@@ -33,7 +33,7 @@ func (p *processor) MediaPrune(ctx context.Context, mediaRemoteCacheDays int) gt
 	}
 
 	go func() {
-		pruned, err := p.mediaManager.PruneAllRemote(ctx, mediaRemoteCacheDays)
+		pruned, err := p.mediaManager.PruneAllRemote(context.Background(), mediaRemoteCacheDays)
 		if err != nil {
 			log.Errorf("MediaPrune: error pruning remote cache: %s", err)
 		} else {
@@ -42,7 +42,7 @@ func (p *processor) MediaPrune(ctx context.Context, mediaRemoteCacheDays int) gt
 	}()
 
 	go func() {
-		pruned, err := p.mediaManager.PruneUnusedLocalAttachments(ctx)
+		pruned, err := p.mediaManager.PruneUnusedLocalAttachments(context.Background())
 		if err != nil {
 			log.Errorf("MediaPrune: error pruning unused local cache: %s", err)
 		} else {
@@ -51,7 +51,7 @@ func (p *processor) MediaPrune(ctx context.Context, mediaRemoteCacheDays int) gt
 	}()
 
 	go func() {
-		pruned, err := p.mediaManager.PruneAllMeta(ctx)
+		pruned, err := p.mediaManager.PruneAllMeta(context.Background())
 		if err != nil {
 			log.Errorf("MediaPrune: error pruning meta: %s", err)
 		} else {


### PR DESCRIPTION
Fixes an issue where async processing was not completing correctly.

In particular this applies to side effects of domain blocks: while the domain block was being entered and enforced correctly, side effects like deleting accounts and updating the instance entry for the blocked instance were not. This fixes that :)

