### PR TITLE
[docs] Remove trailing / from proxy_pass for nginx

### DIFF
--- a/docs/installation_guide/nginx.md
+++ b/docs/installation_guide/nginx.md
@@ -61,7 +61,7 @@ server {
   listen [::]:80;
   server_name example.org;
   location / {
-    proxy_pass http://localhost:8080/;
+    proxy_pass http://localhost:8080;
     proxy_set_header Host $host;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";


### PR DESCRIPTION
The trailing / can break relative URLs.