### PR TITLE
Add an example on how to setup redirect with Traefik

### DIFF
--- a/docs/installation_guide/advanced.md
+++ b/docs/installation_guide/advanced.md
@@ -82,6 +82,20 @@ http {
 
 The above configuration [rewrites](https://www.nginx.com/blog/creating-nginx-rewrite-rules/) queries to `example.org/.well-known/webfinger` and `example.org/.well-known/nodeinfo` to their `fedi.example.org` counterparts, which means that query information is preserved, making it easier to follow the redirect.
 
+If `example.org` is running on [Traefik](https://doc.traefik.io/traefik/), we could use labels similar to the following to setup the redirect.
+
+```docker
+  myservice:
+    image: foo
+    # Other stuff
+    labels:
+      - 'traefik.http.routers.myservice.rule=Host(`example.org`)'
+      - 'traefik.http.middlewares.myservice-gts.redirectregex.permanent=true'
+      - 'traefik.http.middlewares.myservice-gts.redirectregex.regex=^https://(.*)/.well-known/(webfinger|nodeinfo)$$'
+      - 'traefik.http.middlewares.myservice-gts.redirectregex.replacement=https://fedi.$${1}/.well-known/$${2}'
+      - 'traefik.http.routers.myservice.middlewares=myservice-gts@docker'
+```
+
 ### Step 3: What now?
 
 Once you've done steps 1 and 2, proceed as normal with the rest of your GoToSocial installation.


### PR DESCRIPTION
# Description

There is a section in the documentation that explains how admin can setup a redirect from `example.org` to `fedi.example.org` using Nginx. I wanted to achieve the same through Traefik. It took me about an hour to get it working, so thought of sharing it with others too.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
