### PR TITLE
[docs] Explain that before 0.6.0, account confirm was necessary.

### DIFF
--- a/docs/installation_guide/binary.md
+++ b/docs/installation_guide/binary.md
@@ -84,6 +84,15 @@ Run the following command to create a new account:
 
 In the above command, replace `some_username` with your desired username, `some_email@whatever.org` with the email address you want to associate with your account, and `SOME_PASSWORD` with a secure password.
 
+If you are running a version older than 0.6.0, you will need to manually confirm as well:
+
+```bash
+./gotosocial --config-path ./config.yaml admin account confirm --username some_username
+```
+
+Replace `some_username` with the username of the account you just created.
+
+
 If you want your user to have admin rights, you can promote them using a similar command:
 
 ```bash

--- a/docs/installation_guide/docker.md
+++ b/docs/installation_guide/docker.md
@@ -171,6 +171,14 @@ First create a user (replace the username, email, and password with appropriate 
 docker exec -it gotosocial /gotosocial/gotosocial admin account create --username some_username --email someone@example.org --password 'some_very_good_password'
 ```
 
+If you are running a version older than 0.6.0, you will need to manually confirm as well:
+
+```bash
+./gotosocial --config-path ./config.yaml admin account confirm --username some_username
+```
+
+Replace `some_username` with the username of the account you just created.
+
 Now promote the user you just created to admin privileges:
 
 ```bash


### PR DESCRIPTION
Since the documentation site only shows the latest version of the docs, we need the docs to explain how to use the latest stable release, not just the latest git version.

Without this I think #1140 will cause some confusion.