### PR TITLE
Tweak the User-Agent a bit

### DIFF
--- a/internal/transport/controller.go
+++ b/internal/transport/controller.go
@@ -60,6 +60,7 @@ type controller struct {
 func NewController(db db.DB, federatingDB federatingdb.DB, clock pub.Clock, client pub.HttpClient) Controller {
 	applicationName := config.GetApplicationName()
 	host := config.GetAccountDomain()
+	proto := config.GetProtocol()
 	version := config.GetSoftwareVersion()
 
 	c := &controller{
@@ -69,7 +70,7 @@ func NewController(db db.DB, federatingDB federatingdb.DB, clock pub.Clock, clie
 		client:    client,
 		trspCache: cache.New[string, *transport](0, 100, 0),
 		badHosts:  cache.New[string, struct{}](0, 1000, 0),
-		userAgent: fmt.Sprintf("%s; %s (gofed/activity gotosocial-%s)", applicationName, host, version),
+		userAgent: fmt.Sprintf("%s (+%s://%s) gotosocial/%s", applicationName, proto, host, version),
 	}
 
 	// Transport cache has TTL=1hr freq=1min

--- a/internal/transport/controller.go
+++ b/internal/transport/controller.go
@@ -59,7 +59,7 @@ type controller struct {
 // NewController returns an implementation of the Controller interface for creating new transports
 func NewController(db db.DB, federatingDB federatingdb.DB, clock pub.Clock, client pub.HttpClient) Controller {
 	applicationName := config.GetApplicationName()
-	host := config.GetHost()
+	host := config.GetAccountDomain()
 	version := config.GetSoftwareVersion()
 
 	c := &controller{


### PR DESCRIPTION
I've tried to tweak the User-Agent a bit to better match my understanding/interpretation of RFC 7231. But in the real world nobody really seems to agree on how these things should be formatted and what they contain so idk if this change is worth it.

This also flips it to use the account domain instead of the host domain, so that when you're looking at the header you can better identify the source of the request.