### PR TITLE
[chore] extending maximumPasswordLength to 256

### DIFF
--- a/internal/validate/formvalidation.go
+++ b/internal/validate/formvalidation.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	maximumPasswordLength         = 64
+	maximumPasswordLength         = 256
 	minimumPasswordEntropy        = 60 // dictates password strength. See https://github.com/wagslane/go-password-validator
 	minimumReasonLength           = 40
 	maximumReasonLength           = 500

--- a/internal/validate/formvalidation_test.go
+++ b/internal/validate/formvalidation_test.go
@@ -39,7 +39,7 @@ func (suite *ValidationTestSuite) TestCheckPasswordStrength() {
 	shortPassword := "Ok12"
 	specialPassword := "Ok12%"
 	longPassword := "thisisafuckinglongpasswordbutnospecialchars"
-	tooLong := "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Quisque a enim nibh. Vestibulum bibendum leo ac porttitor auctor."
+	tooLong := "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed euismod, ante id iaculis suscipit, nibh nibh varius enim, eget euismod augue augue eget mi. Praesent tincidunt, ex id finibus congue, enim nunc euismod nulla, id tincidunt ipsum neque at nunc. Sed id convallis libero. Sed euismod augue augue eget mi. Praesent tincidunt, ex id finibus congue, enim nunc euismod nulla, id tincidunt ipsum neque at nunc. Sed id convallis libero. Sed euismod augue augue eget mi. Praesent tincidunt, ex id finibus congue, enim nunc euismod nulla, id tincidunt ipsum neque at nunc."
 	strongPassword := "3dX5@Zc%mV*W2MBNEy$@"
 	var err error
 
@@ -75,7 +75,7 @@ func (suite *ValidationTestSuite) TestCheckPasswordStrength() {
 
 	err = validate.NewPassword(tooLong)
 	if assert.Error(suite.T(), err) {
-		assert.Equal(suite.T(), errors.New("password should be no more than 64 chars"), err)
+		assert.Equal(suite.T(), errors.New("password should be no more than 256 chars"), err)
 	}
 
 	err = validate.NewPassword(strongPassword)


### PR DESCRIPTION
Closes: #1365

# Description
extending maximum password limit from 64 to 256 chars.

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.