### PR TITLE
docs: Add AUR Reference

### DIFF
--- a/docs/installation_guide/third_party.md
+++ b/docs/installation_guide/third_party.md
@@ -3,5 +3,6 @@
 Several awesome people have put time and energy into packaging GoToSocial for third-party ecosystems. These projects are listed below:
 
 - [YunoHost GoToSocial Packaging](https://github.com/YunoHost-Apps/gotosocial_ynh) by [OniriCorpe](https://github.com/OniriCorpe).
+- [Unofficial Arch Linux Package](https://aur.archlinux.org/packages/gotosocial)
 
 These packages are not maintained by GoToSocial, so please direct questions and issues to the repository maintainers (and donate to them!).


### PR DESCRIPTION
The AUR is the Arch unofficial repository, where users can upload PKGBUILD's for Arch Linux users to build a package.