### PR TITLE
Update Apache docs to use 127.0.0.1 instead of localhost

### DIFF
--- a/docs/installation_guide/apache-httpd.md
+++ b/docs/installation_guide/apache-httpd.md
@@ -87,8 +87,9 @@ MDCertificateAgreement accepted
 
   SSLEngine On
   ProxyPreserveHost On
-  ProxyPass / http://localhost:8080/
-  ProxyPassReverse / http://localhost:8080/
+  # set to 127.0.0.1 instead of localhost to work around https://stackoverflow.com/a/52550758
+  ProxyPass / http://127.0.0.1:8080/
+  ProxyPassReverse / http://127.0.0.1:8080/
 
   RequestHeader set "X-Forwarded-Proto" expr=https
 </VirtualHost>
@@ -166,18 +167,19 @@ The file you're about to create should look initially for both 80 (required) and
   RewriteEngine On
   RewriteCond %{HTTP:Upgrade} websocket [NC]
   RewriteCond %{HTTP:Connection} upgrade [NC]
-  RewriteRule ^/?(.*) "ws://localhost:8080/$1" [P,L]
+  # set to 127.0.0.1 instead of localhost to work around https://stackoverflow.com/a/52550758
+  RewriteRule ^/?(.*) "ws://127.0.0.1:8080/$1" [P,L]
 
   ProxyPreserveHost On
-  ProxyPass / http://localhost:8080/
-  ProxyPassReverse / http://localhost:8080/
+  ProxyPass / http://127.0.0.1:8080/
+  ProxyPassReverse / http://127.0.0.1:8080/
 
 </VirtualHost>
 ```
 
 Again, replace occurrences of `example.com` in the above config file with the hostname of your GtS server. If your domain name is `gotosocial.example.com`, then `gotosocial.example.com` would be the correct value.
 
-You should also change `http://localhost:8080` to the correct address and port of your GtS server. For example, if you're running GoToSocial on another machine with the local ip of `192.168.178.69` and on port `8080` then `http://192.168.178.69:8080/` would be the correct value.
+You should also change `http://127.0.0.1:8080` to the correct address and port (if it's not on `127.0.0.1:8080`) of your GtS server. For example, if you're running GoToSocial on another machine with the local ip of `192.168.178.69` and on port `8080` then `http://192.168.178.69:8080/` would be the correct value.
 
 `Rewrite*` directives are needed to ensure that Websocket streaming connections also work. See the [websocket](./websocket.md) document for more information on this.
 

--- a/docs/installation_guide/apache-httpd.md
+++ b/docs/installation_guide/apache-httpd.md
@@ -83,7 +83,8 @@ MDCertificateAgreement accepted
   RewriteEngine On
   RewriteCond %{HTTP:Upgrade} websocket [NC]
   RewriteCond %{HTTP:Connection} upgrade [NC]
-  RewriteRule ^/?(.*) "ws://localhost:8080/$1" [P,L]
+  # set to 127.0.0.1 instead of localhost to work around https://stackoverflow.com/a/52550758
+  RewriteRule ^/?(.*) "ws://127.0.0.1:8080/$1" [P,L]
 
   SSLEngine On
   ProxyPreserveHost On
@@ -97,7 +98,7 @@ MDCertificateAgreement accepted
 
 Again, replace occurrences of `example.com` in the above config file with the hostname of your GtS server. If your domain name is `gotosocial.example.com`, then `gotosocial.example.com` would be the correct value.
 
-You should also change `http://localhost:8080` to the correct address and port of your GtS server. For example, if you're running GoToSocial on another machine with the local ip of `192.168.178.69` and on port `8080` then `http://192.168.178.69:8080/` would be the correct value.
+You should also change `http://127.0.0.1:8080` to the correct address and port (if it's not on `127.0.0.1:8080`) of your GtS server. For example, if you're running GoToSocial on another machine with the local ip of `192.168.178.69` and on port `8080` then `http://192.168.178.69:8080/` would be the correct value.
 
 `Rewrite*` directives are needed to ensure that Websocket streaming connections also work. See the [websocket](./websocket.md) document for more information on this.
 
@@ -171,6 +172,7 @@ The file you're about to create should look initially for both 80 (required) and
   RewriteRule ^/?(.*) "ws://127.0.0.1:8080/$1" [P,L]
 
   ProxyPreserveHost On
+  # set to 127.0.0.1 instead of localhost to work around https://stackoverflow.com/a/52550758
   ProxyPass / http://127.0.0.1:8080/
   ProxyPassReverse / http://127.0.0.1:8080/
 


### PR DESCRIPTION
# Description

Update Apache docs to use 127.0.0.1 instead of localhost as done with Nginx at #1264.

## Checklist

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I we have performed a self-review of added code.
- [x] I we have written code that is legible and maintainable by others.
- [x] I we have commented the added code, particularly in hard-to-understand areas.
- [x] I we have made any necessary changes to documentation.