### PR TITLE
Remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,10 +20,8 @@ linters:
     - gocritic
     - gofmt
     - gosec
-    - ifshort
     - nilerr
     - revive
-    - wastedassign
 
 linters-settings:
   govet:

--- a/internal/api/s2s/webfinger/webfingerget.go
+++ b/internal/api/s2s/webfinger/webfingerget.go
@@ -98,5 +98,9 @@ func (m *Module) WebfingerGETRequest(c *gin.Context) {
 		return
 	}
 
+	// allow upstream HTTP proxies to cache this result for a short period.
+	// mastodon and others can cause a massive spike in webfinger requests
+	// for an author when their toot goes viral.
+	c.Header("Cache-Control", "public, max-age=300")
 	c.JSON(http.StatusOK, resp)
 }


### PR DESCRIPTION
These two linters issue deprecation warnings in the latest versions of golangci-lint.