### PR TITLE
Add support for a Request ID to correlate things

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/disintegration/imaging v1.6.2
 	github.com/gin-contrib/cors v1.4.0
 	github.com/gin-contrib/gzip v0.0.6
+	github.com/gin-contrib/requestid v0.0.6
 	github.com/gin-contrib/sessions v0.0.5
 	github.com/gin-gonic/gin v1.8.1
 	github.com/go-fed/httpsig v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,8 @@ github.com/gin-contrib/cors v1.4.0 h1:oJ6gwtUl3lqV0WEIwM/LxPF1QZ5qe2lGWdY2+bz7y0
 github.com/gin-contrib/cors v1.4.0/go.mod h1:bs9pNM0x/UsmHPBWT2xZz9ROh8xYjYkiURUfmBoMlcs=
 github.com/gin-contrib/gzip v0.0.6 h1:NjcunTcGAj5CO1gn4N8jHOSIeRFHIbn51z6K+xaN4d4=
 github.com/gin-contrib/gzip v0.0.6/go.mod h1:QOJlmV2xmayAjkNS2Y8NQsMneuRShOU/kjovCXNuzzk=
+github.com/gin-contrib/requestid v0.0.6 h1:mGcxTnHQ45F6QU5HQRgQUDsAfHprD3P7g2uZ4cSZo9o=
+github.com/gin-contrib/requestid v0.0.6/go.mod h1:9i4vKATX/CdggbkY252dPVasgVucy/ggBeELXuQztm4=
 github.com/gin-contrib/sessions v0.0.5 h1:CATtfHmLMQrMNpJRgzjWXD7worTh7g7ritsQfmF+0jE=
 github.com/gin-contrib/sessions v0.0.5/go.mod h1:vYAuaUPqie3WUSsft6HUlCjlwwoJQs97miaG2+7neKY=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/internal/api/errorhandling.go
+++ b/internal/api/errorhandling.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	"codeberg.org/gruf/go-kv"
+	"github.com/gin-contrib/requestid"
 	"github.com/gin-gonic/gin"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
@@ -51,10 +52,14 @@ func NotFoundHandler(c *gin.Context, instanceGet func(ctx context.Context, domai
 		}
 
 		c.HTML(http.StatusNotFound, "404.tmpl", gin.H{
-			"instance": instance,
+			"instance":  instance,
+			"requestid": requestid.Get(c),
 		})
 	default:
-		c.JSON(http.StatusNotFound, gin.H{"error": http.StatusText(http.StatusNotFound)})
+		c.JSON(http.StatusNotFound, gin.H{
+			"error":     http.StatusText(http.StatusNotFound),
+			"requestid": requestid.Get(c),
+		})
 	}
 }
 
@@ -71,12 +76,16 @@ func genericErrorHandler(c *gin.Context, instanceGet func(ctx context.Context, d
 		}
 
 		c.HTML(errWithCode.Code(), "error.tmpl", gin.H{
-			"instance": instance,
-			"code":     errWithCode.Code(),
-			"error":    errWithCode.Safe(),
+			"instance":  instance,
+			"requestid": requestid.Get(c),
+			"code":      errWithCode.Code(),
+			"error":     errWithCode.Safe(),
 		})
 	default:
-		c.JSON(errWithCode.Code(), gin.H{"error": errWithCode.Safe()})
+		c.JSON(errWithCode.Code(), gin.H{
+			"error":     errWithCode.Safe(),
+			"requestid": requestid.Get(c),
+		})
 	}
 }
 

--- a/internal/router/logger.go
+++ b/internal/router/logger.go
@@ -27,6 +27,7 @@ import (
 	"codeberg.org/gruf/go-errors/v2"
 	"codeberg.org/gruf/go-kv"
 	"codeberg.org/gruf/go-logger/v2/level"
+	"github.com/gin-contrib/requestid"
 	"github.com/gin-gonic/gin"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 )
