### PR TITLE
[feature] Accept incoming federated Flag activity

### DIFF
--- a/internal/ap/extract.go
+++ b/internal/ap/extract.go
@@ -635,6 +635,23 @@ func ExtractObject(i WithObject) (*url.URL, error) {
 	return nil, errors.New("no iri found for object prop")
 }
 
+// ExtractObjects extracts a slice of URL objects from a WithObject interface.
+func ExtractObjects(i WithObject) ([]*url.URL, error) {
+	objectProp := i.GetActivityStreamsObject()
+	if objectProp == nil {
+		return nil, errors.New("object property was nil")
+	}
+
+	urls := make([]*url.URL, 0, objectProp.Len())
+	for iter := objectProp.Begin(); iter != objectProp.End(); iter = iter.Next() {
+		if iter.IsIRI() && iter.GetIRI() != nil {
+			urls = append(urls, iter.GetIRI())
+		}
+	}
+
+	return urls, nil
+}
+
 // ExtractVisibility extracts the gtsmodel.Visibility of a given addressable with a To and CC property.
 //
 // ActorFollowersURI is needed to check whether the visibility is FollowersOnly or not. The passed-in value

--- a/internal/ap/interfaces.go
+++ b/internal/ap/interfaces.go
@@ -157,6 +157,16 @@ type CollectionPageable interface {
 	WithItems
 }
 
