### PR TITLE
[bugfix] Prevent future statuses entering timelines

### DIFF
--- a/internal/visibility/filter_test.go
+++ b/internal/visibility/filter_test.go
@@ -60,8 +60,8 @@ func (suite *FilterStandardTestSuite) SetupSuite() {
 }
 
 func (suite *FilterStandardTestSuite) SetupTest() {
-	testrig.InitTestLog()
 	testrig.InitTestConfig()
+	testrig.InitTestLog()
 
 	suite.db = testrig.NewTestDB()
 	suite.filter = visibility.NewFilter(suite.db)

--- a/internal/visibility/statushometimelineable.go
+++ b/internal/visibility/statushometimelineable.go
@@ -21,17 +21,27 @@ package visibility
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"codeberg.org/gruf/go-kv"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/id"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 )
 
 func (f *filter) StatusHometimelineable(ctx context.Context, targetStatus *gtsmodel.Status, timelineOwnerAccount *gtsmodel.Account) (bool, error) {
-	l := log.WithFields(kv.Fields{
+	l := log.WithFields(kv.Fields{{"statusID", targetStatus.ID}}...)
 
-		{"statusID", targetStatus.ID},
-	}...)
+	// don't timeline statuses more than 5 min in the future
+	maxID, err := id.NewULIDFromTime(time.Now().Add(5 * time.Minute))
+	if err != nil {
+		return false, err
+	}
+
+	if targetStatus.ID > maxID {
+		l.Debug("status not hometimelineable because it's from more than 5 minutes in the future")
+		return false, nil
+	}
 
 	// status owner should always be able to see their own status in their timeline so we can return early if this is the case
 	if targetStatus.AccountID == timelineOwnerAccount.ID {

--- a/internal/visibility/statusvisible.go
+++ b/internal/visibility/statusvisible.go
@@ -29,14 +29,10 @@ import (
 )
 
 func (f *filter) StatusVisible(ctx context.Context, targetStatus *gtsmodel.Status, requestingAccount *gtsmodel.Account) (bool, error) {
-	const getBoosted = true
-
-	l := log.WithFields(kv.Fields{
-
-		{"statusID", targetStatus.ID},
-	}...)
+l := log.WithFields(kv.Fields{{"statusID", targetStatus.ID}}...)
 
 	// Fetch any relevant accounts for the target status
+	const getBoosted = true
 	relevantAccounts, err := f.relevantAccounts(ctx, targetStatus, getBoosted)
 	if err != nil {
 		l.Debugf("error pulling relevant accounts for status %s: %s", targetStatus.ID, err)

--- a/internal/visibility/statusvisible.go
+++ b/internal/visibility/statusvisible.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (f *filter) StatusVisible(ctx context.Context, targetStatus *gtsmodel.Status, requestingAccount *gtsmodel.Account) (bool, error) {
-l := log.WithFields(kv.Fields{{"statusID", targetStatus.ID}}...)
+	l := log.WithFields(kv.Fields{{"statusID", targetStatus.ID}}...)
 
 	// Fetch any relevant accounts for the target status
 	const getBoosted = true


### PR DESCRIPTION
Statuses created more than 5 minutes into the future are now rejected in the visibility package.