### PR TITLE
Add local user and post count to nodeinfo responses

### DIFF
--- a/internal/api/model/well-known.go
+++ b/internal/api/model/well-known.go
@@ -79,8 +79,11 @@ type NodeInfoServices struct {
 
 // NodeInfoUsage represents usage information about this server, such as number of users.
 type NodeInfoUsage struct {
-	Users NodeInfoUsers `json:"users"`
+	Users      NodeInfoUsers `json:"users"`
+	LocalPosts int           `json:"localPosts"`
 }
 
 // NodeInfoUsers is a stub for usage information, currently empty.
-type NodeInfoUsers struct{}
+type NodeInfoUsers struct {
+	Total int `json:"total"`
+}

--- a/internal/processing/federation/getnodeinfo.go
+++ b/internal/processing/federation/getnodeinfo.go
@@ -55,6 +55,17 @@ func (p *processor) GetNodeInfo(ctx context.Context) (*apimodel.Nodeinfo, gtserr
 	openRegistration := config.GetAccountsRegistrationOpen()
 	softwareVersion := config.GetSoftwareVersion()
 
+	host := config.GetHost()
+	userCount, err := p.db.CountInstanceUsers(ctx, host)
+	if err != nil {
+		return nil, gtserror.NewErrorInternalError(err, "Unable to query instance user count")
+	}
+
+	postCount, err := p.db.CountInstanceStatuses(ctx, host)
+	if err != nil {
+		return nil, gtserror.NewErrorInternalError(err, "Unable to query instance status count")
+	}
+
 	return &apimodel.Nodeinfo{
 		Version: nodeInfoVersion,
 		Software: apimodel.NodeInfoSoftware{
@@ -68,7 +79,10 @@ func (p *processor) GetNodeInfo(ctx context.Context) (*apimodel.Nodeinfo, gtserr
 		},
 		OpenRegistrations: openRegistration,
 		Usage: apimodel.NodeInfoUsage{
-			Users: apimodel.NodeInfoUsers{},
+			Users: apimodel.NodeInfoUsers{
+				Total: userCount,
+			},
+			LocalPosts: postCount,
 		},
 		Metadata: make(map[string]interface{}),
 	}, nil


### PR DESCRIPTION
# Description

This fixes #1307 (at least partially). The nodeinfo endpoint should now return the total users on an instance, along with their post count.

I have a couple outstanding questions, specifically around the extra bits I didn't add to the `NodeInfoUsers` struct (the active users in the past month/active users in the past 6 months). 

It doesn't look like there are currently database functions for querying users active since $date (and if there are, I can add those metrics to the node info response). I'm not familiar enough with the GTS database structure to be able to quickly write those queries, but I am willing to dive in and figure it out if you the maintainers would like that (and also split that bit out into a new issue and pull request because it feels like added scope). 

So my main question is do you want those recently active stats in this response? Because I can see arguments around privacy both for and against it, and I don't know what your preference would be.

- fixes #1307 

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.

Just as a note, I have run the tests locally, but they're failing on the `internal/media` package, and I'm not sure if it's related or if it's because I'm running on an m2 macbook and there might be some weirdness there. The output log was too long for my terminal's scrollback, but I can try adjusting that and running the tests again too.

I'm not sure if there are any changes necessary to the documentation, but if there are, let me know and I'll make them.

And similarly, I'm not sure if there are new tests to write or old tests to modify, thanks to my limited scrollback. I'm certainly willing to add tests, but there aren't any for the `internal/processing/federation` package yet, and I'm not entirely sure where to best look at existing tests for guidance on how to structure new tests.

Let me know if this sounds good, or if there's any additional work you would like me to do.