### PR TITLE
[chore] Settings refactor fix 2

### DIFF
--- a/web/source/index.js
+++ b/web/source/index.js
@@ -48,7 +48,7 @@ skulk({
 	},
 	servers: {
 		express: {
-			proxy: "http://localhost:8081",
+			proxy: "http://127.0.0.1:8081",
 			assets: "/assets"
 		}
 	},

--- a/web/source/settings/admin/emoji/category-select.jsx
+++ b/web/source/settings/admin/emoji/category-select.jsx
@@ -44,7 +44,7 @@ function CategorySelect({ field, children }) {
 		isLoading,
 		isSuccess,
 		error
-	} = query.useGetAllEmojiQuery({ filter: "domain:local" });
+	} = query.useListEmojiQuery({ filter: "domain:local" });
 
 	const emojiByCategory = useEmojiByCategory(emoji);
 

--- a/web/source/settings/admin/emoji/local/overview.js
+++ b/web/source/settings/admin/emoji/local/overview.js
@@ -32,7 +32,7 @@ module.exports = function EmojiOverview({ baseUrl }) {
 		data: emoji = [],
 		isLoading,
 		error
-	} = query.useGetAllEmojiQuery({ filter: "domain:local" });
+	} = query.useListEmojiQuery({ filter: "domain:local" });
 
 	return (
 		<>

--- a/web/source/settings/admin/emoji/local/use-shortcode.js
+++ b/web/source/settings/admin/emoji/local/use-shortcode.js
@@ -28,7 +28,7 @@ const shortcodeRegex = /^[a-z0-9_]+$/;
 module.exports = function useShortcode() {
 	const {
 		data: emoji = []
-	} = query.useGetAllEmojiQuery({ filter: "domain:local" });
+	} = query.useListEmojiQuery({ filter: "domain:local" });
 
 	const emojiCodes = React.useMemo(() => {
 		return new Set(emoji.map((e) => e.shortcode));

--- a/web/source/settings/admin/emoji/remote/index.js
+++ b/web/source/settings/admin/emoji/remote/index.js
@@ -31,7 +31,7 @@ module.exports = function RemoteEmoji() {
 		data: emoji = [],
 		isLoading,
 		error
-	} = query.useGetAllEmojiQuery({ filter: "domain:local" });
+	} = query.useListEmojiQuery({ filter: "domain:local" });
 
 	const emojiCodes = React.useMemo(() => {
 		return new Set(emoji.map((e) => e.shortcode));

--- a/web/source/settings/components/authorization/index.jsx
+++ b/web/source/settings/components/authorization/index.jsx
@@ -28,17 +28,18 @@ const Loading = require("../loading");
 const { Error } = require("../error");
 
 module.exports = function Authorization({ App }) {
-	const loginState = Redux.useSelector((state) => state.oauth.loginState);
-	const [hasStoredLogin] = React.useState(loginState != "none" && loginState != "logout");
+	const { loginState, expectingRedirect } = Redux.useSelector((state) => state.oauth);
 
 	const { isLoading, isSuccess, data: account, error } = query.useVerifyCredentialsQuery(undefined, {
-		skip: loginState == "none" || loginState == "logout"
+		skip: loginState == "none" || loginState == "logout" || expectingRedirect
 	});
+
+	console.log("skip verify:", loginState, expectingRedirect);
 
 	let showLogin = true;
 	let content = null;
 
-	if (isLoading && hasStoredLogin) {
+	if (isLoading) {
 		showLogin = false;
 
 		let loadingInfo;

--- a/web/source/settings/lib/query/admin/custom-emoji.js
+++ b/web/source/settings/lib/query/admin/custom-emoji.js
@@ -23,7 +23,7 @@ const Promise = require("bluebird");
 const { unwrapRes } = require("../lib");
 
 module.exports = (build) => ({
-	getAllEmoji: build.query({
+	listEmoji: build.query({
 		query: (params = {}) => ({
 			url: "/api/v1/admin/custom_emojis",
 			params: {
@@ -33,15 +33,15 @@ module.exports = (build) => ({
 		}),
 		providesTags: (res) =>
 			res
-				? [...res.map((emoji) => ({ type: "Emojis", id: emoji.id })), { type: "Emojis", id: "LIST" }]
-				: [{ type: "Emojis", id: "LIST" }]
+				? [...res.map((emoji) => ({ type: "Emoji", id: emoji.id })), { type: "Emoji", id: "LIST" }]
+				: [{ type: "Emoji", id: "LIST" }]
 	}),
 
 	getEmoji: build.query({
 		query: (id) => ({
 			url: `/api/v1/admin/custom_emojis/${id}`
 		}),
-		providesTags: (res, error, id) => [{ type: "Emojis", id }]
+		providesTags: (res, error, id) => [{ type: "Emoji", id }]
 	}),
 
 	addEmoji: build.mutation({
@@ -56,8 +56,8 @@ module.exports = (build) => ({
 		},
 		invalidatesTags: (res) =>
 			res
-				? [{ type: "Emojis", id: "LIST" }, { type: "Emojis", id: res.id }]
-				: [{ type: "Emojis", id: "LIST" }]
+				? [{ type: "Emoji", id: "LIST" }, { type: "Emoji", id: res.id }]
+				: [{ type: "Emoji", id: "LIST" }]
 	}),
 
 	editEmoji: build.mutation({
@@ -74,8 +74,8 @@ module.exports = (build) => ({
 		},
 		invalidatesTags: (res) =>
 			res
-				? [{ type: "Emojis", id: "LIST" }, { type: "Emojis", id: res.id }]
-				: [{ type: "Emojis", id: "LIST" }]
+				? [{ type: "Emoji", id: "LIST" }, { type: "Emoji", id: res.id }]
+				: [{ type: "Emoji", id: "LIST" }]
 	}),
 
 	deleteEmoji: build.mutation({
@@ -83,7 +83,7 @@ module.exports = (build) => ({
 			method: "DELETE",
 			url: `/api/v1/admin/custom_emojis/${id}`
 		}),
-		invalidatesTags: (res, error, id) => [{ type: "Emojis", id }]
+		invalidatesTags: (res, error, id) => [{ type: "Emoji", id }]
 	}),
 
 	searchStatusForEmoji: build.mutation({
@@ -167,7 +167,7 @@ module.exports = (build) => ({
 				}
 			});
 		},
-		invalidatesTags: () => [{ type: "Emojis", id: "LIST" }]
+		invalidatesTags: () => [{ type: "Emoji", id: "LIST" }]
 	})
 });
 

--- a/web/source/settings/lib/query/base.js
+++ b/web/source/settings/lib/query/base.js
@@ -72,7 +72,7 @@ function instanceBasedQuery(args, api, extraOptions) {
 module.exports = createApi({
 	reducerPath: "api",
 	baseQuery: instanceBasedQuery,
-	tagTypes: ["Auth"],
+	tagTypes: ["Auth", "Emoji"],
 	endpoints: (build) => ({
 		instance: build.query({
 			query: () => ({

--- a/web/source/settings/lib/query/oauth.js
+++ b/web/source/settings/lib/query/oauth.js
@@ -121,10 +121,11 @@ const endpoints = (build) => ({
 				}).then(unwrapRes).then((app) => {
 					app.scopes = formData.scopes;
 
-					api.dispatch(oauth.setInstance({
+					api.dispatch(oauth.authorize({
 						instance: instance,
 						registration: app,
-						loginState: "callback"
+						loginState: "callback",
+						expectingRedirect: true
 					}));
 
 					return app;

--- a/web/source/settings/redux/index.js
+++ b/web/source/settings/redux/index.js
@@ -32,6 +32,7 @@ const {
 } = require("redux-persist");
 
 const query = require("../lib/query/base");
+const { Promise } = require("bluebird");
 
 const combinedReducers = combineReducers({
 	oauth: require("./oauth").reducer,
@@ -43,6 +44,14 @@ const persistedReducer = persistReducer({
 	storage: require("redux-persist/lib/storage").default,
 	stateReconciler: require("redux-persist/lib/stateReconciler/autoMergeLevel1").default,
 	whitelist: ["oauth"],
+	migrate: (state) => {
+		return Promise.try(() => {
+			if (state?.oauth != undefined) {
+				state.oauth.expectingRedirect = false;
+			}
+			return state;
+		});
+	}
 }, combinedReducers);
 
 const store = configureStore({

--- a/web/source/settings/redux/oauth.js
+++ b/web/source/settings/redux/oauth.js
@@ -23,17 +23,12 @@ const { createSlice } = require("@reduxjs/toolkit");
 module.exports = createSlice({
 	name: "oauth",
 	initialState: {
-		loginState: 'none'
+		loginState: 'none',
+		expectingRedirect: false
 	},
 	reducers: {
-		setInstance: (state, { payload }) => {
-			return {
-				...state,
-				...payload /* overrides instance, registration keys */
-			};
-		},
-		authorize: (state) => {
-			state.loginState = "callback";
+		authorize: (state, { payload }) => {
+			return payload; // overrides state
 		},
 		setToken: (state, { payload }) => {
 			state.token = `${payload.token_type} ${payload.access_token}`;


### PR DESCRIPTION
Three small fixes building on `settings-refactor`:

- 'Emoji' RTK Query tag type got lost, re-added and renamed
- Replace 'localhost' with '127.0.0.1' in webdev setup proxy, because GTS doesn't listen on ::1
- Fix issue where login flow quickly flashed "expecting callback" error before redirecting to the instance login flow