### PR TITLE
fix logo display on the web index page.

### DIFF
--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/superseriousbusiness/gotosocial/internal/api/model"
@@ -667,7 +668,7 @@ func (c *converter) InstanceToAPIInstance(ctx context.Context, i *gtsmodel.Insta
 
 		if ia, err := c.db.GetInstanceAccount(ctx, ""); err == nil {
 			// assume default logo
-			mi.Thumbnail = config.GetProtocol() + "://" + host + "/assets/logo.png"
+			mi.Thumbnail = config.GetProtocol() + "://" + host + ":" + strconv.Itoa(config.GetPort()) + "/assets/logo.png"
 
 			// take instance account avatar as instance thumbnail if we can
 			if ia.AvatarMediaAttachmentID != "" {


### PR DESCRIPTION
Hi~ I am a student and just start learning to join the open-source community. Please tell me if I did anything wrong. Currently, I am pretty novice but I wish I could help :)

So I found that on the index page, the header template used "instance.Thumbnail" to show the logo. This variable does not contain the port number and thus may not be able to present properly. (http://localhost/assets/logo.png can't show the logo, but http://localhost:8080/assets/logo.png)

I got the port from config and added it to instance.Thumbnail to solve this.

I apologize for not commenting on an issue in advance. I will do better next time.