### PR TITLE
[chore] Change default sqlite busy timeout to 5m

### DIFF
--- a/docs/configuration/database.md
+++ b/docs/configuration/database.md
@@ -138,5 +138,5 @@ db-sqlite-cache-size: "64MiB"
 # See: https://www.sqlite.org/pragma.html#pragma_busy_timeout
 # Examples: ["0s", "1s", "30s", "1m", "5m"]
 # Default: "5s"
-db-sqlite-busy-timeout: "30s"
+db-sqlite-busy-timeout: "5m"
 ```

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -194,7 +194,7 @@ db-sqlite-cache-size: "64MiB"
 # See: https://www.sqlite.org/pragma.html#pragma_busy_timeout
 # Examples: ["0s", "1s", "30s", "1m", "5m"]
 # Default: "5s"
-db-sqlite-busy-timeout: "30s"
+db-sqlite-busy-timeout: "5m"
 
 cache:
   gts:

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -51,7 +51,7 @@ var Defaults = Configuration{
 	DbSqliteJournalMode: "WAL",
 	DbSqliteSynchronous: "NORMAL",
 	DbSqliteCacheSize:   64 * bytesize.MiB,
-	DbSqliteBusyTimeout: time.Second * 30,
+	DbSqliteBusyTimeout: time.Minute * 5,
 
 	WebTemplateBaseDir: "./web/template/",
 	WebAssetBaseDir:    "./web/assets/",

--- a/testrig/config.go
+++ b/testrig/config.go
@@ -55,7 +55,7 @@ var testDefaults = config.Configuration{
 	DbSqliteJournalMode: "WAL",
 	DbSqliteSynchronous: "NORMAL",
 	DbSqliteCacheSize:   64 * bytesize.MiB,
-	DbSqliteBusyTimeout: time.Second * 30,
+	DbSqliteBusyTimeout: time.Minute * 5,
 
 	WebTemplateBaseDir: "./web/template/",
 	WebAssetBaseDir:    "./web/assets/",


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Does what it says on the tin! This is to avoid busy timeouts for really long running queries (which we should fix, but OK, this is a workaround for now).

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
