### PR TITLE
[feature] Implement `/api/v2/instance` endpoint

### DIFF
--- a/cmd/gotosocial/action/server/server.go
+++ b/cmd/gotosocial/action/server/server.go
@@ -160,7 +160,7 @@ var Start action.GTSAction = func(ctx context.Context) error {
 
 	// attach global no route / 404 handler to the router
 	router.AttachNoRouteHandler(func(c *gin.Context) {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(errors.New(http.StatusText(http.StatusNotFound))), processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(errors.New(http.StatusText(http.StatusNotFound))), processor.InstanceGetV1)
 	})
 
 	// build router modules

--- a/cmd/gotosocial/action/testrig/testrig.go
+++ b/cmd/gotosocial/action/testrig/testrig.go
@@ -99,7 +99,7 @@ var Start action.GTSAction = func(ctx context.Context) error {
 
 	// attach global no route / 404 handler to the router
 	router.AttachNoRouteHandler(func(c *gin.Context) {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(errors.New(http.StatusText(http.StatusNotFound))), processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(errors.New(http.StatusText(http.StatusNotFound))), processor.InstanceGetV1)
 	})
 
 	// build router modules

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -4,16 +4,6 @@ definitions:
         title: EmojiUpdateType models an admin update action to take on a custom emoji.
         type: string
         x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
-    InstanceConfigurationAccounts:
-        properties:
-            allow_custom_css:
-                description: Whether or not accounts on this instance are allowed to upload custom CSS for profiles and statuses.
-                example: false
-                type: boolean
-                x-go-name: AllowCustomCSS
-        title: InstanceConfigurationAccounts models instance account config parameters.
-        type: object
-        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
     InstanceConfigurationEmojis:
         properties:
             emoji_size_limit:
@@ -1127,21 +1117,23 @@ definitions:
         type: object
         x-go-name: Field
         x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
-    instanceConfiguration:
+    instanceConfigurationAccounts:
         properties:
-            accounts:
-                $ref: '#/definitions/InstanceConfigurationAccounts'
-            emojis:
-                $ref: '#/definitions/InstanceConfigurationEmojis'
-            media_attachments:
-                $ref: '#/definitions/instanceConfigurationMediaAttachments'
-            polls:
-                $ref: '#/definitions/instanceConfigurationPolls'
-            statuses:
-                $ref: '#/definitions/instanceConfigurationStatuses'
-        title: InstanceConfiguration models instance configuration parameters.
+            allow_custom_css:
+                description: Whether or not accounts on this instance are allowed to upload custom CSS for profiles and statuses.
+                example: false
+                type: boolean
+                x-go-name: AllowCustomCSS
+            max_featured_tags:
+                description: |-
+                    The maximum number of featured tags allowed for each account.
+                    Currently not implemented, so this is hardcoded to 10.
+                format: int64
+                type: integer
+                x-go-name: MaxFeaturedTags
+        title: InstanceConfigurationAccounts models instance account config parameters.
         type: object
-        x-go-name: InstanceConfiguration
+        x-go-name: InstanceConfigurationAccounts
         x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
     instanceConfigurationMediaAttachments:
         properties:
@@ -1250,17 +1242,6 @@ definitions:
         type: object
         x-go-name: InstanceConfigurationStatuses
         x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
-    instanceURLs:
-        properties:
-            streaming_api:
-                description: Websockets address for status and notification streaming.
-                example: wss://example.org
-                type: string
-                x-go-name: StreamingAPI
-        title: InstanceURLs models instance-relevant URLs for client application consumption.
-        type: object
-        x-go-name: InstanceURLs
-        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
     instanceV1:
         properties:
             account_domain:
@@ -1276,7 +1257,7 @@ definitions:
                 type: boolean
                 x-go-name: ApprovalRequired
             configuration:
-                $ref: '#/definitions/instanceConfiguration'
+                $ref: '#/definitions/instanceV1Configuration'
             contact_account:
                 $ref: '#/definitions/account'
             description:
@@ -1359,7 +1340,7 @@ definitions:
                 type: string
                 x-go-name: URI
             urls:
-                $ref: '#/definitions/instanceURLs'
+                $ref: '#/definitions/instanceV1URLs'
             version:
                 description: |-
                     The version of GoToSocial installed on the instance.
@@ -1370,14 +1351,253 @@ definitions:
                 example: 0.1.1 cb85f65
                 type: string
                 x-go-name: Version
-        title: InstanceV1 models information about this or another instance.
+        title: InstanceV1 models information about this instance.
         type: object
         x-go-name: InstanceV1
         x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV1Configuration:
+        properties:
+            accounts:
+                $ref: '#/definitions/instanceConfigurationAccounts'
+            emojis:
+                $ref: '#/definitions/InstanceConfigurationEmojis'
+            media_attachments:
+                $ref: '#/definitions/instanceConfigurationMediaAttachments'
+            polls:
+                $ref: '#/definitions/instanceConfigurationPolls'
+            statuses:
+                $ref: '#/definitions/instanceConfigurationStatuses'
+        title: InstanceV1Configuration models instance configuration parameters.
+        type: object
+        x-go-name: InstanceV1Configuration
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV1URLs:
+        properties:
+            streaming_api:
+                description: Websockets address for status and notification streaming.
+                example: wss://example.org
+                type: string
+                x-go-name: StreamingAPI
+        title: InstanceV1URLs models instance-relevant URLs for client application consumption.
+        type: object
+        x-go-name: InstanceV1URLs
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
     instanceV2:
-        title: InstanceV2 models information about this or another instance.
+        properties:
+            account_domain:
+                description: |-
+                    The domain of accounts on this instance.
+                    This will not necessarily be the same as
+                    domain.
+                example: example.org
+                type: string
+                x-go-name: AccountDomain
+            configuration:
+                $ref: '#/definitions/instanceV2Configuration'
+            contact:
+                $ref: '#/definitions/instanceV2Contact'
+            description:
+                description: |-
+                    Description of the instance.
+
+                    Should be HTML formatted, but might be plaintext.
+
+                    This should be displayed on the 'about' page for an instance.
+                type: string
+                x-go-name: Description
+            domain:
+                description: The domain of the instance.
+                example: gts.example.org
+                type: string
+                x-go-name: Domain
+            languages:
+                description: Primary languages of the instance + moderators/admins.
+                example:
+                    - en
+                items:
+                    type: string
+                type: array
+                x-go-name: Languages
+            registrations:
+                $ref: '#/definitions/instanceV2Registrations'
+            rules:
+                description: |-
+                    An itemized list of rules for this website.
+                    Currently not implemented (will always be empty array).
+                items: {}
+                type: array
+                x-go-name: Rules
+            source_url:
+                description: The URL for the source code of the software running on this instance, in keeping with AGPL license requirements.
+                example: https://github.com/superseriousbusiness/gotosocial
+                type: string
+                x-go-name: SourceURL
+            thumbnail:
+                $ref: '#/definitions/instanceV2Thumbnail'
+            title:
+                description: The title of the instance.
+                example: GoToSocial Example Instance
+                type: string
+                x-go-name: Title
+            usage:
+                $ref: '#/definitions/instanceV2Usage'
+            version:
+                description: |-
+                    The version of GoToSocial installed on the instance.
+
+                    This will contain at least a semantic version number.
+
+                    It may also contain, after a space, the short git commit ID of the running software.
+                example: 0.1.1 cb85f65
+                type: string
+                x-go-name: Version
+        title: InstanceV2 models information about this instance.
         type: object
         x-go-name: InstanceV2
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2Configuration:
+        properties:
+            accounts:
+                $ref: '#/definitions/instanceConfigurationAccounts'
+            emojis:
+                $ref: '#/definitions/InstanceConfigurationEmojis'
+            media_attachments:
+                $ref: '#/definitions/instanceConfigurationMediaAttachments'
+            polls:
+                $ref: '#/definitions/instanceConfigurationPolls'
+            statuses:
+                $ref: '#/definitions/instanceConfigurationStatuses'
+            translation:
+                $ref: '#/definitions/instanceV2ConfigurationTranslation'
+            urls:
+                $ref: '#/definitions/instanceV1URLs'
+        title: Configured values and limits for this instance.
+        type: object
+        x-go-name: InstanceV2Configuration
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2ConfigurationTranslation:
+        properties:
+            enabled:
+                description: |-
+                    Whether the Translations API is available on this instance.
+                    Not implemented so this value is always false.
+                type: boolean
+                x-go-name: Enabled
+        title: Hints related to translation.
+        type: object
+        x-go-name: InstanceV2ConfigurationTranslation
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2Contact:
+        properties:
+            account:
+                $ref: '#/definitions/account'
+            email:
+                description: |-
+                    An email address that can be messaged regarding inquiries or issues.
+                    Empty string if no email address set.
+                example: someone@example.org
+                type: string
+                x-go-name: Email
+        title: Hints related to contacting a representative of the instance.
+        type: object
+        x-go-name: InstanceV2Contact
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2Registrations:
+        properties:
+            approval_required:
+                description: Whether registrations require moderator approval.
+                example: true
+                type: boolean
+                x-go-name: ApprovalRequired
+            enabled:
+                description: Whether registrations are enabled.
+                example: false
+                type: boolean
+                x-go-name: Enabled
+            message:
+                description: |-
+                    A custom message (html string) to be shown when registrations are closed.
+                    Value will be null if no message is set.
+                example: <p>Registrations are currently closed on example.org because of spam bots!</p>
+                type: string
+                x-go-name: Message
+        title: Information about registering for this instance.
+        type: object
+        x-go-name: InstanceV2Registrations
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2Thumbnail:
+        properties:
+            blurhash:
+                description: |-
+                    A hash computed by the BlurHash algorithm, for generating colorful preview thumbnails when media has not been downloaded yet.
+                    Key/value not set if no blurhash available.
+                example: UeKUpFxuo~R%0nW;WCnhF6RjaJt757oJodS$
+                type: string
+                x-go-name: Blurhash
+            thumbnail_description:
+                description: |-
+                    Description of the instance thumbnail.
+                    Key/value not set if no description available.
+                example: picture of a cute lil' friendly sloth
+                type: string
+                x-go-name: Description
+            thumbnail_type:
+                description: |-
+                    MIME type of the instance thumbnail.
+                    Key/value not set if thumbnail image type unknown.
+                example: image/png
+                type: string
+                x-go-name: Type
+            url:
+                description: The URL for the thumbnail image.
+                example: https://example.org/fileserver/01BPSX2MKCRVMD4YN4D71G9CP5/attachment/original/01H88X0KQ2DFYYDSWYP93VDJZA.png
+                type: string
+                x-go-name: URL
+            versions:
+                $ref: '#/definitions/instanceV2ThumbnailVersions'
+        title: An image used to represent this instance.
+        type: object
+        x-go-name: InstanceV2Thumbnail
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2ThumbnailVersions:
+        properties:
+            '@1x':
+                description: |-
+                    The URL for the thumbnail image at 1x resolution.
+                    Key/value not set if scaled versions not available.
+                type: string
+                x-go-name: Size1URL
+            '@2x':
+                description: |-
+                    The URL for the thumbnail image at 2x resolution.
+                    Key/value not set if scaled versions not available.
+                type: string
+                x-go-name: Size2URL
+        title: Links to scaled resolution images, for high DPI screens.
+        type: object
+        x-go-name: InstanceV2ThumbnailVersions
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2Usage:
+        properties:
+            users:
+                $ref: '#/definitions/instanceV2Users'
+        title: Usage data for this instance.
+        type: object
+        x-go-name: InstanceV2Usage
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2Users:
+        properties:
+            active_month:
+                description: |-
+                    The number of active users in the past 4 weeks.
+                    Currently not implemented: will always be 0.
+                example: 0
+                format: int64
+                type: integer
+                x-go-name: ActiveMonth
+        title: Usage data related to users on this instance.
+        type: object
+        x-go-name: InstanceV2Users
         x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
     mediaDimensions:
         properties:

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -1127,119 +1127,6 @@ definitions:
         type: object
         x-go-name: Field
         x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
-    instance:
-        properties:
-            account_domain:
-                description: |-
-                    The domain of accounts on this instance.
-                    This will not necessarily be the same as
-                    simply the Host part of the URI.
-                example: example.org
-                type: string
-                x-go-name: AccountDomain
-            approval_required:
-                description: New account registrations require admin approval.
-                type: boolean
-                x-go-name: ApprovalRequired
-            configuration:
-                $ref: '#/definitions/instanceConfiguration'
-            contact_account:
-                $ref: '#/definitions/account'
-            description:
-                description: |-
-                    Description of the instance.
-
-                    Should be HTML formatted, but might be plaintext.
-
-                    This should be displayed on the 'about' page for an instance.
-                type: string
-                x-go-name: Description
-            email:
-                description: An email address that may be used for inquiries.
-                example: admin@example.org
-                type: string
-                x-go-name: Email
-            invites_enabled:
-                description: Invites are enabled on this instance.
-                type: boolean
-                x-go-name: InvitesEnabled
-            languages:
-                description: Primary language of the instance.
-                example: en
-                items:
-                    type: string
-                type: array
-                x-go-name: Languages
-            max_toot_chars:
-                description: |-
-                    Maximum allowed length of a post on this instance, in characters.
-
-                    This is provided for compatibility with Tusky and other apps.
-                example: 5000
-                format: uint64
-                type: integer
-                x-go-name: MaxTootChars
-            registrations:
-                description: New account registrations are enabled on this instance.
-                type: boolean
-                x-go-name: Registrations
-            short_description:
-                description: |-
-                    A shorter description of the instance.
-
-                    Should be HTML formatted, but might be plaintext.
-
-                    This should be displayed on the instance splash/landing page.
-                type: string
-                x-go-name: ShortDescription
-            stats:
-                additionalProperties:
-                    format: int64
-                    type: integer
-                description: 'Statistics about the instance: number of posts, accounts, etc.'
-                type: object
-                x-go-name: Stats
-            thumbnail:
-                description: URL of the instance avatar/banner image.
-                example: https://example.org/files/instance/thumbnail.jpeg
-                type: string
-                x-go-name: Thumbnail
-            thumbnail_description:
-                description: Description of the instance thumbnail.
-                example: picture of a cute lil' friendly sloth
-                type: string
-                x-go-name: ThumbnailDescription
-            thumbnail_type:
-                description: MIME type of the instance thumbnail.
-                example: image/png
-                type: string
-                x-go-name: ThumbnailType
-            title:
-                description: The title of the instance.
-                example: GoToSocial Example Instance
-                type: string
-                x-go-name: Title
-            uri:
-                description: The URI of the instance.
-                example: https://gts.example.org
-                type: string
-                x-go-name: URI
-            urls:
-                $ref: '#/definitions/instanceURLs'
-            version:
-                description: |-
-                    The version of GoToSocial installed on the instance.
-
-                    This will contain at least a semantic version number.
-
-                    It may also contain, after a space, the short git commit ID of the running software.
-                example: 0.1.1 cb85f65
-                type: string
-                x-go-name: Version
-        title: Instance models information about this or another instance.
-        type: object
-        x-go-name: Instance
-        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
     instanceConfiguration:
         properties:
             accounts:
@@ -1373,6 +1260,124 @@ definitions:
         title: InstanceURLs models instance-relevant URLs for client application consumption.
         type: object
         x-go-name: InstanceURLs
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV1:
+        properties:
+            account_domain:
+                description: |-
+                    The domain of accounts on this instance.
+                    This will not necessarily be the same as
+                    simply the Host part of the URI.
+                example: example.org
+                type: string
+                x-go-name: AccountDomain
+            approval_required:
+                description: New account registrations require admin approval.
+                type: boolean
+                x-go-name: ApprovalRequired
+            configuration:
+                $ref: '#/definitions/instanceConfiguration'
+            contact_account:
+                $ref: '#/definitions/account'
+            description:
+                description: |-
+                    Description of the instance.
+
+                    Should be HTML formatted, but might be plaintext.
+
+                    This should be displayed on the 'about' page for an instance.
+                type: string
+                x-go-name: Description
+            email:
+                description: An email address that may be used for inquiries.
+                example: admin@example.org
+                type: string
+                x-go-name: Email
+            invites_enabled:
+                description: Invites are enabled on this instance.
+                type: boolean
+                x-go-name: InvitesEnabled
+            languages:
+                description: Primary language of the instance.
+                example: en
+                items:
+                    type: string
+                type: array
+                x-go-name: Languages
+            max_toot_chars:
+                description: |-
+                    Maximum allowed length of a post on this instance, in characters.
+
+                    This is provided for compatibility with Tusky and other apps.
+                example: 5000
+                format: uint64
+                type: integer
+                x-go-name: MaxTootChars
+            registrations:
+                description: New account registrations are enabled on this instance.
+                type: boolean
+                x-go-name: Registrations
+            short_description:
+                description: |-
+                    A shorter description of the instance.
+
+                    Should be HTML formatted, but might be plaintext.
+
+                    This should be displayed on the instance splash/landing page.
+                type: string
+                x-go-name: ShortDescription
+            stats:
+                additionalProperties:
+                    format: int64
+                    type: integer
+                description: 'Statistics about the instance: number of posts, accounts, etc.'
+                type: object
+                x-go-name: Stats
+            thumbnail:
+                description: URL of the instance avatar/banner image.
+                example: https://example.org/files/instance/thumbnail.jpeg
+                type: string
+                x-go-name: Thumbnail
+            thumbnail_description:
+                description: Description of the instance thumbnail.
+                example: picture of a cute lil' friendly sloth
+                type: string
+                x-go-name: ThumbnailDescription
+            thumbnail_type:
+                description: MIME type of the instance thumbnail.
+                example: image/png
+                type: string
+                x-go-name: ThumbnailType
+            title:
+                description: The title of the instance.
+                example: GoToSocial Example Instance
+                type: string
+                x-go-name: Title
+            uri:
+                description: The URI of the instance.
+                example: https://gts.example.org
+                type: string
+                x-go-name: URI
+            urls:
+                $ref: '#/definitions/instanceURLs'
+            version:
+                description: |-
+                    The version of GoToSocial installed on the instance.
+
+                    This will contain at least a semantic version number.
+
+                    It may also contain, after a space, the short git commit ID of the running software.
+                example: 0.1.1 cb85f65
+                type: string
+                x-go-name: Version
+        title: InstanceV1 models information about this or another instance.
+        type: object
+        x-go-name: InstanceV1
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    instanceV2:
+        title: InstanceV2 models information about this or another instance.
+        type: object
+        x-go-name: InstanceV2
         x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
     mediaDimensions:
         properties:
