### PR TITLE
Add AppArmor profile for Debian and Ubuntu installations

### DIFF
--- a/docs/installation_guide/binary.md
+++ b/docs/installation_guide/binary.md
@@ -141,7 +141,3 @@ sudo systemctl enable --now gotosocial.service
 
 If you want to run other webservers on port 443 or want to add an additional layer of security you might want to use [nginx](./nginx.md), [Caddy](./caddy.md) or [Apache httpd](./apache-httpd.md) as reverse proxy
 
-## 8. SELinux (optional)
-
-If SELinux is available on your system, you can optionally install [SELinux policy](https://github.com/lzap/gotosocial-selinux) to further improve security.
-

--- a/example/apparmor/gotosocial
+++ b/example/apparmor/gotosocial
@@ -1,0 +1,50 @@
+#include <tunables/global>
+
+profile gotosocial flags=(attach_disconnected, mediate_deleted) {
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+
+  /gotosocial/gotosocial mrix,
+  /usr/bin/gotosocial mrix,
+  /usr/local/bin/gotosocial mrix,
+
+  owner /gotosocial/{,**} r,
+  owner /gotosocial/storage/** wk,
+
+  # Allow GoToSocial to write logs
+  #
+  # NOTE: you only need to allow write permissions to /var/log/syslog if you've
+  # enabled logging to syslog. Otherwise, you can comment out that line.
+  /var/log/gotosocial/* w,
+  owner /var/log/syslog w,
+
+  # These directories are not currently used by any of the recommended
+  # GoToSocial installation methods, but they may be used in the future and/or
+  # for custom installations.
+  owner /etc/gotosocial/{,**} r,
+  owner /usr/lib/gotosocial/{,**} r,
+  owner /usr/share/gotosocial/{,**} r,
+  owner /usr/local/etc/gotosocial/{,**} r,
+  owner /usr/local/lib/gotosocial/{,**} r,
+  owner /usr/local/share/gotosocial/{,**} r,
+  owner /var/lib/gotosocial/{,**} r,
+  owner /opt/gotosocial/{,**} r,
+  owner /run/gotosocial/{,**} r,
+
+  /proc/sys/net/core/somaxconn r,
+  /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
+  owner @{PROC}/@{pid}/cpuset r,
+
+  # TCP / UDP network access
+  network inet stream,
+  network inet6 stream,
+  network inet dgram,
+  network inet6 dgram,
+
+  # Allow GoToSocial to send signals to/receive signals from worker processes
+  # Allow GoToSocial to receive signals from unconfined processes
+  signal (receive) peer=unconfined,
+  signal (send,receive) peer=gotosocial,
+}
+
+# vim:syntax=apparmor

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,9 @@ copyright: GoToSocial is licensed under the GNU AGPL v3 LICENSE. Copyright (C) 2
 plugins:
   - render_swagger
 
+markdown_extensions:
+  - markdown.extensions.admonition
+
 extra_javascript:
   - assets/js/swagger-ui-bundle.js
 


### PR DESCRIPTION
This PR adds an AppArmor profile for GoToSocial to `examples/apparmor/gotosocial`. The security guarantees provided by the profile should be roughly comparable to those provided by SELinux, but will work on Debian-family Linux distros (as well as some others, like OpenSUSE). The profile I've provided has been primarily tested and verified to work with the Docker-based deployment for GTS, but should also work for people who use the binary installation method.

I've also updated the security documentation (`Federation > Security`) to include an "application sandboxing" section, which currently has some AppArmor setup instructions that I've included as well as instructions for SELinux (which were previously provided in `Installation Guide > Binary Installation From Release`.