### PR TITLE
[bugfix] Mount bookmarks endpoint correctly

### DIFF
--- a/internal/api/client/bookmarks/bookmarks.go
+++ b/internal/api/client/bookmarks/bookmarks.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	// BasePath is the base path for serving the bookmarks API
-	BasePath = "/api/v1/bookmarks"
+	// BasePath is the base path for serving the bookmarks API, minus the 'api' prefix
+	BasePath = "/v1/bookmarks"
 )
 
 type Module struct {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request fixes an issue where bookmarks were being mounted at `/api/api/v1/bookmarks` instead of `/api/v1/bookmarks`

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
