### PR TITLE
[bugfix] fix media create error not being checked

### DIFF
--- a/internal/api/client/media/mediacreate.go
+++ b/internal/api/client/media/mediacreate.go
@@ -124,7 +124,7 @@ func (m *Module) MediaCreatePOSTHandler(c *gin.Context) {
 	}
 
 	apiAttachment, errWithCode := m.processor.MediaCreate(c.Request.Context(), authed, form)
-	if err != nil {
+	if errWithCode != nil {
 		api.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
 		return
 	}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This PR fixes the errWithCode not being checked while processing media via the client API endpoint, leading to null pointer panics when trying to upload bad media.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas. -- N/A
- [x] I/we have made any necessary changes to documentation. -- N/A
- [x] I/we have added tests that cover new code. -- N/A
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
