### PR TITLE
[packaging] embed assets in binary + use as fallback when they're missing on the filesystem

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,9 +2,7 @@
 .vscode
 archive
 dist
-docs
 example
 scripts
 test
-testrig
-vendor
+Dockerfile*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,6 +50,7 @@ builds:
 dockers:
   # https://goreleaser.com/customization/docker/
   -
+    dockerfile: prebuilt.Dockerfile
     use: buildx
     goos: linux
     goarch: amd64
@@ -63,13 +64,8 @@ dockers:
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
-    extra_files:
-    - web
-    - go.mod
-    - go.sum
-    - cmd
-    - internal
   -
+    dockerfile: prebuilt.Dockerfile
     use: buildx
     goos: linux
     goarch: arm64
@@ -83,13 +79,8 @@ dockers:
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
-    extra_files:
-    - web
-    - go.mod
-    - go.sum
-    - cmd
-    - internal
   -
+    dockerfile: prebuilt.Dockerfile
     use: buildx
     goos: linux
     goarch: arm
@@ -104,13 +95,8 @@ dockers:
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
-    extra_files:
-    - web
-    - go.mod
-    - go.sum
-    - cmd
-    - internal
   -
+    dockerfile: prebuilt.Dockerfile
     use: buildx
     goos: linux
     goarch: arm
@@ -125,12 +111,6 @@ dockers:
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
-    extra_files:
-    - web
-    - go.mod
-    - go.sum
-    - cmd
-    - internal
 docker_manifests:
   - name_template: superseriousbusiness/{{ .ProjectName }}:{{ .Version }}
     image_templates:
@@ -159,9 +139,6 @@ archives:
     - LICENSE
     - README.md
     - CHANGELOG*
-    # web stuff minus source
-    - web/assets
-    - web/template
     # example config files
     - example/config.yaml
     - example/gotosocial.service

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
       - netgo
       - osusergo
       - static_build
+      # - no_embedded_assets
     env:
       - CGO_ENABLED=0
     goos:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1.4
 # Dockerfile reference: https://docs.docker.com/engine/reference/builder/
 
 # stage 1: generate up-to-date swagger.yaml to put in the final container
 FROM --platform=${BUILDPLATFORM} quay.io/goswagger/swagger:v0.30.0 AS swagger
 
-COPY go.mod /go/src/github.com/superseriousbusiness/gotosocial/go.mod
-COPY go.sum /go/src/github.com/superseriousbusiness/gotosocial/go.sum
-COPY cmd /go/src/github.com/superseriousbusiness/gotosocial/cmd
-COPY internal /go/src/github.com/superseriousbusiness/gotosocial/internal
 WORKDIR /go/src/github.com/superseriousbusiness/gotosocial
-RUN swagger generate spec -o /go/src/github.com/superseriousbusiness/gotosocial/swagger.yaml --scan-models
+COPY go.mod go.sum ./
+COPY cmd ./
+COPY internal ./
+RUN swagger generate spec -o ./swagger.yaml --scan-models --exclude-deps
+
 
 # stage 2: generate the web/assets/dist bundles
 FROM --platform=${BUILDPLATFORM} node:16.15.1-alpine3.15 AS bundler
@@ -19,7 +19,25 @@ RUN yarn install --cwd web/source && \
     BUDO_BUILD=1 node web/source  && \
     rm -r web/source
 
-# stage 3: build the executor container
+
+# stage 3: build the application
+FROM --platform=${BUILDPLATFORM} golang:1.19-alpine3.16 AS gobuild
+# pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
+WORKDIR /go/src/github.com/superseriousbusiness/gotosocial
+COPY go.mod go.sum vendor ./
+RUN go mod download && go mod verify
+
+
+COPY . .
+# we need the built assets, so they can be bundled into the build.
+COPY --from=bundler web ./
+COPY --from=swagger /go/src/github.com/superseriousbusiness/gotosocial/swagger.yaml ./web/assets/
+
+ARG VERSION=SNAPSHOT
+RUN CGO_ENABLED=0 go build -v -tags=netgo,osusergo,static_build -ldflags='-s -w -extldflags -static -X main.Version=${VERSION}' -o gotosocial github.com/superseriousbusiness/gotosocial/cmd/gotosocial
+
+
+# stage 4: use the executor image which will copy in the remaining assets
 FROM --platform=${TARGETPLATFORM} alpine:3.15.4 as executor
 
 # switch to non-root user:group for GtS
@@ -34,14 +52,15 @@ USER 1000:1000
 # First make sure storage exists + is owned by 1000:1000, then go back
 # to just /gotosocial, where we'll run from
 WORKDIR "/gotosocial/storage"
+WORKDIR "/gotosocial/web/assets"
+WORKDIR "/gotosocial/web/templates"
 WORKDIR "/gotosocial"
 
-# copy the dist binary created by goreleaser or build.sh
-COPY --chown=1000:1000 gotosocial /gotosocial/gotosocial
+# copy in the application. not now, but when this image is used in another Dockerfile's FROM statement.
+# this makes it work both in the CI goreleaser buildcontext, and also when used in the standalone docker file
+COPY --chown=1000:1000 --from=gobuild /go/src/github.com/superseriousbusiness/gotosocial/gotosocial /gotosocial/gotosocial
 
