### PR TITLE
[chore] Add name to instance field for autosuggestion

### DIFF
--- a/web/source/settings/components/authorization/login.jsx
+++ b/web/source/settings/components/authorization/login.jsx
@@ -60,6 +60,7 @@ module.exports = function Login({ }) {
 			<TextInput
 				field={form.instance}
 				label="Instance"
+				name="instance"
 			/>
 			<MutationButton label="Login" result={result} />
 		</form>


### PR DESCRIPTION
Adds back the `name` attribute for the instance field, so you get the same autosuggestions from previous entries