### PR TITLE
Use Host domain for UA

### DIFF
--- a/internal/transport/controller.go
+++ b/internal/transport/controller.go
@@ -59,7 +59,7 @@ type controller struct {
 // NewController returns an implementation of the Controller interface for creating new transports
 func NewController(db db.DB, federatingDB federatingdb.DB, clock pub.Clock, client pub.HttpClient) Controller {
 	applicationName := config.GetApplicationName()
-	host := config.GetAccountDomain()
+	host := config.GetHost()
 	proto := config.GetProtocol()
 	version := config.GetSoftwareVersion()
 


### PR DESCRIPTION
Somehow I managed to read the code wrong and swapped Host for AccountDomain in d6f4d196c978d81041ea99a32e2d6f63b0639472, whereas the commit message makes it clear my intent was to use tho Host (so we get the address the server is running on in the header).

This eh, fixes my brainfart. Sorry :sweat:.