-# copy over the web directories with templates, assets etc
-COPY --chown=1000:1000 --from=bundler web /gotosocial/web
-COPY --chown=1000:1000 --from=swagger /go/src/github.com/superseriousbusiness/gotosocial/swagger.yaml web/assets/swagger.yaml
+VOLUME [ "/gotosocial/storage", "/gotosocial/web" ]
 
-VOLUME [ "/gotosocial/storage" ]
-ENTRYPOINT [ "/gotosocial/gotosocial", "server", "start" ]
+# using CMD instead of ENTRYPOINT allows to start the container with sh for debugging work.
+CMD [ "/gotosocial/gotosocial", "server", "start" ]

--- a/cmd/gotosocial/action/embedded/embedded.go
+++ b/cmd/gotosocial/action/embedded/embedded.go
@@ -1,0 +1,116 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package embedded
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/superseriousbusiness/gotosocial/cmd/gotosocial/action"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/web"
+)
+
+var ListEmbeddedFiles action.GTSAction = func(ctx context.Context) error {
+	return fs.WalkDir(web.EmbeddedFiles, ".", func(path string, dir fs.DirEntry, err error) error {
+		if !dir.IsDir() {
+			fmt.Println(path)
+		}
+		return nil
+	})
+}
+
+func ViewEmbeddedFile(sourcePath string) error {
+	f, err := web.EmbeddedFiles.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	content, err := io.ReadAll(f)
+	fmt.Printf("%s", content)
+	return err
+}
+
+func ExtractEmbeddedFile(sourcePath, targetBaseDir string) error {
+	if targetBaseDir == "" {
+		// select target dir based on configuration
+		if strings.HasPrefix(sourcePath, string(web.EmbeddedAssets)) {
+			targetBaseDir = config.GetWebAssetBaseDir()
+		} else if strings.HasPrefix(sourcePath, string(web.EmbeddedTemplates)) {
+			targetBaseDir = config.GetWebTemplateBaseDir()
+		}
+		// remove the duplicate template / assets path element (it's part of `sourcePath` already)
+		targetBaseDir = filepath.Dir(strings.TrimSuffix(targetBaseDir, "/"))
+	}
+
+	targetPath := filepath.Join(targetBaseDir, sourcePath)
+	_, err := os.Stat(targetPath)
+	if err == nil { //nolint:gocritic,ifElseChain
+		// target file seems to exist, move existing content to *.bak first
+		if err := createBackup(targetPath); err != nil {
+			return fmt.Errorf("could not create backup of '%s': %s", targetPath, err)
+		}
+	} else if errors.Is(err.(*fs.PathError).Err, fs.ErrNotExist) { //nolint:forcetypeassert
+		// ErrNotExist is not an error, but everything else is.
+		// We still need to ensure the parent path exists.
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+			return fmt.Errorf("could not create parent directory for '%s': %s", targetPath, err)
+		}
+	} else {
+		return fmt.Errorf("could not check for existing file '%s': %s", targetPath, err)
+	}
+
+	// open files & copy content
+	targetFile, err := os.Create(targetPath)
+	if err != nil {
+		return fmt.Errorf("could not open new file '%s': %s", targetPath, err)
+	}
+	defer targetFile.Close()
+	sourceFile, err := web.EmbeddedFiles.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("could not open embedded file '%s': %s", sourcePath, err)
+	}
+	defer sourceFile.Close()
+
+	_, err = io.Copy(targetFile, sourceFile)
+	if err != nil {
+		return fmt.Errorf("could not copy to '%s': %s", targetFile.Name(), err)
+	}
+	return nil
+}
+
+func createBackup(path string) error {
+	original, err := os.OpenFile(path, os.O_RDONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("could not open existing file '%s': %s", path, err)
+	}
+	defer original.Close()
+	backup, err := os.Create(path + ".bak")
+	if err != nil {
+		return fmt.Errorf("could not open new backup file '%s': %s", path, err)
+	}
+	defer backup.Close()
+	_, err = io.Copy(backup, original)
+	return err
+}

