### PR TITLE
[bugfix] create admin_account_actions table in tx

### DIFF
--- a/internal/db/bundb/migrations/20220315160814_admin_account_actions.go
+++ b/internal/db/bundb/migrations/20220315160814_admin_account_actions.go
@@ -29,7 +29,7 @@ func init() {
 	up := func(ctx context.Context, db *bun.DB) error {
 		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 			// create table for the new admin action struct
-			if _, err := db.NewCreateTable().Model(&gtsmodel.AdminAccountAction{}).IfNotExists().Exec(ctx); err != nil {
+			if _, err := tx.NewCreateTable().Model(&gtsmodel.AdminAccountAction{}).IfNotExists().Exec(ctx); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
The migration that adds the `admin_account_actions` table did so at the same time as adding indexes onto the new table. This code was ran inside a `RunInTx` function, but the table creation did not use the transaction reference, while the creation of the indexes did. This could cause a race between the table and index creations, depending on the scheduling order. If the table creation did not win the race, then the migration would fail.

This changeset corrects the table creation to also be done inside the same transaction as the index creation.

Signed-off-by: Terin Stock <terinjokes@gmail.com>