### PR TITLE
[docs]: add link to SELinux policy

### DIFF
--- a/docs/installation_guide/binary.md
+++ b/docs/installation_guide/binary.md
@@ -139,3 +139,8 @@ sudo systemctl enable --now gotosocial.service
 ## 8. Reverse proxy (optional)
 
 If you want to run other webservers on port 443 or want to add an additional layer of security you might want to use [nginx](./nginx.md), [Caddy](./caddy.md) or [Apache httpd](./apache-httpd.md) as reverse proxy
+
+## 8. SELinux (optional)
+
+If SELinux is available on your system, you can optionally install [SELinux policy](https://github.com/lzap/gotosocial-selinux) to further improve security.
+


### PR DESCRIPTION
This adds a link into the Installation - Binary section. SELinux is not relevant for container deployments, so I think this is the best place. Cheers!