### PR TITLE
Change default log path

### DIFF
--- a/example/gotosocial.service
+++ b/example/gotosocial.service
@@ -17,7 +17,7 @@ Restart=on-failure
 ExecStart=/gotosocial/gotosocial --config-path config.yaml server start
 WorkingDirectory=/gotosocial
 
-StandardOutput=append:/var/log/gotosocial/gotosocial.log
+StandardOutput=append:/var/log/gotosocial.log
 StandardError=inherit
 
 


### PR DESCRIPTION
On some systems (tested on Debian 11) when the `/var/log/gotosocial` directory doesn't exist, it doesn't automatically get created, and the service fails to start with a permission denied error.

Changing the default log path to have no subdirectory means no errors when starting up for the first time.

Fixes #1023