### PR TITLE
[chore] Fix new emoji preview title/alt text

### DIFF
--- a/web/source/settings/admin/emoji/local/new-emoji.js
+++ b/web/source/settings/admin/emoji/local/new-emoji.js
@@ -73,8 +73,8 @@ module.exports = function NewEmojiForm() {
 		emojiOrShortcode = <img
 			className="emoji"
 			src={image.previewValue}
-			title={`:${shortcode}:`}
-			alt={shortcode}
+			title={`:${shortcode.value}:`}
+			alt={shortcode.value}
 		/>;
 	}
 


### PR DESCRIPTION
Wrongly used `shortcode` (text hook) instead of `shortcode.value` which gave.. some interesting titles
![image](https://user-images.githubusercontent.com/23422690/213191851-1e5b487d-ea21-4b03-87c0-a77721f44966.png)
