### PR TITLE
[chore/frontend] remove references to unused bundle.js

### DIFF
--- a/internal/web/profile.go
+++ b/internal/web/profile.go
@@ -110,9 +110,9 @@ func (m *Module) profileGETHandler(c *gin.Context) {
 	}
 
 	stylesheets := []string{
-		"/assets/Fork-Awesome/css/fork-awesome.min.css",
-		"/assets/dist/status.css",
-		"/assets/dist/profile.css",
+		assetsPathPrefix + "/Fork-Awesome/css/fork-awesome.min.css",
+		distPathPrefix + "/status.css",
+		distPathPrefix + "/profile.css",
 	}
 	if config.GetAccountsAllowCustomCSS() {
 		stylesheets = append(stylesheets, "/@"+account.Username+"/custom.css")
@@ -128,10 +128,7 @@ func (m *Module) profileGETHandler(c *gin.Context) {
 		"statuses_next":    statusResp.NextLink,
 		"show_back_to_top": showBackToTop,
 		"stylesheets":      stylesheets,
-		"javascript": []string{
-			"/assets/dist/bundle.js",
-			"/assets/dist/frontend.js",
-		},
+		"javascript":       []string{distPathPrefix + "/frontend.js"},
 	})
 }
 

--- a/internal/web/settings-panel.go
+++ b/internal/web/settings-panel.go
@@ -39,14 +39,12 @@ func (m *Module) SettingsPanelHandler(c *gin.Context) {
 		"instance": instance,
 		"stylesheets": []string{
 			assetsPathPrefix + "/Fork-Awesome/css/fork-awesome.min.css",
-			assetsPathPrefix + "/dist/_colors.css",
-			assetsPathPrefix + "/dist/base.css",
-			assetsPathPrefix + "/dist/profile.css",
-			assetsPathPrefix + "/dist/status.css",
-			assetsPathPrefix + "/dist/settings-style.css",
+			distPathPrefix + "/_colors.css",
+			distPathPrefix + "/base.css",
+			distPathPrefix + "/profile.css",
+			distPathPrefix + "/status.css",
+			distPathPrefix + "/settings-style.css",
 		},
-		"javascript": []string{
-			assetsPathPrefix + "/dist/settings.js",
-		},
+		"javascript": []string{distPathPrefix + "/settings.js"},
 	})
 }

--- a/internal/web/thread.go
+++ b/internal/web/thread.go
@@ -105,8 +105,8 @@ func (m *Module) threadGETHandler(c *gin.Context) {
 	}
 
 	stylesheets := []string{
-		"/assets/Fork-Awesome/css/fork-awesome.min.css",
-		"/assets/dist/status.css",
+		assetsPathPrefix + "/Fork-Awesome/css/fork-awesome.min.css",
+		distPathPrefix + "/status.css",
 	}
 	if config.GetAccountsAllowCustomCSS() {
 		stylesheets = append(stylesheets, "/@"+username+"/custom.css")
@@ -118,10 +118,7 @@ func (m *Module) threadGETHandler(c *gin.Context) {
 		"context":     context,
 		"ogMeta":      ogBase(instance).withStatus(status),
 		"stylesheets": stylesheets,
-		"javascript": []string{
-			"/assets/dist/bundle.js",
-			"/assets/dist/frontend.js",
-		},
+		"javascript":  []string{distPathPrefix + "/frontend.js"},
 	})
 }
 

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -38,6 +38,7 @@ const (
 	rssFeedPath      = profilePath + "/feed.rss"
 	statusPath       = profilePath + "/statuses/:" + statusIDKey
 	assetsPathPrefix = "/assets"
+	distPathPrefix   = assetsPathPrefix + "/dist"
 	userPanelPath    = "/settings/user"
 	adminPanelPath   = "/settings/admin"
 


### PR DESCRIPTION
Since @f0x52 reworked our frontend stuff, we don't use `/assets/dist/bundle.js` anymore, but we still had references to it in some of our static pages, which was causing misleading 404s. This fixes that and also does some other small bits of tidying up.