### PR TITLE
Enable / document non-buildx cross compilation for docker image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,7 +330,7 @@ If all goes according to plan, you should now have a number of multiple-architec
 
 ### Manually
 
-If you prefer a simple approach to building a Docker container, with fewer dependencies, you can also just build in the following way:
+If you prefer a simple approach to building a Docker container, with fewer dependencies (go-swagger, Node, Yarn), you can also just build in the following way:
 
 ```bash
 ./scripts/build.sh && docker buildx build -t superseriousbusiness/gotosocial:latest .
@@ -338,7 +338,16 @@ If you prefer a simple approach to building a Docker container, with fewer depen
 
 The above command first builds the `gotosocial` binary, then invokes Docker buildx to build the container image.
 
-You don't need to install go-swagger, Node, or Yarn to build Docker images this way.
+
+If you want to build a docker image for a different CPU architechture without setting up buildx (for example for ARMv7 aka 32-bit ARM), you can use:
+
+```bash
+GOOS=linux GOARCH=arm ./scripts/build.sh && sudo docker build --build-arg BUILDPLATFORM=linux/amd64 --build-arg TARGETPLATFORM=linux/arm/v7 -t superseriousbusiness/gotosocial:latest .
+```
+
+See also: [exhaustive list of GOOS and GOARCH values](https://gist.github.com/lizkes/975ab2d1b5f9d5fdee5d3fa665bcfde6)
+And: [exhaustive list of possible values for docker's `--platform`](https://github.com/tonistiigi/binfmt/#build-test-image)
+
 
 ## Financial Compensation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -342,7 +342,7 @@ The above command first builds the `gotosocial` binary, then invokes Docker buil
 If you want to build a docker image for a different CPU architechture without setting up buildx (for example for ARMv7 aka 32-bit ARM), you can use:
 
 ```bash
-GOOS=linux GOARCH=arm ./scripts/build.sh && sudo docker build --build-arg BUILDPLATFORM=linux/amd64 --build-arg TARGETPLATFORM=linux/arm/v7 -t superseriousbusiness/gotosocial:latest .
+GOOS=linux GOARCH=arm ./scripts/build.sh && docker build --build-arg BUILDPLATFORM=linux/amd64 --build-arg TARGETPLATFORM=linux/arm/v7 -t superseriousbusiness/gotosocial:latest .
 ```
 
 See also: [exhaustive list of GOOS and GOARCH values](https://gist.github.com/lizkes/975ab2d1b5f9d5fdee5d3fa665bcfde6)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.3
 # Dockerfile reference: https://docs.docker.com/engine/reference/builder/
 
+# When using buildx, these variables will be set by the tool:
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+# However, declaring them as build arguments like this allows them to be set manually with `--build-arg` as well. 
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.3
 # Dockerfile reference: https://docs.docker.com/engine/reference/builder/
 
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+
 # stage 1: generate up-to-date swagger.yaml to put in the final container
 FROM --platform=${BUILDPLATFORM} quay.io/goswagger/swagger:v0.30.0 AS swagger
 


### PR DESCRIPTION
I wanted to document the process I used to build GTS for my ARM-based Single-board-computer  

Yes,  I could have updated docker and installed/configured whatever buildx requires instead, but I chose to do this because we don't technically need buildx as go's cross compilation is 10/10 and needs no `qemu`  :smiling_imp: 

My pet peeve:  When there is an option that does not list all of its possible values. So I wanted to document those:
  -  `GOOS`/`GOARCH`  for `./build.sh`
  - and the  `--platform` argument in the `Dockerfile`