### PR TITLE
Add quick start docker compose example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,19 @@ RUN yarn install --cwd web/source && \
 # stage 3: build the executor container
 FROM --platform=${TARGETPLATFORM} alpine:3.15.4 as executor
 
+RUN mkdir -p /gotosocial/data & mkdir -p /gotosocial/storage \
+    & chown 1000:1000 -R /gotosocial
+
 # copy the dist binary created by goreleaser or build.sh
 COPY --chown=1000:1000 gotosocial /gotosocial/gotosocial
+COPY --chown=1000:1000 scripts/quick-start.sh /gotosocial/quick-start.sh
 
 # copy over the web directories with templates, assets etc
 COPY --chown=1000:1000 --from=bundler web /gotosocial/web
 COPY --chown=1000:1000 --from=swagger /go/src/github.com/superseriousbusiness/gotosocial/swagger.yaml web/assets/swagger.yaml
 
-WORKDIR "/gotosocial"
+WORKDIR /gotosocial
+VOLUME ["/gotosocial/data", "/gotosocial/storage"]
+EXPOSE 8080
+
 ENTRYPOINT [ "/gotosocial/gotosocial", "server", "start" ]

--- a/docs/installation_guide/docker.md
+++ b/docs/installation_guide/docker.md
@@ -78,7 +78,7 @@ image: superseriousbusiness/gotosocial:0.3.1
 
 #### Host
 
-Change the `GTS_HOST` environment variable to the domain you are running GoToSocial on.
+Change the `GTS_HOST` environment variable to the domain you are running GoToSocial on. If you want your ActivityPub identity to be different than the host name, set the `GTS_ACCOUNT_DOMAIN` environment variable. For example, your `GTS_HOST` is `gts.example.org`, but you want your user to be `myuser@example.org`, instead of `myuser@gts.example.org`, you would get `GTS_ACCOUNT_DOMAIN` as `example.org`.
 
 #### User (optional / probably not necessary)
 
@@ -167,3 +167,8 @@ GoToSocial should now be running on your machine! To verify this, open your brow
 ## (Optional) Reverse Proxy
 
 If you want to run other webservers on port 443, or want to add an additional layer of security you might want to add [NGINX](https://nginx.org), [Traefik](https://doc.traefik.io/traefik/), or [Apache httpd](https://httpd.apache.org/) into your docker-compose to use as a reverse proxy.
+
+
+## (Optional) Quick Initialize User
+
+If you are deploying a single user install where shell access and/or executing commands on the container is complicated or undesirable, it is possible to initialize an admin user with a different `ENTRYPOINT`. Use `wget` to download the latest quickstart [docker-compose.yml](https://raw.githubusercontent.com/superseriousbusiness/gotosocial/main/example/docker-compose-quickstart/docker-compose.yml) example and customize as needed.

--- a/example/docker-compose-quickstart/docker-compose.yml
+++ b/example/docker-compose-quickstart/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.8"
+
+services:
+  gotosocial:
+    image: superseriousbusiness/gotosocial:latest
+    container_name: gotosocial
+    user: 1000:1000
+    entrypoint: /gotosocial/quick-start.sh
+    networks:
+      - gotosocial
+    environment:
+      GTS_HOST: example.org
+      GTS_ACCOUNT_DOMAIN: example.org
+      GTS_DB_TYPE: sqlite
+      GTS_DB_ADDRESS: /gotosocial/data/sqlite.db
+      GTS_LETSENCRYPT_ENABLED: "false"
+      GTS_LETSENCRYPT_EMAIL_ADDRESS: ""
+      GTS_ADMIN_USERNAME: myuser
+      GTS_ADMIN_EMAIL: myuser@example.org
+      GTS_ADMIN_PASSWORD: "${GTS_ADMIN_PASSWORD}"
+      GTS_LANDING_PAGE_USER: myuser
+    ports:
+      - "443:8080"
+      #- "80:80"
+    volumes:
+      - gotosocial_db:/gotosocial/data
+      - gotosocial_storage:/gotosocial/storage
+    restart: "always"
+
+networks:
+  gotosocial:
+    ipam:
+      driver: default
+
+volumes:
+  gotosocial_db:
+  gotosocial_storage:

--- a/scripts/quick-start.sh
+++ b/scripts/quick-start.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+if [ "$GTS_ADMIN_USERNAME" != "" ]
+then
+    /gotosocial/gotosocial admin account confirm --username ${GTS_ADMIN_USERNAME}
+    ADMIN_NOT_EXISTS=$?
+
+    if [ $ADMIN_NOT_EXISTS == 1 ]
+    then
+        echo "Initializing Admin user ${GTS_ADMIN_USERNAME}"
+        /gotosocial/gotosocial admin account create --username ${GTS_ADMIN_USERNAME} --email ${GTS_ADMIN_EMAIL} --password '${GTS_ADMIN_PASSWORD}'
+
+        /gotosocial/gotosocial admin account promote --username ${GTS_ADMIN_USERNAME}
+    else
+        echo "Existing admin user ${GTS_ADMIN_USERNAME} found"
+    fi
+fi
+
+/gotosocial/gotosocial server start


### PR DESCRIPTION
Modified the Dockerfile to create the folders necessary to use the example with a volume mount or local volume bind.

Provide an optional entrypoint that will create the initial admin user based upon provided environment variables.
* GTS_ADMIN_USERNAME
* GTS_ADMIN_EMAIL
* GTS_ADMIN_PASSWORD