### PR TITLE
[bugfix] Close reader gracefully when streaming recache of remote media to fileserver api caller

### DIFF
--- a/internal/api/client/fileserver/fileserver_test.go
+++ b/internal/api/client/fileserver/fileserver_test.go
@@ -1,0 +1,109 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package fileserver_test
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/api/client/fileserver"
+	"github.com/superseriousbusiness/gotosocial/internal/concurrency"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/email"
+	"github.com/superseriousbusiness/gotosocial/internal/federation"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/superseriousbusiness/gotosocial/internal/media"
+	"github.com/superseriousbusiness/gotosocial/internal/messages"
+	"github.com/superseriousbusiness/gotosocial/internal/oauth"
+	"github.com/superseriousbusiness/gotosocial/internal/processing"
+	"github.com/superseriousbusiness/gotosocial/internal/storage"
+	"github.com/superseriousbusiness/gotosocial/internal/typeutils"
+	"github.com/superseriousbusiness/gotosocial/testrig"
+)
+
+type FileserverTestSuite struct {
+	// standard suite interfaces
+	suite.Suite
+	db           db.DB
+	storage      *storage.Driver
+	federator    federation.Federator
+	tc           typeutils.TypeConverter
+	processor    processing.Processor
+	mediaManager media.Manager
+	oauthServer  oauth.Server
+	emailSender  email.Sender
+
+	// standard suite models
+	testTokens       map[string]*gtsmodel.Token
+	testClients      map[string]*gtsmodel.Client
+	testApplications map[string]*gtsmodel.Application
+	testUsers        map[string]*gtsmodel.User
+	testAccounts     map[string]*gtsmodel.Account
+	testAttachments  map[string]*gtsmodel.MediaAttachment
+
+	// item being tested
+	fileServer *fileserver.FileServer
+}
+
+/*
+	TEST INFRASTRUCTURE
+*/
+
+func (suite *FileserverTestSuite) SetupSuite() {
+	testrig.InitTestConfig()
+	testrig.InitTestLog()
+
+	fedWorker := concurrency.NewWorkerPool[messages.FromFederator](-1, -1)
+	clientWorker := concurrency.NewWorkerPool[messages.FromClientAPI](-1, -1)
+
+	suite.db = testrig.NewTestDB()
+	suite.storage = testrig.NewInMemoryStorage()
+	suite.federator = testrig.NewTestFederator(suite.db, testrig.NewTestTransportController(testrig.NewMockHTTPClient(nil, "../../../../testrig/media"), suite.db, fedWorker), suite.storage, suite.mediaManager, fedWorker)
+	suite.emailSender = testrig.NewEmailSender("../../../../web/template/", nil)
+
+	suite.processor = testrig.NewTestProcessor(suite.db, suite.storage, suite.federator, suite.emailSender, testrig.NewTestMediaManager(suite.db, suite.storage), clientWorker, fedWorker)
+	suite.tc = testrig.NewTestTypeConverter(suite.db)
+	suite.mediaManager = testrig.NewTestMediaManager(suite.db, suite.storage)
+	suite.oauthServer = testrig.NewTestOauthServer(suite.db)
+
+	suite.fileServer = fileserver.New(suite.processor).(*fileserver.FileServer)
+}
+
+func (suite *FileserverTestSuite) SetupTest() {
+	testrig.StandardDBSetup(suite.db, nil)
+	testrig.StandardStorageSetup(suite.storage, "../../../../testrig/media")
+	suite.testTokens = testrig.NewTestTokens()
+	suite.testClients = testrig.NewTestClients()
+	suite.testApplications = testrig.NewTestApplications()
+	suite.testUsers = testrig.NewTestUsers()
+	suite.testAccounts = testrig.NewTestAccounts()
+	suite.testAttachments = testrig.NewTestAttachments()
+}
+
+func (suite *FileserverTestSuite) TearDownSuite() {
+	if err := suite.db.Stop(context.Background()); err != nil {
+		log.Panicf("error closing db connection: %s", err)
+	}
+}
+
+func (suite *FileserverTestSuite) TearDownTest() {
+	testrig.StandardDBTeardown(suite.db)
+	testrig.StandardStorageTeardown(suite.storage)
+}

