### PR TITLE
[chore] Remove unused `admin account suspend` action

### DIFF
--- a/cmd/gotosocial/action/admin/account/account.go
+++ b/cmd/gotosocial/action/admin/account/account.go
@@ -232,12 +232,6 @@ var Disable action.GTSAction = func(ctx context.Context) error {
 	return dbConn.Stop(ctx)
 }
 
-// Suspend suspends the target account, cleanly removing all of its media, followers, following, likes, statuses, etc.
-var Suspend action.GTSAction = func(ctx context.Context) error {
-	// TODO
-	return nil
-}
-
 // Password sets the password of target account.
 var Password action.GTSAction = func(ctx context.Context) error {
 	dbConn, err := bundb.NewBunDBService(ctx)

--- a/cmd/gotosocial/admin.go
+++ b/cmd/gotosocial/admin.go
@@ -37,13 +37,13 @@ func adminCommands() *cobra.Command {
 
 	adminAccountCmd := &cobra.Command{
 		Use:   "account",
-		Short: "admin commands related to accounts",
+		Short: "admin commands related to local (this instance) accounts",
 	}
 	config.AddAdminAccount(adminAccountCmd)
 
 	adminAccountCreateCmd := &cobra.Command{
 		Use:   "create",
-		Short: "create a new account",
+		Short: "create a new local account",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return preRun(preRunArgs{cmd: cmd})
 		},
@@ -56,7 +56,7 @@ func adminCommands() *cobra.Command {
 
 	adminAccountConfirmCmd := &cobra.Command{
 		Use:   "confirm",
-		Short: "confirm an existing account manually, thereby skipping email confirmation",
+		Short: "confirm an existing local account manually, thereby skipping email confirmation",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return preRun(preRunArgs{cmd: cmd})
 		},
@@ -69,7 +69,7 @@ func adminCommands() *cobra.Command {
 
 	adminAccountPromoteCmd := &cobra.Command{
 		Use:   "promote",
-		Short: "promote an account to admin",
+		Short: "promote a local account to admin",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return preRun(preRunArgs{cmd: cmd})
 		},
@@ -82,7 +82,7 @@ func adminCommands() *cobra.Command {
 
 	adminAccountDemoteCmd := &cobra.Command{
 		Use:   "demote",
-		Short: "demote an account from admin to normal user",
+		Short: "demote a local account from admin to normal user",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return preRun(preRunArgs{cmd: cmd})
 		},
@@ -95,7 +95,7 @@ func adminCommands() *cobra.Command {
 
 	adminAccountDisableCmd := &cobra.Command{
 		Use:   "disable",
-		Short: "prevent an account from signing in or posting etc, but don't delete anything",
+		Short: "prevent a local account from signing in or posting etc, but don't delete anything",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return preRun(preRunArgs{cmd: cmd})
 		},
@@ -121,7 +121,7 @@ func adminCommands() *cobra.Command {
 
 	adminAccountPasswordCmd := &cobra.Command{
 		Use:   "password",
-		Short: "set a new password for the given account",
+		Short: "set a new password for the given local account",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return preRun(preRunArgs{cmd: cmd})
 		},

--- a/cmd/gotosocial/admin.go
+++ b/cmd/gotosocial/admin.go
@@ -106,19 +106,6 @@ func adminCommands() *cobra.Command {
 	config.AddAdminAccount(adminAccountDisableCmd)
 	adminAccountCmd.AddCommand(adminAccountDisableCmd)
 
-	adminAccountSuspendCmd := &cobra.Command{
-		Use:   "suspend",
-		Short: "completely remove an account and all of its posts, media, etc",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return preRun(preRunArgs{cmd: cmd})
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return run(cmd.Context(), account.Suspend)
-		},
-	}
-	config.AddAdminAccount(adminAccountSuspendCmd)
-	adminAccountCmd.AddCommand(adminAccountSuspendCmd)
-
 	adminAccountPasswordCmd := &cobra.Command{
 		Use:   "password",
 		Short: "set a new password for the given local account",

--- a/docs/admin/cli.md
+++ b/docs/admin/cli.md
@@ -44,7 +44,7 @@ This command can be used to create a new account on your instance.
 `gotosocial admin account create --help`:
 
 ```text
-create a new account
+create a new local account
 
 Usage:
   gotosocial admin account create [flags]
@@ -73,7 +73,7 @@ This command can be used to confirm a user+account on your instance, allowing th
 `gotosocial admin account confirm --help`:
 
 ```text
-confirm an existing account manually, thereby skipping email confirmation
+confirm an existing local account manually, thereby skipping email confirmation
 
 Usage:
   gotosocial admin account confirm [flags]
@@ -96,7 +96,7 @@ This command can be used to promote a user to admin.
 `gotosocial admin account promote --help`:
 
 ```text
-promote an account to admin
+promote a local account to admin
 
 Usage:
   gotosocial admin account promote [flags]
@@ -119,7 +119,7 @@ This command can be used to demote a user from admin to normal user.
 `gotosocial admin account demote --help`:
 
 ```text
-demote an account from admin to normal user
+demote a local account from admin to normal user
 
 Usage:
   gotosocial admin account demote [flags]
@@ -137,12 +137,12 @@ gotosocial admin account demote --username some_username --config-path config.ya
 
 ### gotosocial admin account disable
 
-This command can be used to disable an account: prevent it from signing in or doing anything, without deleting data.
+This command can be used to disable an account on your instance: prevent it from signing in or doing anything, without deleting data.
 
 `gotosocial admin account disable --help`:
 
 ```text
-prevent an account from signing in or posting etc, but don't delete anything
+prevent a local account from signing in or posting etc, but don't delete anything
 
 Usage:
   gotosocial admin account disable [flags]
@@ -185,12 +185,12 @@ gotosocial admin account suspend --username some_username --config-path config.y
 
 ### gotosocial admin account password
 
-This command can be used to set a new password on the given account.
+This command can be used to set a new password on the given local account.
 
 `gotosocial admin account password --help`:
 
 ```text
-set a new password for the given account
+set a new password for the given local account
 
 Usage:
   gotosocial admin account password [flags]

--- a/docs/admin/cli.md
+++ b/docs/admin/cli.md
@@ -158,31 +158,6 @@ Example:
 gotosocial admin account disable --username some_username --config-path config.yaml
 ```
 
-### gotosocial admin account suspend
-
-This command can be used to completely remove an account's media/posts/etc and prevent it from logging in.
-
-In other words, this 'deletes' the account (without actually removing the account entry, meaning the username cannot be used again).
-
-`gotosocial admin account suspend --help`:
-
-```text
-completely remove an account and all of its posts, media, etc
-
-Usage:
-  gotosocial admin account suspend [flags]
-
-Flags:
-  -h, --help              help for suspend
-      --username string   the username to create/delete/etc
-```
-
-Example:
-
-```bash
-gotosocial admin account suspend --username some_username --config-path config.yaml
-```
-
 ### gotosocial admin account password
 
 This command can be used to set a new password on the given local account.


### PR DESCRIPTION
It was confusing because it was a no-op and people were trying to use it.

So now it's removed, bam!

Also added the word 'local' into the docs to show that `admin account` commands are for local/this-instance accounts only.