### PR TITLE
[bugfix] update go-cache to v3.2.0 with support for ignoring errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	codeberg.org/gruf/go-bytesize v1.0.0
 	codeberg.org/gruf/go-byteutil v1.0.2
-	codeberg.org/gruf/go-cache/v3 v3.1.8
+	codeberg.org/gruf/go-cache/v3 v3.2.0
 	codeberg.org/gruf/go-debug v1.2.0
 	codeberg.org/gruf/go-errors/v2 v2.0.2
 	codeberg.org/gruf/go-kv v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ codeberg.org/gruf/go-bytesize v1.0.0/go.mod h1:n/GU8HzL9f3UNp/mUKyr1qVmTlj7+xacp
 codeberg.org/gruf/go-byteutil v1.0.0/go.mod h1:cWM3tgMCroSzqoBXUXMhvxTxYJp+TbCr6ioISRY5vSU=
 codeberg.org/gruf/go-byteutil v1.0.2 h1:OesVyK5VKWeWdeDR00zRJ+Oy8hjXx1pBhn7WVvcZWVE=
 codeberg.org/gruf/go-byteutil v1.0.2/go.mod h1:cWM3tgMCroSzqoBXUXMhvxTxYJp+TbCr6ioISRY5vSU=
-codeberg.org/gruf/go-cache/v3 v3.1.8 h1:wbUef/QtRstEb7sSpQYHT5CtSFtKkeZr4ZhOTXqOpac=
-codeberg.org/gruf/go-cache/v3 v3.1.8/go.mod h1:h6im2UVGdrGtNt4IVKARVeoW4kAdok5ts7CbH15UWXs=
+codeberg.org/gruf/go-cache/v3 v3.2.0 h1:pHJhS3SqufVnA2bxgzQpBh9Mfsljqulx2ynpy6thTE8=
+codeberg.org/gruf/go-cache/v3 v3.2.0/go.mod h1:d4xafgOjVE+4+82WjIqqJl8NQusXkgUHbkTuXoeB3fA=
 codeberg.org/gruf/go-debug v1.2.0 h1:WBbTMnK1ArFKUmgv04aO2JiC/daTOB8zQGi521qb7OU=
 codeberg.org/gruf/go-debug v1.2.0/go.mod h1:N+vSy9uJBQgpQcJUqjctvqFz7tBHJf+S/PIjLILzpLg=
 codeberg.org/gruf/go-errors/v2 v2.0.0/go.mod h1:ZRhbdhvgoUA3Yw6e56kd9Ox984RrvbEFC2pOXyHDJP4=

--- a/internal/cache/gts.go
+++ b/internal/cache/gts.go
@@ -185,7 +185,7 @@ func (c *gtsCaches) User() *result.Cache[*gtsmodel.User] {
 }
 
 func (c *gtsCaches) initAccount() {
-	c.account = result.NewSized([]result.Lookup{
+	c.account = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "URI"},
 		{Name: "URL"},
@@ -200,7 +200,7 @@ func (c *gtsCaches) initAccount() {
 }
 
 func (c *gtsCaches) initBlock() {
-	c.block = result.NewSized([]result.Lookup{
+	c.block = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "AccountID.TargetAccountID"},
 		{Name: "URI"},
@@ -220,7 +220,7 @@ func (c *gtsCaches) initDomainBlock() {
 }
 
 func (c *gtsCaches) initEmoji() {
-	c.emoji = result.NewSized([]result.Lookup{
+	c.emoji = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "URI"},
 		{Name: "Shortcode.Domain"},
@@ -234,7 +234,7 @@ func (c *gtsCaches) initEmoji() {
 }
 
 func (c *gtsCaches) initEmojiCategory() {
-	c.emojiCategory = result.NewSized([]result.Lookup{
+	c.emojiCategory = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "Name"},
 	}, func(c1 *gtsmodel.EmojiCategory) *gtsmodel.EmojiCategory {
@@ -246,7 +246,7 @@ func (c *gtsCaches) initEmojiCategory() {
 }
 
 func (c *gtsCaches) initMention() {
-	c.mention = result.NewSized([]result.Lookup{
+	c.mention = result.New([]result.Lookup{
 		{Name: "ID"},
 	}, func(m1 *gtsmodel.Mention) *gtsmodel.Mention {
 		m2 := new(gtsmodel.Mention)
@@ -257,7 +257,7 @@ func (c *gtsCaches) initMention() {
 }
 
 func (c *gtsCaches) initNotification() {
-	c.notification = result.NewSized([]result.Lookup{
+	c.notification = result.New([]result.Lookup{
 		{Name: "ID"},
 	}, func(n1 *gtsmodel.Notification) *gtsmodel.Notification {
 		n2 := new(gtsmodel.Notification)
@@ -268,7 +268,7 @@ func (c *gtsCaches) initNotification() {
 }
 
 func (c *gtsCaches) initStatus() {
-	c.status = result.NewSized([]result.Lookup{
+	c.status = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "URI"},
 		{Name: "URL"},
@@ -282,7 +282,7 @@ func (c *gtsCaches) initStatus() {
 
 // initTombstone will initialize the gtsmodel.Tombstone cache.
 func (c *gtsCaches) initTombstone() {
-	c.tombstone = result.NewSized([]result.Lookup{
+	c.tombstone = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "URI"},
 	}, func(t1 *gtsmodel.Tombstone) *gtsmodel.Tombstone {
@@ -294,7 +294,7 @@ func (c *gtsCaches) initTombstone() {
 }
 
 func (c *gtsCaches) initUser() {
-	c.user = result.NewSized([]result.Lookup{
+	c.user = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "AccountID"},
 		{Name: "Email"},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ codeberg.org/gruf/go-bytesize
 # codeberg.org/gruf/go-byteutil v1.0.2
 ## explicit; go 1.16
 codeberg.org/gruf/go-byteutil
-# codeberg.org/gruf/go-cache/v3 v3.1.8
+# codeberg.org/gruf/go-cache/v3 v3.2.0
 ## explicit; go 1.19
 codeberg.org/gruf/go-cache/v3
 codeberg.org/gruf/go-cache/v3/result


### PR DESCRIPTION
# Description

Fixes an issue that @blackle noticed and reported in matrix regarding the database caching context canceled errors. A very nice find, Good sleuthing!.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code. _(not applicable)_
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
