### PR TITLE
Remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,10 +20,8 @@ linters:
     - gocritic
     - gofmt
     - gosec
-    - ifshort
     - nilerr
     - revive
-    - wastedassign
 
 linters-settings:
   govet:


### PR DESCRIPTION
These linters print warnings when used in recent versions of golangci-lint.