### PR TITLE
[docs] postgres collation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ shell.nix
 
 # ignore custom GOBIN path
 /bin
+
+# ignore config dirs from IDEs
+/.idea/
+/.fleet/

--- a/docs/configuration/database.md
+++ b/docs/configuration/database.md
@@ -37,10 +37,12 @@ Then you should have already created database `gotosocial` in Postgres, and give
 The psql commands to do this will look something like:
 
 ```psql
-create database gotosocial;
+create database gotosocial with locale C.UTF-8 template template0;
 create user gotosocial with password 'some_really_good_password';
 grant all privileges on database gotosocial to gotosocial;
 ```
+
+GoToSocial makes use of ULIDs (Universally Unique Lexicographically Sortable Identifiers) which will not work in non-English collate environments. For this reason it is important to create the database with `C.UTF-8` locale. To do that on systems which were already initialized with non-C locale, `template0` pristine database template must be used.
 
 ## Settings
 


### PR DESCRIPTION
Check your Postgres collation for Mastodon instance now. A story about incorrectly ordered toots (long).

I spent three evenings investigating why my instance stopped updating notifications and statuses correctly. I figured out that statuses were not gone, but not ordered correctly. Like if something shaked them a bit, but not much, just a bit.

I was debugging goroutines, learning about Universally Unique Lexicographically Sortable Identifier (ULID) which is the ID that is used in the ActivityPub protocol. No luck. This is how they look like btw:

01GHGAC5EHKSQQ0YRPXNWVZ7EJ
01GHGA78BHHQ8A3T6SFVYXAV4Y

These ULIDs are used as unique identifiers and because they are lexicographically sortable, Mastodon implementations take advantage of that and sort by this database column.

Now it might be clear, but jeeez I spent some time until I finally figured: I created my Postgres database on a system with cs_CZ.UTF-8 locale. Therefore my database was created with cs_CZ collation.

See, in Czech, we have one special character "CH" and Czech collation it goes between "H" and "I". That was the problem and this is the big lesson that I learned.

Always create SQL database for Mastodon instances with "neutral" (English, none or C) collation: C.UTF-8. In case of Postgres, what you need to do is:

create database xxx with locale C.UTF-8 template template0

To check your collate, on Postgres do:

SELECT datcollate AS collation FROM pg_database WHERE datname = current_database();

Czech is not the only language that might bring problems I suppose. Check your databases now! Boost it. Thanks! Have fun.

https://social.zapletalovi.com/@lukas/statuses/01GHHJQKMCGSB8TV1SMGE6JDM0