### PR TITLE
[bugfix] Change emailVerified to true for admin account create

### DIFF
--- a/cmd/gotosocial/action/admin/account/account.go
+++ b/cmd/gotosocial/action/admin/account/account.go
@@ -78,7 +78,7 @@ var Create action.GTSAction = func(ctx context.Context) error {
 		return err
 	}
 
-	_, err = dbConn.NewSignup(ctx, username, "", false, email, password, nil, "", "", false, false)
+	_, err = dbConn.NewSignup(ctx, username, "", false, email, password, nil, "", "", true, false)
 	if err != nil {
 		return err
 	}

--- a/docs/admin/cli.md
+++ b/docs/admin/cli.md
@@ -68,7 +68,7 @@ gotosocial admin account create \
 
 ### gotosocial admin account confirm
 
-This command can be used to confirm a user+account on your instance, allowing them to log in and use the account.
+This command can be used to confirm a user+account on your instance, allowing them to log in and use the account. Note that if the account was created using `admin account create` this is not necessary.
 
 `gotosocial admin account confirm --help`:
 

--- a/docs/installation_guide/binary.md
+++ b/docs/installation_guide/binary.md
@@ -72,9 +72,9 @@ The server should now start up and you should be able to access the splash page 
 
 Note that for this example we're assuming that we're allowed to run on port 443 (standard https port), and that nothing else is running on this port.
 
-## 5: Create and confirm your user
+## 5: Create your user
 
-You can use the GoToSocial binary to also create, confirm, and promote your user account.
+You can use the GoToSocial binary to also create and promote your user account.
 
 Run the following command to create a new account:
 
@@ -83,14 +83,6 @@ Run the following command to create a new account:
 ```
 
 In the above command, replace `some_username` with your desired username, `some_email@whatever.org` with the email address you want to associate with your account, and `SOME_PASSWORD` with a secure password.
-
-Run the following command to confirm the account you just created:
-
-```bash
-./gotosocial --config-path ./config.yaml admin account confirm --username some_username
-```
-
-Replace `some_username` with the username of the account you just created.
 
 If you want your user to have admin rights, you can promote them using a similar command:
 

--- a/docs/installation_guide/docker.md
+++ b/docs/installation_guide/docker.md
@@ -134,18 +134,12 @@ time=2022-04-19T09:48:36Z level=info msg=listening on 0.0.0.0:8080
 
 ### Create your first User
 
-Now that GoToSocial is running, you can execute commands inside the running container to create, confirm, and promote your admin user.
+Now that GoToSocial is running, you can execute commands inside the running container to create and promote your admin user.
 
 First create a user (replace the username, email, and password with appropriate values):
 
 ```bash
 docker exec -it gotosocial /gotosocial/gotosocial admin account create --username some_username --email someone@example.org --password 'some_very_good_password'
-```
-
-Now confirm the user, replacing username with the value you used in the command above.
-
-```bash
-docker exec -it gotosocial /gotosocial/gotosocial admin account confirm --username some_username
 ```
 
 Now promote the user you just created to admin privileges:


### PR DESCRIPTION
The NewSignup method was already being called with requireApproval=false, but it had emailVerified=false as well, which meant that it was necessary to use the `admin account confirm` command to verify the email before the newly-created user could log in.

I think that was probably an oversight; effectively it did require approval anyway. Changing emailVerified to true allows you to just create the account and log in immediately, streamlining the setup and reducing the opportunity for manual error to sneak in.

Also updated the docs to remove the mention of needing to confirm new accounts. However, I've left the confirmation command alone because I think once we have web signups, it will be needed in that context.

It's possible I've overlooked something about the `admin account confirm` and it does in fact still make sense even for accounts created thru the CLI; if so please feel free to close this!