### PR TITLE
[chore] Use 'immediate' lock for sqlite transactions

### DIFF
--- a/docs/configuration/database.md
+++ b/docs/configuration/database.md
@@ -126,7 +126,7 @@ db-tls-ca-cert: ""
 # A multiplier of 8 is a sensible default, but you may wish to increase this for instances
 # running on very performant hardware, or decrease it for instances using v. slow CPUs.
 #
-# If you set this to 0 or less, it will be adjusted to 1.
+# If you set the multiplier to less than 1, only one open connection will be used regardless of cpu count.
 #
 # Examples: [16, 8, 10, 2]
 # Default: 8

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -182,7 +182,7 @@ db-tls-ca-cert: ""
 # A multiplier of 8 is a sensible default, but you may wish to increase this for instances
 # running on very performant hardware, or decrease it for instances using v. slow CPUs.
 #
-# If you set this to 0 or less, it will be adjusted to 1.
+# If you set the multiplier to less than 1, only one open connection will be used regardless of cpu count.
 #
 # Examples: [16, 8, 10, 2]
 # Default: 8

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -328,11 +328,11 @@ func sqliteConn(ctx context.Context) (*DBConn, error) {
 */
 
 // maxOpenConns returns multiplier * GOMAXPROCS,
-// clamping multiplier to 1 if it was below 1.
+// returning just 1 instead if multiplier < 1.
 func maxOpenConns() int {
 	multiplier := config.GetDbMaxOpenConnsMultiplier()
 	if multiplier < 1 {
-		multiplier = 1
+		return 1
 	}
 	return multiplier * runtime.GOMAXPROCS(0)
 }


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates sqlite preferences to use 'immediate' locking mode for transactions instead of the default 'deferred' mode. This won't make much of a difference right now, but should be useful in future when we implement proper retry behavior on `SQLITE_BUSY` errors.

Also tidies up some of the sqlite preferences stuff a little bit, and adds some explanatory comments for why we do certain things.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code. n/a
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