@@ -3920,14 +3925,14 @@ paths:
                 - follow_requests
     /api/v1/instance:
         get:
-            operationId: instanceGet
+            operationId: instanceGetV1
             produces:
                 - application/json
             responses:
                 "200":
                     description: Instance information.
                     schema:
-                        $ref: '#/definitions/instance'
+                        $ref: '#/definitions/instanceV1'
                 "406":
                     description: not acceptable
                 "500":
@@ -5269,6 +5274,23 @@ paths:
             summary: Change the password of authenticated user.
             tags:
                 - user
+    /api/v2/instance:
+        get:
+            operationId: instanceGetV2
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Instance information.
+                    schema:
+                        $ref: '#/definitions/instanceV2'
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal error
+            summary: View instance information.
+            tags:
+                - instance
     /nodeinfo/2.0:
         get:
             description: 'See: https://nodeinfo.diaspora.software/schema.html'

--- a/internal/api/activitypub/emoji/emojiget.go
+++ b/internal/api/activitypub/emoji/emojiget.go
@@ -33,25 +33,25 @@ func (m *Module) EmojiGetHandler(c *gin.Context) {
 	requestedEmojiID := strings.ToUpper(c.Param(EmojiIDKey))
 	if requestedEmojiID == "" {
 		err := errors.New("no emoji id specified in request")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	format, err := apiutil.NegotiateAccept(c, apiutil.ActivityPubAcceptHeaders...)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	resp, errWithCode := m.processor.GetFediEmoji(apiutil.TransferSignatureContext(c), requestedEmojiID, c.Request.URL)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
 	b, err := json.Marshal(resp)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/activitypub/users/followers.go
+++ b/internal/api/activitypub/users/followers.go
@@ -35,13 +35,13 @@ func (m *Module) FollowersGETHandler(c *gin.Context) {
 	requestedUsername := strings.ToLower(c.Param(UsernameKey))
 	if requestedUsername == "" {
 		err := errors.New("no username specified in request")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -53,13 +53,13 @@ func (m *Module) FollowersGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.GetFediFollowers(apiutil.TransferSignatureContext(c), requestedUsername, c.Request.URL)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
 	b, err := json.Marshal(resp)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/activitypub/users/following.go
+++ b/internal/api/activitypub/users/following.go
@@ -35,13 +35,13 @@ func (m *Module) FollowingGETHandler(c *gin.Context) {
 	requestedUsername := strings.ToLower(c.Param(UsernameKey))
 	if requestedUsername == "" {
 		err := errors.New("no username specified in request")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -53,13 +53,13 @@ func (m *Module) FollowingGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.GetFediFollowing(apiutil.TransferSignatureContext(c), requestedUsername, c.Request.URL)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
 	b, err := json.Marshal(resp)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/activitypub/users/inboxpost.go
+++ b/internal/api/activitypub/users/inboxpost.go
@@ -34,18 +34,18 @@ func (m *Module) InboxPOSTHandler(c *gin.Context) {
 	requestedUsername := strings.ToLower(c.Param(UsernameKey))
 	if requestedUsername == "" {
 		err := errors.New("no username specified in request")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if posted, err := m.processor.InboxPost(apiutil.TransferSignatureContext(c), c.Writer, c.Request); err != nil {
 		if withCode, ok := err.(gtserror.WithCode); ok {
-			apiutil.ErrorHandler(c, withCode, m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, withCode, m.processor.InstanceGetV1)
 		} else {
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		}
 	} else if !posted {
 		err := errors.New("unable to process request")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 	}
 }

--- a/internal/api/activitypub/users/outboxget.go
+++ b/internal/api/activitypub/users/outboxget.go
@@ -90,13 +90,13 @@ func (m *Module) OutboxGETHandler(c *gin.Context) {
 	requestedUsername := strings.ToLower(c.Param(UsernameKey))
 	if requestedUsername == "" {
 		err := errors.New("no username specified in request")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -111,7 +111,7 @@ func (m *Module) OutboxGETHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(pageString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", PageKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		page = i
@@ -131,13 +131,13 @@ func (m *Module) OutboxGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.GetFediOutbox(apiutil.TransferSignatureContext(c), requestedUsername, page, maxID, minID, c.Request.URL)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
 	b, err := json.Marshal(resp)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/activitypub/users/publickeyget.go
+++ b/internal/api/activitypub/users/publickeyget.go
@@ -39,13 +39,13 @@ func (m *Module) PublicKeyGETHandler(c *gin.Context) {
 	requestedUsername := strings.ToLower(c.Param(UsernameKey))
 	if requestedUsername == "" {
 		err := errors.New("no username specified in request")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -57,13 +57,13 @@ func (m *Module) PublicKeyGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.GetFediUser(apiutil.TransferSignatureContext(c), requestedUsername, c.Request.URL)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
 	b, err := json.Marshal(resp)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/activitypub/users/repliesget.go
+++ b/internal/api/activitypub/users/repliesget.go
@@ -97,7 +97,7 @@ func (m *Module) StatusRepliesGETHandler(c *gin.Context) {
 	requestedUsername := strings.ToLower(c.Param(UsernameKey))
 	if requestedUsername == "" {
 		err := errors.New("no username specified in request")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -105,13 +105,13 @@ func (m *Module) StatusRepliesGETHandler(c *gin.Context) {
 	requestedStatusID := strings.ToUpper(c.Param(StatusIDKey))
 	if requestedStatusID == "" {
 		err := errors.New("no status id specified in request")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -126,7 +126,7 @@ func (m *Module) StatusRepliesGETHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(pageString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", PageKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		page = i
@@ -138,7 +138,7 @@ func (m *Module) StatusRepliesGETHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(onlyOtherAccountsString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", OnlyOtherAccountsKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		onlyOtherAccounts = i
@@ -152,13 +152,13 @@ func (m *Module) StatusRepliesGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.GetFediStatusReplies(apiutil.TransferSignatureContext(c), requestedUsername, requestedStatusID, page, onlyOtherAccounts, minID, c.Request.URL)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
 	b, err := json.Marshal(resp)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/activitypub/users/statusget.go
+++ b/internal/api/activitypub/users/statusget.go
@@ -35,7 +35,7 @@ func (m *Module) StatusGETHandler(c *gin.Context) {
 	requestedUsername := strings.ToLower(c.Param(UsernameKey))
 	if requestedUsername == "" {
 		err := errors.New("no username specified in request")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -43,13 +43,13 @@ func (m *Module) StatusGETHandler(c *gin.Context) {
 	requestedStatusID := strings.ToUpper(c.Param(StatusIDKey))
 	if requestedStatusID == "" {
 		err := errors.New("no status id specified in request")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -61,13 +61,13 @@ func (m *Module) StatusGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.GetFediStatus(apiutil.TransferSignatureContext(c), requestedUsername, requestedStatusID, c.Request.URL)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
 	b, err := json.Marshal(resp)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/activitypub/users/userget.go
+++ b/internal/api/activitypub/users/userget.go
@@ -43,13 +43,13 @@ func (m *Module) UsersGETHandler(c *gin.Context) {
 	requestedUsername := strings.ToLower(c.Param(UsernameKey))
 	if requestedUsername == "" {
 		err := errors.New("no username specified in request")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -61,13 +61,13 @@ func (m *Module) UsersGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.GetFediUser(apiutil.TransferSignatureContext(c), requestedUsername, c.Request.URL)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
 	b, err := json.Marshal(resp)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/auth/authorize.go
+++ b/internal/api/auth/authorize.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/uuid"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
-	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
@@ -43,7 +42,7 @@ func (m *Module) AuthorizeGETHandler(c *gin.Context) {
 	s := sessions.Default(c)
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.HTMLAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -54,13 +53,13 @@ func (m *Module) AuthorizeGETHandler(c *gin.Context) {
 		form := &apimodel.OAuthAuthorize{}
 		if err := c.ShouldBind(form); err != nil {
 			m.clearSession(s)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, oauth.HelpfulAdvice), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, oauth.HelpfulAdvice), m.processor.InstanceGetV1)
 			return
 		}
 
 		if errWithCode := saveAuthFormToSession(s, form); errWithCode != nil {
 			m.clearSession(s)
-			apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 			return
 		}
 
@@ -73,7 +72,7 @@ func (m *Module) AuthorizeGETHandler(c *gin.Context) {
 	if !ok || clientID == "" {
 		m.clearSession(s)
 		err := fmt.Errorf("key %s was not found in session", sessionClientID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, oauth.HelpfulAdvice), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, oauth.HelpfulAdvice), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -87,7 +86,7 @@ func (m *Module) AuthorizeGETHandler(c *gin.Context) {
 		} else {
 			errWithCode = gtserror.NewErrorInternalError(err, safe, oauth.HelpfulAdvice)
 		}
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
@@ -101,7 +100,7 @@ func (m *Module) AuthorizeGETHandler(c *gin.Context) {
 		} else {
 			errWithCode = gtserror.NewErrorInternalError(err, safe, oauth.HelpfulAdvice)
 		}
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
@@ -115,7 +114,7 @@ func (m *Module) AuthorizeGETHandler(c *gin.Context) {
 		} else {
 			errWithCode = gtserror.NewErrorInternalError(err, safe, oauth.HelpfulAdvice)
 		}
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
@@ -128,7 +127,7 @@ func (m *Module) AuthorizeGETHandler(c *gin.Context) {
 	if !ok || redirect == "" {
 		m.clearSession(s)
 		err := fmt.Errorf("key %s was not found in session", sessionRedirectURI)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, oauth.HelpfulAdvice), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, oauth.HelpfulAdvice), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -136,13 +135,13 @@ func (m *Module) AuthorizeGETHandler(c *gin.Context) {
 	if !ok || scope == "" {
 		m.clearSession(s)
 		err := fmt.Errorf("key %s was not found in session", sessionScope)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, oauth.HelpfulAdvice), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, oauth.HelpfulAdvice), m.processor.InstanceGetV1)
 		return
 	}
 
-	instance, errWithCode := m.processor.InstanceGet(c.Request.Context(), config.GetHost())
+	instance, errWithCode := m.processor.InstanceGetV1(c.Request.Context())
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
@@ -206,7 +205,7 @@ func (m *Module) AuthorizePOSTHandler(c *gin.Context) {
 
 	if len(errs) != 0 {
 		errs = append(errs, oauth.HelpfulAdvice)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(errors.New("one or more missing keys on session during AuthorizePOSTHandler"), errs...), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(errors.New("one or more missing keys on session during AuthorizePOSTHandler"), errs...), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -220,7 +219,7 @@ func (m *Module) AuthorizePOSTHandler(c *gin.Context) {
 		} else {
 			errWithCode = gtserror.NewErrorInternalError(err, safe, oauth.HelpfulAdvice)
 		}
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
@@ -234,7 +233,7 @@ func (m *Module) AuthorizePOSTHandler(c *gin.Context) {
 		} else {
 			errWithCode = gtserror.NewErrorInternalError(err, safe, oauth.HelpfulAdvice)
 		}
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
@@ -263,7 +262,7 @@ func (m *Module) AuthorizePOSTHandler(c *gin.Context) {
 	}
 
 	if errWithCode := m.processor.OAuthHandleAuthorizeRequest(c.Writer, c.Request); errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 	}
 }
 

--- a/internal/api/auth/oob.go
+++ b/internal/api/auth/oob.go
@@ -28,21 +28,19 @@ import (
 	"github.com/gin-gonic/gin"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
-	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
 func (m *Module) OobHandler(c *gin.Context) {
-	host := config.GetHost()
-	instance, errWithCode := m.processor.InstanceGet(c.Request.Context(), host)
+	instance, errWithCode := m.processor.InstanceGetV1(c.Request.Context())
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
-	instanceGet := func(ctx context.Context, domain string) (*apimodel.Instance, gtserror.WithCode) {
+	instanceGet := func(ctx context.Context) (*apimodel.InstanceV1, gtserror.WithCode) {
 		return instance, nil
 	}
 
@@ -69,7 +67,7 @@ func (m *Module) OobHandler(c *gin.Context) {
 
 	if len(errs) != 0 {
 		errs = append(errs, oauth.HelpfulAdvice)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(errors.New("one or more missing keys on session during OobHandler"), errs...), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(errors.New("one or more missing keys on session during OobHandler"), errs...), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/auth/signin.go
+++ b/internal/api/auth/signin.go
@@ -45,14 +45,14 @@ type login struct {
 // If an idp provider is set, then the user will be redirected to that to do their sign in.
 func (m *Module) SignInGETHandler(c *gin.Context) {
 	if _, err := apiutil.NegotiateAccept(c, apiutil.HTMLAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !config.GetOIDCEnabled() {
-		instance, errWithCode := m.processor.InstanceGet(c.Request.Context(), config.GetHost())
+		instance, errWithCode := m.processor.InstanceGetV1(c.Request.Context())
 		if errWithCode != nil {
-			apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 			return
 		}
 
@@ -71,7 +71,7 @@ func (m *Module) SignInGETHandler(c *gin.Context) {
 	if !ok {
 		m.clearSession(s)
 		err := fmt.Errorf("key %s was not found in session", sessionInternalState)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -87,7 +87,7 @@ func (m *Module) SignInPOSTHandler(c *gin.Context) {
 	form := &login{}
 	if err := c.ShouldBind(form); err != nil {
 		m.clearSession(s)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, oauth.HelpfulAdvice), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, oauth.HelpfulAdvice), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -95,14 +95,14 @@ func (m *Module) SignInPOSTHandler(c *gin.Context) {
 	if errWithCode != nil {
 		// don't clear session here, so the user can just press back and try again
 		// if they accidentally gave the wrong password or something
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
 	s.Set(sessionUserID, userid)
 	if err := s.Save(); err != nil {
 		err := fmt.Errorf("error saving user id onto session: %s", err)
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err, oauth.HelpfulAdvice), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err, oauth.HelpfulAdvice), m.processor.InstanceGetV1)
 	}
 
 	c.Redirect(http.StatusFound, "/oauth"+OauthAuthorizePath)

--- a/internal/api/auth/token.go
+++ b/internal/api/auth/token.go
@@ -42,7 +42,7 @@ type tokenRequestForm struct {
 // The idea here is to serve an oauth access token to a user, which can be used for authorizing against non-public APIs.
 func (m *Module) TokenPOSTHandler(c *gin.Context) {
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/accounts/accountcreate.go
+++ b/internal/api/client/accounts/accountcreate.go
@@ -73,23 +73,23 @@ import (
 func (m *Module) AccountCreatePOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, false, false)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.AccountCreateRequest{}
 	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if err := validateCreateAccount(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -97,14 +97,14 @@ func (m *Module) AccountCreatePOSTHandler(c *gin.Context) {
 	signUpIP := net.ParseIP(clientIP)
 	if signUpIP == nil {
 		err := errors.New("ip address could not be parsed from request")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 	form.IP = signUpIP
 
 	ti, errWithCode := m.processor.AccountCreate(c.Request.Context(), authed, form)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/accounts/accountdelete.go
+++ b/internal/api/client/accounts/accountdelete.go
@@ -68,26 +68,26 @@ import (
 func (m *Module) AccountDeletePOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.AccountDeleteRequest{}
 	if err := c.ShouldBind(&form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if form.Password == "" {
 		err = errors.New("no password provided in account delete request")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form.DeleteOriginID = authed.Account.ID
 
 	if errWithCode := m.processor.AccountDeleteLocal(c.Request.Context(), authed, form); errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/accounts/accountget.go
+++ b/internal/api/client/accounts/accountget.go
@@ -69,25 +69,25 @@ import (
 func (m *Module) AccountGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetAcctID := c.Param(IDKey)
 	if targetAcctID == "" {
 		err := errors.New("no account id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	acctInfo, errWithCode := m.processor.AccountGet(c.Request.Context(), authed, targetAcctID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/accounts/accountupdate.go
+++ b/internal/api/client/accounts/accountupdate.go
@@ -138,24 +138,24 @@ import (
 func (m *Module) AccountUpdateCredentialsPATCHHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form, err := parseUpdateAccountForm(c)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	acctSensitive, errWithCode := m.processor.AccountUpdate(c.Request.Context(), authed, form)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/accounts/accountverify.go
+++ b/internal/api/client/accounts/accountverify.go
@@ -59,18 +59,18 @@ import (
 func (m *Module) AccountVerifyGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	acctSensitive, errWithCode := m.processor.AccountGet(c.Request.Context(), authed, authed.Account.ID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/accounts/block.go
+++ b/internal/api/client/accounts/block.go
@@ -69,25 +69,25 @@ import (
 func (m *Module) AccountBlockPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetAcctID := c.Param(IDKey)
 	if targetAcctID == "" {
 		err := errors.New("no account id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	relationship, errWithCode := m.processor.AccountBlockCreate(c.Request.Context(), authed, targetAcctID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/accounts/follow.go
+++ b/internal/api/client/accounts/follow.go
@@ -91,32 +91,32 @@ import (
 func (m *Module) AccountFollowPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetAcctID := c.Param(IDKey)
 	if targetAcctID == "" {
 		err := errors.New("no account id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.AccountFollowRequest{}
 	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 	form.ID = targetAcctID
 
 	relationship, errWithCode := m.processor.AccountFollowCreate(c.Request.Context(), authed, form)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/accounts/followers.go
+++ b/internal/api/client/accounts/followers.go
@@ -72,25 +72,25 @@ import (
 func (m *Module) AccountFollowersGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetAcctID := c.Param(IDKey)
 	if targetAcctID == "" {
 		err := errors.New("no account id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	followers, errWithCode := m.processor.AccountFollowersGet(c.Request.Context(), authed, targetAcctID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/accounts/following.go
+++ b/internal/api/client/accounts/following.go
@@ -72,25 +72,25 @@ import (
 func (m *Module) AccountFollowingGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetAcctID := c.Param(IDKey)
 	if targetAcctID == "" {
 		err := errors.New("no account id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	following, errWithCode := m.processor.AccountFollowingGet(c.Request.Context(), authed, targetAcctID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/accounts/relationships.go
+++ b/internal/api/client/accounts/relationships.go
@@ -57,12 +57,12 @@ import (
 func (m *Module) AccountRelationshipsGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -72,7 +72,7 @@ func (m *Module) AccountRelationshipsGETHandler(c *gin.Context) {
 		id := c.Query("id")
 		if id == "" {
 			err = errors.New("no account id(s) specified in query")
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		targetAccountIDs = append(targetAccountIDs, id)
@@ -83,7 +83,7 @@ func (m *Module) AccountRelationshipsGETHandler(c *gin.Context) {
 	for _, targetAccountID := range targetAccountIDs {
 		r, errWithCode := m.processor.AccountRelationshipGet(c.Request.Context(), authed, targetAccountID)
 		if errWithCode != nil {
-			apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 			return
 		}
 		relationships = append(relationships, *r)

--- a/internal/api/client/accounts/statuses.go
+++ b/internal/api/client/accounts/statuses.go
@@ -133,19 +133,19 @@ import (
 func (m *Module) AccountStatusesGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, false, false, false, false)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetAcctID := c.Param(IDKey)
 	if targetAcctID == "" {
 		err := errors.New("no account id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -155,7 +155,7 @@ func (m *Module) AccountStatusesGETHandler(c *gin.Context) {
 		i, err := strconv.ParseInt(limitString, 10, 32)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", LimitKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		limit = int(i)
@@ -167,7 +167,7 @@ func (m *Module) AccountStatusesGETHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(excludeRepliesString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", ExcludeRepliesKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		excludeReplies = i
@@ -179,7 +179,7 @@ func (m *Module) AccountStatusesGETHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(excludeReblogsString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", ExcludeReblogsKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		excludeReblogs = i
@@ -203,7 +203,7 @@ func (m *Module) AccountStatusesGETHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(pinnedString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", PinnedKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		pinnedOnly = i
@@ -215,7 +215,7 @@ func (m *Module) AccountStatusesGETHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(mediaOnlyString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", OnlyMediaKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		mediaOnly = i
@@ -227,7 +227,7 @@ func (m *Module) AccountStatusesGETHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(publicOnlyString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", OnlyPublicKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		publicOnly = i
@@ -235,7 +235,7 @@ func (m *Module) AccountStatusesGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.AccountStatusesGet(c.Request.Context(), authed, targetAcctID, limit, excludeReplies, excludeReblogs, maxID, minID, pinnedOnly, mediaOnly, publicOnly)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/accounts/unblock.go
+++ b/internal/api/client/accounts/unblock.go
@@ -70,25 +70,25 @@ import (
 func (m *Module) AccountUnblockPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetAcctID := c.Param(IDKey)
 	if targetAcctID == "" {
 		err := errors.New("no account id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	relationship, errWithCode := m.processor.AccountBlockRemove(c.Request.Context(), authed, targetAcctID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/accounts/unfollow.go
+++ b/internal/api/client/accounts/unfollow.go
@@ -70,25 +70,25 @@ import (
 func (m *Module) AccountUnfollowPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetAcctID := c.Param(IDKey)
 	if targetAcctID == "" {
 		err := errors.New("no account id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	relationship, errWithCode := m.processor.AccountFollowRemove(c.Request.Context(), authed, targetAcctID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/accountaction.go
+++ b/internal/api/client/admin/accountaction.go
@@ -85,38 +85,38 @@ import (
 func (m *Module) AccountActionPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.AdminAccountActionRequest{}
 	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if form.Type == "" {
 		err := errors.New("no type specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetAcctID := c.Param(IDKey)
 	if targetAcctID == "" {
 		err := errors.New("no account id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 	form.TargetAccountID = targetAcctID
 
 	if errWithCode := m.processor.AdminAccountAction(c.Request.Context(), authed, form); errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/domainblockcreate.go
+++ b/internal/api/client/admin/domainblockcreate.go
@@ -126,18 +126,18 @@ import (
 func (m *Module) DomainBlocksPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -147,7 +147,7 @@ func (m *Module) DomainBlocksPOSTHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(importString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", ImportQueryKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		imp = i
@@ -155,13 +155,13 @@ func (m *Module) DomainBlocksPOSTHandler(c *gin.Context) {
 
 	form := &apimodel.DomainBlockCreateRequest{}
 	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if err := validateCreateDomainBlock(form, imp); err != nil {
 		err := fmt.Errorf("error validating form: %s", err)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -169,7 +169,7 @@ func (m *Module) DomainBlocksPOSTHandler(c *gin.Context) {
 		// we're importing multiple blocks
 		domainBlocks, errWithCode := m.processor.AdminDomainBlocksImport(c.Request.Context(), authed, form)
 		if errWithCode != nil {
-			apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 			return
 		}
 		c.JSON(http.StatusOK, domainBlocks)
@@ -179,7 +179,7 @@ func (m *Module) DomainBlocksPOSTHandler(c *gin.Context) {
 	// we're just creating one block
 	domainBlock, errWithCode := m.processor.AdminDomainBlockCreate(c.Request.Context(), authed, form)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 	c.JSON(http.StatusOK, domainBlock)

--- a/internal/api/client/admin/domainblockdelete.go
+++ b/internal/api/client/admin/domainblockdelete.go
@@ -72,31 +72,31 @@ import (
 func (m *Module) DomainBlockDELETEHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	domainBlockID := c.Param(IDKey)
 	if domainBlockID == "" {
 		err := errors.New("no domain block id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	domainBlock, errWithCode := m.processor.AdminDomainBlockDelete(c.Request.Context(), authed, domainBlockID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/domainblockget.go
+++ b/internal/api/client/admin/domainblockget.go
@@ -73,25 +73,25 @@ import (
 func (m *Module) DomainBlockGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	domainBlockID := c.Param(IDKey)
 	if domainBlockID == "" {
 		err := errors.New("no domain block id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -101,7 +101,7 @@ func (m *Module) DomainBlockGETHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(exportString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", ExportQueryKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		export = i
@@ -109,7 +109,7 @@ func (m *Module) DomainBlockGETHandler(c *gin.Context) {
 
 	domainBlock, errWithCode := m.processor.AdminDomainBlockGet(c.Request.Context(), authed, domainBlockID, export)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/domainblocksget.go
+++ b/internal/api/client/admin/domainblocksget.go
@@ -78,18 +78,18 @@ import (
 func (m *Module) DomainBlocksGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -99,7 +99,7 @@ func (m *Module) DomainBlocksGETHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(exportString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", ExportQueryKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		export = i
@@ -107,7 +107,7 @@ func (m *Module) DomainBlocksGETHandler(c *gin.Context) {
 
 	domainBlocks, errWithCode := m.processor.AdminDomainBlocksGet(c.Request.Context(), authed, export)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/emojicategoriesget.go
+++ b/internal/api/client/admin/emojicategoriesget.go
@@ -69,24 +69,24 @@ import (
 func (m *Module) EmojiCategoriesGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	categories, errWithCode := m.processor.AdminEmojiCategoriesGet(c.Request.Context())
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/emojicreate.go
+++ b/internal/api/client/admin/emojicreate.go
@@ -100,35 +100,35 @@ import (
 func (m *Module) EmojiCreatePOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.EmojiCreateRequest{}
 	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if err := validateCreateEmoji(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiEmoji, errWithCode := m.processor.AdminEmojiCreate(c.Request.Context(), authed, form)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/emojidelete.go
+++ b/internal/api/client/admin/emojidelete.go
@@ -78,31 +78,31 @@ import (
 func (m *Module) EmojiDELETEHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	emojiID := c.Param(IDKey)
 	if emojiID == "" {
 		err := errors.New("no emoji id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	emoji, errWithCode := m.processor.AdminEmojiDelete(c.Request.Context(), authed, emojiID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/emojiget.go
+++ b/internal/api/client/admin/emojiget.go
@@ -68,31 +68,31 @@ import (
 func (m *Module) EmojiGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	emojiID := c.Param(IDKey)
 	if emojiID == "" {
 		err := errors.New("no emoji id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	emoji, errWithCode := m.processor.AdminEmojiGet(c.Request.Context(), authed, emojiID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/emojisget.go
+++ b/internal/api/client/admin/emojisget.go
@@ -125,18 +125,18 @@ import (
 func (m *Module) EmojisGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -149,7 +149,7 @@ func (m *Module) EmojisGETHandler(c *gin.Context) {
 		i, err := strconv.ParseInt(limitString, 10, 32)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", LimitKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		limit = int(i)
@@ -177,7 +177,7 @@ func (m *Module) EmojisGETHandler(c *gin.Context) {
 				shortcode = strings.Trim(filter[10:], ":") // remove any errant ":"
 			default:
 				err := fmt.Errorf("filter %s not recognized; accepted values are 'domain:[domain]', 'disabled', 'enabled', 'shortcode:[shortcode]'", filter)
-				apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+				apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 				return
 			}
 		}
@@ -200,7 +200,7 @@ func (m *Module) EmojisGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.AdminEmojisGet(c.Request.Context(), authed, domain, includeDisabled, includeEnabled, shortcode, maxShortcodeDomain, minShortcodeDomain, limit)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/emojiupdate.go
+++ b/internal/api/client/admin/emojiupdate.go
@@ -123,42 +123,42 @@ import (
 func (m *Module) EmojiPATCHHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	emojiID := c.Param(IDKey)
 	if emojiID == "" {
 		err := errors.New("no emoji id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.EmojiUpdateRequest{}
 	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if err := validateUpdateEmoji(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	emoji, errWithCode := m.processor.AdminEmojiUpdate(c.Request.Context(), emojiID, form)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/mediacleanup.go
+++ b/internal/api/client/admin/mediacleanup.go
@@ -71,19 +71,19 @@ import (
 func (m *Module) MediaCleanupPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.MediaCleanupRequest{}
 	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -98,7 +98,7 @@ func (m *Module) MediaCleanupPOSTHandler(c *gin.Context) {
 	}
 
 	if errWithCode := m.processor.AdminMediaPrune(c.Request.Context(), remoteCacheDays); errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/mediarefetch.go
+++ b/internal/api/client/admin/mediarefetch.go
@@ -74,18 +74,18 @@ import (
 func (m *Module) MediaRefetchPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if errWithCode := m.processor.AdminMediaRefetch(c.Request.Context(), authed, c.Query(DomainQueryKey)); errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/reportget.go
+++ b/internal/api/client/admin/reportget.go
@@ -71,31 +71,31 @@ import (
 func (m *Module) ReportGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	reportID := c.Param(IDKey)
 	if reportID == "" {
 		err := errors.New("no report id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	report, errWithCode := m.processor.AdminReportGet(c.Request.Context(), authed, reportID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/reportresolve.go
+++ b/internal/api/client/admin/reportresolve.go
@@ -87,37 +87,37 @@ import (
 func (m *Module) ReportResolvePOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	reportID := c.Param(IDKey)
 	if reportID == "" {
 		err := errors.New("no report id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.AdminReportResolveRequest{}
 	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	report, errWithCode := m.processor.AdminReportResolve(c.Request.Context(), authed, reportID, form.ActionTakenComment)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/admin/reportsget.go
+++ b/internal/api/client/admin/reportsget.go
@@ -127,18 +127,18 @@ import (
 func (m *Module) ReportsGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := fmt.Errorf("user %s not an admin", authed.User.ID)
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -147,7 +147,7 @@ func (m *Module) ReportsGETHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(resolvedString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", ResolvedKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		resolved = &i
@@ -158,7 +158,7 @@ func (m *Module) ReportsGETHandler(c *gin.Context) {
 		i, err := strconv.Atoi(limitString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", LimitKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 
@@ -173,7 +173,7 @@ func (m *Module) ReportsGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.AdminReportsGet(c.Request.Context(), authed, resolved, c.Query(AccountIDKey), c.Query(TargetAccountIDKey), c.Query(MaxIDKey), c.Query(SinceIDKey), c.Query(MinIDKey), limit)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/apps/appcreate.go
+++ b/internal/api/client/apps/appcreate.go
@@ -77,48 +77,48 @@ const (
 func (m *Module) AppsPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, false, false, false, false)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.ApplicationCreateRequest{}
 	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if len([]rune(form.ClientName)) > formFieldLen {
 		err := fmt.Errorf("client_name must be less than %d characters", formFieldLen)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if len([]rune(form.RedirectURIs)) > formRedirectLen {
 		err := fmt.Errorf("redirect_uris must be less than %d characters", formRedirectLen)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if len([]rune(form.Scopes)) > formFieldLen {
 		err := fmt.Errorf("scopes must be less than %d characters", formFieldLen)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if len([]rune(form.Website)) > formFieldLen {
 		err := fmt.Errorf("website must be less than %d characters", formFieldLen)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiApp, errWithCode := m.processor.AppCreate(c.Request.Context(), authed, form)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/blocks/blocksget.go
+++ b/internal/api/client/blocks/blocksget.go
@@ -96,12 +96,12 @@ import (
 func (m *Module) BlocksGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -123,7 +123,7 @@ func (m *Module) BlocksGETHandler(c *gin.Context) {
 		i, err := strconv.ParseInt(limitString, 10, 32)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", LimitKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		limit = int(i)
@@ -131,7 +131,7 @@ func (m *Module) BlocksGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.BlocksGet(c.Request.Context(), authed, maxID, sinceID, limit)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/bookmarks/bookmarksget.go
+++ b/internal/api/client/bookmarks/bookmarksget.go
@@ -56,12 +56,12 @@ const (
 func (m *Module) BookmarksGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -71,7 +71,7 @@ func (m *Module) BookmarksGETHandler(c *gin.Context) {
 		i, err := strconv.ParseInt(limitString, 10, 64)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", LimitKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		limit = int(i)
@@ -91,12 +91,12 @@ func (m *Module) BookmarksGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.BookmarksGet(c.Request.Context(), authed, maxID, minID, limit)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/customemojis/customemojisget.go
+++ b/internal/api/client/customemojis/customemojisget.go
@@ -57,18 +57,18 @@ import (
 //			description: internal server error
 func (m *Module) CustomEmojisGETHandler(c *gin.Context) {
 	if _, err := oauth.Authed(c, true, true, true, true); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	emojis, errWithCode := m.processor.CustomEmojisGet(c)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/favourites/favouritesget.go
+++ b/internal/api/client/favourites/favouritesget.go
@@ -78,12 +78,12 @@ import (
 func (m *Module) FavouritesGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -105,7 +105,7 @@ func (m *Module) FavouritesGETHandler(c *gin.Context) {
 		i, err := strconv.ParseInt(limitString, 10, 32)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", LimitKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		limit = int(i)
@@ -113,7 +113,7 @@ func (m *Module) FavouritesGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.FavedTimelineGet(c.Request.Context(), authed, maxID, minID, limit)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/filters/filtersget.go
+++ b/internal/api/client/filters/filtersget.go
@@ -12,12 +12,12 @@ import (
 // FiltersGETHandler returns a list of filters set by/for the authed account
 func (m *Module) FiltersGETHandler(c *gin.Context) {
 	if _, err := oauth.Authed(c, true, true, true, true); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/followrequests/authorize.go
+++ b/internal/api/client/followrequests/authorize.go
@@ -72,25 +72,25 @@ import (
 func (m *Module) FollowRequestAuthorizePOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	originAccountID := c.Param(IDKey)
 	if originAccountID == "" {
 		err := errors.New("no account id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	relationship, errWithCode := m.processor.FollowRequestAccept(c.Request.Context(), authed, originAccountID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/followrequests/get.go
+++ b/internal/api/client/followrequests/get.go
@@ -74,18 +74,18 @@ import (
 func (m *Module) FollowRequestGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	accts, errWithCode := m.processor.FollowRequestsGet(c.Request.Context(), authed)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/followrequests/reject.go
+++ b/internal/api/client/followrequests/reject.go
@@ -70,25 +70,25 @@ import (
 func (m *Module) FollowRequestRejectPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	originAccountID := c.Param(IDKey)
 	if originAccountID == "" {
 		err := errors.New("no account id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	relationship, errWithCode := m.processor.FollowRequestReject(c.Request.Context(), authed, originAccountID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/instance/instance.go
+++ b/internal/api/client/instance/instance.go
@@ -26,12 +26,10 @@ import (
 )
 
 const (
-	// InstanceInformationPath is for serving instance info requests, minus the 'api' prefix.
-	InstanceInformationPath = "/v1/instance"
-	// InstancePeersPath is for serving instance peers requests.
-	InstancePeersPath = InstanceInformationPath + "/peers"
-	// PeersFilterKey is used to provide filters to /api/v1/instance/peers
-	PeersFilterKey = "filter"
+	InstanceInformationPathV1 = "/v1/instance"
+	InstanceInformationPathV2 = "/v2/instance"
+	InstancePeersPath         = InstanceInformationPathV1 + "/peers"
+	PeersFilterKey            = "filter" // PeersFilterKey is used to provide filters to /api/v1/instance/peers
 )
 
 type Module struct {
@@ -45,7 +43,9 @@ func New(processor processing.Processor) *Module {
 }
 
 func (m *Module) Route(attachHandler func(method string, path string, f ...gin.HandlerFunc) gin.IRoutes) {
-	attachHandler(http.MethodGet, InstanceInformationPath, m.InstanceInformationGETHandler)
-	attachHandler(http.MethodPatch, InstanceInformationPath, m.InstanceUpdatePATCHHandler)
+	attachHandler(http.MethodGet, InstanceInformationPathV1, m.InstanceInformationGETHandlerV1)
+	attachHandler(http.MethodGet, InstanceInformationPathV2, m.InstanceInformationGETHandlerV2)
+
+	attachHandler(http.MethodPatch, InstanceInformationPathV1, m.InstanceUpdatePATCHHandler)
 	attachHandler(http.MethodGet, InstancePeersPath, m.InstancePeersGETHandler)
 }

--- a/internal/api/client/instance/instanceget.go
+++ b/internal/api/client/instance/instanceget.go
@@ -22,13 +22,12 @@ import (
 	"net/http"
 
 	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
-	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 
 	"github.com/gin-gonic/gin"
 )
 
-// InstanceInformationGETHandler swagger:operation GET /api/v1/instance instanceGet
+// InstanceInformationV1GETHandlerV1 swagger:operation GET /api/v1/instance instanceGetV1
 //
 // View instance information.
 //
@@ -43,20 +42,55 @@ import (
 //		'200':
 //			description: "Instance information."
 //			schema:
-//				"$ref": "#/definitions/instance"
+//				"$ref": "#/definitions/instanceV1"
 //		'406':
 //			description: not acceptable
 //		'500':
 //			description: internal error
-func (m *Module) InstanceInformationGETHandler(c *gin.Context) {
+func (m *Module) InstanceInformationGETHandlerV1(c *gin.Context) {
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
-	instance, errWithCode := m.processor.InstanceGet(c.Request.Context(), config.GetHost())
+	instance, errWithCode := m.processor.InstanceGetV1(c.Request.Context())
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
+		return
+	}
+
+	c.JSON(http.StatusOK, instance)
+}
+
+// InstanceInformationGETHandlerV2 swagger:operation GET /api/v2/instance instanceGetV2
+//
+// View instance information.
+//
+//	---
+//	tags:
+//	- instance
+//
+//	produces:
+//	- application/json
+//
+//	responses:
+//		'200':
+//			description: "Instance information."
+//			schema:
+//				"$ref": "#/definitions/instanceV2"
+//		'406':
+//			description: not acceptable
+//		'500':
+//			description: internal error
+func (m *Module) InstanceInformationGETHandlerV2(c *gin.Context) {
+	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
+		return
+	}
+
+	instance, errWithCode := m.processor.InstanceGetV2(c.Request.Context())
+	if errWithCode != nil {
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/instance/instancepatch.go
+++ b/internal/api/client/instance/instancepatch.go
@@ -130,35 +130,35 @@ import (
 func (m *Module) InstanceUpdatePATCHHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !*authed.User.Admin {
 		err := errors.New("user is not an admin so cannot update instance settings")
-		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorForbidden(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.InstanceSettingsUpdateRequest{}
 	if err := c.ShouldBind(&form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if err := validateInstanceUpdate(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	i, errWithCode := m.processor.InstancePatch(c.Request.Context(), form)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/instance/instancepatch_test.go
+++ b/internal/api/client/instance/instancepatch_test.go
@@ -52,7 +52,7 @@ func (suite *InstancePatchTestSuite) TestInstancePatch1() {
 
 	// set up the request
 	recorder := httptest.NewRecorder()
-	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPath, bodyBytes, w.FormDataContentType(), true)
+	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPathV1, bodyBytes, w.FormDataContentType(), true)
 
 	// call the handler
 	suite.instanceModule.InstanceUpdatePATCHHandler(ctx)
@@ -161,7 +161,7 @@ func (suite *InstancePatchTestSuite) TestInstancePatch2() {
 
 	// set up the request
 	recorder := httptest.NewRecorder()
-	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPath, bodyBytes, w.FormDataContentType(), true)
+	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPathV1, bodyBytes, w.FormDataContentType(), true)
 
 	// call the handler
 	suite.instanceModule.InstanceUpdatePATCHHandler(ctx)
@@ -270,7 +270,7 @@ func (suite *InstancePatchTestSuite) TestInstancePatch3() {
 
 	// set up the request
 	recorder := httptest.NewRecorder()
-	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPath, bodyBytes, w.FormDataContentType(), true)
+	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPathV1, bodyBytes, w.FormDataContentType(), true)
 
 	// call the handler
 	suite.instanceModule.InstanceUpdatePATCHHandler(ctx)
@@ -377,7 +377,7 @@ func (suite *InstancePatchTestSuite) TestInstancePatch4() {
 
 	// set up the request
 	recorder := httptest.NewRecorder()
-	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPath, bodyBytes, w.FormDataContentType(), true)
+	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPathV1, bodyBytes, w.FormDataContentType(), true)
 
 	// call the handler
 	suite.instanceModule.InstanceUpdatePATCHHandler(ctx)
@@ -406,7 +406,7 @@ func (suite *InstancePatchTestSuite) TestInstancePatch5() {
 
 	// set up the request
 	recorder := httptest.NewRecorder()
-	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPath, bodyBytes, w.FormDataContentType(), true)
+	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPathV1, bodyBytes, w.FormDataContentType(), true)
 
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 	ctx.Set(oauth.SessionAuthorizedToken, oauth.DBTokenToToken(suite.testTokens["local_account_1"]))
@@ -440,7 +440,7 @@ func (suite *InstancePatchTestSuite) TestInstancePatch6() {
 
 	// set up the request
 	recorder := httptest.NewRecorder()
-	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPath, bodyBytes, w.FormDataContentType(), true)
+	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPathV1, bodyBytes, w.FormDataContentType(), true)
 
 	// call the handler
 	suite.instanceModule.InstanceUpdatePATCHHandler(ctx)
@@ -549,7 +549,7 @@ func (suite *InstancePatchTestSuite) TestInstancePatch7() {
 
 	// set up the request
 	recorder := httptest.NewRecorder()
-	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPath, bodyBytes, w.FormDataContentType(), true)
+	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPathV1, bodyBytes, w.FormDataContentType(), true)
 
 	// call the handler
 	suite.instanceModule.InstanceUpdatePATCHHandler(ctx)
@@ -578,7 +578,7 @@ func (suite *InstancePatchTestSuite) TestInstancePatch8() {
 
 	// set up the request
 	recorder := httptest.NewRecorder()
-	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPath, bodyBytes, w.FormDataContentType(), true)
+	ctx := suite.newContext(recorder, http.MethodPatch, instance.InstanceInformationPathV1, bodyBytes, w.FormDataContentType(), true)
 
 	// call the handler
 	suite.instanceModule.InstanceUpdatePATCHHandler(ctx)

--- a/internal/api/client/instance/instancepatch_test.go
+++ b/internal/api/client/instance/instancepatch_test.go
@@ -106,7 +106,8 @@ func (suite *InstancePatchTestSuite) TestInstancePatch1() {
       "max_expiration": 2629746
     },
     "accounts": {
-      "allow_custom_css": true
+      "allow_custom_css": true,
+      "max_featured_tags": 10
     },
     "emojis": {
       "emoji_size_limit": 51200
@@ -215,7 +216,8 @@ func (suite *InstancePatchTestSuite) TestInstancePatch2() {
       "max_expiration": 2629746
     },
     "accounts": {
-      "allow_custom_css": true
+      "allow_custom_css": true,
+      "max_featured_tags": 10
     },
     "emojis": {
       "emoji_size_limit": 51200
@@ -324,7 +326,8 @@ func (suite *InstancePatchTestSuite) TestInstancePatch3() {
       "max_expiration": 2629746
     },
     "accounts": {
-      "allow_custom_css": true
+      "allow_custom_css": true,
+      "max_featured_tags": 10
     },
     "emojis": {
       "emoji_size_limit": 51200
@@ -494,7 +497,8 @@ func (suite *InstancePatchTestSuite) TestInstancePatch6() {
       "max_expiration": 2629746
     },
     "accounts": {
-      "allow_custom_css": true
+      "allow_custom_css": true,
+      "max_featured_tags": 10
     },
     "emojis": {
       "emoji_size_limit": 51200
@@ -636,7 +640,8 @@ func (suite *InstancePatchTestSuite) TestInstancePatch8() {
       "max_expiration": 2629746
     },
     "accounts": {
-      "allow_custom_css": true
+      "allow_custom_css": true,
+      "max_featured_tags": 10
     },
     "emojis": {
       "emoji_size_limit": 51200
@@ -678,6 +683,24 @@ func (suite *InstancePatchTestSuite) TestInstancePatch8() {
   },
   "max_toot_chars": 5000
 }`, dst.String())
+
+	// extra bonus: check the v2 model thumbnail after the patch
+	instanceV2, err := suite.processor.InstanceGetV2(ctx)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	instanceV2ThumbnailJson, err := json.MarshalIndent(instanceV2.Thumbnail, "", "  ")
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Equal(`{
+  "url": "http://localhost:8080/fileserver/01AY6P665V14JJR0AFVRT7311Y/attachment/original/`+instanceAccount.AvatarMediaAttachment.ID+`.gif",`+`
+  "thumbnail_type": "image/gif",
+  "thumbnail_description": "A bouncing little green peglin.",
+  "blurhash": "LG9t;qRS4YtO.4WDRlt5IXoxtPj["
+}`, string(instanceV2ThumbnailJson))
 }
 
 func TestInstancePatchTestSuite(t *testing.T) {

--- a/internal/api/client/instance/instancepeersget.go
+++ b/internal/api/client/instance/instancepeersget.go
@@ -102,14 +102,14 @@ import (
 func (m *Module) InstancePeersGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, false, false, false, false)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	var isUnauthenticated = authed.Account == nil || authed.User == nil
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -127,7 +127,7 @@ func (m *Module) InstancePeersGETHandler(c *gin.Context) {
 				includeOpen = true
 			default:
 				err := fmt.Errorf("filter %s not recognized; accepted values are 'open', 'suspended'", trimmed)
-				apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+				apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 				return
 			}
 		}
@@ -141,19 +141,19 @@ func (m *Module) InstancePeersGETHandler(c *gin.Context) {
 
 	if includeOpen && !config.GetInstanceExposePeers() && isUnauthenticated {
 		err := fmt.Errorf("peers open query requires an authenticated account/user")
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if includeSuspended && !config.GetInstanceExposeSuspended() && isUnauthenticated {
 		err := fmt.Errorf("peers suspended query requires an authenticated account/user")
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	data, errWithCode := m.processor.InstancePeersGet(c.Request.Context(), includeSuspended, includeOpen, flat)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/lists/listsgets.go
+++ b/internal/api/client/lists/listsgets.go
@@ -30,12 +30,12 @@ import (
 // ListsGETHandler returns a list of lists created by/for the authed account
 func (m *Module) ListsGETHandler(c *gin.Context) {
 	if _, err := oauth.Authed(c, true, true, true, true); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/media/mediacreate.go
+++ b/internal/api/client/media/mediacreate.go
@@ -97,35 +97,35 @@ func (m *Module) MediaCreatePOSTHandler(c *gin.Context) {
 	apiVersion := c.Param(APIVersionKey)
 	if apiVersion != APIv1 && apiVersion != APIv2 {
 		err := errors.New("api version must be one of v1 or v2 for this path")
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.AttachmentRequest{}
 	if err := c.ShouldBind(&form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if err := validateCreateMedia(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiAttachment, errWithCode := m.processor.MediaCreate(c.Request.Context(), authed, form)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/media/mediaget.go
+++ b/internal/api/client/media/mediaget.go
@@ -69,31 +69,31 @@ import (
 func (m *Module) MediaGETHandler(c *gin.Context) {
 	if apiVersion := c.Param(APIVersionKey); apiVersion != APIv1 {
 		err := errors.New("api version must be one v1 for this path")
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	attachmentID := c.Param(IDKey)
 	if attachmentID == "" {
 		err := errors.New("no attachment id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	attachment, errWithCode := m.processor.MediaGet(c.Request.Context(), authed, attachmentID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/media/mediaupdate.go
+++ b/internal/api/client/media/mediaupdate.go
@@ -101,42 +101,42 @@ import (
 func (m *Module) MediaPUTHandler(c *gin.Context) {
 	if apiVersion := c.Param(APIVersionKey); apiVersion != APIv1 {
 		err := errors.New("api version must be one v1 for this path")
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	attachmentID := c.Param(IDKey)
 	if attachmentID == "" {
 		err := errors.New("no attachment id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.AttachmentUpdateRequest{}
 	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if err := validateUpdateMedia(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	attachment, errWithCode := m.processor.MediaUpdate(c.Request.Context(), authed, attachmentID, form)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/notifications/notificationsclear.go
+++ b/internal/api/client/notifications/notificationsclear.go
@@ -61,18 +61,18 @@ import (
 func (m *Module) NotificationsClearPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	errWithCode := m.processor.NotificationsClear(c.Request.Context(), authed)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/notifications/notificationsget.go
+++ b/internal/api/client/notifications/notificationsget.go
@@ -111,12 +111,12 @@ import (
 func (m *Module) NotificationsGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -126,7 +126,7 @@ func (m *Module) NotificationsGETHandler(c *gin.Context) {
 		i, err := strconv.ParseInt(limitString, 10, 32)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", LimitKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		limit = int(i)
@@ -148,7 +148,7 @@ func (m *Module) NotificationsGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.NotificationsGet(c.Request.Context(), authed, excludeTypes, limit, maxID, sinceID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/reports/reportcreate.go
+++ b/internal/api/client/reports/reportcreate.go
@@ -69,42 +69,42 @@ import (
 func (m *Module) ReportPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.ReportCreateRequest{}
 	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if form.AccountID == "" {
 		err = errors.New("account_id must be set")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !regexes.ULID.MatchString(form.AccountID) {
 		err = errors.New("account_id was not valid")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if length := len([]rune(form.Comment)); length > 1000 {
 		err = fmt.Errorf("comment length must be no more than 1000 chars, provided comment was %d chars", length)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiReport, errWithCode := m.processor.ReportCreate(c.Request.Context(), authed, form)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/reports/reportget.go
+++ b/internal/api/client/reports/reportget.go
@@ -69,25 +69,25 @@ import (
 func (m *Module) ReportGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetReportID := c.Param(IDKey)
 	if targetReportID == "" {
 		err := errors.New("no report id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	report, errWithCode := m.processor.ReportGet(c.Request.Context(), authed, targetReportID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/reports/reportsget.go
+++ b/internal/api/client/reports/reportsget.go
@@ -122,12 +122,12 @@ import (
 func (m *Module) ReportsGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -136,7 +136,7 @@ func (m *Module) ReportsGETHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(resolvedString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", ResolvedKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		resolved = &i
@@ -147,7 +147,7 @@ func (m *Module) ReportsGETHandler(c *gin.Context) {
 		i, err := strconv.Atoi(limitString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", LimitKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 
@@ -162,7 +162,7 @@ func (m *Module) ReportsGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.ReportsGet(c.Request.Context(), authed, resolved, c.Query(TargetAccountIDKey), c.Query(MaxIDKey), c.Query(SinceIDKey), c.Query(MinIDKey), limit)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/search/searchget.go
+++ b/internal/api/client/search/searchget.go
@@ -66,12 +66,12 @@ import (
 func (m *Module) SearchGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -82,7 +82,7 @@ func (m *Module) SearchGETHandler(c *gin.Context) {
 		excludeUnreviewed, err = strconv.ParseBool(excludeUnreviewedString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", ExcludeUnreviewedKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 	}
@@ -90,7 +90,7 @@ func (m *Module) SearchGETHandler(c *gin.Context) {
 	query := c.Query(QueryKey)
 	if query == "" {
 		err := errors.New("query parameter q was empty")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -101,7 +101,7 @@ func (m *Module) SearchGETHandler(c *gin.Context) {
 		resolve, err = strconv.ParseBool(resolveString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", ResolveKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 	}
@@ -112,7 +112,7 @@ func (m *Module) SearchGETHandler(c *gin.Context) {
 		i, err := strconv.ParseInt(limitString, 10, 32)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", LimitKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		limit = int(i)
@@ -130,7 +130,7 @@ func (m *Module) SearchGETHandler(c *gin.Context) {
 		i, err := strconv.ParseInt(offsetString, 10, 32)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", OffsetKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		offset = int(i)
@@ -143,7 +143,7 @@ func (m *Module) SearchGETHandler(c *gin.Context) {
 		following, err = strconv.ParseBool(followingString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", FollowingKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 	}
@@ -163,7 +163,7 @@ func (m *Module) SearchGETHandler(c *gin.Context) {
 
 	results, errWithCode := m.processor.SearchGet(c.Request.Context(), authed, searchQuery)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/statuses/statusbookmark.go
+++ b/internal/api/client/statuses/statusbookmark.go
@@ -72,25 +72,25 @@ import (
 func (m *Module) StatusBookmarkPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetStatusID := c.Param(IDKey)
 	if targetStatusID == "" {
 		err := errors.New("no status id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiStatus, errWithCode := m.processor.StatusBookmark(c.Request.Context(), authed, targetStatusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/statuses/statusboost.go
+++ b/internal/api/client/statuses/statusboost.go
@@ -75,25 +75,25 @@ import (
 func (m *Module) StatusBoostPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetStatusID := c.Param(IDKey)
 	if targetStatusID == "" {
 		err := errors.New("no status id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiStatus, errWithCode := m.processor.StatusBoost(c.Request.Context(), authed, targetStatusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/statuses/statusboostedby.go
+++ b/internal/api/client/statuses/statusboostedby.go
@@ -68,20 +68,20 @@ import (
 func (m *Module) StatusBoostedByGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetStatusID := c.Param(IDKey)
 	if targetStatusID == "" {
 		err := errors.New("no status id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiAccounts, errWithCode := m.processor.StatusBoostedBy(c.Request.Context(), authed, targetStatusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/statuses/statuscontext.go
+++ b/internal/api/client/statuses/statuscontext.go
@@ -74,25 +74,25 @@ import (
 func (m *Module) StatusContextGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetStatusID := c.Param(IDKey)
 	if targetStatusID == "" {
 		err := errors.New("no status id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	statusContext, errWithCode := m.processor.StatusGetContext(c.Request.Context(), authed, targetStatusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/statuses/statuscreate.go
+++ b/internal/api/client/statuses/statuscreate.go
@@ -75,18 +75,18 @@ import (
 func (m *Module) StatusCreatePOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.AdvancedStatusCreateForm{}
 	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -100,13 +100,13 @@ func (m *Module) StatusCreatePOSTHandler(c *gin.Context) {
 	// form.Status += "\n\nsent from " + user + "'s iphone\n"
 
 	if err := validateCreateStatus(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiStatus, errWithCode := m.processor.StatusCreate(c.Request.Context(), authed, form)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/statuses/statusdelete.go
+++ b/internal/api/client/statuses/statusdelete.go
@@ -74,25 +74,25 @@ import (
 func (m *Module) StatusDELETEHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetStatusID := c.Param(IDKey)
 	if targetStatusID == "" {
 		err := errors.New("no status id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiStatus, errWithCode := m.processor.StatusDelete(c.Request.Context(), authed, targetStatusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/statuses/statusfave.go
+++ b/internal/api/client/statuses/statusfave.go
@@ -71,25 +71,25 @@ import (
 func (m *Module) StatusFavePOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetStatusID := c.Param(IDKey)
 	if targetStatusID == "" {
 		err := errors.New("no status id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiStatus, errWithCode := m.processor.StatusFave(c.Request.Context(), authed, targetStatusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/statuses/statusfavedby.go
+++ b/internal/api/client/statuses/statusfavedby.go
@@ -72,25 +72,25 @@ import (
 func (m *Module) StatusFavedByGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetStatusID := c.Param(IDKey)
 	if targetStatusID == "" {
 		err := errors.New("no status id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiAccounts, errWithCode := m.processor.StatusFavedBy(c.Request.Context(), authed, targetStatusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/statuses/statusget.go
+++ b/internal/api/client/statuses/statusget.go
@@ -71,25 +71,25 @@ import (
 func (m *Module) StatusGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetStatusID := c.Param(IDKey)
 	if targetStatusID == "" {
 		err := errors.New("no status id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiStatus, errWithCode := m.processor.StatusGet(c.Request.Context(), authed, targetStatusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/statuses/statusunbookmark.go
+++ b/internal/api/client/statuses/statusunbookmark.go
@@ -72,25 +72,25 @@ import (
 func (m *Module) StatusUnbookmarkPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetStatusID := c.Param(IDKey)
 	if targetStatusID == "" {
 		err := errors.New("no status id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiStatus, errWithCode := m.processor.StatusUnbookmark(c.Request.Context(), authed, targetStatusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/statuses/statusunboost.go
+++ b/internal/api/client/statuses/statusunboost.go
@@ -72,25 +72,25 @@ import (
 func (m *Module) StatusUnboostPOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetStatusID := c.Param(IDKey)
 	if targetStatusID == "" {
 		err := errors.New("no status id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiStatus, errWithCode := m.processor.StatusUnboost(c.Request.Context(), authed, targetStatusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/statuses/statusunfave.go
+++ b/internal/api/client/statuses/statusunfave.go
@@ -71,25 +71,25 @@ import (
 func (m *Module) StatusUnfavePOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	targetStatusID := c.Param(IDKey)
 	if targetStatusID == "" {
 		err := errors.New("no status id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	apiStatus, errWithCode := m.processor.StatusUnfave(c.Request.Context(), authed, targetStatusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/streaming/stream.go
+++ b/internal/api/client/streaming/stream.go
@@ -137,7 +137,7 @@ func (m *Module) StreamGETHandler(c *gin.Context) {
 	streamType := c.Query(StreamQueryKey)
 	if streamType == "" {
 		err := fmt.Errorf("no stream type provided under query key %s", StreamQueryKey)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -149,20 +149,20 @@ func (m *Module) StreamGETHandler(c *gin.Context) {
 		if token = c.GetHeader(AccessTokenHeader); token == "" {
 			const errStr = "no access token provided"
 			err := gtserror.NewErrorUnauthorized(errors.New(errStr), errStr)
-			apiutil.ErrorHandler(c, err, m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, err, m.processor.InstanceGetV1)
 			return
 		}
 	}
 
 	account, errWithCode := m.processor.AuthorizeStreamingRequest(c.Request.Context(), token)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
 	stream, errWithCode := m.processor.OpenStreamForAccount(c.Request.Context(), account, streamType)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/timelines/home.go
+++ b/internal/api/client/timelines/home.go
@@ -112,12 +112,12 @@ import (
 func (m *Module) HomeTimelineGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -145,7 +145,7 @@ func (m *Module) HomeTimelineGETHandler(c *gin.Context) {
 		i, err := strconv.ParseInt(limitString, 10, 32)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", LimitKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		limit = int(i)
@@ -157,7 +157,7 @@ func (m *Module) HomeTimelineGETHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(localString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", LocalKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		local = i
@@ -165,7 +165,7 @@ func (m *Module) HomeTimelineGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.HomeTimelineGet(c.Request.Context(), authed, maxID, sinceID, minID, limit, local)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/timelines/public.go
+++ b/internal/api/client/timelines/public.go
@@ -123,12 +123,12 @@ func (m *Module) PublicTimelineGETHandler(c *gin.Context) {
 	}
 
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -156,7 +156,7 @@ func (m *Module) PublicTimelineGETHandler(c *gin.Context) {
 		i, err := strconv.ParseInt(limitString, 10, 32)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", LimitKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		limit = int(i)
@@ -168,7 +168,7 @@ func (m *Module) PublicTimelineGETHandler(c *gin.Context) {
 		i, err := strconv.ParseBool(localString)
 		if err != nil {
 			err := fmt.Errorf("error parsing %s: %s", LocalKey, err)
-			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 			return
 		}
 		local = i
@@ -176,7 +176,7 @@ func (m *Module) PublicTimelineGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.PublicTimelineGet(c.Request.Context(), authed, maxID, sinceID, minID, limit, local)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/client/user/passwordchange.go
+++ b/internal/api/client/user/passwordchange.go
@@ -68,35 +68,35 @@ import (
 func (m *Module) PasswordChangePOSTHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, true, true, true, true)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	form := &apimodel.PasswordChangeRequest{}
 	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if form.OldPassword == "" {
 		err := errors.New("password change request missing field old_password")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if form.NewPassword == "" {
 		err := errors.New("password change request missing field new_password")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if errWithCode := m.processor.UserChangePassword(c.Request.Context(), authed, form); errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/fileserver/servefile.go
+++ b/internal/api/fileserver/servefile.go
@@ -41,7 +41,7 @@ import (
 func (m *Module) ServeFile(c *gin.Context) {
 	authed, err := oauth.Authed(c, false, false, false, false)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -51,28 +51,28 @@ func (m *Module) ServeFile(c *gin.Context) {
 	accountID := c.Param(AccountIDKey)
 	if accountID == "" {
 		err := fmt.Errorf("missing %s from request", AccountIDKey)
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err), m.processor.InstanceGetV1)
 		return
 	}
 
 	mediaType := c.Param(MediaTypeKey)
 	if mediaType == "" {
 		err := fmt.Errorf("missing %s from request", MediaTypeKey)
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err), m.processor.InstanceGetV1)
 		return
 	}
 
 	mediaSize := c.Param(MediaSizeKey)
 	if mediaSize == "" {
 		err := fmt.Errorf("missing %s from request", MediaSizeKey)
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err), m.processor.InstanceGetV1)
 		return
 	}
 
 	fileName := c.Param(FileNameKey)
 	if fileName == "" {
 		err := fmt.Errorf("missing %s from request", FileNameKey)
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -83,7 +83,7 @@ func (m *Module) ServeFile(c *gin.Context) {
 		FileName:  fileName,
 	})
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
@@ -106,7 +106,7 @@ func (m *Module) ServeFile(c *gin.Context) {
 	// attempt to look up the content to provide a preview of the link, and they ask for text/html.
 	format, err := apiutil.NegotiateAccept(c, apiutil.MIME(content.ContentType))
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -125,7 +125,7 @@ func (m *Module) ServeFile(c *gin.Context) {
 	if _, err := io.ReadFull(content.Content, b); err != nil &&
 		(err != io.ErrUnexpectedEOF && err != io.EOF) {
 		err = fmt.Errorf("ServeFile: error reading from content: %w", err)
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -142,7 +142,7 @@ func (m *Module) ServeFile(c *gin.Context) {
 	tfs, err := iotools.TempFileSeeker(r)
 	if err != nil {
 		err = fmt.Errorf("ServeFile: error creating temp file seeker: %w", err)
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 	defer func() {

--- a/internal/api/model/instance.go
+++ b/internal/api/model/instance.go
@@ -20,10 +20,10 @@ package model
 
 import "mime/multipart"
 
-// Instance models information about this or another instance.
+// InstanceV1 models information about this or another instance.
 //
-// swagger:model instance
-type Instance struct {
+// swagger:model instanceV1
+type InstanceV1 struct {
 	// The URI of the instance.
 	// example: https://gts.example.org
 	URI string `json:"uri,omitempty"`
@@ -91,6 +91,86 @@ type Instance struct {
 	//
 	// example: 5000
 	MaxTootChars uint `json:"max_toot_chars"`
+}
+
+// InstanceV2 models information about this or another instance.
+//
+// swagger:model instanceV2
+type InstanceV2 struct {
+	// The domain of the instance.
+	// example: gts.example.org
+	Domain string `json:"domain"`
+	// The domain of accounts on this instance.
+	// This will not necessarily be the same as
+	// domain.
+	// example: example.org
+	AccountDomain string `json:"account_domain"`
+	// The title of the instance.
+	// example: GoToSocial Example Instance
+	Title string `json:"title"`
+	// The version of GoToSocial installed on the instance.
+	//
+	// This will contain at least a semantic version number.
+	//
+	// It may also contain, after a space, the short git commit ID of the running software.
+	//
+	// example: 0.1.1 cb85f65
+	Version string `json:"version"`
+	// The URL for the source code of the software running on this instance, in keeping with AGPL license requirements.
+	// example: https://github.com/superseriousbusiness/gotosocial
+	SourceURL string `json:"source_url"`
+	// Description of the instance.
+	//
+	// Should be HTML formatted, but might be plaintext.
+	//
+	// This should be displayed on the 'about' page for an instance.
+	Description string `json:"description"`
+
+	Usage InstanceUsage `json:"usage"`
+	// A shorter description of the instance.
+	//
+	// Should be HTML formatted, but might be plaintext.
+	//
+	// This should be displayed on the instance splash/landing page.
+	ShortDescription string `json:"short_description"`
+	// An email address that may be used for inquiries.
+	// example: admin@example.org
+	Email string `json:"email"`
+	// Primary language of the instance.
+	// example: en
+	Languages []string `json:"languages,omitempty"`
+	// New account registrations are enabled on this instance.
+	Registrations bool `json:"registrations"`
+	// New account registrations require admin approval.
+	ApprovalRequired bool `json:"approval_required"`
+	// Invites are enabled on this instance.
+	InvitesEnabled bool `json:"invites_enabled"`
+	// Configuration object containing values about status limits etc.
+	// This key/value will be omitted for remote instances.
+	Configuration *InstanceConfiguration `json:"configuration,omitempty"`
+	// URLs of interest for client applications.
+	URLS *InstanceURLs `json:"urls,omitempty"`
+	// Statistics about the instance: number of posts, accounts, etc.
+	Stats map[string]int `json:"stats,omitempty"`
+	// URL of the instance avatar/banner image.
+	// example: https://example.org/files/instance/thumbnail.jpeg
+	Thumbnail string `json:"thumbnail"`
+	// MIME type of the instance thumbnail.
+	// example: image/png
+	ThumbnailType string `json:"thumbnail_type,omitempty"`
+	// Description of the instance thumbnail.
+	// example: picture of a cute lil' friendly sloth
+	ThumbnailDescription string `json:"thumbnail_description,omitempty"`
+	// Contact account for the instance.
+	ContactAccount *Account `json:"contact_account,omitempty"`
+}
+
+type InstanceUsage struct {
+	Users InstanceUsers `json:"users"`
+}
+
+type InstanceUsers struct {
+	ActiveMonth int `json:"active_month"`
 }
 
 // InstanceConfiguration models instance configuration parameters.

--- a/internal/api/model/instance.go
+++ b/internal/api/model/instance.go
@@ -20,173 +20,41 @@ package model
 
 import "mime/multipart"
 
-// InstanceV1 models information about this or another instance.
+// InstanceSettingsUpdateRequest models an instance update request.
 //
-// swagger:model instanceV1
-type InstanceV1 struct {
-	// The URI of the instance.
-	// example: https://gts.example.org
-	URI string `json:"uri,omitempty"`
-	// The domain of accounts on this instance.
-	// This will not necessarily be the same as
-	// simply the Host part of the URI.
-	// example: example.org
-	AccountDomain string `json:"account_domain,omitempty"`
-	// The title of the instance.
-	// example: GoToSocial Example Instance
-	Title string `json:"title,omitempty"`
-	// Description of the instance.
-	//
-	// Should be HTML formatted, but might be plaintext.
-	//
-	// This should be displayed on the 'about' page for an instance.
-	Description string `json:"description"`
-	// A shorter description of the instance.
-	//
-	// Should be HTML formatted, but might be plaintext.
-	//
-	// This should be displayed on the instance splash/landing page.
-	ShortDescription string `json:"short_description"`
-	// An email address that may be used for inquiries.
-	// example: admin@example.org
-	Email string `json:"email"`
-	// The version of GoToSocial installed on the instance.
-	//
-	// This will contain at least a semantic version number.
-	//
-	// It may also contain, after a space, the short git commit ID of the running software.
-	//
-	// example: 0.1.1 cb85f65
-	Version string `json:"version"`
-	// Primary language of the instance.
-	// example: en
-	Languages []string `json:"languages,omitempty"`
-	// New account registrations are enabled on this instance.
-	Registrations bool `json:"registrations"`
-	// New account registrations require admin approval.
-	ApprovalRequired bool `json:"approval_required"`
-	// Invites are enabled on this instance.
-	InvitesEnabled bool `json:"invites_enabled"`
-	// Configuration object containing values about status limits etc.
-	// This key/value will be omitted for remote instances.
-	Configuration *InstanceConfiguration `json:"configuration,omitempty"`
-	// URLs of interest for client applications.
-	URLS *InstanceURLs `json:"urls,omitempty"`
-	// Statistics about the instance: number of posts, accounts, etc.
-	Stats map[string]int `json:"stats,omitempty"`
-	// URL of the instance avatar/banner image.
-	// example: https://example.org/files/instance/thumbnail.jpeg
-	Thumbnail string `json:"thumbnail"`
-	// MIME type of the instance thumbnail.
-	// example: image/png
-	ThumbnailType string `json:"thumbnail_type,omitempty"`
-	// Description of the instance thumbnail.
-	// example: picture of a cute lil' friendly sloth
-	ThumbnailDescription string `json:"thumbnail_description,omitempty"`
-	// Contact account for the instance.
-	ContactAccount *Account `json:"contact_account,omitempty"`
-	// Maximum allowed length of a post on this instance, in characters.
-	//
-	// This is provided for compatibility with Tusky and other apps.
-	//
-	// example: 5000
-	MaxTootChars uint `json:"max_toot_chars"`
+// swagger:ignore
+type InstanceSettingsUpdateRequest struct {
+	// Title to use for the instance. Max 40 characters.
+	Title *string `form:"title" json:"title" xml:"title"`
+	// Username for the instance contact account. Must be the username of an existing admin.
+	ContactUsername *string `form:"contact_username" json:"contact_username" xml:"contact_username"`
+	// Email for reaching the instance administrator(s).
+	ContactEmail *string `form:"contact_email" json:"contact_email" xml:"contact_email"`
+	// Short description of the instance, max 500 chars. HTML formatting accepted.
+	ShortDescription *string `form:"short_description" json:"short_description" xml:"short_description"`
+	// Longer description of the instance, max 5,000 chars. HTML formatting accepted.
+	Description *string `form:"description" json:"description" xml:"description"`
+	// Terms and conditions of the instance, max 5,000 chars. HTML formatting accepted.
+	Terms *string `form:"terms" json:"terms" xml:"terms"`
+	// Image to use as the instance thumbnail.
+	Avatar *multipart.FileHeader `form:"thumbnail" json:"thumbnail" xml:"thumbnail"`
+	// Image description for the instance avatar.
+	AvatarDescription *string `form:"thumbnail_description" json:"thumbnail_description" xml:"thumbnail_description"`
+	// Image to use as the instance header.
+	Header *multipart.FileHeader `form:"header" json:"header" xml:"header"`
 }
 
-// InstanceV2 models information about this or another instance.
+// InstanceConfigurationAccounts models instance account config parameters.
 //
-// swagger:model instanceV2
-type InstanceV2 struct {
-	// The domain of the instance.
-	// example: gts.example.org
-	Domain string `json:"domain"`
-	// The domain of accounts on this instance.
-	// This will not necessarily be the same as
-	// domain.
-	// example: example.org
-	AccountDomain string `json:"account_domain"`
-	// The title of the instance.
-	// example: GoToSocial Example Instance
-	Title string `json:"title"`
-	// The version of GoToSocial installed on the instance.
+// swagger:model instanceConfigurationAccounts
+type InstanceConfigurationAccounts struct {
+	// Whether or not accounts on this instance are allowed to upload custom CSS for profiles and statuses.
 	//
-	// This will contain at least a semantic version number.
-	//
-	// It may also contain, after a space, the short git commit ID of the running software.
-	//
-	// example: 0.1.1 cb85f65
-	Version string `json:"version"`
-	// The URL for the source code of the software running on this instance, in keeping with AGPL license requirements.
-	// example: https://github.com/superseriousbusiness/gotosocial
-	SourceURL string `json:"source_url"`
-	// Description of the instance.
-	//
-	// Should be HTML formatted, but might be plaintext.
-	//
-	// This should be displayed on the 'about' page for an instance.
-	Description string `json:"description"`
-
-	Usage InstanceUsage `json:"usage"`
-	// A shorter description of the instance.
-	//
-	// Should be HTML formatted, but might be plaintext.
-	//
-	// This should be displayed on the instance splash/landing page.
-	ShortDescription string `json:"short_description"`
-	// An email address that may be used for inquiries.
-	// example: admin@example.org
-	Email string `json:"email"`
-	// Primary language of the instance.
-	// example: en
-	Languages []string `json:"languages,omitempty"`
-	// New account registrations are enabled on this instance.
-	Registrations bool `json:"registrations"`
-	// New account registrations require admin approval.
-	ApprovalRequired bool `json:"approval_required"`
-	// Invites are enabled on this instance.
-	InvitesEnabled bool `json:"invites_enabled"`
-	// Configuration object containing values about status limits etc.
-	// This key/value will be omitted for remote instances.
-	Configuration *InstanceConfiguration `json:"configuration,omitempty"`
-	// URLs of interest for client applications.
-	URLS *InstanceURLs `json:"urls,omitempty"`
-	// Statistics about the instance: number of posts, accounts, etc.
-	Stats map[string]int `json:"stats,omitempty"`
-	// URL of the instance avatar/banner image.
-	// example: https://example.org/files/instance/thumbnail.jpeg
-	Thumbnail string `json:"thumbnail"`
-	// MIME type of the instance thumbnail.
-	// example: image/png
-	ThumbnailType string `json:"thumbnail_type,omitempty"`
-	// Description of the instance thumbnail.
-	// example: picture of a cute lil' friendly sloth
-	ThumbnailDescription string `json:"thumbnail_description,omitempty"`
-	// Contact account for the instance.
-	ContactAccount *Account `json:"contact_account,omitempty"`
-}
-
-type InstanceUsage struct {
-	Users InstanceUsers `json:"users"`
-}
-
-type InstanceUsers struct {
-	ActiveMonth int `json:"active_month"`
-}
-
-// InstanceConfiguration models instance configuration parameters.
-//
-// swagger:model instanceConfiguration
-type InstanceConfiguration struct {
-	// Instance configuration pertaining to status limits.
-	Statuses *InstanceConfigurationStatuses `json:"statuses"`
-	// Instance configuration pertaining to media attachment types + size limits.
-	MediaAttachments *InstanceConfigurationMediaAttachments `json:"media_attachments"`
-	// Instance configuration pertaining to poll limits.
-	Polls *InstanceConfigurationPolls `json:"polls"`
-	// Instance configuration pertaining to accounts.
-	Accounts *InstanceConfigurationAccounts `json:"accounts"`
-	// Instance configuration pertaining to emojis.
-	Emojis *InstanceConfigurationEmojis `json:"emojis"`
+	// example: false
+	AllowCustomCSS bool `json:"allow_custom_css"`
+	// The maximum number of featured tags allowed for each account.
+	// Currently not implemented, so this is hardcoded to 10.
+	MaxFeaturedTags int `json:"max_featured_tags"`
 }
 
 // InstanceConfigurationStatuses models instance status config parameters.
@@ -265,51 +133,10 @@ type InstanceConfigurationPolls struct {
 	MaxExpiration int `json:"max_expiration"`
 }
 
-// InstanceConfigurationAccounts models instance account config parameters.
-type InstanceConfigurationAccounts struct {
-	// Whether or not accounts on this instance are allowed to upload custom CSS for profiles and statuses.
-	//
-	// example: false
-	AllowCustomCSS bool `json:"allow_custom_css"`
-}
-
 // InstanceConfigurationEmojis models instance emoji config parameters.
 type InstanceConfigurationEmojis struct {
 	// Max allowed emoji image size in bytes.
 	//
 	// example: 51200
 	EmojiSizeLimit int `json:"emoji_size_limit"`
-}
-
-// InstanceURLs models instance-relevant URLs for client application consumption.
-//
-// swagger:model instanceURLs
-type InstanceURLs struct {
-	// Websockets address for status and notification streaming.
-	// example: wss://example.org
-	StreamingAPI string `json:"streaming_api"`
-}
-
-// InstanceSettingsUpdateRequest models an instance update request.
-//
-// swagger:ignore
-type InstanceSettingsUpdateRequest struct {
-	// Title to use for the instance. Max 40 characters.
-	Title *string `form:"title" json:"title" xml:"title"`
-	// Username for the instance contact account. Must be the username of an existing admin.
-	ContactUsername *string `form:"contact_username" json:"contact_username" xml:"contact_username"`
-	// Email for reaching the instance administrator(s).
-	ContactEmail *string `form:"contact_email" json:"contact_email" xml:"contact_email"`
-	// Short description of the instance, max 500 chars. HTML formatting accepted.
-	ShortDescription *string `form:"short_description" json:"short_description" xml:"short_description"`
-	// Longer description of the instance, max 5,000 chars. HTML formatting accepted.
-	Description *string `form:"description" json:"description" xml:"description"`
-	// Terms and conditions of the instance, max 5,000 chars. HTML formatting accepted.
-	Terms *string `form:"terms" json:"terms" xml:"terms"`
-	// Image to use as the instance thumbnail.
-	Avatar *multipart.FileHeader `form:"thumbnail" json:"thumbnail" xml:"thumbnail"`
-	// Image description for the instance avatar.
-	AvatarDescription *string `form:"thumbnail_description" json:"thumbnail_description" xml:"thumbnail_description"`
-	// Image to use as the instance header.
-	Header *multipart.FileHeader `form:"header" json:"header" xml:"header"`
 }

--- a/internal/api/model/instancev1.go
+++ b/internal/api/model/instancev1.go
@@ -1,0 +1,117 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2023 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package model
+
+// InstanceV1 models information about this instance.
+//
+// swagger:model instanceV1
+type InstanceV1 struct {
+	// The URI of the instance.
+	// example: https://gts.example.org
+	URI string `json:"uri,omitempty"`
+	// The domain of accounts on this instance.
+	// This will not necessarily be the same as
+	// simply the Host part of the URI.
+	// example: example.org
+	AccountDomain string `json:"account_domain,omitempty"`
+	// The title of the instance.
+	// example: GoToSocial Example Instance
+	Title string `json:"title,omitempty"`
+	// Description of the instance.
+	//
+	// Should be HTML formatted, but might be plaintext.
+	//
+	// This should be displayed on the 'about' page for an instance.
+	Description string `json:"description"`
+	// A shorter description of the instance.
+	//
+	// Should be HTML formatted, but might be plaintext.
+	//
+	// This should be displayed on the instance splash/landing page.
+	ShortDescription string `json:"short_description"`
+	// An email address that may be used for inquiries.
+	// example: admin@example.org
+	Email string `json:"email"`
+	// The version of GoToSocial installed on the instance.
+	//
+	// This will contain at least a semantic version number.
+	//
+	// It may also contain, after a space, the short git commit ID of the running software.
+	//
+	// example: 0.1.1 cb85f65
+	Version string `json:"version"`
+	// Primary language of the instance.
+	// example: en
+	Languages []string `json:"languages,omitempty"`
+	// New account registrations are enabled on this instance.
+	Registrations bool `json:"registrations"`
+	// New account registrations require admin approval.
+	ApprovalRequired bool `json:"approval_required"`
+	// Invites are enabled on this instance.
+	InvitesEnabled bool `json:"invites_enabled"`
+	// Configuration object containing values about status limits etc.
+	// This key/value will be omitted for remote instances.
+	Configuration InstanceV1Configuration `json:"configuration,omitempty"`
+	// URLs of interest for client applications.
+	URLs InstanceV1URLs `json:"urls,omitempty"`
+	// Statistics about the instance: number of posts, accounts, etc.
+	Stats map[string]int `json:"stats,omitempty"`
+	// URL of the instance avatar/banner image.
+	// example: https://example.org/files/instance/thumbnail.jpeg
+	Thumbnail string `json:"thumbnail"`
+	// MIME type of the instance thumbnail.
+	// example: image/png
+	ThumbnailType string `json:"thumbnail_type,omitempty"`
+	// Description of the instance thumbnail.
+	// example: picture of a cute lil' friendly sloth
+	ThumbnailDescription string `json:"thumbnail_description,omitempty"`
+	// Contact account for the instance.
+	ContactAccount *Account `json:"contact_account,omitempty"`
+	// Maximum allowed length of a post on this instance, in characters.
+	//
+	// This is provided for compatibility with Tusky and other apps.
+	//
+	// example: 5000
+	MaxTootChars uint `json:"max_toot_chars"`
+}
+
+// InstanceV1URLs models instance-relevant URLs for client application consumption.
+//
+// swagger:model instanceV1URLs
+type InstanceV1URLs struct {
+	// Websockets address for status and notification streaming.
+	// example: wss://example.org
+	StreamingAPI string `json:"streaming_api"`
+}
+
+// InstanceV1Configuration models instance configuration parameters.
+//
+// swagger:model instanceV1Configuration
+type InstanceV1Configuration struct {
+	// Instance configuration pertaining to status limits.
+	Statuses InstanceConfigurationStatuses `json:"statuses"`
+	// Instance configuration pertaining to media attachment types + size limits.
+	MediaAttachments InstanceConfigurationMediaAttachments `json:"media_attachments"`
+	// Instance configuration pertaining to poll limits.
+	Polls InstanceConfigurationPolls `json:"polls"`
+	// Instance configuration pertaining to accounts.
+	Accounts InstanceConfigurationAccounts `json:"accounts"`
+	// Instance configuration pertaining to emojis.
+	Emojis InstanceConfigurationEmojis `json:"emojis"`
+}

--- a/internal/api/model/instancev2.go
+++ b/internal/api/model/instancev2.go
@@ -1,0 +1,189 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2023 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package model
+
+// InstanceV2 models information about this instance.
+//
+// swagger:model instanceV2
+type InstanceV2 struct {
+	// The domain of the instance.
+	// example: gts.example.org
+	Domain string `json:"domain"`
+	// The domain of accounts on this instance.
+	// This will not necessarily be the same as
+	// domain.
+	// example: example.org
+	AccountDomain string `json:"account_domain"`
+	// The title of the instance.
+	// example: GoToSocial Example Instance
+	Title string `json:"title"`
+	// The version of GoToSocial installed on the instance.
+	//
+	// This will contain at least a semantic version number.
+	//
+	// It may also contain, after a space, the short git commit ID of the running software.
+	//
+	// example: 0.1.1 cb85f65
+	Version string `json:"version"`
+	// The URL for the source code of the software running on this instance, in keeping with AGPL license requirements.
+	// example: https://github.com/superseriousbusiness/gotosocial
+	SourceURL string `json:"source_url"`
+	// Description of the instance.
+	//
+	// Should be HTML formatted, but might be plaintext.
+	//
+	// This should be displayed on the 'about' page for an instance.
+	Description string `json:"description"`
+	// Basic anonymous usage data for this instance.
+	Usage InstanceV2Usage `json:"usage"`
+	// An image used to represent this instance.
+	Thumbnail InstanceV2Thumbnail `json:"thumbnail"`
+	// Primary languages of the instance + moderators/admins.
+	// example: ["en"]
+	Languages []string `json:"languages"`
+	// Configured values and limits for this instance.
+	Configuration InstanceV2Configuration `json:"configuration"`
+	// Information about registering for this instance.
+	Registrations InstanceV2Registrations `json:"registrations"`
+	//  Hints related to contacting a representative of the instance.
+	Contact InstanceV2Contact `json:"contact"`
+	// An itemized list of rules for this website.
+	// Currently not implemented (will always be empty array).
+	Rules []interface{} `json:"rules"`
+}
+
+// Usage data for this instance.
+//
+// swagger:model instanceV2Usage
+type InstanceV2Usage struct {
+	Users InstanceV2Users `json:"users"`
+}
+
+// Usage data related to users on this instance.
+//
+// swagger:model instanceV2Users
+type InstanceV2Users struct {
+	// The number of active users in the past 4 weeks.
+	// Currently not implemented: will always be 0.
+	// example: 0
+	ActiveMonth int `json:"active_month"`
+}
+
+// An image used to represent this instance.
+//
+// swagger:model instanceV2Thumbnail
+type InstanceV2Thumbnail struct {
+	// The URL for the thumbnail image.
+	// example: https://example.org/fileserver/01BPSX2MKCRVMD4YN4D71G9CP5/attachment/original/01H88X0KQ2DFYYDSWYP93VDJZA.png
+	URL string `json:"url"`
+	// MIME type of the instance thumbnail.
+	// Key/value not set if thumbnail image type unknown.
+	// example: image/png
+	Type string `json:"thumbnail_type,omitempty"`
+	// Description of the instance thumbnail.
+	// Key/value not set if no description available.
+	// example: picture of a cute lil' friendly sloth
+	Description string `json:"thumbnail_description,omitempty"`
+	// A hash computed by the BlurHash algorithm, for generating colorful preview thumbnails when media has not been downloaded yet.
+	// Key/value not set if no blurhash available.
+	// example: UeKUpFxuo~R%0nW;WCnhF6RjaJt757oJodS$
+	Blurhash string `json:"blurhash,omitempty"`
+	// Links to scaled resolution images, for high DPI screens.
+	// Key/value not set if no extra versions available.
+	Versions *InstanceV2ThumbnailVersions `json:"versions,omitempty"`
+}
+
+// Links to scaled resolution images, for high DPI screens.
+//
+// swagger:model instanceV2ThumbnailVersions
+type InstanceV2ThumbnailVersions struct {
+	// The URL for the thumbnail image at 1x resolution.
+	// Key/value not set if scaled versions not available.
+	Size1URL string `json:"@1x,omitempty"`
+	// The URL for the thumbnail image at 2x resolution.
+	// Key/value not set if scaled versions not available.
+	Size2URL string `json:"@2x,omitempty"`
+}
+
+// InstanceV2URLs models instance-relevant URLs for client application consumption.
+//
+// swagger:model instanceV1URLs
+type InstanceV2URLs struct {
+	// Websockets address for status and notification streaming.
+	// example: wss://example.org
+	Streaming string `json:"streaming"`
+}
+
+// Hints related to translation.
+//
+// swagger:model instanceV2ConfigurationTranslation
+type InstanceV2ConfigurationTranslation struct {
+	// Whether the Translations API is available on this instance.
+	// Not implemented so this value is always false.
+	Enabled bool `json:"enabled"`
+}
+
+// Configured values and limits for this instance.
+//
+// swagger:model instanceV2Configuration
+type InstanceV2Configuration struct {
+	// URLs of interest for clients apps.
+	URLs InstanceV2URLs `json:"urls"`
+	// Limits related to accounts.
+	Accounts InstanceConfigurationAccounts `json:"accounts"`
+	// Limits related to authoring statuses.
+	Statuses InstanceConfigurationStatuses `json:"statuses"`
+	// Hints for which attachments will be accepted.
+	MediaAttachments InstanceConfigurationMediaAttachments `json:"media_attachments"`
+	// Limits related to polls.
+	Polls InstanceConfigurationPolls `json:"polls"`
+	// Hints related to translation.
+	Translation InstanceV2ConfigurationTranslation `json:"translation"`
+	// Instance configuration pertaining to emojis.
+	Emojis InstanceConfigurationEmojis `json:"emojis"`
+}
+
+// Information about registering for this instance.
+//
+// swagger:model instanceV2Registrations
+type InstanceV2Registrations struct {
+	// Whether registrations are enabled.
+	// example: false
+	Enabled bool `json:"enabled"`
+	// Whether registrations require moderator approval.
+	// example: true
+	ApprovalRequired bool `json:"approval_required"`
+	// A custom message (html string) to be shown when registrations are closed.
+	// Value will be null if no message is set.
+	// example: <p>Registrations are currently closed on example.org because of spam bots!</p>
+	Message *string `json:"message"`
+}
+
+// Hints related to contacting a representative of the instance.
+//
+// swagger:model instanceV2Contact
+type InstanceV2Contact struct {
+	// An email address that can be messaged regarding inquiries or issues.
+	// Empty string if no email address set.
+	// example: someone@example.org
+	Email string `json:"email"`
+	// An account that can be contacted regarding inquiries or issues.
+	// Key/value not present if no contact account set.
+	Account *Account `json:"account,omitempty"`
+}

--- a/internal/api/nodeinfo/nodeinfoget.go
+++ b/internal/api/nodeinfo/nodeinfoget.go
@@ -46,19 +46,19 @@ import (
 //				"$ref": "#/definitions/nodeinfo"
 func (m *Module) NodeInfo2GETHandler(c *gin.Context) {
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	nodeInfo, errWithCode := m.processor.GetNodeInfo(c.Request.Context())
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
 	b, err := json.Marshal(nodeInfo)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/util/errorhandling.go
+++ b/internal/api/util/errorhandling.go
@@ -25,7 +25,6 @@ import (
 	"codeberg.org/gruf/go-kv"
 	"github.com/gin-gonic/gin"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
-	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 )
@@ -41,11 +40,10 @@ import (
 // 404 header and footer.
 //
 // If an error is returned by InstanceGet, the function will panic.
-func NotFoundHandler(c *gin.Context, instanceGet func(ctx context.Context, domain string) (*apimodel.Instance, gtserror.WithCode), accept string) {
+func NotFoundHandler(c *gin.Context, instanceGet func(ctx context.Context) (*apimodel.InstanceV1, gtserror.WithCode), accept string) {
 	switch accept {
 	case string(TextHTML):
-		host := config.GetHost()
-		instance, err := instanceGet(c.Request.Context(), host)
+		instance, err := instanceGet(c.Request.Context())
 		if err != nil {
 			panic(err)
 		}
@@ -61,11 +59,10 @@ func NotFoundHandler(c *gin.Context, instanceGet func(ctx context.Context, domai
 // genericErrorHandler is a more general version of the NotFoundHandler, which can
 // be used for serving either generic error pages with some rendered help text,
 // or just some error json if the caller prefers (or has no preference).
-func genericErrorHandler(c *gin.Context, instanceGet func(ctx context.Context, domain string) (*apimodel.Instance, gtserror.WithCode), accept string, errWithCode gtserror.WithCode) {
+func genericErrorHandler(c *gin.Context, instanceGet func(ctx context.Context) (*apimodel.InstanceV1, gtserror.WithCode), accept string, errWithCode gtserror.WithCode) {
 	switch accept {
 	case string(TextHTML):
-		host := config.GetHost()
-		instance, err := instanceGet(c.Request.Context(), host)
+		instance, err := instanceGet(c.Request.Context())
 		if err != nil {
 			panic(err)
 		}
@@ -85,7 +82,7 @@ func genericErrorHandler(c *gin.Context, instanceGet func(ctx context.Context, d
 // the caller prefers to see an html page with the error rendered there. If not, or
 // if something goes wrong during the function, it will recover and just try to serve
 // an appropriate application/json content-type error.
-func ErrorHandler(c *gin.Context, errWithCode gtserror.WithCode, instanceGet func(ctx context.Context, domain string) (*apimodel.Instance, gtserror.WithCode)) {
+func ErrorHandler(c *gin.Context, errWithCode gtserror.WithCode, instanceGet func(ctx context.Context) (*apimodel.InstanceV1, gtserror.WithCode)) {
 	// set the error on the gin context so that it can be logged
 	// in the gin logger middleware (internal/router/logger.go)
 	c.Error(errWithCode) //nolint:errcheck

--- a/internal/api/wellknown/nodeinfo/nodeinfoget.go
+++ b/internal/api/wellknown/nodeinfo/nodeinfoget.go
@@ -46,13 +46,13 @@ import (
 //				"$ref": "#/definitions/wellKnownResponse"
 func (m *Module) NodeInfoWellKnownGETHandler(c *gin.Context) {
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	resp, errWithCode := m.processor.GetNodeInfoRel(c.Request.Context())
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/api/wellknown/webfinger/webfingerget.go
+++ b/internal/api/wellknown/webfinger/webfingerget.go
@@ -57,33 +57,33 @@ import (
 //				"$ref": "#/definitions/wellKnownResponse"
 func (m *Module) WebfingerGETRequest(c *gin.Context) {
 	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	resourceQuery, set := c.GetQuery("resource")
 	if !set || resourceQuery == "" {
 		err := errors.New("no 'resource' in request query")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	requestedUsername, requestedHost, err := util.ExtractWebfingerParts(resourceQuery)
 	if err != nil {
 		err := fmt.Errorf("bad webfinger request with resource query %s: %w", resourceQuery, err)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if requestedHost != config.GetHost() && requestedHost != config.GetAccountDomain() {
 		err := fmt.Errorf("requested host %s does not belong to this instance", requestedHost)
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	resp, errWithCode := m.processor.GetWebfingerAccount(c.Request.Context(), requestedUsername)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/processing/instance.go
+++ b/internal/processing/instance.go
@@ -44,7 +44,7 @@ func (p *processor) getThisInstance(ctx context.Context) (*gtsmodel.Instance, er
 func (p *processor) InstanceGetV1(ctx context.Context) (*apimodel.InstanceV1, gtserror.WithCode) {
 	i, err := p.getThisInstance(ctx)
 	if err != nil {
-		return nil, gtserror.NewErrorInternalError(fmt.Errorf("db error fetching instance %s: %s", err))
+		return nil, gtserror.NewErrorInternalError(fmt.Errorf("db error fetching instance: %s", err))
 	}
 
 	ai, err := p.tc.InstanceToAPIV1Instance(ctx, i)
@@ -58,7 +58,7 @@ func (p *processor) InstanceGetV1(ctx context.Context) (*apimodel.InstanceV1, gt
 func (p *processor) InstanceGetV2(ctx context.Context) (*apimodel.InstanceV2, gtserror.WithCode) {
 	i, err := p.getThisInstance(ctx)
 	if err != nil {
-		return nil, gtserror.NewErrorInternalError(fmt.Errorf("db error fetching instance %s: %s", err))
+		return nil, gtserror.NewErrorInternalError(fmt.Errorf("db error fetching instance: %s", err))
 	}
 
 	ai, err := p.tc.InstanceToAPIV2Instance(ctx, i)

--- a/internal/processing/processor.go
+++ b/internal/processing/processor.go
@@ -170,13 +170,15 @@ type Processor interface {
 	// FollowRequestReject handles the rejection of a follow request from the given account ID.
 	FollowRequestReject(ctx context.Context, auth *oauth.Auth, accountID string) (*apimodel.Relationship, gtserror.WithCode)
 
-	// InstanceGet retrieves instance information for serving at api/v1/instance
-	InstanceGet(ctx context.Context, domain string) (*apimodel.Instance, gtserror.WithCode)
+	// InstanceGetV1 retrieves instance information for serving at api/v1/instance
+	InstanceGetV1(ctx context.Context) (*apimodel.InstanceV1, gtserror.WithCode)
+	// InstanceGetV1 retrieves instance information for serving at api/v2/instance
+	InstanceGetV2(ctx context.Context) (*apimodel.InstanceV2, gtserror.WithCode)
 	InstancePeersGet(ctx context.Context, includeSuspended bool, includeOpen bool, flat bool) (interface{}, gtserror.WithCode)
 	// InstancePatch updates this instance according to the given form.
 	//
 	// It should already be ascertained that the requesting account is authenticated and an admin.
-	InstancePatch(ctx context.Context, form *apimodel.InstanceSettingsUpdateRequest) (*apimodel.Instance, gtserror.WithCode)
+	InstancePatch(ctx context.Context, form *apimodel.InstanceSettingsUpdateRequest) (*apimodel.InstanceV1, gtserror.WithCode)
 
 	// MediaCreate handles the creation of a media attachment, using the given form.
 	MediaCreate(ctx context.Context, authed *oauth.Auth, form *apimodel.AttachmentRequest) (*apimodel.Attachment, gtserror.WithCode)

--- a/internal/transport/derefinstance.go
+++ b/internal/transport/derefinstance.go
@@ -113,7 +113,7 @@ func dereferenceByAPIV1Instance(ctx context.Context, t *transport, iri *url.URL)
 	}
 
 	// try to parse the returned bytes directly into an Instance model
-	apiResp := &apimodel.Instance{}
+	apiResp := &apimodel.InstanceV1{}
 	if err := json.Unmarshal(b, apiResp); err != nil {
 		return nil, err
 	}

--- a/internal/typeutils/converter.go
+++ b/internal/typeutils/converter.go
@@ -79,8 +79,10 @@ type TypeConverter interface {
 	StatusToAPIStatus(ctx context.Context, s *gtsmodel.Status, requestingAccount *gtsmodel.Account) (*apimodel.Status, error)
 	// VisToAPIVis converts a gts visibility into its api equivalent
 	VisToAPIVis(ctx context.Context, m gtsmodel.Visibility) apimodel.Visibility
-	// InstanceToAPIInstance converts a gts instance into its api equivalent for serving at /api/v1/instance
-	InstanceToAPIInstance(ctx context.Context, i *gtsmodel.Instance) (*apimodel.Instance, error)
+	// InstanceToAPIV1Instance converts a gts instance into its api equivalent for serving at /api/v1/instance
+	InstanceToAPIV1Instance(ctx context.Context, i *gtsmodel.Instance) (*apimodel.InstanceV1, error)
+	// InstanceToAPIV2Instance converts a gts instance into its api equivalent for serving at /api/v2/instance
+	InstanceToAPIV2Instance(ctx context.Context, i *gtsmodel.Instance) (*apimodel.InstanceV2, error)
 	// RelationshipToAPIRelationship converts a gts relationship into its api equivalent for serving in various places
 	RelationshipToAPIRelationship(ctx context.Context, r *gtsmodel.Relationship) (*apimodel.Relationship, error)
 	// NotificationToAPINotification converts a gts notification into a api notification

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -675,8 +675,8 @@ func (c *converter) VisToAPIVis(ctx context.Context, m gtsmodel.Visibility) apim
 	return ""
 }
 
-func (c *converter) InstanceToAPIInstance(ctx context.Context, i *gtsmodel.Instance) (*apimodel.Instance, error) {
-	mi := &apimodel.Instance{
+func (c *converter) InstanceToAPIV1Instance(ctx context.Context, i *gtsmodel.Instance) (*apimodel.InstanceV1, error) {
+	mi := &apimodel.InstanceV1{
 		URI:              i.URI,
 		Title:            i.Title,
 		Description:      i.Description,
@@ -782,6 +782,10 @@ func (c *converter) InstanceToAPIInstance(ctx context.Context, i *gtsmodel.Insta
 	}
 
 	return mi, nil
+}
+
+func (c *converter) InstanceToAPIV2Instance(ctx context.Context, i *gtsmodel.Instance) (*apimodel.InstanceV2, error) {
+	return nil, nil
 }
 
 func (c *converter) RelationshipToAPIRelationship(ctx context.Context, r *gtsmodel.Relationship) (*apimodel.Relationship, error) {

--- a/internal/typeutils/internaltofrontend_test.go
+++ b/internal/typeutils/internaltofrontend_test.go
@@ -24,8 +24,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
-	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
 type InternalToFrontendTestSuite struct {
@@ -454,93 +455,207 @@ func (suite *InternalToFrontendTestSuite) TestVideoAttachmentToFrontend() {
 }`, string(b))
 }
 
-func (suite *InternalToFrontendTestSuite) TestInstanceToFrontend() {
-	testInstance := &gtsmodel.Instance{
-		CreatedAt:        testrig.TimeMustParse("2021-10-20T11:36:45Z"),
-		UpdatedAt:        testrig.TimeMustParse("2021-10-20T11:36:45Z"),
-		Domain:           "example.org",
-		Title:            "example instance",
-		URI:              "https://example.org",
-		ShortDescription: "a little description",
-		Description:      "a much longer description",
-		ContactEmail:     "someone@example.org",
-		Version:          "software-from-hell 0.666",
+func (suite *InternalToFrontendTestSuite) TestInstanceV1ToFrontend() {
+	ctx := context.Background()
+
+	i := &gtsmodel.Instance{}
+	if err := suite.db.GetWhere(ctx, []db.Where{{Key: "domain", Value: config.GetHost()}}, i); err != nil {
+		suite.FailNow(err.Error())
 	}
 
-	apiInstance, err := suite.typeconverter.InstanceToAPIV1Instance(context.Background(), testInstance)
-	suite.NoError(err)
+	instance, err := suite.typeconverter.InstanceToAPIV1Instance(ctx, i)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
 
-	b, err := json.MarshalIndent(apiInstance, "", "  ")
+	b, err := json.MarshalIndent(instance, "", "  ")
 	suite.NoError(err)
 
 	suite.Equal(`{
-  "uri": "https://example.org",
-  "title": "example instance",
-  "description": "a much longer description",
-  "short_description": "a little description",
-  "email": "someone@example.org",
-  "version": "software-from-hell 0.666",
-  "registrations": false,
-  "approval_required": false,
+  "uri": "http://localhost:8080",
+  "account_domain": "localhost:8080",
+  "title": "GoToSocial Testrig Instance",
+  "description": "\u003cp\u003eThis is the GoToSocial testrig. It doesn't federate or anything.\u003c/p\u003e\u003cp\u003eWhen the testrig is shut down, all data on it will be deleted.\u003c/p\u003e\u003cp\u003eDon't use this in production!\u003c/p\u003e",
+  "short_description": "\u003cp\u003eThis is the GoToSocial testrig. It doesn't federate or anything.\u003c/p\u003e\u003cp\u003eWhen the testrig is shut down, all data on it will be deleted.\u003c/p\u003e\u003cp\u003eDon't use this in production!\u003c/p\u003e",
+  "email": "admin@example.org",
+  "version": "0.0.0-testrig",
+  "registrations": true,
+  "approval_required": true,
   "invites_enabled": false,
-  "thumbnail": "",
-  "max_toot_chars": 0
-}`, string(b))
-}
-
-func (suite *InternalToFrontendTestSuite) TestInstanceToFrontendWithAdminAccount() {
-	testInstance := &gtsmodel.Instance{
-		CreatedAt:        testrig.TimeMustParse("2021-10-20T11:36:45Z"),
-		UpdatedAt:        testrig.TimeMustParse("2021-10-20T11:36:45Z"),
-		Domain:           "example.org",
-		Title:            "example instance",
-		URI:              "https://example.org",
-		ShortDescription: "a little description",
-		Description:      "a much longer description",
-		ContactEmail:     "someone@example.org",
-		ContactAccountID: suite.testAccounts["remote_account_2"].ID,
-		Version:          "software-from-hell 0.666",
-	}
-
-	apiInstance, err := suite.typeconverter.InstanceToAPIV1Instance(context.Background(), testInstance)
-	suite.NoError(err)
-
-	b, err := json.MarshalIndent(apiInstance, "", "  ")
-	suite.NoError(err)
-
-	suite.Equal(`{
-  "uri": "https://example.org",
-  "title": "example instance",
-  "description": "a much longer description",
-  "short_description": "a little description",
-  "email": "someone@example.org",
-  "version": "software-from-hell 0.666",
-  "registrations": false,
-  "approval_required": false,
-  "invites_enabled": false,
-  "thumbnail": "",
+  "configuration": {
+    "statuses": {
+      "max_characters": 5000,
+      "max_media_attachments": 6,
+      "characters_reserved_per_url": 25
+    },
+    "media_attachments": {
+      "supported_mime_types": [
+        "image/jpeg",
+        "image/gif",
+        "image/png",
+        "image/webp",
+        "video/mp4"
+      ],
+      "image_size_limit": 10485760,
+      "image_matrix_limit": 16777216,
+      "video_size_limit": 41943040,
+      "video_frame_rate_limit": 60,
+      "video_matrix_limit": 16777216
+    },
+    "polls": {
+      "max_options": 6,
+      "max_characters_per_option": 50,
+      "min_expiration": 300,
+      "max_expiration": 2629746
+    },
+    "accounts": {
+      "allow_custom_css": true,
+      "max_featured_tags": 10
+    },
+    "emojis": {
+      "emoji_size_limit": 51200
+    }
+  },
+  "urls": {
+    "streaming_api": "wss://localhost:8080"
+  },
+  "stats": {
+    "domain_count": 2,
+    "status_count": 16,
+    "user_count": 4
+  },
+  "thumbnail": "http://localhost:8080/assets/logo.png",
   "contact_account": {
-    "id": "01FHMQX3GAABWSM0S2VZEC2SWC",
-    "username": "Some_User",
-    "acct": "Some_User@example.org",
-    "display_name": "some user",
-    "locked": true,
+    "id": "01F8MH17FWEB39HZJ76B6VXSKF",
+    "username": "admin",
+    "acct": "admin",
+    "display_name": "",
+    "locked": false,
     "bot": false,
-    "created_at": "2020-08-10T12:13:28.000Z",
-    "note": "i'm a real son of a gun",
-    "url": "http://example.org/@Some_User",
+    "created_at": "2022-05-17T13:10:59.000Z",
+    "note": "",
+    "url": "http://localhost:8080/@admin",
     "avatar": "",
     "avatar_static": "",
     "header": "http://localhost:8080/assets/default_header.png",
     "header_static": "http://localhost:8080/assets/default_header.png",
-    "followers_count": 0,
-    "following_count": 0,
-    "statuses_count": 0,
-    "last_status_at": null,
+    "followers_count": 1,
+    "following_count": 1,
+    "statuses_count": 4,
+    "last_status_at": "2021-10-20T10:41:37.000Z",
     "emojis": [],
-    "fields": []
+    "fields": [],
+    "enable_rss": true,
+    "role": "admin"
   },
-  "max_toot_chars": 0
+  "max_toot_chars": 5000
+}`, string(b))
+}
+
+func (suite *InternalToFrontendTestSuite) TestInstanceV2ToFrontend() {
+	ctx := context.Background()
+
+	i := &gtsmodel.Instance{}
+	if err := suite.db.GetWhere(ctx, []db.Where{{Key: "domain", Value: config.GetHost()}}, i); err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	instance, err := suite.typeconverter.InstanceToAPIV2Instance(ctx, i)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	b, err := json.MarshalIndent(instance, "", "  ")
+	suite.NoError(err)
+
+	suite.Equal(`{
+  "domain": "localhost:8080",
+  "account_domain": "localhost:8080",
+  "title": "GoToSocial Testrig Instance",
+  "version": "0.0.0-testrig",
+  "source_url": "https://github.com/superseriousbusiness/gotosocial",
+  "description": "\u003cp\u003eThis is the GoToSocial testrig. It doesn't federate or anything.\u003c/p\u003e\u003cp\u003eWhen the testrig is shut down, all data on it will be deleted.\u003c/p\u003e\u003cp\u003eDon't use this in production!\u003c/p\u003e",
+  "usage": {
+    "users": {
+      "active_month": 0
+    }
+  },
+  "thumbnail": {
+    "url": "http://localhost:8080/assets/logo.png"
+  },
+  "languages": [],
+  "configuration": {
+    "urls": {
+      "streaming": "wss://localhost:8080"
+    },
+    "accounts": {
+      "allow_custom_css": true,
+      "max_featured_tags": 10
+    },
+    "statuses": {
+      "max_characters": 5000,
+      "max_media_attachments": 6,
+      "characters_reserved_per_url": 25
+    },
+    "media_attachments": {
+      "supported_mime_types": [
+        "image/jpeg",
+        "image/gif",
+        "image/png",
+        "image/webp",
+        "video/mp4"
+      ],
+      "image_size_limit": 10485760,
+      "image_matrix_limit": 16777216,
+      "video_size_limit": 41943040,
+      "video_frame_rate_limit": 60,
+      "video_matrix_limit": 16777216
+    },
+    "polls": {
+      "max_options": 6,
+      "max_characters_per_option": 50,
+      "min_expiration": 300,
+      "max_expiration": 2629746
+    },
+    "translation": {
+      "enabled": false
+    },
+    "emojis": {
+      "emoji_size_limit": 51200
+    }
+  },
+  "registrations": {
+    "enabled": true,
+    "approval_required": true,
+    "message": null
+  },
+  "contact": {
+    "email": "admin@example.org",
+    "account": {
+      "id": "01F8MH17FWEB39HZJ76B6VXSKF",
+      "username": "admin",
+      "acct": "admin",
+      "display_name": "",
+      "locked": false,
+      "bot": false,
+      "created_at": "2022-05-17T13:10:59.000Z",
+      "note": "",
+      "url": "http://localhost:8080/@admin",
+      "avatar": "",
+      "avatar_static": "",
+      "header": "http://localhost:8080/assets/default_header.png",
+      "header_static": "http://localhost:8080/assets/default_header.png",
+      "followers_count": 1,
+      "following_count": 1,
+      "statuses_count": 4,
+      "last_status_at": "2021-10-20T10:41:37.000Z",
+      "emojis": [],
+      "fields": [],
+      "enable_rss": true,
+      "role": "admin"
+    }
+  },
+  "rules": []
 }`, string(b))
 }
 

--- a/internal/typeutils/internaltofrontend_test.go
+++ b/internal/typeutils/internaltofrontend_test.go
@@ -467,7 +467,7 @@ func (suite *InternalToFrontendTestSuite) TestInstanceToFrontend() {
 		Version:          "software-from-hell 0.666",
 	}
 
-	apiInstance, err := suite.typeconverter.InstanceToAPIInstance(context.Background(), testInstance)
+	apiInstance, err := suite.typeconverter.InstanceToAPIV1Instance(context.Background(), testInstance)
 	suite.NoError(err)
 
 	b, err := json.MarshalIndent(apiInstance, "", "  ")
@@ -502,7 +502,7 @@ func (suite *InternalToFrontendTestSuite) TestInstanceToFrontendWithAdminAccount
 		Version:          "software-from-hell 0.666",
 	}
 
-	apiInstance, err := suite.typeconverter.InstanceToAPIInstance(context.Background(), testInstance)
+	apiInstance, err := suite.typeconverter.InstanceToAPIV1Instance(context.Background(), testInstance)
 	suite.NoError(err)
 
 	b, err := json.MarshalIndent(apiInstance, "", "  ")

--- a/internal/web/base.go
+++ b/internal/web/base.go
@@ -36,10 +36,9 @@ func (m *Module) baseHandler(c *gin.Context) {
 		return
 	}
 
-	host := config.GetHost()
-	instance, err := m.processor.InstanceGet(c.Request.Context(), host)
+	instance, err := m.processor.InstanceGetV1(c.Request.Context())
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/web/confirmemail.go
+++ b/internal/web/confirmemail.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
-	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 )
 
@@ -34,20 +33,19 @@ func (m *Module) confirmEmailGETHandler(c *gin.Context) {
 	// if there's no token in the query, just serve the 404 web handler
 	token := c.Query(tokenParam)
 	if token == "" {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(errors.New(http.StatusText(http.StatusNotFound))), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(errors.New(http.StatusText(http.StatusNotFound))), m.processor.InstanceGetV1)
 		return
 	}
 
 	user, errWithCode := m.processor.UserConfirmEmail(ctx, token)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
-	host := config.GetHost()
-	instance, err := m.processor.InstanceGet(ctx, host)
+	instance, err := m.processor.InstanceGetV1(ctx)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/web/customcss.go
+++ b/internal/web/customcss.go
@@ -34,12 +34,12 @@ const textCSSUTF8 = string(apiutil.TextCSS + "; charset=utf-8")
 func (m *Module) customCSSGETHandler(c *gin.Context) {
 	if !config.GetAccountsAllowCustomCSS() {
 		err := errors.New("accounts-allow-custom-css is not enabled on this instance")
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.TextCSS); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -47,13 +47,13 @@ func (m *Module) customCSSGETHandler(c *gin.Context) {
 	username := strings.ToLower(c.Param(usernameKey))
 	if username == "" {
 		err := errors.New("no account username specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	customCSS, errWithCode := m.processor.AccountGetCustomCSSForUsername(c.Request.Context(), username)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/web/domain-blocklist.go
+++ b/internal/web/domain-blocklist.go
@@ -36,26 +36,25 @@ const (
 func (m *Module) domainBlockListGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, false, false, false, false)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !config.GetInstanceExposeSuspendedWeb() && (authed.Account == nil || authed.User == nil) {
 		err := fmt.Errorf("this instance does not expose the list of suspended domains publicly")
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
-	host := config.GetHost()
-	instance, err := m.processor.InstanceGet(c.Request.Context(), host)
+	instance, err := m.processor.InstanceGetV1(c.Request.Context())
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 
 	domainBlocks, errWithCode := m.processor.InstancePeersGet(c.Request.Context(), true, false, false)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/web/opengraph.go
+++ b/internal/web/opengraph.go
@@ -57,7 +57,7 @@ type ogMeta struct {
 // the base root of an instance. It also serves as a
 // foundation for building account / status ogMeta on
 // top of.
-func ogBase(instance *apimodel.Instance) *ogMeta {
+func ogBase(instance *apimodel.InstanceV1) *ogMeta {
 	var locale string
 	if len(instance.Languages) > 0 {
 		locale = instance.Languages[0]

--- a/internal/web/profile.go
+++ b/internal/web/profile.go
@@ -45,25 +45,24 @@ func (m *Module) profileGETHandler(c *gin.Context) {
 
 	authed, err := oauth.Authed(c, false, false, false, false)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	username := strings.ToLower(c.Param(usernameKey))
 	if username == "" {
 		err := errors.New("no account username specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
-	host := config.GetHost()
-	instance, err := m.processor.InstanceGet(ctx, host)
+	instance, err := m.processor.InstanceGetV1(ctx)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 
-	instanceGet := func(ctx context.Context, domain string) (*apimodel.Instance, gtserror.WithCode) {
+	instanceGet := func(ctx context.Context) (*apimodel.InstanceV1, gtserror.WithCode) {
 		return instance, nil
 	}
 
@@ -145,14 +144,14 @@ func (m *Module) returnAPProfile(ctx context.Context, c *gin.Context, username s
 
 	user, errWithCode := m.processor.GetFediUser(ctx, username, c.Request.URL)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet) //nolint:contextcheck
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1) //nolint:contextcheck
 		return
 	}
 
 	b, mErr := json.Marshal(user)
 	if mErr != nil {
 		err := fmt.Errorf("could not marshal json: %s", mErr)
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet) //nolint:contextcheck
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1) //nolint:contextcheck
 		return
 	}
 

--- a/internal/web/rss.go
+++ b/internal/web/rss.go
@@ -82,7 +82,7 @@ func (m *Module) rssFeedGETHandler(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.AppRSSXML); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -90,7 +90,7 @@ func (m *Module) rssFeedGETHandler(c *gin.Context) {
 	username := strings.ToLower(c.Param(usernameKey))
 	if username == "" {
 		err := errors.New("no account username specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -99,7 +99,7 @@ func (m *Module) rssFeedGETHandler(c *gin.Context) {
 
 	getRssFeed, accountLastPostedPublic, errWithCode := m.processor.AccountGetRSSFeedForUsername(ctx, username)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
@@ -111,13 +111,13 @@ func (m *Module) rssFeedGETHandler(c *gin.Context) {
 		// we either have no cache entry for this, or we have an expired cache entry; generate a new one
 		rssFeed, errWithCode = getRssFeed()
 		if errWithCode != nil {
-			apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 			return
 		}
 
 		eTag, err := generateEtag(bytes.NewBufferString(rssFeed))
 		if err != nil {
-			apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 			return
 		}
 
@@ -145,7 +145,7 @@ func (m *Module) rssFeedGETHandler(c *gin.Context) {
 		// we had a cache entry already so we didn't call to get the rss feed yet
 		rssFeed, errWithCode = getRssFeed()
 		if errWithCode != nil {
-			apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet)
+			apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 			return
 		}
 	}

--- a/internal/web/settings-panel.go
+++ b/internal/web/settings-panel.go
@@ -23,15 +23,13 @@ import (
 
 	"github.com/gin-gonic/gin"
 	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
-	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 )
 
 func (m *Module) SettingsPanelHandler(c *gin.Context) {
-	host := config.GetHost()
-	instance, err := m.processor.InstanceGet(c.Request.Context(), host)
+	instance, err := m.processor.InstanceGetV1(c.Request.Context())
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/web/thread.go
+++ b/internal/web/thread.go
@@ -40,7 +40,7 @@ func (m *Module) threadGETHandler(c *gin.Context) {
 
 	authed, err := oauth.Authed(c, false, false, false, false)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -48,7 +48,7 @@ func (m *Module) threadGETHandler(c *gin.Context) {
 	username := strings.ToLower(c.Param(usernameKey))
 	if username == "" {
 		err := errors.New("no account username specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -56,18 +56,17 @@ func (m *Module) threadGETHandler(c *gin.Context) {
 	statusID := strings.ToUpper(c.Param(statusIDKey))
 	if statusID == "" {
 		err := errors.New("no status id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
-	host := config.GetHost()
-	instance, err := m.processor.InstanceGet(ctx, host)
+	instance, err := m.processor.InstanceGetV1(ctx)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet)
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 
-	instanceGet := func(ctx context.Context, domain string) (*apimodel.Instance, gtserror.WithCode) {
+	instanceGet := func(ctx context.Context) (*apimodel.InstanceV1, gtserror.WithCode) {
 		return instance, nil
 	}
 
@@ -135,14 +134,14 @@ func (m *Module) returnAPStatus(ctx context.Context, c *gin.Context, username st
 
 	status, errWithCode := m.processor.GetFediStatus(ctx, username, statusID, c.Request.URL)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGet) //nolint:contextcheck
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1) //nolint:contextcheck
 		return
 	}
 
 	b, mErr := json.Marshal(status)
 	if mErr != nil {
 		err := fmt.Errorf("could not marshal json: %s", mErr)
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGet) //nolint:contextcheck
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1) //nolint:contextcheck
 		return
 	}
 


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request does the following

- implement the `/api/v2/instance` endpoint, as described here: https://docs.joinmastodon.org/methods/instance/
- mark the existing get instance function as specifically v1 to differentiate it properly from the v2 function
- remove 'domain' from the function signature of getInstance, since it was never used anywhere
- tidy up some of the logic for converting a gts model instance to a v1 api model instance (return errors rather than swallowing them).

closes https://github.com/superseriousbusiness/gotosocial/issues/1388
relates to https://github.com/superseriousbusiness/gotosocial/issues/1339

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
