### PR TITLE
Add caching to webfinger responses

### DIFF
--- a/internal/api/s2s/webfinger/webfingerget.go
+++ b/internal/api/s2s/webfinger/webfingerget.go
@@ -98,5 +98,9 @@ func (m *Module) WebfingerGETRequest(c *gin.Context) {
 		return
 	}
 
+	// allow upstream HTTP proxies to cache this result for a short period.
+	// mastodon and others can cause a massive spike in webfinger requests
+	// for an author when their toot goes viral.
+	c.Header("Cache-Control", "public, max-age=300")
 	c.JSON(http.StatusOK, resp)
 }


### PR DESCRIPTION
Per #1205, this adds a short period of caching to the webfinger response to minimize the work necessary to handle the duplicate requests in a viral thundering herd.

Any other endpoints need this? Is 5 minutes a reasonable value?