### PR TITLE
[chore] bump go-cache to v3.1.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	codeberg.org/gruf/go-bytesize v1.0.0
 	codeberg.org/gruf/go-byteutil v1.0.2
 	codeberg.org/gruf/go-cache/v2 v2.1.4
-	codeberg.org/gruf/go-cache/v3 v3.1.6
+	codeberg.org/gruf/go-cache/v3 v3.1.7
 	codeberg.org/gruf/go-debug v1.2.0
 	codeberg.org/gruf/go-errors/v2 v2.0.2
 	codeberg.org/gruf/go-kv v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ codeberg.org/gruf/go-byteutil v1.0.2 h1:OesVyK5VKWeWdeDR00zRJ+Oy8hjXx1pBhn7WVvcZ
 codeberg.org/gruf/go-byteutil v1.0.2/go.mod h1:cWM3tgMCroSzqoBXUXMhvxTxYJp+TbCr6ioISRY5vSU=
 codeberg.org/gruf/go-cache/v2 v2.1.4 h1:r+6wJiTHZn0qqf+p1VtAjGOgXXJl7s8txhPIwoSMZtI=
 codeberg.org/gruf/go-cache/v2 v2.1.4/go.mod h1:j7teiz814lG0PfSfnUs+6HA+2/jcjTAR71Ou3Wbt2Xk=
-codeberg.org/gruf/go-cache/v3 v3.1.6 h1:LMpQoLRoGTH64WyLCew6wMVqC3Vzve09MCYbt5c0WR4=
-codeberg.org/gruf/go-cache/v3 v3.1.6/go.mod h1:h6im2UVGdrGtNt4IVKARVeoW4kAdok5ts7CbH15UWXs=
+codeberg.org/gruf/go-cache/v3 v3.1.7 h1:mWeLxh4CnIfBIbzxdCPlPsRjrernqIlFsMQdLQhUBMo=
+codeberg.org/gruf/go-cache/v3 v3.1.7/go.mod h1:h6im2UVGdrGtNt4IVKARVeoW4kAdok5ts7CbH15UWXs=
 codeberg.org/gruf/go-debug v1.2.0 h1:WBbTMnK1ArFKUmgv04aO2JiC/daTOB8zQGi521qb7OU=
 codeberg.org/gruf/go-debug v1.2.0/go.mod h1:N+vSy9uJBQgpQcJUqjctvqFz7tBHJf+S/PIjLILzpLg=
 codeberg.org/gruf/go-errors/v2 v2.0.0/go.mod h1:ZRhbdhvgoUA3Yw6e56kd9Ox984RrvbEFC2pOXyHDJP4=

--- a/internal/db/bundb/tombstone.go
+++ b/internal/db/bundb/tombstone.go
@@ -36,9 +36,9 @@ type tombstoneDB struct {
 
 func (t *tombstoneDB) init() {
 	// Initialize tombstone result cache
-	t.cache = result.NewSized([]string{
-		"ID",
-		"URI",
+	t.cache = result.NewSized([]result.Lookup{
+		{Name: "ID"},
+		{Name: "URI"},
 	}, func(t1 *gtsmodel.Tombstone) *gtsmodel.Tombstone {
 		t2 := new(gtsmodel.Tombstone)
 		*t2 = *t1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -16,7 +16,7 @@ codeberg.org/gruf/go-byteutil
 # codeberg.org/gruf/go-cache/v2 v2.1.4
 ## explicit; go 1.19
 codeberg.org/gruf/go-cache/v2
-# codeberg.org/gruf/go-cache/v3 v3.1.6
+# codeberg.org/gruf/go-cache/v3 v3.1.7
 ## explicit; go 1.19
 codeberg.org/gruf/go-cache/v3/result
 codeberg.org/gruf/go-cache/v3/ttl


### PR DESCRIPTION
fixes possible issues with zero value keys (not likely to have appeared in tombstones, but will be important when using in other areas of db)