### PR TITLE
Fix #923 and markdown css

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ yarn run dev
 
 The Pinafore instance will start running on `localhost:4002`.
 
-To connect to the testrig, navigate to `https://localhost:4002` and enter your instance name as `localhost:8080`.
+To connect to the testrig, navigate to `http://localhost:4002` and enter your instance name as `localhost:8080`.
 
 At the login screen, enter the email address `zork@example.org` and password `password`. You will get a confirmation prompt. Accept, and you are logged in as Zork.
 

--- a/web/source/css/profile.css
+++ b/web/source/css/profile.css
@@ -126,6 +126,7 @@ main {
 			word-break: break-all;
 			text-overflow: ellipsis;
 			overflow: hidden;
+			user-select: all;
 		}
 	}
 

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -178,6 +178,14 @@ main {
 					-webkit-overflow-scrolling: touch;
 				}
 			}
+
+			img {
+				max-width: 100%;
+				margin: 5px auto;
+			}
+			img[alt~="!center"] {
+				display: block;
+			}
 		}
 
 		.emoji {

--- a/web/template/profile.tmpl
+++ b/web/template/profile.tmpl
@@ -13,7 +13,7 @@
             <div id="profile-basic-filler2"></div>
             <a href="{{.account.Avatar}}" class="avatar"><img src="{{.account.Avatar}}" alt="{{if .account.DisplayName}}{{.account.DisplayName}}{{else}}{{.account.Username}}{{end}}'s avatar"></a>
             <div class="displayname">{{if .account.DisplayName}}{{emojify .account.Emojis (escape .account.DisplayName)}}{{else}}{{.account.Username}}{{end}}</div>
-            <div class="username"><span>@{{.account.Username}}</span><span>@{{.instance.AccountDomain}}</span></div>
+            <div class="username">@{{.account.Username}}@{{.instance.AccountDomain}}</div>
         </div>
         <div class="detailed">
             <div class="bio">


### PR DESCRIPTION
Fixing #923 and this issue
![Bildschirmfoto 2022-10-25 um 12 26 13](https://user-images.githubusercontent.com/22565269/197757353-0db36006-ba12-4aa0-8f24-ac7444083589.png)

I am not entirely sure if the solution for centered imgs (alt needs to contain `!center`) is a good one since it will be read by screen readers.
Although maybe this is even a good solution to indicate that nothing on the same height of the img exists.