### PR TITLE
[chore] gitignore /bin entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,12 @@ web/assets/swagger.yaml
 example/docker-compose/docker-volume
 
 # excludes debug build
-cmd/gotosocial/__debug_bin
+/cmd/gotosocial/__debug_bin
 
 # ignore f0x' nix-shell, direnv
 shell.nix
 .direnv
 .envrc
+
+# ignore custom GOBIN path
+/bin


### PR DESCRIPTION
Hey,

I like to keep GOBIN in the project directories so when switching Go versions (my main Go is still 1.18 because our slower infra ops team) binaries do not fight between projects.

Just for the record, this tool https://direnv.net allows switching Go versions easily:

```
[lzap@nuc gotosocial]$ cat .envrc 
GOVER=1.19.3
export GOROOT="$(go$GOVER env GOROOT)"
PATH_add "$(go$GOVER env GOROOT)/bin"
export GOBIN="$(pwd)/bin"
PATH_add "$(pwd)/bin"
```

Thanks!