### PR TITLE
[docs] Update nginx docs to use 127.0.0.1 instead of localhost

### DIFF
--- a/docs/installation_guide/nginx.md
+++ b/docs/installation_guide/nginx.md
@@ -63,7 +63,8 @@ server {
   listen [::]:80;
   server_name example.org;
   location / {
-    proxy_pass http://localhost:8080;
+    # set to 127.0.0.1 instead of localhost to work around https://stackoverflow.com/a/52550758
+    proxy_pass http://127.0.0.1:8080;
     proxy_set_header Host $host;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
@@ -74,7 +75,7 @@ server {
 }
 ```
 
-Change `proxy_pass` to the ip and port that you're actually serving GoToSocial on and change `server_name` to your own domain name.
+Change `proxy_pass` to the ip and port that you're actually serving GoToSocial on (if it's not on `127.0.0.1:8080`), and change `server_name` to your own domain name.
 
 If your domain name is `example.org` then `server_name example.org;` would be the correct value.
 
@@ -152,7 +153,8 @@ If you open the NGINX config again, you'll see that Certbot added some extra lin
 server {
   server_name example.org;
   location / {
-    proxy_pass http://localhost:8080/;
+    # set to 127.0.0.1 instead of localhost to work around https://stackoverflow.com/a/52550758
+    proxy_pass http://127.0.0.1:8080/;
     proxy_set_header Host $host;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates our default nginx config documentation to resolve an issue with the default config refusing requests, to ensure others don't run into the same problem in future.

Basically, lots of these were appearing:

```
*459 connect() failed (111: Connection refused) while connecting to upstream
```

This change resolves it, see https://stackoverflow.com/a/52550758.

closes https://github.com/superseriousbusiness/gotosocial/issues/1263

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
