### PR TITLE
[bugfix] Fix new domain block date

### DIFF
--- a/internal/db/bundb/domain.go
+++ b/internal/db/bundb/domain.go
@@ -47,7 +47,7 @@ func normalizeDomain(domain string) (out string, err error) {
 	return out, err
 }
 
-func (d *domainDB) CreateDomainBlock(ctx context.Context, block gtsmodel.DomainBlock) db.Error {
+func (d *domainDB) CreateDomainBlock(ctx context.Context, block *gtsmodel.DomainBlock) db.Error {
 	domain, err := normalizeDomain(block.Domain)
 	if err != nil {
 		return err
@@ -56,13 +56,13 @@ func (d *domainDB) CreateDomainBlock(ctx context.Context, block gtsmodel.DomainB
 
 	// Attempt to insert new domain block
 	if _, err := d.conn.NewInsert().
-		Model(&block).
-		Exec(ctx, &block); err != nil {
+		Model(block).
+		Exec(ctx); err != nil {
 		return d.conn.ProcessError(err)
 	}
 
 	// Cache this domain block
-	d.cache.Put(block.Domain, &block)
+	d.cache.Put(block.Domain, block)
 
 	return nil
 }

--- a/internal/db/bundb/domain_test.go
+++ b/internal/db/bundb/domain_test.go
@@ -34,13 +34,9 @@ type DomainTestSuite struct {
 func (suite *DomainTestSuite) TestIsDomainBlocked() {
 	ctx := context.Background()
 
-	now := time.Now()
-
 	domainBlock := &gtsmodel.DomainBlock{
 		ID:                 "01G204214Y9TNJEBX39C7G88SW",
 		Domain:             "some.bad.apples",
-		CreatedAt:          now,
-		UpdatedAt:          now,
 		CreatedByAccountID: suite.testAccounts["admin_account"].ID,
 		CreatedByAccount:   suite.testAccounts["admin_account"],
 	}
@@ -50,13 +46,14 @@ func (suite *DomainTestSuite) TestIsDomainBlocked() {
 	suite.NoError(err)
 	suite.False(blocked)
 
-	err = suite.db.CreateDomainBlock(ctx, *domainBlock)
+	err = suite.db.CreateDomainBlock(ctx, domainBlock)
 	suite.NoError(err)
 
 	// domain block now exists
 	blocked, err = suite.db.IsDomainBlocked(ctx, domainBlock.Domain)
 	suite.NoError(err)
 	suite.True(blocked)
+	suite.WithinDuration(time.Now(), domainBlock.CreatedAt, 10*time.Second)
 }
 
 func (suite *DomainTestSuite) TestIsDomainBlockedNonASCII() {
@@ -82,7 +79,7 @@ func (suite *DomainTestSuite) TestIsDomainBlockedNonASCII() {
 	suite.NoError(err)
 	suite.False(blocked)
 
-	err = suite.db.CreateDomainBlock(ctx, *domainBlock)
+	err = suite.db.CreateDomainBlock(ctx, domainBlock)
 	suite.NoError(err)
 
 	// domain block now exists
@@ -118,7 +115,7 @@ func (suite *DomainTestSuite) TestIsDomainBlockedNonASCII2() {
 	suite.NoError(err)
 	suite.False(blocked)
 
-	err = suite.db.CreateDomainBlock(ctx, *domainBlock)
+	err = suite.db.CreateDomainBlock(ctx, domainBlock)
 	suite.NoError(err)
 
 	// domain block now exists

--- a/internal/db/domain.go
+++ b/internal/db/domain.go
@@ -28,7 +28,7 @@ import (
 // Domain contains DB functions related to domains and domain blocks.
 type Domain interface {
 	// CreateDomainBlock ...
-	CreateDomainBlock(ctx context.Context, block gtsmodel.DomainBlock) Error
+	CreateDomainBlock(ctx context.Context, block *gtsmodel.DomainBlock) Error
 
 	// GetDomainBlock ...
 	GetDomainBlock(ctx context.Context, domain string) (*gtsmodel.DomainBlock, Error)

--- a/internal/processing/admin/createdomainblock.go
+++ b/internal/processing/admin/createdomainblock.go
@@ -56,7 +56,7 @@ func (p *processor) DomainBlockCreate(ctx context.Context, account *gtsmodel.Acc
 			return nil, gtserror.NewErrorInternalError(fmt.Errorf("error creating id for new domain block %s: %s", domain, err))
 		}
 
-		newBlock := gtsmodel.DomainBlock{
+		newBlock := &gtsmodel.DomainBlock{
 			ID:                 blockID,
 			Domain:             domain,
 			CreatedByAccountID: account.ID,
@@ -72,7 +72,7 @@ func (p *processor) DomainBlockCreate(ctx context.Context, account *gtsmodel.Acc
 		}
 
 		// Set the newly created block
-		block = &newBlock
+		block = newBlock
 
 		// Process the side effects of the domain block asynchronously since it might take a while
 		go func() {


### PR DESCRIPTION
We weren't setting the date correctly on new domain blocks. Or rather we were, but it wasn't being set correctly on the returned domain block. This fixes that :)

closes https://github.com/superseriousbusiness/gotosocial/issues/870