### PR TITLE
[chore] dependabot: prefix correctly, ignore npm deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/web/source" # Location of package manifests
-    schedule:
-      interval: "weekly"
+    commit-message:
+      prefix: "[chore]"
+    labels:
+      - "chore"


### PR DESCRIPTION
We don't really need prs for npm dependencies, this tones down how needy dependabot is a little bit