### PR TITLE
Add RSS autodiscovery on profiles that enable RSS

### DIFF
--- a/web/template/header.tmpl
+++ b/web/template/header.tmpl
@@ -39,6 +39,7 @@
 	{{ if .ogMeta.ImageWidth }}<meta name="og:image:width" content="{{ .ogMeta.ImageWidth }}">
 	<meta name="og:image:height" content="{{ .ogMeta.ImageHeight }}">
 	{{ end }}{{ end }}<link rel="shortcut icon" href="{{ .instance.Thumbnail }}" type="{{ if .instance.ThumbnailType }}{{ .instance.ThumbnailType }}{{ else }}image/png{{ end }}">
+	{{ if .rssFeed }}<link rel="alternate" type="application/rss+xml" href="{{ .rssFeed }}" title="{{ if .ogMeta }}{{ .ogMeta.Title }}{{ else }}{{.instance.Title}}{{ end }}">{{ end }}
 	<link rel="stylesheet" href="/assets/dist/_colors.css">
 	<link rel="stylesheet" href="/assets/dist/base.css">
 	{{range .stylesheets}}<link rel="stylesheet" href="{{.}}">


### PR DESCRIPTION
One-line change, implements this feature request:

https://github.com/superseriousbusiness/gotosocial/issues/1358

This adds a <link> element to profiles that have RSS feeds so that browsers and feed readers can automatically discover it.

Tested using the testrig and Vivaldi. As expected, the RSS icon appeared in the URL bar when viewing the profiles for the_mighty_zork and admin, but not 1happyturtle, and not on individual posts or the instance home page.
