### PR TITLE
Set User-Agent header in transport

### DIFF
--- a/internal/transport/deliver.go
+++ b/internal/transport/deliver.go
@@ -82,7 +82,6 @@ func (t *transport) Deliver(ctx context.Context, b []byte, to *url.URL) error {
 
 	req.Header.Add("Content-Type", string(api.AppActivityLDJSON))
 	req.Header.Add("Accept-Charset", "utf-8")
-	req.Header.Add("User-Agent", t.controller.userAgent)
 	req.Header.Set("Host", to.Host)
 
 	resp, err := t.POST(req, b)

--- a/internal/transport/dereference.go
+++ b/internal/transport/dereference.go
@@ -63,7 +63,6 @@ func (t *transport) Dereference(ctx context.Context, iri *url.URL) ([]byte, erro
 
 	req.Header.Add("Accept", string(api.AppActivityLDJSON)+","+string(api.AppActivityJSON))
 	req.Header.Add("Accept-Charset", "utf-8")
-	req.Header.Add("User-Agent", t.controller.userAgent)
 	req.Header.Set("Host", iri.Host)
 
 	// Perform the HTTP request

--- a/internal/transport/derefinstance.go
+++ b/internal/transport/derefinstance.go
@@ -93,7 +93,6 @@ func dereferenceByAPIV1Instance(ctx context.Context, t *transport, iri *url.URL)
 	}
 
 	req.Header.Add("Accept", string(api.AppJSON))
-	req.Header.Add("User-Agent", t.controller.userAgent)
 	req.Header.Set("Host", cleanIRI.Host)
 
 	resp, err := t.GET(req)
@@ -244,7 +243,6 @@ func callNodeInfoWellKnown(ctx context.Context, t *transport, iri *url.URL) (*ur
 		return nil, err
 	}
 	req.Header.Add("Accept", string(api.AppJSON))
-	req.Header.Add("User-Agent", t.controller.userAgent)
 	req.Header.Set("Host", cleanIRI.Host)
 
 	resp, err := t.GET(req)
@@ -296,7 +294,6 @@ func callNodeInfo(ctx context.Context, t *transport, iri *url.URL) (*apimodel.No
 		return nil, err
 	}
 	req.Header.Add("Accept", string(api.AppJSON))
-	req.Header.Add("User-Agent", t.controller.userAgent)
 	req.Header.Set("Host", iri.Host)
 
 	resp, err := t.GET(req)

--- a/internal/transport/derefmedia.go
+++ b/internal/transport/derefmedia.go
@@ -36,7 +36,6 @@ func (t *transport) DereferenceMedia(ctx context.Context, iri *url.URL) (io.Read
 		return nil, 0, err
 	}
 	req.Header.Add("Accept", "*/*") // we don't know what kind of media we're going to get here
-	req.Header.Add("User-Agent", t.controller.userAgent)
 	req.Header.Set("Host", iri.Host)
 
 	// Perform the HTTP request

--- a/internal/transport/finger.go
+++ b/internal/transport/finger.go
@@ -41,7 +41,6 @@ func (t *transport) Finger(ctx context.Context, targetUsername string, targetDom
 	}
 	req.Header.Add("Accept", string(api.AppJSON))
 	req.Header.Add("Accept", "application/jrd+json")
-	req.Header.Add("User-Agent", t.controller.userAgent)
 	req.Header.Set("Host", req.URL.Host)
 
 	// Perform the HTTP request

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -134,6 +134,8 @@ func (t *transport) do(r *http.Request, signer func(*http.Request) error, retryO
 		{"url", r.URL.String()},
 	}...)
 
+	r.Header.Set("User-Agent", t.controller.userAgent)
+
 	for i := 0; i < maxRetries; i++ {
 		// Reset signing header fields
 		now := t.controller.clock.Now().UTC()


### PR DESCRIPTION
Currently requests set their own User-Agent. Set it in the transport instead, unless it's been explicitly set on the request. This retains the flexibility of tweaking the UA if necessary, without having to remember to set it.