### PR TITLE
[frogend] Implement editing domain blocks by delete + recreate

### DIFF
--- a/web/source/settings/lib/api/admin.js
+++ b/web/source/settings/lib/api/admin.js
@@ -59,8 +59,10 @@ module.exports = function ({ apiCall, getChanges }) {
 
 		updateDomainBlock: function updateDomainBlock(domain) {
 			return function (dispatch, getState) {
+				const state = getState().admin.newInstanceBlocks[domain];
 				return Promise.try(() => {
-					const state = getState().admin.newInstanceBlocks[domain];
+					return dispatch(apiCall("DELETE", `/api/v1/admin/domain_blocks/${state.id}`));
+				}).then(() => {
 					const update = getChanges(state, {
 						formKeys: ["domain", "obfuscate", "public_comment", "private_comment"],
 					});


### PR DESCRIPTION
Currently there's no API endpoint to PATCH a domain block (to update reasoning/obfuscation).

There was already frontend code that just sent a POST again, doing nothing. Changed the code to DELETE the old id, and then just re-create the block for that domain with the new settings.

Not sure if deleting + recreating a block has disproportionate load on the backend? Or if it's better to just remove this part of the interface until we have an actual PATCH endpoint for it to use