--- a/cmd/gotosocial/embedded.go
+++ b/cmd/gotosocial/embedded.go
@@ -1,0 +1,89 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/superseriousbusiness/gotosocial/cmd/gotosocial/action/embedded"
+)
+
+func embeddedCommands() *cobra.Command {
+	embeddedCmd := &cobra.Command{
+		Use:   "embedded",
+		Short: "work with assets embedded in the gotosocial executable for customization",
+	}
+
+	embeddedListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "generate list of assets embedded in this executable",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return preRun(preRunArgs{cmd: cmd, skipValidation: true})
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd.Context(), embedded.ListEmbeddedFiles)
+		},
+	}
+	embeddedCmd.AddCommand(embeddedListCmd)
+
+	embeddedViewCmd := &cobra.Command{
+		Use:   "view <embedded-path>",
+		Short: "print content of an embedded asset",
+		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return preRun(preRunArgs{cmd: cmd, skipValidation: true})
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd.Context(), func(ctx context.Context) error {
+				return embedded.ViewEmbeddedFile(args[0])
+			})
+		},
+	}
+	embeddedCmd.AddCommand(embeddedViewCmd)
+
+	var targetBaseDirFlag string
+	embeddedExtractCmd := &cobra.Command{
+		Use:     "extract <embedded-path>...",
+		Short:   "write content of an embedded asset to a file on disk, creating a backup if the target already existed.",
+		Example: "gotosocial embedded extract template/index.tmpl",
+		Args:    cobra.MinimumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return preRun(preRunArgs{cmd: cmd, skipValidation: true})
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd.Context(), func(ctx context.Context) error {
+				for _, path := range args {
+					fmt.Println(path)
+					err := embedded.ExtractEmbeddedFile(path, targetBaseDirFlag)
+					if err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+		},
+	}
+	embeddedExtractCmd.Flags().StringVar(&targetBaseDirFlag, "target-base-dir", "", "Destination to write the file(s) to.\nIf left empty, files will be written to web-{template/asset}-base-dir as defined in config")
+	embeddedCmd.AddCommand(embeddedExtractCmd)
+
+	return embeddedCmd
+}