@@ -34,7 +35,7 @@ import (
 // loggingMiddleware provides a request logging and panic recovery gin handler.
 func loggingMiddleware(c *gin.Context) {
 	// Initialize the logging fields
-	fields := make(kv.Fields, 6, 7)
+	fields := make(kv.Fields, 7, 8)
 
 	// Determine pre-handler time
 	before := time.Now()
@@ -71,6 +72,7 @@ func loggingMiddleware(c *gin.Context) {
 		fields[3] = kv.Field{"method", c.Request.Method}
 		fields[4] = kv.Field{"statusCode", code}
 		fields[5] = kv.Field{"path", path}
+		fields[6] = kv.Field{"requestid", requestid.Get(c)}
 
 		// Create log entry with fields
 		l := log.WithFields(fields...)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"codeberg.org/gruf/go-debug"
+	"github.com/gin-contrib/requestid"
 	"github.com/gin-gonic/gin"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
@@ -151,6 +152,7 @@ func New(ctx context.Context, db db.DB) (Router, error) {
 
 	// create the actual engine here -- this is the core request routing handler for gts
 	engine := gin.New()
+	engine.Use(requestid.New())
 	engine.Use(loggingMiddleware)
 
 	// 8 MiB

--- a/vendor/github.com/gin-contrib/requestid/.gitignore
+++ b/vendor/github.com/gin-contrib/requestid/.gitignore
@@ -1,0 +1,15 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/vendor/github.com/gin-contrib/requestid/.golangci.yml
+++ b/vendor/github.com/gin-contrib/requestid/.golangci.yml
@@ -1,0 +1,43 @@
+linters:
+  enable-all: false
+  disable-all: true
+  fast: false
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - rowserrcheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    - gofumpt
+
+run:
+  timeout: 3m

--- a/vendor/github.com/gin-contrib/requestid/.goreleaser.yaml
+++ b/vendor/github.com/gin-contrib/requestid/.goreleaser.yaml
@@ -1,0 +1,57 @@
+project_name: queue
+
+builds:
+  -
+    # If true, skip the build.
+    # Useful for library projects.
+    # Default is false
+    skip: true
+
+changelog:
+  # Set it to true if you wish to skip the changelog generation.
+  # This may result in an empty release notes on GitHub/GitLab/Gitea.
+  skip: false
+
+  # Changelog generation implementation to use.
+  #
+  # Valid options are:
+  # - `git`: uses `git log`;
+  # - `github`: uses the compare GitHub API, appending the author login to the changelog.
+  # - `gitlab`: uses the compare GitLab API, appending the author name and email to the changelog.
+  # - `github-native`: uses the GitHub release notes generation API, disables the groups feature.
+  #
+  # Defaults to `git`.
+  use: git
+
+  # Sorts the changelog by the commit's messages.
+  # Could either be asc, desc or empty
+  # Default is empty
+  sort: asc
+
+  # Group commits messages by given regex and title.
+  # Order value defines the order of the groups.
+  # Proving no regex means all commits will be grouped under the default group.
+  # Groups are disabled when using github-native, as it already groups things by itself.
+  #
+  # Default is no groups.
+  groups:
+    - title: Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: 'Bug fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: 'Enhancements'
+      regexp: "^.*chore[(\\w)]*:+.*$"
+      order: 2
+    - title: Others
+      order: 999
+
+  filters:
+    # Commit messages matching the regexp listed here will be removed from
+    # the changelog
+    # Default is empty
+    exclude:
+      - '^docs'
+      - 'CICD'
+      - typo

--- a/vendor/github.com/gin-contrib/requestid/LICENSE
+++ b/vendor/github.com/gin-contrib/requestid/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Gin-Gonic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/gin-contrib/requestid/README.md
+++ b/vendor/github.com/gin-contrib/requestid/README.md
@@ -1,0 +1,76 @@
+# RequestID
+
+[![Run Tests](https://github.com/gin-contrib/requestid/actions/workflows/go.yml/badge.svg?branch=master)](https://github.com/gin-contrib/requestid/actions/workflows/go.yml)
+[![codecov](https://codecov.io/gh/gin-contrib/requestid/branch/master/graph/badge.svg)](https://codecov.io/gh/gin-contrib/requestid)
+[![Go Report Card](https://goreportcard.com/badge/github.com/gin-contrib/requestid)](https://goreportcard.com/report/github.com/gin-contrib/requestid)
+[![GoDoc](https://godoc.org/github.com/gin-contrib/requestid?status.svg)](https://godoc.org/github.com/gin-contrib/requestid)
+[![Join the chat at https://gitter.im/gin-gonic/gin](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/gin-gonic/gin)
+
+Request ID middleware for Gin Framework. Adds an indentifier to the response using the `X-Request-ID` header. Passes the `X-Request-ID` value back to the caller if it's sent in the request headers.
+
+## Config
+
+define your custom generator function:
+
+```go
+func main() {
+
+  r := gin.New()
+
+  r.Use(
+    requestid.New(
+      requestid.WithGenerator(func() string {
+        return "test"
+      }),
+      requestid.WithCustomHeaderStrKey("your-customer-key"),
+    ),
+  )
+
+  // Example ping request.
+  r.GET("/ping", func(c *gin.Context) {
+    c.String(http.StatusOK, "pong "+fmt.Sprint(time.Now().Unix()))
+  })
+
+  // Listen and Server in 0.0.0.0:8080
+  r.Run(":8080")
+}
+```
+
+## Example
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "time"
+
+  "github.com/gin-contrib/requestid"
+  "github.com/gin-gonic/gin"
+)
+
+func main() {
+
+  r := gin.New()
+
+  r.Use(requestid.New())
+
+  // Example ping request.
+  r.GET("/ping", func(c *gin.Context) {
+    c.String(http.StatusOK, "pong "+fmt.Sprint(time.Now().Unix()))
+  })
+
+  // Listen and Server in 0.0.0.0:8080
+  r.Run(":8080")
+}
+```
+
+How to get the request identifier:
+
+```go
+// Example / request.
+r.GET("/", func(c *gin.Context) {
+  c.String(http.StatusOK, "id:"+requestid.Get(c))
+})
+```

--- a/vendor/github.com/gin-contrib/requestid/options.go
+++ b/vendor/github.com/gin-contrib/requestid/options.go
@@ -1,0 +1,36 @@
+package requestid
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// Option for queue system
+type Option func(*config)
+
+type (
+	Generator func() string
+	Handler   func(c *gin.Context, requestID string)
+)
+
+type HeaderStrKey string
+
+// WithGenerator set generator function
+func WithGenerator(g Generator) Option {
+	return func(cfg *config) {
+		cfg.generator = g
+	}
+}
+
+// WithCustomeHeaderStrKey set custom header key for request id
+func WithCustomHeaderStrKey(s HeaderStrKey) Option {
+	return func(cfg *config) {
+		cfg.headerKey = s
+	}
+}
+
+// WithHandler set handler function for request id with context
+func WithHandler(handler Handler) Option {
+	return func(cfg *config) {
+		cfg.handler = handler
+	}
+}

--- a/vendor/github.com/gin-contrib/requestid/requestid.go
+++ b/vendor/github.com/gin-contrib/requestid/requestid.go
@@ -1,0 +1,55 @@
+package requestid
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+var headerXRequestID string
+
+// Config defines the config for RequestID middleware
+type config struct {
+	// Generator defines a function to generate an ID.
+	// Optional. Default: func() string {
+	//   return uuid.New().String()
+	// }
+	generator Generator
+	headerKey HeaderStrKey
+	handler   Handler
+}
+
+// New initializes the RequestID middleware.
+func New(opts ...Option) gin.HandlerFunc {
+	cfg := &config{
+		generator: func() string {
+			return uuid.New().String()
+		},
+		headerKey: "X-Request-ID",
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	headerXRequestID = string(cfg.headerKey)
+
+	return func(c *gin.Context) {
+		// Get id from request
+		rid := c.GetHeader(headerXRequestID)
+		if rid == "" {
+			rid = cfg.generator()
+			c.Request.Header.Add(headerXRequestID, rid)
+		}
+		if cfg.handler != nil {
+			cfg.handler(c, rid)
+		}
+		// Set the id to ensure that the requestid is in the response
+		c.Header(headerXRequestID, rid)
+		c.Next()
+	}
+}
+
+// Get returns the request identifier
+func Get(c *gin.Context) string {
+	return c.Writer.Header().Get(headerXRequestID)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -119,6 +119,9 @@ github.com/gin-contrib/cors
 # github.com/gin-contrib/gzip v0.0.6
 ## explicit; go 1.13
 github.com/gin-contrib/gzip
+# github.com/gin-contrib/requestid v0.0.6
+## explicit; go 1.15
+github.com/gin-contrib/requestid
 # github.com/gin-contrib/sessions v0.0.5
 ## explicit; go 1.18
 github.com/gin-contrib/sessions

--- a/web/template/404.tmpl
+++ b/web/template/404.tmpl
@@ -11,7 +11,8 @@
 		</p>
 		<p>
 			If you believe this 404 was an error, you can contact
-			the instance admin.
+			the instance admin. Provide them with the following request
+			ID: <code>{{ .requestid }}</code>.
 		</p>
 	</section>
 </main>

--- a/web/template/error.tmpl
+++ b/web/template/error.tmpl
@@ -2,6 +2,7 @@
     <main>
         <section class="error">
           <span>❌</span> <pre>{{.error}}</pre>
+          <span>request ID</span> <code>{{.requestid}}</code>
         </section>
     </main>
 {{ template "footer.tmpl" .}}


### PR DESCRIPTION
I was looking to add some basic request tracing into GTS. Though the logs are useful, it's sometimes hard to understand which request caused what additional log lines to be emitted, queries that were run etc.

I've managed to figure out how to plumb a request ID through the API endpoints, so when an error is returned you now get the request ID and the logs show things like:

```
timestamp="25/11/2022 14:24:42.781" func=router.loggingMiddleware.func1 level=INFO latency="1.038625ms" clientIP="127.0.0.1" userAgent="Mozilla/5.0 (X11; Linux x86_64; rv:107.0) Gecko/20100101 Firefox/107.0" method="GET" statusCode=404 path="/assets/dist/base.css" requestid="1952bc1d-2629-4b91-a097-dac1ef364635" msg="Not Found: wrote 908B"
```

What I would like to do now is to ensure that request ID is passed through in the rest of the code base. This would ensure log lines that are emitted for DB queries (for example I'd like to have the `requestid` in the TRACE lines), or any outgoing requests, have the same `requestid` attached to them if they were triggered by an incoming HTTP request. If that were to happen and you ingest your logs somewhere centrally you'd have a much easier time understanding what GTS is doing and hopefully improve the debugging experience.

Looking at the code base, it seems most other functions call `log.WithField(s)` directly and set their fields. I can't really figure out an entry point that would allow me to universally set the `requestid` from the HTTP request and pass it through. I'm not sure if that's currently possible, or if there's some other way to do this?