### PR TITLE
[feature] domain block wildcarding

### DIFF
--- a/internal/cache/domain/domain.go
+++ b/internal/cache/domain/domain.go
@@ -1,0 +1,126 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package domain
+
+import (
+	"fmt"
+	"time"
+
+	"codeberg.org/gruf/go-cache/v3/ttl"
+	"github.com/miekg/dns"
+)
+
+type BlockCache struct {
+	pcache *ttl.Cache[string, bool]
+	blocks []block
+	loaded bool
+}
+
+func New(pcap int, pttl time.Duration) *BlockCache {
+	c := new(BlockCache)
+	c.pcache = new(ttl.Cache[string, bool])
+	c.pcache.Init(0, pcap, pttl)
+	return c
+}
+
+func (b *BlockCache) Start(pfreq time.Duration) bool {
+	return b.pcache.Start(pfreq)
+}
+
+func (b *BlockCache) Stop() bool {
+	return b.pcache.Stop()
+}
+
+func (b *BlockCache) IsBlocked(domain string, load func() ([]string, error)) (bool, error) {
+	var blocked bool
+
+	// Acquire cache lock
+	b.pcache.Lock()
+	defer b.pcache.Unlock()
+
+	if !b.loaded {
+		// Load domains from callback
+		domains, err := load()
+		if err != nil {
+			return false, fmt.Errorf("error reloading cache: %w", err)
+		}
+
+		// Drop all domain blocks and recreate
+		b.blocks = make([]block, len(domains))
+
+		for i, domain := range domains {
+			// Store pre-split labels for each domain block
+			b.blocks[i].labels = dns.SplitDomainName(domain)
+		}
+
+		// Mark as loaded
+		b.loaded = true
+	}
+
+	// Check primary cache for result
+	entry, ok := b.pcache.Cache.Get(domain)
+	if ok {
+		return entry.Value, nil
+	}
+
+	// Split domain into it separate labels
+	labels := dns.SplitDomainName(domain)
+
+	// Compare this to our stored blocks
+	for _, block := range b.blocks {
+		if block.Blocks(labels) {
+			blocked = true
+			break
+		}
+	}
+
+	// Store block result in primary cache
+	b.pcache.Cache.Set(domain, &ttl.Entry[string, bool]{
+		Key:    domain,
+		Value:  blocked,
+		Expiry: time.Now().Add(b.pcache.TTL),
+	})
+
+	return blocked, nil
+}
+
+func (b *BlockCache) Clear() {
+	b.pcache.Lock()
+	b.loaded = false
+	b.pcache.Unlock()
+	b.pcache.Clear()
+}
+
+type block struct {
+	labels []string
+}
+
+func (b block) Blocks(labels []string) bool {
+	if len(labels) < len(b.labels) {
+		return false
+	}
+
+	for i := range b.labels {
+		if labels[i] != b.labels[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/cache/domain/domain.go
+++ b/internal/cache/domain/domain.go
@@ -73,7 +73,15 @@ func (b *BlockCache) IsBlocked(domain string, load func() ([]string, error)) (bo
 	b.pcache.Lock()
 	defer b.pcache.Unlock()
 
+	// Check primary cache for result
+	entry, ok := b.pcache.Cache.Get(domain)
+	if ok {
+		return entry.Value, nil
+	}
+
 	if b.blocks == nil {
+		// Cache is not hydrated
+		//
 		// Load domains from callback
 		domains, err := load()
 		if err != nil {
@@ -87,12 +95,6 @@ func (b *BlockCache) IsBlocked(domain string, load func() ([]string, error)) (bo
 			// Store pre-split labels for each domain block
 			b.blocks[i].labels = dns.SplitDomainName(domain)
 		}
-	}
-
-	// Check primary cache for result
-	entry, ok := b.pcache.Cache.Get(domain)
-	if ok {
-		return entry.Value, nil
 	}
 
 	// Split domain into it separate labels

--- a/internal/cache/domain/domain.go
+++ b/internal/cache/domain/domain.go
@@ -132,12 +132,14 @@ func (b *BlockCache) Clear() {
 }
 
 // block represents a domain block, and stores the
-// deconstructed labels of singular domain block.
+// deconstructed labels of a singular domain block.
 // e.g. []string{"gts", "superseriousbusiness", "org"}.
 type block struct {
 	labels []string
 }
 
+// Blocks checks whether the separated domain labels of an
+// incoming domain matches the stored (receiving struct) block.
 func (b block) Blocks(labels []string) bool {
 	// Calculate length difference
 	d := len(labels) - len(b.labels)
@@ -145,7 +147,19 @@ func (b block) Blocks(labels []string) bool {
 		return false
 	}
 
-	// Iterate backwards through domain labels
+	// Iterate backwards through domain block's
+	// labels, omparing against the incoming domain's.
+	//
+	// So for the following input:
+	// labels   = []string{"mail", "google", "com"}
+	// b.labels = []string{"google", "com"}
+	//
+	// These would be matched in reverse order along
+	// the entirety of the block object's labels:
+	// "com"    => match
+	// "google" => match
+	//
+	// And so would reach the end and return true.
 	for i := len(b.labels) - 1; i >= 0; i-- {
 		if b.labels[i] != labels[i+d] {
 			return false

--- a/internal/cache/domain/domain.go
+++ b/internal/cache/domain/domain.go
@@ -121,7 +121,7 @@ func (b *BlockCache) IsBlocked(domain string, load func() ([]string, error)) (bo
 // Clear will drop the currently loaded domain list, and clear the primary cache.
 // This will trigger a reload on next call to .IsBlocked().
 func (b *BlockCache) Clear() {
-	// Drop all blocks
+	// Drop all blocks.
 	b.pcache.Lock()
 	b.blocks = nil
 	b.pcache.Unlock()

--- a/internal/cache/domain/domain_test.go
+++ b/internal/cache/domain/domain_test.go
@@ -1,0 +1,67 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/superseriousbusiness/gotosocial/internal/cache/domain"
+)
+
+func TestBlockCache(t *testing.T) {
+	c := domain.New(100, time.Second)
+
+	blocks := []string{
+		"google.com",
+		"google.co.uk",
+		"pleroma.bad.host",
+	}
+
+	loader := func() ([]string, error) {
+		t.Log("load: returning blocked domains")
+		return blocks, nil
+	}
+
+	// Check a list of known blocked domains.
+	for _, domain := range []string{
+		"google.com",
+		"mail.google.com",
+		"google.co.uk",
+		"mail.google.co.uk",
+		"pleroma.bad.host",
+		"dev.pleroma.bad.host",
+	} {
+		t.Logf("checking domain is blocked: %s", domain)
+		if b, _ := c.IsBlocked(domain, loader); !b {
+			t.Errorf("domain should be blocked: %s", domain)
+		}
+	}
+
+	// Check a list of known unblocked domains.
+	for _, domain := range []string{
+		"askjeeves.com",
+		"ask-kim.co.uk",
+		"google.ie",
+		"mail.google.ie",
+		"gts.bad.host",
+		"mastodon.bad.host",
+	} {
+		t.Logf("checking domain isn't blocked: %s", domain)
+		if b, _ := c.IsBlocked(domain, loader); b {
+			t.Errorf("domain should not be blocked: %s", domain)
+		}
+	}
+
+	// Clear the cache
+	c.Clear()
+
+	knownErr := errors.New("known error")
+
+	// Check that reload is actually performed and returns our error
+	if _, err := c.IsBlocked("", func() ([]string, error) {
+		t.Log("load: returning known error")
+		return nil, knownErr
+	}); !errors.Is(err, knownErr) {
+		t.Errorf("is blocked did not return expected error: %v", err)
+	}
+}

--- a/internal/cache/domain/domain_test.go
+++ b/internal/cache/domain/domain_test.go
@@ -1,3 +1,21 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package domain_test
 
 import (

--- a/internal/cache/gts.go
+++ b/internal/cache/gts.go
@@ -20,6 +20,7 @@ package cache
 
 import (
 	"codeberg.org/gruf/go-cache/v3/result"
+	"github.com/superseriousbusiness/gotosocial/internal/cache/domain"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 )
@@ -41,8 +42,8 @@ type GTSCaches interface {
 	// Block provides access to the gtsmodel Block (account) database cache.
 	Block() *result.Cache[*gtsmodel.Block]
 
-	// DomainBlock provides access to the gtsmodel DomainBlock database cache.
-	DomainBlock() *result.Cache[*gtsmodel.DomainBlock]
+	// DomainBlock provides access to the domain block database cache.
+	DomainBlock() *domain.BlockCache
 
 	// Emoji provides access to the gtsmodel Emoji database cache.
 	Emoji() *result.Cache[*gtsmodel.Emoji]
@@ -74,7 +75,7 @@ func NewGTS() GTSCaches {
 type gtsCaches struct {
 	account       *result.Cache[*gtsmodel.Account]
 	block         *result.Cache[*gtsmodel.Block]
-	domainBlock   *result.Cache[*gtsmodel.DomainBlock]
+	domainBlock   *domain.BlockCache
 	emoji         *result.Cache[*gtsmodel.Emoji]
 	emojiCategory *result.Cache[*gtsmodel.EmojiCategory]
 	mention       *result.Cache[*gtsmodel.Mention]
@@ -151,7 +152,7 @@ func (c *gtsCaches) Block() *result.Cache[*gtsmodel.Block] {
 	return c.block
 }
 
-func (c *gtsCaches) DomainBlock() *result.Cache[*gtsmodel.DomainBlock] {
+func (c *gtsCaches) DomainBlock() *domain.BlockCache {
 	return c.domainBlock
 }
 
@@ -212,14 +213,10 @@ func (c *gtsCaches) initBlock() {
 }
 
 func (c *gtsCaches) initDomainBlock() {
-	c.domainBlock = result.NewSized([]result.Lookup{
-		{Name: "Domain"},
-	}, func(d1 *gtsmodel.DomainBlock) *gtsmodel.DomainBlock {
-		d2 := new(gtsmodel.DomainBlock)
-		*d2 = *d1
-		return d2
-	}, config.GetCacheGTSDomainBlockMaxSize())
-	c.domainBlock.SetTTL(config.GetCacheGTSDomainBlockTTL(), true)
+	c.domainBlock = domain.New(
+		config.GetCacheGTSDomainBlockMaxSize(),
+		config.GetCacheGTSDomainBlockTTL(),
+	)
 }
 
 func (c *gtsCaches) initEmoji() {

--- a/internal/db/bundb/domain.go
+++ b/internal/db/bundb/domain.go
@@ -79,7 +79,8 @@ func (d *domainDB) GetDomainBlock(ctx context.Context, domain string) (*gtsmodel
 	}
 
 	// Check for easy case, domain referencing *us*
-	if domain == "" || domain == config.GetAccountDomain() {
+	if domain == "" || domain == config.GetAccountDomain() ||
+		domain == config.GetHost() {
 		return nil, db.ErrNoEntries
 	}
 
@@ -127,7 +128,8 @@ func (d *domainDB) IsDomainBlocked(ctx context.Context, domain string) (bool, db
 	}
 
 	// Check for easy case, domain referencing *us*
-	if domain == "" || domain == config.GetAccountDomain() {
+	if domain == "" || domain == config.GetAccountDomain() ||
+		domain == config.GetHost() {
 		return false, nil
 	}
 

--- a/internal/db/bundb/domain.go
+++ b/internal/db/bundb/domain.go
@@ -31,11 +31,6 @@ import (
 	"golang.org/x/net/idna"
 )
 
-// maxDomainParts is the maximum number of subdomain parts in
-// domain that we accept both going into the database, and during
-// fetch attempts to reduce risk of denial of service.
-const maxDomainParts = 5
-
 type domainDB struct {
 	conn  *DBConn
 	state *state.State

--- a/internal/db/bundb/domain.go
+++ b/internal/db/bundb/domain.go
@@ -98,8 +98,6 @@ func (d *domainDB) GetDomainBlock(ctx context.Context, domain string) (*gtsmodel
 
 	// Create first domain lookup attempt (this is root level + TLD)
 	lookup := parts[len(parts)-2] + "." + parts[len(parts)-1]
-
-	// Drop the last 2 appended elements
 	parts = parts[:len(parts)-2]
 
 	for i := 0; i < maxDomainParts; i++ {
@@ -129,8 +127,6 @@ func (d *domainDB) GetDomainBlock(ctx context.Context, domain string) (*gtsmodel
 
 		// Prepend the next subdomain part to lookup
 		lookup = parts[len(parts)-1] + "." + lookup
-
-		// Drop the used domain element
 		parts = parts[:len(parts)-1]
 	}
 

--- a/internal/db/bundb/domain.go
+++ b/internal/db/bundb/domain.go
@@ -110,7 +110,7 @@ func (d *domainDB) GetDomainBlock(ctx context.Context, domain string) (*gtsmodel
 			// We return early if this is one of:
 			// - NOT db.ErrNoEntries, i.e. unrecoverable error
 			// - cached db.ErrNoEntries, i.e. have tried this before
-			if !errors.Is(err, db.ErrNoEntries) || cached {
+			if cached || !errors.Is(err, db.ErrNoEntries) {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
For domain blocks, it would now also block all subdomains under that given domain.

e.g. if you block `example.com` then the following would also be blocked
- `gts.example.com`
- `pleroma.example.com`
- `gts.pleroma.example.com`