### PR TITLE
[bugfix] add in-use checks for admin cli account creation

### DIFF
--- a/cmd/gotosocial/action/admin/account/account.go
+++ b/cmd/gotosocial/action/admin/account/account.go
@@ -46,12 +46,28 @@ var Create action.GTSAction = func(ctx context.Context) error {
 		return err
 	}
 
+	usernameAvailable, err := dbConn.IsUsernameAvailable(ctx, username)
+	if err != nil {
+		return err
+	}
+	if !usernameAvailable {
+		return fmt.Errorf("username %s is already in use", username)
+	}
+
 	email := config.GetAdminAccountEmail()
 	if email == "" {
 		return errors.New("no email set")
 	}
 	if err := validate.Email(email); err != nil {
 		return err
+	}
+
+	emailAvailable, err := dbConn.IsEmailAvailable(ctx, email)
+	if err != nil {
+		return err
+	}
+	if !emailAvailable {
+		return fmt.Errorf("email address %s is already in use", email)
 	}
 
 	password := config.GetAdminAccountPassword()


### PR DESCRIPTION
Check whether username/email address are available when creating accounts via the admin CLI

closes https://github.com/superseriousbusiness/gotosocial/issues/903