### PR TITLE
[docs] Fix documentation edit link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: GoToSocial Documentation
 theme: readthedocs
 repo_url: https://github.com/superseriousbusiness/gotosocial
+edit_uri: edit/main/docs/
 copyright: GoToSocial is licensed under the GNU AGPL v3 LICENSE. Copyright (C) 2021-2022 GoToSocial Authors admin@gotosocial.org
 plugins:
   - render_swagger


### PR DESCRIPTION
# Description

This pull request fixes the "Edit on GitHub" link on the generated documentation.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).