### PR TITLE
[bugfix] Fix unicode-unaware word boundary check in hashtags

### DIFF
--- a/internal/regexes/regexes.go
+++ b/internal/regexes/regexes.go
@@ -66,16 +66,10 @@ var (
 	// such as @whatever_user@example.org, returning whatever_user and example.org (without the @ symbols)
 	MentionName = regexp.MustCompile(mentionName)
 
-	// mention regex can be played around with here: https://regex101.com/r/G1oGR0/1
+	// mention regex can be played around with here: https://regex101.com/r/P0vpYG/1
 	mentionFinder = `(?:^|\s)(@\w+(?:@[a-zA-Z0-9_\-\.]+)?)`
 	// MentionFinder extracts mentions from a piece of text.
 	MentionFinder = regexp.MustCompile(mentionFinder)
-
-	// hashtag regex can be played with here: https://regex101.com/r/bpyGlj/1
-	hashtagFinder = fmt.Sprintf(`(?:^|\s)(?:#*)(#[\p{L}\p{N}]{1,%d})(?:#|\b)`, maximumHashtagLength)
-	// HashtagFinder finds possible hashtags in a string.
-	// It returns just the string part of the hashtag, not the # symbol.
-	HashtagFinder = regexp.MustCompile(hashtagFinder)
 
 	emojiShortcode = fmt.Sprintf(`\w{2,%d}`, maximumEmojiShortcodeLength)
 	// EmojiShortcode validates an emoji name.

--- a/internal/regexes/regexes.go
+++ b/internal/regexes/regexes.go
@@ -47,7 +47,6 @@ const (
 const (
 	maximumUsernameLength       = 64
 	maximumEmojiShortcodeLength = 30
-	maximumHashtagLength        = 30
 )
 
 var (

--- a/internal/util/statustools_test.go
+++ b/internal/util/statustools_test.go
@@ -82,14 +82,17 @@ func (suite *StatusTestSuite) TestDeriveHashtagsOK() {
 	here's a link with a fragment: https://example.org/whatever#ahhh
 	here's another link with a fragment: https://example.org/whatever/#ahhh
 
-#ThisShouldAlsoWork #not_this_though
+(#ThisShouldAlsoWork) #not_this_though
 
 #111111 thisalsoshouldn'twork#### ##
 
-#alimentación, #saúde, #lävistää, #ö, #네`
+#alimentación, #saúde, #lävistää, #ö, #네
+#ThisOneIsThirtyOneCharactersLon...  ...ng
+#ThisOneIsThirteyCharactersLong
+`
 
 	tags := util.DeriveHashtagsFromText(statusText)
-	assert.Len(suite.T(), tags, 11)
+	assert.Len(suite.T(), tags, 12)
 	assert.Equal(suite.T(), "testing123", tags[0])
 	assert.Equal(suite.T(), "also", tags[1])
 	assert.Equal(suite.T(), "thisshouldwork", tags[2])
@@ -101,6 +104,7 @@ func (suite *StatusTestSuite) TestDeriveHashtagsOK() {
 	assert.Equal(suite.T(), "lävistää", tags[8])
 	assert.Equal(suite.T(), "ö", tags[9])
 	assert.Equal(suite.T(), "네", tags[10])
+	assert.Equal(suite.T(), "ThisOneIsThirteyCharactersLong", tags[11])
 
 	statusText = `#올빼미 hej`
 	tags = util.DeriveHashtagsFromText(statusText)

--- a/internal/util/statustools_test.go
+++ b/internal/util/statustools_test.go
@@ -77,26 +77,46 @@ func (suite *StatusTestSuite) TestDeriveHashtagsOK() {
 
 # testing this one shouldn't work
 
-			#thisshouldwork
+			#thisshouldwork #dupe #dupe!! #dupe
 
 	here's a link with a fragment: https://example.org/whatever#ahhh
+	here's another link with a fragment: https://example.org/whatever/#ahhh
 
 #ThisShouldAlsoWork #not_this_though
 
 #111111 thisalsoshouldn'twork#### ##
 
-#alimentación, #saúde
-`
+#alimentación, #saúde, #lävistää, #ö, #네`
 
 	tags := util.DeriveHashtagsFromText(statusText)
-	assert.Len(suite.T(), tags, 7)
+	assert.Len(suite.T(), tags, 11)
 	assert.Equal(suite.T(), "testing123", tags[0])
 	assert.Equal(suite.T(), "also", tags[1])
 	assert.Equal(suite.T(), "thisshouldwork", tags[2])
-	assert.Equal(suite.T(), "ThisShouldAlsoWork", tags[3])
-	assert.Equal(suite.T(), "111111", tags[4])
-	assert.Equal(suite.T(), "alimentación", tags[5])
-	assert.Equal(suite.T(), "saúde", tags[6])
+	assert.Equal(suite.T(), "dupe", tags[3])
+	assert.Equal(suite.T(), "ThisShouldAlsoWork", tags[4])
+	assert.Equal(suite.T(), "111111", tags[5])
+	assert.Equal(suite.T(), "alimentación", tags[6])
+	assert.Equal(suite.T(), "saúde", tags[7])
+	assert.Equal(suite.T(), "lävistää", tags[8])
+	assert.Equal(suite.T(), "ö", tags[9])
+	assert.Equal(suite.T(), "네", tags[10])
+
+	statusText = `#올빼미 hej`
+	tags = util.DeriveHashtagsFromText(statusText)
+	assert.Equal(suite.T(), "올빼미", tags[0])
+}
+
+func (suite *StatusTestSuite) TestHashtagSpansOK() {
+	statusText := `#0 #3   #8aa`
+
+	spans := util.FindHashtagSpansInText(statusText)
+	assert.Equal(suite.T(), 0, spans[0].First)
+	assert.Equal(suite.T(), 2, spans[0].Second)
+	assert.Equal(suite.T(), 3, spans[1].First)
+	assert.Equal(suite.T(), 5, spans[1].Second)
+	assert.Equal(suite.T(), 8, spans[2].First)
+	assert.Equal(suite.T(), 12, spans[2].Second)
 }
 
 func (suite *StatusTestSuite) TestDeriveEmojiOK() {
@@ -127,7 +147,7 @@ Here's some normal text with an :emoji: at the end
 func (suite *StatusTestSuite) TestDeriveMultiple() {
 	statusText := `Another test @foss_satan@fossbros-anonymous.io
 
-	#Hashtag
+	#HashTag
 
 	Text`
 
@@ -139,7 +159,7 @@ func (suite *StatusTestSuite) TestDeriveMultiple() {
 	assert.Equal(suite.T(), "@foss_satan@fossbros-anonymous.io", ms[0])
 
 	assert.Len(suite.T(), hs, 1)
-	assert.Equal(suite.T(), "Hashtag", hs[0])
+	assert.Contains(suite.T(), hs, "HashTag")
 
 	assert.Len(suite.T(), es, 0)
 }


### PR DESCRIPTION
Go `\b` does not care for Unicode, and without lookahead in the regex engine, the workarounds got very ugly. So I replaced the regex with a parser that uses Go's Unicode functions directly.

The parser runs in O(n) time and performance should be comparable.

Might even be faster since I think this is less work, but I don't know how to benchmark. :)

I'm sure it's all sorts of unidiomatic but maybe it can be salvaged!

Hashtags that wouldn't work before were those ending in non-ASCII characters, like `#blå`, since `\b` would consider `l` followed by `å` to be a word boundary.