+// Flaggable represents the minimum interface for an activitystreams 'Flag' activity.
+type Flaggable interface {
+	WithJSONLDId
+	WithTypeName
+
+	WithActor
+	WithContent
+	WithObject
+}
+
 // WithJSONLDId represents an activity with JSONLDIdProperty
 type WithJSONLDId interface {
 	GetJSONLDId() vocab.JSONLDIdProperty

--- a/internal/federation/federatingdb/create.go
+++ b/internal/federation/federatingdb/create.go
@@ -323,32 +323,10 @@ func (f *federatingDB) activityLike(ctx context.Context, asType vocab.Type, rece
 */
 
 func (f *federatingDB) activityFlag(ctx context.Context, asType vocab.Type, receivingAccount *gtsmodel.Account, requestingAccount *gtsmodel.Account) error {
-	flag, ok := asType.(vocab.ActivityStreamsFlag)
+	_, ok := asType.(vocab.ActivityStreamsFlag)
 	if !ok {
 		return errors.New("activityFlag: could not convert type to flag")
 	}
-
-	report, err := f.typeConverter.ASFlagToReport(ctx, flag)
-	if err != nil {
-		return fmt.Errorf("activityLike: could not convert Like to fave: %s", err)
-	}
-
-	newID, err := id.NewULID()
-	if err != nil {
-		return err
-	}
-	fave.ID = newID
-
-	if err := f.db.Put(ctx, fave); err != nil {
-		return fmt.Errorf("activityLike: database error inserting fave: %s", err)
-	}
-
-	f.fedWorker.Queue(messages.FromFederator{
-		APObjectType:     ap.ActivityLike,
-		APActivityType:   ap.ActivityCreate,
-		GTSModel:         fave,
-		ReceivingAccount: receivingAccount,
-	})
 
 	return nil
 }

--- a/internal/processing/fromfederator.go
+++ b/internal/processing/fromfederator.go
@@ -82,6 +82,9 @@ func (p *processor) ProcessFromFederator(ctx context.Context, federatorMsg messa
 		case ap.ActivityBlock:
 			// CREATE A BLOCK
 			return p.processCreateBlockFromFederator(ctx, federatorMsg)
+		case ap.ActivityFlag:
+			// CREATE A FLAG / REPORT
+			return p.processCreateFlagFromFederator(ctx, federatorMsg)
 		}
 	case ap.ActivityUpdate:
 		// UPDATE SOMETHING
@@ -354,6 +357,13 @@ func (p *processor) processCreateBlockFromFederator(ctx context.Context, federat
 	// TODO: same with notifications
 	// TODO: same with bookmarks
 
+	return nil
+}
+
+func (p *processor) processCreateFlagFromFederator(ctx context.Context, federatorMsg messages.FromFederator) error {
+	// TODO: handle side effects of flag creation:
+	// - send email to admins
+	// - notify admins
 	return nil
 }
 

--- a/internal/regexes/regexes.go
+++ b/internal/regexes/regexes.go
@@ -150,6 +150,10 @@ var (
 	// It captures the account id, media type, media size, file name, and file extension, eg
 	// `01F8MH1H7YV1Z7D2C8K2730QBF`, `attachment`, `small`, `01F8MH8RMYQ6MSNY3JM2XT1CQ5`, `jpeg`.
 	FilePath = regexp.MustCompile(filePath)
+
+	// MisskeyReportNotes captures a list of Note URIs from report content created by Misskey.
+	// https://regex101.com/r/EnTOBV/1
+	MisskeyReportNotes = regexp.MustCompile(`(?:^Note: ((?:http|https):\/\/.*)$)`)
 )
 
 // bufpool is a memory pool of byte buffers for use in our regex utility functions.

--- a/internal/regexes/regexes.go
+++ b/internal/regexes/regexes.go
@@ -153,7 +153,7 @@ var (
 
 	// MisskeyReportNotes captures a list of Note URIs from report content created by Misskey.
 	// https://regex101.com/r/EnTOBV/1
-	MisskeyReportNotes = regexp.MustCompile(`(?:^Note: ((?:http|https):\/\/.*)$)`)
+	MisskeyReportNotes = regexp.MustCompile(`(?m)(?:^Note: ((?:http|https):\/\/.*)$)`)
 )
 
 // bufpool is a memory pool of byte buffers for use in our regex utility functions.

--- a/internal/typeutils/astointernal_test.go
+++ b/internal/typeutils/astointernal_test.go
@@ -225,6 +225,10 @@ func (suite *ASToInternalTestSuite) TestParseOwncastService() {
 	fmt.Printf("\n\n\n%s\n\n\n", string(b))
 }
 
+func (suite *ASToInternalTestSuite) TestParseFlag1() {
+	
+}
+
 func TestASToInternalTestSuite(t *testing.T) {
 	suite.Run(t, new(ASToInternalTestSuite))
 }

--- a/internal/typeutils/converter.go
+++ b/internal/typeutils/converter.go
@@ -139,6 +139,8 @@ type TypeConverter interface {
 	//
 	// NOTE -- this is different from one status being boosted multiple times! In this case, new boosts should indeed be created.
 	ASAnnounceToStatus(ctx context.Context, announceable ap.Announceable) (status *gtsmodel.Status, new bool, err error)
+	// ASFlagToReport converts a remote activitystreams 'flag' representation into a gts model report.
+	ASFlagToReport(ctx context.Context, flaggable ap.Flaggable) (report *gtsmodel.Report, err error)
 
 	/*
 		INTERNAL (gts) MODEL TO ACTIVITYSTREAMS MODEL

--- a/internal/typeutils/util.go
+++ b/internal/typeutils/util.go
@@ -1,11 +1,38 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2023 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package typeutils
 
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/regexes"
 )
+
+type statusInteractions struct {
+	Faved      bool
+	Muted      bool
+	Bookmarked bool
+	Reblogged  bool
+}
 
 func (c *converter) interactionsWithStatusForAccount(ctx context.Context, s *gtsmodel.Status, requestingAccount *gtsmodel.Account) (*statusInteractions, error) {
 	si := &statusInteractions{}
@@ -38,10 +65,14 @@ func (c *converter) interactionsWithStatusForAccount(ctx context.Context, s *gts
 	return si, nil
 }
 
-// StatusInteractions denotes interactions with a status on behalf of an account.
-type statusInteractions struct {
-	Faved      bool
-	Muted      bool
-	Bookmarked bool
-	Reblogged  bool
+func misskeyReportInlineURLs(content string) []*url.URL {
+	m := regexes.MisskeyReportNotes.FindAllStringSubmatch(content, -1)
+	urls := make([]*url.URL, 0, len(m))
+	for _, sm := range m {
+		url, err := url.Parse(sm[1])
+		if err == nil && url != nil {
+			urls = append(urls, url)
+		}
+	}
+	return urls
 }

--- a/internal/typeutils/util_test.go
+++ b/internal/typeutils/util_test.go
@@ -1,0 +1,47 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2023 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package typeutils
+
+import (
+	"testing"
+)
+
+func TestMisskeyReportContentURLs1(t *testing.T) {
+	content := `Note: https://bad.instance/@tobi/statuses/01GPB56GPJ37JTK9HW308HQKBQ
+Note: https://bad.instance/@tobi/statuses/01GPB56GPJ37JTK9HW308HQKBQ
+Note: https://bad.instance/@tobi/statuses/01GPB56GPJ37JTK9HW308HQKBQ
+-----
+Test report from Calckey`
+
+	urls := misskeyReportInlineURLs(content)
+	if l := len(urls); l != 3 {
+		t.Fatalf("wanted 3 urls, got %d", l)
+	}
+}
+
+func TestMisskeyReportContentURLs2(t *testing.T) {
+	content := `This is a report
+with just a normal url in it: https://example.org, and is not
+misskey-formatted`
+
+	urls := misskeyReportInlineURLs(content)
+	if l := len(urls); l != 0 {
+		t.Fatalf("wanted 0 urls, got %d", l)
+	}
+}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request allows Flags / reports to be created in GoToSocial via the federated (s2s) interface.

Right now, it doesn't handle any other side effects of flags aside from putting the parsed report in the database.

Works for mastodon-style Flag where `object` can be an array of account URI + one or more status URIs, and also for Misskey-style Flag where status URLs are included in the `content` field of the Flag. 

Relates to https://github.com/superseriousbusiness/gotosocial/issues/1309

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