--- a/internal/iotools/io.go
+++ b/internal/iotools/io.go
@@ -1,0 +1,103 @@
+package iotools
+
+import (
+	"io"
+)
+
+// ReadFnCloser takes an io.Reader and wraps it to use the provided function to implement io.Closer.
+func ReadFnCloser(r io.Reader, close func() error) io.ReadCloser {
+	return &readFnCloser{
+		Reader: r,
+		close:  close,
+	}
+}
+
+type readFnCloser struct {
+	io.Reader
+	close func() error
+}
+
+func (r *readFnCloser) Close() error {
+	return r.close()
+}
+
+// WriteFnCloser takes an io.Writer and wraps it to use the provided function to implement io.Closer.
+func WriteFnCloser(w io.Writer, close func() error) io.WriteCloser {
+	return &writeFnCloser{
+		Writer: w,
+		close:  close,
+	}
+}
+
+type writeFnCloser struct {
+	io.Writer
+	close func() error
+}
+
+func (r *writeFnCloser) Close() error {
+	return r.close()
+}
+
+// SilentReader wraps an io.Reader to silence any
+// error output during reads. Instead they are stored
+// and accessible (not concurrency safe!) via .Error().
+type SilentReader struct {
+	io.Reader
+	err error
+}
+
+// SilenceReader wraps an io.Reader within SilentReader{}.
+func SilenceReader(r io.Reader) *SilentReader {
+	return &SilentReader{Reader: r}
+}
+
+func (r *SilentReader) Read(b []byte) (int, error) {
+	n, err := r.Reader.Read(b)
+	if err != nil {
+		// Store error for now
+		if r.err == nil {
+			r.err = err
+		}
+
+		// Pretend we're happy
+		// to continue reading.
+		n = len(b)
+	}
+	return n, nil
+}
+
+func (r *SilentReader) Error() error {
+	return r.err
+}
+
+// SilentWriter wraps an io.Writer to silence any
+// error output during writes. Instead they are stored
+// and accessible (not concurrency safe!) via .Error().
+type SilentWriter struct {
+	io.Writer
+	err error
+}
+
+// SilenceWriter wraps an io.Writer within SilentWriter{}.
+func SilenceWriter(w io.Writer) *SilentWriter {
+	return &SilentWriter{Writer: w}
+}
+
+func (w *SilentWriter) Write(b []byte) (int, error) {
+	n, err := w.Writer.Write(b)
+	if err != nil {
+		// Store error for now
+		if w.err == nil {
+			w.err = err
+		}
+
+		// Pretend we're happy
+		// to continue writing.
+		n = len(b)
+	}
+	return n, nil
+}
+
+func (w *SilentWriter) Error() error {
+	return w.err
+}