--- a/cmd/gotosocial/main.go
+++ b/cmd/gotosocial/main.go
@@ -63,6 +63,7 @@ func main() {
 	rootCmd.AddCommand(testrigCommands())
 	rootCmd.AddCommand(debugCommands())
 	rootCmd.AddCommand(adminCommands())
+	rootCmd.AddCommand(embeddedCommands())
 
 	// run
 	if err := rootCmd.Execute(); err != nil {

--- a/docs/admin/frontend_customization.md
+++ b/docs/admin/frontend_customization.md
@@ -1,0 +1,75 @@
+# Frontend Customization
+
+Starting with v0.7.0, gotosocial embeds all frontend assets within the executable.
+To override these, you can use directories on the filesystem, whose path is defined by [configuration variables](../configuration/web.md).
+gotosocial attempts to read files from these directories first before using the embedded assets.
+
+## Working with embedded assets using the CLI
+
+The `gotosocial embedded` subcommand is provided to manage the embedded assets:
+
+```
+Usage:
+  gotosocial embedded [command]
+
+Available Commands:
+  extract     write content of an embedded asset to a file on disk, creating a backup if the target already existed.
+  list        generate list of assets embedded in this executable
+  view        print content of an embedded asset
+```
+
+### Customizing the frontend
+
+> NOTE:
+> When running outside of docker, make sure to call the following commands from the user that is normally running gotosocial.
+
+> NOTE:
+> When running within docker, you should mount the `web-asset-base-dir` and `web-template-base-dir` as volumes, so customizations are persisted (The example docker-compose.yaml file already does this).
+> In the following examples, treat `gotosocial` as an alias to `docker run <containername> gotosocial`.
+
+1. Find the asset you want to modify.
+    ```
+    gotosocial embedded list
+    ```
+
+2. Extract the desired asset to the location where gotosocial is going to use it.
+    For example, to customize the landing page of your instance, call
+    ```
+    gotosocial embedded extract template/index.tmpl
+    ```
+    With default configuration, you should have a file `web/templates/index.tmpl` next to your gotosocial executable.
+
+3. Customize the template (templates are written in plain HTML + [go template syntax](https://pkg.go.dev/html/template)) and restart gotosocial to apply the changes.
+
+## A word of caution
+
+It's important to note that assets will change between gotosocial versions, and especially customized templates can become incompatible with the updated version.
+We treat the API surface used in templates as private, but we try to point out major breaking changes on a best effort basis in the release notes.
+
+### Migrating your customizations to a new release
+
+When updating you should compare your customizations with files that ship with the new version.
+For this, you can use something like the following bash snippet:
+
+```sh
+OLD_GTS="$(which gotosocial)"
+NEW_GTS="/tmp/gotosocial_new"
+NEW_EMBEDDED="/tmp/$($NEW_GTS --version)"
+OLD_EMBEDDED="/tmp/$($OLD_GTS --version)"
+CUSTOMDIR="$(dirname $(which gotosocial))/web"
+
+CUSTOMIZED_FILES=$(find "$CUSTOMDIR" -type f)
+for f in $CUSTOMIZED_FILES; do
+    f=${f#"$CUSTOMDIR/"} # strip leading tree parts
+    "$OLD_GTS" embedded extract --target-base-dir "$OLD_EMBEDDED" "$f"
+    "$NEW_GTS" embedded extract --target-base-dir "$NEW_EMBEDDED" "$f" > /dev/null
+    cmp "$OLD_EMBEDDED/$f" "$NEW_EMBEDDED/$f"
+    if [[ $? -eq 0 ]]; then 
+        echo "  has not changed"
+    else
+        echo "  differs in new version:"
+        # remove -p to directly apply changes
+        git merge-file -p -L customized -L old -L new "$CUSTOMDIR/$f" "$OLD_EMBEDDED/$f" "$NEW_EMBEDDED/$f"
+    fi
+done
+```

--- a/docs/configuration/web.md
+++ b/docs/configuration/web.md
@@ -1,5 +1,9 @@
 # Web
 
+Starting with v0.7.0, gotosocial embeds all assets for the web frontend inside the executable.
+The configuration defines directories where assets additionally can be read from to allow for customization of the frontend.
+Head over to [Frontend Customization](TODO) to learn more about this use case.
+
 ## Settings
 
 ```yaml
@@ -9,12 +13,14 @@
 
 # Config pertaining to templating and serving of web pages/email notifications and the like
 
-# String. Directory from which gotosocial will attempt to load html templates (.tmpl files).
+# String. Directory from which gotosocial will attempt to load html templates (.tmpl files),
+#   overriding the embedded templates.
 # Examples: ["/some/absolute/path/", "./relative/path/", "../../some/weird/path/"]
 # Default: "./web/template/"
 web-template-base-dir: "./web/template/"
 
 # String. Directory from which gotosocial will attempt to serve static web assets (images, scripts).
+#   overriding the embedded assets.
 # Examples: ["/some/absolute/path/", "./relative/path/", "../../some/weird/path/"]
 # Default: "./web/assets/"
 web-asset-base-dir: "./web/assets/"

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ It began as a solo project, and then picked up steam as more developers became i
 
 ## Known Issues
 
-Since GoToSocial is still in alpha, there are plenty of bugs. We use [GitHub issues](https://github.com/superseriousbusiness/gotosocial/issues?q=is%3Aissue+is%3Aopen+label%3Abug) to track these. The [FAQ](docs/faq.md) also describes some of the features that haven't been implemented yet.
+Since GoToSocial is still in alpha, there are plenty of bugs. We use [GitHub issues](https://github.com/superseriousbusiness/gotosocial/issues?q=is%3Aissue+is%3Aopen+label%3Abug) to track these. The [FAQ](./faq.md) also describes some of the features that haven't been implemented yet.
 
 ### Client App Issues
 

--- a/docs/installation_guide/binary.md
+++ b/docs/installation_guide/binary.md
@@ -36,7 +36,7 @@ Then extract it:
 tar -xzf gotosocial_0.5.2_linux_amd64.tar.gz
 ```
 
-This will put the `gotosocial` binary in your current directory, in addition to the `web` folder, which contains assets for the web frontend, and an `example` folder, which contains a sample configuration file.
+This will put the `gotosocial` binary in your current directory, in addition to the `example` folder, which contains a sample configuration file.
 
 ## 3. Edit Configuration File
 

--- a/example/docker-compose/docker-compose.yaml
+++ b/example/docker-compose/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
       #- "127.0.0.1:8080:8080"
     volumes:
       - ~/gotosocial/data:/gotosocial/storage
+      - ~/gotosocial/web:/gotosocial/web
     restart: "always"
 
 networks:

--- a/internal/email/noopsender.go
+++ b/internal/email/noopsender.go
@@ -20,10 +20,10 @@ package email
 
 import (
 	"bytes"
-	"text/template"
+	"html/template"
 
-	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/superseriousbusiness/gotosocial/internal/templates"
 )
 
 // NewNoopSender returns a no-op email sender that will just execute the given sendCallback
@@ -31,9 +31,7 @@ import (
 //
 // Passing a nil function is also acceptable, in which case the send functions will just return nil.
 func NewNoopSender(sendCallback func(toAddress string, message string)) (Sender, error) {
-	templateBaseDir := config.GetWebTemplateBaseDir()
-
-	t, err := loadTemplates(templateBaseDir)
+	t, err := templates.ParseTemplates("email_*.tmpl", "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -20,10 +20,11 @@ package email
 
 import (
 	"fmt"
+	"html/template"
 	"net/smtp"
-	"text/template"
 
 	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/templates"
 )
 
 // Sender contains functions for sending emails to instance users/new signups.
@@ -37,8 +38,7 @@ type Sender interface {
 
 // NewSender returns a new email Sender interface with the given configuration, or an error if something goes wrong.
 func NewSender() (Sender, error) {
-	templateBaseDir := config.GetWebTemplateBaseDir()
-	t, err := loadTemplates(templateBaseDir)
+	t, err := templates.ParseTemplates("email_*.tmpl", "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/email/util.go
+++ b/internal/email/util.go
@@ -20,25 +20,8 @@ package email
 
 import (
 	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
-	"text/template"
 )
-
-func loadTemplates(templateBaseDir string) (*template.Template, error) {
-	if !filepath.IsAbs(templateBaseDir) {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return nil, fmt.Errorf("error getting current working directory: %s", err)
-		}
-		templateBaseDir = filepath.Join(cwd, templateBaseDir)
-	}
-
-	// look for all templates that start with 'email_'
-	return template.ParseGlob(filepath.Join(templateBaseDir, "email_*"))
-}
 
 // https://datatracker.ietf.org/doc/html/rfc2822
 // I did not read the RFC, I just copy and pasted from

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -177,11 +177,8 @@ func New(ctx context.Context, db db.DB) (Router, error) {
 		return nil, err
 	}
 
-	// set template functions
-	LoadTemplateFunctions(engine)
-
 	// load templates onto the engine
-	if err := LoadTemplates(engine); err != nil {
+	if _, err := LoadTemplates(engine, ""); err != nil {
 		return nil, err
 	}
 

--- a/internal/router/template.go
+++ b/internal/router/template.go
@@ -19,156 +19,19 @@
 package router
 
 import (
-	"fmt"
 	"html/template"
-	"os"
-	"path/filepath"
-	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/superseriousbusiness/gotosocial/internal/api/model"
-	"github.com/superseriousbusiness/gotosocial/internal/config"
-	"github.com/superseriousbusiness/gotosocial/internal/log"
-	"github.com/superseriousbusiness/gotosocial/internal/text"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+
+	"github.com/superseriousbusiness/gotosocial/internal/templates"
 )
 
-const (
-	justTime     = "15:04"
-	dateYear     = "Jan 02, 2006"
-	dateTime     = "Jan 02, 15:04"
-	dateYearTime = "Jan 02, 2006, 15:04"
-	monthYear    = "Jan, 2006"
-	badTimestamp = "bad timestamp"
-)
-
-// LoadTemplates loads html templates for use by the given engine
-func LoadTemplates(engine *gin.Engine) error {
-	templateBaseDir := config.GetWebTemplateBaseDir()
-	if templateBaseDir == "" {
-		return fmt.Errorf("%s cannot be empty and must be a relative or absolute path", config.WebTemplateBaseDirFlag())
+// LoadTemplates loads html templates for use by the given engine.
+// If `templateBaseDir` is empty its value is read from config instead.
+func LoadTemplates(engine *gin.Engine, templateBaseDir string) (*template.Template, error) {
+	templates, err := templates.ParseTemplates("*.tmpl", templateBaseDir)
+	if err == nil {
+		engine.SetHTMLTemplate(templates)
 	}
-
-	templateBaseDir, err := filepath.Abs(templateBaseDir)
-	if err != nil {
-		return fmt.Errorf("error getting absolute path of %s: %s", templateBaseDir, err)
-	}
-
-	if _, err := os.Stat(filepath.Join(templateBaseDir, "index.tmpl")); err != nil {
-		return fmt.Errorf("%s doesn't seem to contain the templates; index.tmpl is missing: %w", templateBaseDir, err)
-	}
-
-	engine.LoadHTMLGlob(filepath.Join(templateBaseDir, "*"))
-	return nil
-}
-
-func oddOrEven(n int) string {
-	if n%2 == 0 {
-		return "even"
-	}
-	return "odd"
-}
-
-func escape(str string) template.HTML {
-	/* #nosec G203 */
-	return template.HTML(template.HTMLEscapeString(str))
-}
-
-func noescape(str string) template.HTML {
-	/* #nosec G203 */
-	return template.HTML(str)
-}
-
-func noescapeAttr(str string) template.HTMLAttr {
-	/* #nosec G203 */
-	return template.HTMLAttr(str)
-}
-
-func timestamp(stamp string) string {
-	t, err := util.ParseISO8601(stamp)
-	if err != nil {
-		log.Errorf("error parsing timestamp %s: %s", stamp, err)
-		return badTimestamp
-	}
-
-	t = t.Local()
-
-	tYear, tMonth, tDay := t.Date()
-	now := time.Now()
-	currentYear, currentMonth, currentDay := now.Date()
-
-	switch {
-	case tYear == currentYear && tMonth == currentMonth && tDay == currentDay:
-		return "Today, " + t.Format(justTime)
-	case tYear == currentYear:
-		return t.Format(dateTime)
-	default:
-		return t.Format(dateYear)
-	}
-}
-
-func timestampPrecise(stamp string) string {
-	t, err := util.ParseISO8601(stamp)
-	if err != nil {
-		log.Errorf("error parsing timestamp %s: %s", stamp, err)
-		return badTimestamp
-	}
-	return t.Local().Format(dateYearTime)
-}
-
-func timestampVague(stamp string) string {
-	t, err := util.ParseISO8601(stamp)
-	if err != nil {
-		log.Errorf("error parsing timestamp %s: %s", stamp, err)
-		return badTimestamp
-	}
-	return t.Format(monthYear)
-}
-
-type iconWithLabel struct {
-	faIcon string
-	label  string
-}
-
-func visibilityIcon(visibility model.Visibility) template.HTML {
-	var icon iconWithLabel
-
-	switch visibility {
-	case model.VisibilityPublic:
-		icon = iconWithLabel{"globe", "public"}
-	case model.VisibilityUnlisted:
-		icon = iconWithLabel{"unlock", "unlisted"}
-	case model.VisibilityPrivate:
-		icon = iconWithLabel{"lock", "private"}
-	case model.VisibilityMutualsOnly:
-		icon = iconWithLabel{"handshake-o", "mutuals only"}
-	case model.VisibilityDirect:
-		icon = iconWithLabel{"envelope", "direct"}
-	}
-
-	/* #nosec G203 */
-	return template.HTML(fmt.Sprintf(`<i aria-label="Visibility: %v" class="fa fa-%v"></i>`, icon.label, icon.faIcon))
-}
-
-// text is a template.HTML to affirm that the input of this function is already escaped
-func emojify(emojis []model.Emoji, inputText template.HTML) template.HTML {
-	out := text.Emojify(emojis, string(inputText))
-
-	/* #nosec G203 */
-	// (this is escaped above)
-	return template.HTML(out)
-}
-
-func LoadTemplateFunctions(engine *gin.Engine) {
-	engine.SetFuncMap(template.FuncMap{
-		"escape":           escape,
-		"noescape":         noescape,
-		"noescapeAttr":     noescapeAttr,
-		"oddOrEven":        oddOrEven,
-		"visibilityIcon":   visibilityIcon,
-		"timestamp":        timestamp,
-		"timestampVague":   timestampVague,
-		"timestampPrecise": timestampPrecise,
-		"emojify":          emojify,
-	})
+	return templates, err
 }

--- a/internal/templates/functions.go
+++ b/internal/templates/functions.go
@@ -1,0 +1,149 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package templates
+
+import (
+	"fmt"
+	"html/template"
+	"time"
+
+	"github.com/superseriousbusiness/gotosocial/internal/api/model"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/superseriousbusiness/gotosocial/internal/text"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
+)
+
+const (
+	justTime     = "15:04"
+	dateYear     = "Jan 02, 2006"
+	dateTime     = "Jan 02, 15:04"
+	dateYearTime = "Jan 02, 2006, 15:04"
+	monthYear    = "Jan, 2006"
+	badTimestamp = "bad timestamp"
+)
+
+func oddOrEven(n int) string {
+	if n%2 == 0 {
+		return "even"
+	}
+	return "odd"
+}
+
+func escape(str string) template.HTML {
+	/* #nosec G203 */
+	return template.HTML(template.HTMLEscapeString(str))
+}
+
+func noescape(str string) template.HTML {
+	/* #nosec G203 */
+	return template.HTML(str)
+}
+
+func noescapeAttr(str string) template.HTMLAttr {
+	/* #nosec G203 */
+	return template.HTMLAttr(str)
+}
+
+func timestamp(stamp string) string {
+	t, err := util.ParseISO8601(stamp)
+	if err != nil {
+		log.Errorf("error parsing timestamp %s: %s", stamp, err)
+		return badTimestamp
+	}
+
+	t = t.Local()
+
+	tYear, tMonth, tDay := t.Date()
+	now := time.Now()
+	currentYear, currentMonth, currentDay := now.Date()
+
+	switch {
+	case tYear == currentYear && tMonth == currentMonth && tDay == currentDay:
+		return "Today, " + t.Format(justTime)
+	case tYear == currentYear:
+		return t.Format(dateTime)
+	default:
+		return t.Format(dateYear)
+	}
+}
+
+func timestampPrecise(stamp string) string {
+	t, err := util.ParseISO8601(stamp)
+	if err != nil {
+		log.Errorf("error parsing timestamp %s: %s", stamp, err)
+		return badTimestamp
+	}
+	return t.Local().Format(dateYearTime)
+}
+
+func timestampVague(stamp string) string {
+	t, err := util.ParseISO8601(stamp)
+	if err != nil {
+		log.Errorf("error parsing timestamp %s: %s", stamp, err)
+		return badTimestamp
+	}
+	return t.Format(monthYear)
+}
+
+type iconWithLabel struct {
+	faIcon string
+	label  string
+}
+
+func visibilityIcon(visibility model.Visibility) template.HTML {
+	var icon iconWithLabel
+
+	switch visibility {
+	case model.VisibilityPublic:
+		icon = iconWithLabel{"globe", "public"}
+	case model.VisibilityUnlisted:
+		icon = iconWithLabel{"unlock", "unlisted"}
+	case model.VisibilityPrivate:
+		icon = iconWithLabel{"lock", "private"}
+	case model.VisibilityMutualsOnly:
+		icon = iconWithLabel{"handshake-o", "mutuals only"}
+	case model.VisibilityDirect:
+		icon = iconWithLabel{"envelope", "direct"}
+	}
+
+	/* #nosec G203 */
+	return template.HTML(fmt.Sprintf(`<i aria-label="Visibility: %v" class="fa fa-%v"></i>`, icon.label, icon.faIcon))
+}
+
+// text is a template.HTML to affirm that the input of this function is already escaped
+func emojify(emojis []model.Emoji, inputText template.HTML) template.HTML {
+	out := text.Emojify(emojis, string(inputText))
+
+	/* #nosec G203 */
+	// (this is escaped above)
+	return template.HTML(out)
+}
+
+// EngineTemplateFuncs is map of names usable in templates to call go functions
+var EngineTemplateFuncs = template.FuncMap{
+	"escape":           escape,
+	"noescape":         noescape,
+	"noescapeAttr":     noescapeAttr,
+	"oddOrEven":        oddOrEven,
+	"visibilityIcon":   visibilityIcon,
+	"timestamp":        timestamp,
+	"timestampVague":   timestampVague,
+	"timestampPrecise": timestampPrecise,
+	"emojify":          emojify,
+}

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -1,0 +1,52 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package templates
+
+import (
+	"fmt"
+	"html/template"
+	"path/filepath"
+
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/web"
+)
+
+// ParseTemplates reads the templates from disk or embedded in the executable.
+// It throws errors if an invalid path to the templates is given, or the
+// templates can't be parsed.
+// If templateBaseDir is empty its value is read from config instead.
+func ParseTemplates(matchOn, templateBaseDir string) (*template.Template, error) {
+	if templateBaseDir == "" {
+		templateBaseDir = config.GetWebTemplateBaseDir()
+		if templateBaseDir == "" {
+			return nil, fmt.Errorf("%s cannot be empty and must be a relative or absolute path", config.WebTemplateBaseDirFlag())
+		}
+	}
+
+	var err error
+	templateBaseDir, err = filepath.Abs(templateBaseDir)
+	if err != nil {
+		return nil, fmt.Errorf("error getting absolute path of %s: %s", templateBaseDir, err)
+	}
+
+	templateSource := web.NewHybridFS(web.EmbeddedTemplates, templateBaseDir)
+	return template.New("").
+		Funcs(EngineTemplateFuncs).
+		ParseFS(templateSource, matchOn)
+}

--- a/internal/typeutils/defaulticons.go
+++ b/internal/typeutils/defaulticons.go
@@ -19,14 +19,15 @@
 package typeutils
 
 import (
+	"io/fs"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"strings"
 
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/superseriousbusiness/gotosocial/web"
 )
 
 const defaultHeaderPath = "/assets/default_header.png"
@@ -44,10 +45,10 @@ func populateDefaultAvatars() (defaultAvatars []string) {
 		log.Panicf("populateDefaultAvatars: error getting abs path for web assets: %s", err)
 	}
 
-	defaultAvatarsAbsFilePath := filepath.Join(webAssetsAbsFilePath, "default_avatars")
-	defaultAvatarFiles, err := os.ReadDir(defaultAvatarsAbsFilePath)
+	filesys := web.NewHybridFS(web.EmbeddedAssets, webAssetsAbsFilePath)
+	defaultAvatarFiles, err := fs.ReadDir(filesys, "default_avatars")
 	if err != nil {
-		log.Warnf("populateDefaultAvatars: error reading default avatars at %s: %s", defaultAvatarsAbsFilePath, err)
+		log.Warnf("populateDefaultAvatars: error reading default avatars: %s", err)
 		return
 	}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - "admin/admin_panel.md"
     - "admin/cli.md"
     - "admin/backup_and_restore.md"
+    - "admin/frontend_customization.md"
   - "Federation":
     - "federation/index.md"
     - "federation/glossary.md"

--- a/prebuilt.Dockerfile
+++ b/prebuilt.Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1.4
+# Dockerfile reference: https://docs.docker.com/engine/reference/builder/
+
+FROM --platform=${TARGETPLATFORM} alpine:3.15.4 as executor
+
+# switch to non-root user:group for GtS
+USER 1000:1000
+
+# Because we're doing multi-arch builds we can't easily do `RUN mkdir [...]`
+# but we can hack around that by having docker's WORKDIR make the dirs for
+# us, as the user created above.
+#
+# See https://docs.docker.com/engine/reference/builder/#workdir
+#
+# First make sure storage exists + is owned by 1000:1000, then go back
+# to just /gotosocial, where we'll run from
+WORKDIR "/gotosocial/storage"
+WORKDIR "/gotosocial/web/assets"
+WORKDIR "/gotosocial/web/templates"
+WORKDIR "/gotosocial"
+
+# copy in the application, containing all the assets in the binary.
+COPY --chown=1000:1000 gotosocial /gotosocial/gotosocial
+
+VOLUME [ "/gotosocial/storage", "/gotosocial/web" ]
+
+# using CMD instead of ENTRYPOINT allows to start the container with sh for debugging work.
+CMD [ "/gotosocial/gotosocial", "server", "start" ]

--- a/testrig/gin.go
+++ b/testrig/gin.go
@@ -28,8 +28,8 @@ import (
 // CreateGinTextContext creates a new gin.Context suitable for a test, with an instantiated gin.Engine.
 func CreateGinTestContext(rw http.ResponseWriter, r *http.Request) (*gin.Context, *gin.Engine) {
 	ctx, eng := gin.CreateTestContext(rw)
-	router.LoadTemplateFunctions(eng)
-	if err := router.LoadTemplates(eng); err != nil {
+	// FIXME @cleanup: why is this in addition to testrig/router.go#ConfigureTemplatesWithGin()?
+	if _, err := router.LoadTemplates(eng, ""); err != nil {
 		panic(err)
 	}
 	ctx.Request = r

--- a/testrig/router.go
+++ b/testrig/router.go
@@ -20,8 +20,8 @@ package testrig
 
 import (
 	"context"
+	"html/template"
 	"os"
-	"path/filepath"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -60,6 +60,5 @@ func NewTestRouter(db db.DB) router.Router {
 
 // ConfigureTemplatesWithGin will panic on any errors related to template loading during tests
 func ConfigureTemplatesWithGin(engine *gin.Engine, templatePath string) {
-	router.LoadTemplateFunctions(engine)
-	engine.LoadHTMLGlob(filepath.Join(templatePath, "*"))
+	template.Must(router.LoadTemplates(engine, templatePath))
 }

--- a/web/embed.go
+++ b/web/embed.go
@@ -19,18 +19,10 @@
 package web
 
 import (
-	"embed"
 	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
-)
-
-var (
-	// embed subdirectories we want to always ship with the binary.
-	// the all: prefix is required to also include files prefixed with . and _
-	//go:embed all:template all:assets
-	embeddedFiles embed.FS
 )
 
 // HybridFS is a fs.FS that tries to read files from a specified location on disk,

--- a/web/embed.go
+++ b/web/embed.go
@@ -1,0 +1,82 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package web
+
+import (
+	"embed"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+var (
+	// embed subdirectories we want to always ship with the binary.
+	// the all: prefix is required to also include files prefixed with . and _
+	//go:embed all:template all:assets
+	embeddedFiles embed.FS
+)
+
+// HybridFS is a fs.FS that tries to read files from a specified location on disk,
+// and falls back to assets embedded in the executable. Can and should be used for
+// any assets that live in subdirectories of this module.
+type HybridFS struct {
+	embeddedBaseDir EmbeddedFileGroup
+	hostBaseDir     string
+}
+
+// EmbeddedFileGroup represents a subdirectory of this module, i.e. web/template/
+type EmbeddedFileGroup string
+
+const (
+	EmbeddedTemplates EmbeddedFileGroup = "template"
+	EmbeddedAssets    EmbeddedFileGroup = "assets"
+)
+
+// NewHybridFS creates an fs.FS that combines reading from embedded files and from disk.
+func NewHybridFS(group EmbeddedFileGroup, baseDir string) HybridFS {
+	return HybridFS{
+		embeddedBaseDir: group,
+		hostBaseDir:     baseDir,
+	}
+}
+
+func (h HybridFS) Open(name string) (f fs.File, err error) {
+	// NOTE: we are responsible here for checking for tree traversal (as per
+	// fs.FS interface definition).
+	// Because we want to be able to use a hostBaseDir that is outside of PWD,
+	// we don't verify ValidPath() on the full path (it would reject absolute
+	// paths and relative paths containing `..`), but only the given asset
+	// name. In other words: We trust the value of h.hostBaseDir to not contain
+	// a malicious path.
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+
+	// first try to read from host filesystem in the chosen hostBaseDir
+	f, err = os.Open(filepath.Join(h.hostBaseDir, name))
+
+	// fall back to buildtime embedded files
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
+		path := filepath.Join(string(h.embeddedBaseDir), name)
+		f, err = embeddedFiles.Open(path)
+	}
+
+	return f, err
+}

--- a/web/embed.go
+++ b/web/embed.go
@@ -67,7 +67,7 @@ func (h HybridFS) Open(name string) (f fs.File, err error) {
 	// fall back to buildtime embedded files
 	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		path := filepath.Join(string(h.embeddedBaseDir), name)
-		f, err = embeddedFiles.Open(path)
+		f, err = EmbeddedFiles.Open(path)
 	}
 
 	return f, err

--- a/web/embed_disabled.go
+++ b/web/embed_disabled.go
@@ -1,0 +1,27 @@
+//go:build no_embedded_assets
+// +build no_embedded_assets
+
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package web
+
+import "embed"
+
+// placeholder for an empty embed.FS used in embed.go
+var embeddedFiles embed.FS = embed.FS{}

--- a/web/embed_disabled.go
+++ b/web/embed_disabled.go
@@ -24,4 +24,4 @@ package web
 import "embed"
 
 // placeholder for an empty embed.FS used in embed.go
-var embeddedFiles embed.FS = embed.FS{}
+var EmbeddedFiles embed.FS = embed.FS{}

--- a/web/embed_enabled.go
+++ b/web/embed_enabled.go
@@ -27,4 +27,4 @@ import "embed"
 // the all: prefix is required to also include files prefixed with . and _
 //
 //go:embed all:assets all:template
-var embeddedFiles embed.FS
+var EmbeddedFiles embed.FS

--- a/web/embed_enabled.go
+++ b/web/embed_enabled.go
@@ -1,0 +1,30 @@
+//go:build !no_embedded_assets
+// +build !no_embedded_assets
+
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package web
+
+import "embed"
+
+// embed subdirectories we want to always ship with the binary.
+// the all: prefix is required to also include files prefixed with . and _
+//
+//go:embed all:assets all:template
+var embeddedFiles embed.FS


### PR DESCRIPTION
Embed both assets and templates in the executable to simplify packaging and installation/updates even further.
It still tries to read files from disk (for ease of customization), but falls back to embedded files.

###  TODO
The functionality as described is working. For a meaningful change work is still to be done:
- [x] implement hybrid FS
- [x] use hybrid FS for remaining asset types (default avatars)
- [x] change builds to not bundle assets
- [x] add cli to extract assets for customization (analogous to [`gitea embedded`](https://docs.gitea.io/en-us/cmd-embedded/))
- [x] adapt documentation
- [ ] add e2e tests with different configurations (eg check landing page response on `GTS_WEB_TEMPLATE_BASE_DIR=/dev/null ./gotosocial testrig start`)

