### PR TITLE
[chore/performance] use only 1 sqlite db connection regardless of multiplier

### DIFF
--- a/docs/configuration/database.md
+++ b/docs/configuration/database.md
@@ -128,6 +128,10 @@ db-tls-ca-cert: ""
 #
 # If you set the multiplier to less than 1, only one open connection will be used regardless of cpu count.
 #
+# PLEASE NOTE!!: This setting currently only applies for Postgres. SQLite will always use 1 connection regardless
+# of what is set here. This behavior will change in future when we implement better SQLITE_BUSY handling.
+# See https://github.com/superseriousbusiness/gotosocial/issues/1407 for more details.
+#
 # Examples: [16, 8, 10, 2]
 # Default: 8
 db-max-open-conns-multiplier: 8

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -184,6 +184,10 @@ db-tls-ca-cert: ""
 #
 # If you set the multiplier to less than 1, only one open connection will be used regardless of cpu count.
 #
+# PLEASE NOTE!!: This setting currently only applies for Postgres. SQLite will always use 1 connection regardless
+# of what is set here. This behavior will change in future when we implement better SQLITE_BUSY handling.
+# See https://github.com/superseriousbusiness/gotosocial/issues/1407 for more details.
+#
 # Examples: [16, 8, 10, 2]
 # Default: 8
 db-max-open-conns-multiplier: 8

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -304,9 +304,9 @@ func sqliteConn(ctx context.Context) (*DBConn, error) {
 	// Tune db connections for sqlite, see:
 	// - https://bun.uptrace.dev/guide/running-bun-in-production.html#database-sql
 	// - https://www.alexedwards.net/blog/configuring-sqldb
-	sqldb.SetMaxOpenConns(maxOpenConns()) // x number of conns per cpu
-	sqldb.SetMaxIdleConns(1)              // only keep max 1 idle connection around
-	sqldb.SetConnMaxLifetime(0)           // don't kill connections due to age
+	sqldb.SetMaxOpenConns(1)    // only 1 connection regardless of multiplier, see https://github.com/superseriousbusiness/gotosocial/issues/1407
+	sqldb.SetMaxIdleConns(1)    // only keep max 1 idle connection around
+	sqldb.SetConnMaxLifetime(0) // don't kill connections due to age
 
 	// Wrap Bun database conn in our own wrapper
 	conn := WrapDBConn(bun.NewDB(sqldb, sqlitedialect.New()))


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This PR hard limits the number of sqlite db connections to 1, regardless of CPU and multiplier settings. This is a temporary workaround until we add retry logic for `sqlite_busy` errors. See https://github.com/superseriousbusiness/gotosocial/issues/1407

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code. n/a
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
