### PR TITLE
[docs] Both HTTP proxies and NAT can cause rate limiting issues

### DIFF
--- a/docs/api/ratelimiting.md
+++ b/docs/api/ratelimiting.md
@@ -18,10 +18,14 @@ In case the rate limit is exceeded, an [HTTP 429 Too Many Requests](https://deve
 
 ### My rate limit keeps being exceeded! Why?
 
-If you find that your rate limit is regularly being exceeded (both for yourself and other callers) during normal use of your instance, it's possible that your `trusted-proxies` setting is not configured correctly. This can result in your instance seeing all incoming IP addresses as the same address: namely, the IP address of your reverse proxy. This means that all incoming requests are *sharing the same rate limit*, rather than being split correctly per IP.
+If you find that your rate limit is regularly being exceeded (both for yourself and other callers) during normal use of your instance, it may be that GoToSocial can't tell the clients apart by IP address. You can investigate this by viewing the logs of your instance. If (almost) all logged IP addresses appear to be the same IP address (something like `172.x.x.x`), then the rate limiting will cause problems.
 
-You can investigate this by viewing the logs of your instance. If (almost) all logged IP addresses appear to be the same IP address (something like `172.x.x.x`), then it's likely that your `trusted-proxies` is not correctly configured. If this is the case, try adding the IP address of your reverse proxy to the list of `trusted-proxies`, and restarting your instance.
+This happens when your server is running inside NAT (port forwarding), or behind an HTTP proxy without the correct configuration, causing your instance to see all incoming IP addresses as the same address: namely, the IP address of your reverse proxy or gateway. This means that all incoming requests are *sharing the same rate limit*, rather than being split correctly per IP.
+
+If you are using an HTTP proxy then it's likely that your `trusted-proxies` is not correctly configured. If this is the case, try adding the IP address of your reverse proxy to the list of `trusted-proxies`, and restarting your instance.
+
+If you don't have an HTTP proxy, then it's likely caused by NAT. In this case you should disable rate limiting altogether.
 
 ### Can I configure the rate limit? Can I just turn it off?
 
-Yes! See the config setting `advanced-rate-limit-requests`.
+Yes! Set `advanced-rate-limit-requests: 0` in the config.


### PR DESCRIPTION
In the case of the clients being treated as the same IP when there is no HTTP proxy, I believe the only fix is to disable rate limiting altogether, since there seems to be no way to get the actual IP.

Also explain specifically that setting the rate limit to zero turns off rate limiting rather than actually setting the limit to zero, since this is not intuitive.