### PR TITLE
[frogend] Replace ch units to prevent layout shift on page load

### DIFF
--- a/web/source/css/base.css
+++ b/web/source/css/base.css
@@ -62,8 +62,8 @@ body {
 	min-width: 100%;
 	width: 100%;
 
-	grid-template-columns: auto minmax(auto, 90ch) auto;
-	grid-template-columns: auto min(92%, 90ch) auto;
+	grid-template-columns: auto minmax(auto, 50rem) auto;
+	grid-template-columns: auto min(92%, 50rem) auto;
 	grid-template-rows: auto 1fr auto;
 }
 

--- a/web/source/css/profile.css
+++ b/web/source/css/profile.css
@@ -44,7 +44,7 @@ main {
 	.headerimage {
 		width: 100%;
 		aspect-ratio: 3 / 1;
-		max-height: 30ch;
+		max-height: 16rem;
 		overflow: hidden;
 		box-shadow: $boxshadow;
 


### PR DESCRIPTION
We use the `ch` CSS unit in a few places, most notably the main page column width. It's relative to the current font's width of the 0 character, which has the fun side-effect that it changes value during page load, when the font gets swapped from the fallback sans-serif to the asset loaded Noto Sans.
I picked `rem` values instead that are roughly equivalent in apparent size, so there's no more page-load shift
 
## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