--- a/internal/iotools/io.go
+++ b/internal/iotools/io.go
@@ -1,3 +1,21 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package iotools
 
 import (

--- a/internal/media/manager_test.go
+++ b/internal/media/manager_test.go
@@ -440,7 +440,7 @@ func (suite *ManagerTestSuite) TestSlothVineProcessBlocking() {
 	processedThumbnailBytes, err := suite.storage.Get(ctx, attachment.Thumbnail.Path)
 	suite.NoError(err)
 	suite.NotEmpty(processedThumbnailBytes)
-	
+
 	processedThumbnailBytesExpected, err := os.ReadFile("./test/test-mp4-thumbnail.jpg")
 	suite.NoError(err)
 	suite.NotEmpty(processedThumbnailBytesExpected)

--- a/internal/processing/media/getfile.go
+++ b/internal/processing/media/getfile.go
@@ -19,7 +19,6 @@
 package media
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -29,7 +28,7 @@ import (
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
-	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/superseriousbusiness/gotosocial/internal/iotools"
 	"github.com/superseriousbusiness/gotosocial/internal/media"
 	"github.com/superseriousbusiness/gotosocial/internal/transport"
 	"github.com/superseriousbusiness/gotosocial/internal/uris"
@@ -135,7 +134,6 @@ func (p *processor) getAttachmentContent(ctx context.Context, requestingAccount 
 	}
 
 	var data media.DataFunc
-	var postDataCallback media.PostDataCallbackFunc
 
 	if mediaSize == media.SizeSmall {
 		// if it's the thumbnail that's requested then the user will have to wait a bit while we process the
@@ -155,7 +153,7 @@ func (p *processor) getAttachmentContent(ctx context.Context, requestingAccount 
 		//
 		// this looks a bit like this:
 		//
-		//                http fetch                   buffered pipe
+		//                http fetch                       pipe
 		// remote server ------------> data function ----------------> api caller
 		//                                   |
 		//                                   | tee
@@ -166,18 +164,13 @@ func (p *processor) getAttachmentContent(ctx context.Context, requestingAccount 
 		// This pipe will connect the caller to the in-process media retrieval...
 		pipeReader, pipeWriter := io.Pipe()
 
-		// Buffer the writer side of the pipe, so that if the caller drops
-		// the connection during the flow, the media download can continue
-		// without worrying about trying to push into a blocked pipe.
-		bufferedPipeWriter := bufio.NewWriterSize(pipeWriter, int(attachmentContent.ContentLength))
+		// Wrap the output pipe to silence any errors during the actual media
+		// streaming process. We catch the error later but they must be silenced
+		// during stream to prevent interruptions to storage of the actual media.
+		silencedWriter := iotools.SilenceWriter(pipeWriter)
 
-		// Buffer the reader side of the pipe too, so that if the caller can't
-		// read bytes as fast as the media processor can, they won't get
-		// an EOF before they're finished reading everything.
-		bufferedPipeReader := bufio.NewReaderSize(pipeReader, int(attachmentContent.ContentLength))
-
-		// Pass the buffered reader side of the pipe to the caller to slurp from.
-		attachmentContent.Content = io.NopCloser(bufferedPipeReader)
+		// Pass the reader side of the pipe to the caller to slurp from.
+		attachmentContent.Content = pipeReader
 
 		// Create a data function which injects the writer end of the pipe
 		// into the data retrieval process. If something goes wrong while
@@ -187,50 +180,39 @@ func (p *processor) getAttachmentContent(ctx context.Context, requestingAccount 
 		data = func(innerCtx context.Context) (io.ReadCloser, int64, error) {
 			t, err := p.transportController.NewTransportForUsername(innerCtx, requestingUsername)
 			if err != nil {
-				if pipeErr := pipeReader.Close(); pipeErr != nil {
-					log.Errorf("error closing pipeReader: %s", pipeErr)
-				}
+				// propagate the transport error to read end of pipe.
+				_ = pipeWriter.CloseWithError(fmt.Errorf("error getting transport for user: %w", err))
 				return nil, 0, err
 			}
 
 			readCloser, fileSize, err := t.DereferenceMedia(transport.WithFastfail(innerCtx), remoteMediaIRI)
 			if err != nil {
-				if pipeErr := pipeReader.Close(); pipeErr != nil {
-					log.Errorf("error closing pipeReader: %s", pipeErr)
-				}
+				// propagate the dereference error to read end of pipe.
+				_ = pipeWriter.CloseWithError(fmt.Errorf("error dereferencing media: %w", err))
 				return nil, 0, err
 			}
 
 			// Make a TeeReader so that everything read from the readCloser,
-			// aka the remote instance, will also be written into the bufferedPipeWriter,
-			// which the caller is listening on via the pipe we created.
-			teeReader := io.TeeReader(readCloser, bufferedPipeWriter)
+			// aka the remote instance, will also be written into the pipe.
+			teeReader := io.TeeReader(readCloser, silencedWriter)
 
-			// We wrap this in a teeReadCloser (which implements io.ReadCloser),
-			// so that whoever uses the teeReader can close the readCloser
-			// when they're done with it.
-			return teeReadCloser{
-				teeReader: teeReader,
-				close:     readCloser.Close,
-			}, fileSize, nil
-		}
+			// Wrap teereader to implement original readcloser's close,
+			// and also ensuring that we close the pipe from write end.
+			return iotools.ReadFnCloser(teeReader, func() error {
+				defer func() {
+					// We use the error (if any) encountered by the
+					// silenced writer to close connection to make sure it
+					// gets propagated to the attachment.Content reader.
+					_ = pipeWriter.CloseWithError(silencedWriter.Error())
+				}()
 
-		// Flush + close the pipewriter after data has been piped into
-		// it, so the reader on the other side doesn't keep waiting.
-		//
-		// It's the caller's responsibility to close the reader.
-		postDataCallback = func(innerCtx context.Context) error {
-			defer func() {
-				if err := pipeWriter.Close(); err != nil {
-					log.Errorf("error flushing bufferedPipeWriter: %s", err)
-				}
-			}()
-			return bufferedPipeWriter.Flush()
+				return readCloser.Close()
+			}), fileSize, nil
 		}
 	}
 
 	// put the media recached in the queue
-	processingMedia, err := p.mediaManager.RecacheMedia(ctx, data, postDataCallback, wantedMediaID)
+	processingMedia, err := p.mediaManager.RecacheMedia(ctx, data, nil, wantedMediaID)
 	if err != nil {
 		return nil, gtserror.NewErrorNotFound(fmt.Errorf("error recaching media: %s", err))
 	}

--- a/internal/processing/media/getfile.go
+++ b/internal/processing/media/getfile.go
@@ -175,11 +175,17 @@ func (p *processor) getAttachmentContent(ctx context.Context, requestingAccount 
 		data = func(innerCtx context.Context) (io.ReadCloser, int64, error) {
 			t, err := p.transportController.NewTransportForUsername(innerCtx, requestingUsername)
 			if err != nil {
+				if pipeErr := pipeReader.Close(); pipeErr != nil {
+					log.Errorf("error closing pipeReader: %s", pipeErr)
+				}
 				return nil, 0, err
 			}
 
 			readCloser, fileSize, err := t.DereferenceMedia(transport.WithFastfail(innerCtx), remoteMediaIRI)
 			if err != nil {
+				if pipeErr := pipeReader.Close(); pipeErr != nil {
+					log.Errorf("error closing pipeReader: %s", pipeErr)
+				}
 				return nil, 0, err
 			}
 

--- a/internal/processing/media/util.go
+++ b/internal/processing/media/util.go
@@ -20,7 +20,6 @@ package media
 
 import (
 	"fmt"
-	"io"
 	"strconv"
 	"strings"
 )
@@ -61,17 +60,4 @@ func parseFocus(focus string) (focusx, focusy float32, err error) {
 	}
 	focusy = float32(fy)
 	return
-}
-
-type teeReadCloser struct {
-	teeReader io.Reader
-	close     func() error
-}
-
-func (t teeReadCloser) Read(p []byte) (n int, err error) {
-	return t.teeReader.Read(p)
-}
-
-func (t teeReadCloser) Close() error {
-	return t.close()
 }


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This PR implements graceful failure when streaming an image to an API client during a media recache, in cases where the media is no longer present on a remote instance, or some other failure occurs.

Here's the situation before:

1. a client request a piece of media that was cached previously, but needs to be recached now
2. the async Data function is passed back to the worker, with a tee reader pipe jammed into it which the API caller will slurp from as the media is recached into storage
3. the caller waits for data to be blasted into the pipe
4. the Data function fails
5. the pipe stays open, the caller keeps waiting for that data, which will never come 
6. request eventually times out (depending on reverse proxy / client settings), but the gin request hangs around inside gts forever blocked

With these changes now:

1. a client request a piece of media that was cached previously, but needs to be recached now
2. the async Data function is passed back to the worker, with a tee reader pipe jammed into it which the API caller will slurp from as the media is recached into storage
3. the caller waits for data to be blasted into the pipe
4. the Data function fails, **and the pipe reader is closed when this happens**
5. the caller in the API function checks if any data is coming through the pipe, or if there's an EOF
6. in case of error, a 404 is returned to the caller immediately and the request completes + gets cleaned up

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation (N/A)
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
