### PR TITLE
[bugfix] fix unordered favorites

### DIFF
--- a/internal/db/bundb/timeline.go
+++ b/internal/db/bundb/timeline.go
@@ -233,7 +233,7 @@ func (t *timelineDB) GetFavedTimeline(ctx context.Context, accountID string, max
 
 	// Sort by favourite ID rather than status ID
 	slices.SortFunc(faves, func(a, b *gtsmodel.StatusFave) bool {
-		return a.ID < b.ID
+		return b.CreatedAt.Before(a.CreatedAt)
 	})
 
 	statuses := make([]*gtsmodel.Status, 0, len(faves))


### PR DESCRIPTION
This fixes #1151.

This lists favorites in the order they have been created, not by the date of the actual post. E.g. the most recently favored/liked post will be on top.

As this is my first contribution to GoToSocial, please let me know if I missed anything.