### PR TITLE
[bugfix] use the landing page user directly

### DIFF
--- a/internal/web/base.go
+++ b/internal/web/base.go
@@ -32,7 +32,7 @@ func (m *Module) baseHandler(c *gin.Context) {
 
 	// if a landingPageUser is set in the config, redirect to that user's profile
 	if landingPageUser := config.GetLandingPageUser(); landingPageUser != "" {
-		c.Redirect(http.StatusFound, "/@"+c.Param(strings.ToLower(landingPageUser)))
+		c.Redirect(http.StatusFound, "/@"+strings.ToLower(landingPageUser))
 		return
 	}
 


### PR DESCRIPTION
If set, the landing page user configuration value is used as a Gin context parameter, which seems incorrect, since a normal request isn't going to have a parameter named after an arbitrarily configured user. Instead, the user name should be used directly when building the redirect URL.