### PR TITLE
Plumb a request ID through HTTP and logger

### DIFF
--- a/cmd/gotosocial/action/server/server.go
+++ b/cmd/gotosocial/action/server/server.go
@@ -154,6 +154,7 @@ var Start action.GTSAction = func(ctx context.Context) error {
 
 	// attach global middlewares which are used for every request
 	router.AttachGlobalMiddleware(
+		middleware.RequestID(),
 		middleware.Logger(),
 		middleware.UserAgent(),
 		middleware.CORS(),

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/disintegration/imaging v1.6.2
 	github.com/gin-contrib/cors v1.4.0
 	github.com/gin-contrib/gzip v0.0.6
+	github.com/gin-contrib/requestid v0.0.6
 	github.com/gin-contrib/sessions v0.0.5
 	github.com/gin-gonic/gin v1.8.2
 	github.com/go-fed/httpsig v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/gin-contrib/cors v1.4.0 h1:oJ6gwtUl3lqV0WEIwM/LxPF1QZ5qe2lGWdY2+bz7y0
 github.com/gin-contrib/cors v1.4.0/go.mod h1:bs9pNM0x/UsmHPBWT2xZz9ROh8xYjYkiURUfmBoMlcs=
 github.com/gin-contrib/gzip v0.0.6 h1:NjcunTcGAj5CO1gn4N8jHOSIeRFHIbn51z6K+xaN4d4=
 github.com/gin-contrib/gzip v0.0.6/go.mod h1:QOJlmV2xmayAjkNS2Y8NQsMneuRShOU/kjovCXNuzzk=
+github.com/gin-contrib/requestid v0.0.6 h1:mGcxTnHQ45F6QU5HQRgQUDsAfHprD3P7g2uZ4cSZo9o=
+github.com/gin-contrib/requestid v0.0.6/go.mod h1:9i4vKATX/CdggbkY252dPVasgVucy/ggBeELXuQztm4=
 github.com/gin-contrib/sessions v0.0.5 h1:CATtfHmLMQrMNpJRgzjWXD7worTh7g7ritsQfmF+0jE=
 github.com/gin-contrib/sessions v0.0.5/go.mod h1:vYAuaUPqie3WUSsft6HUlCjlwwoJQs97miaG2+7neKY=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -27,6 +27,7 @@ import (
 	"codeberg.org/gruf/go-errors/v2"
 	"codeberg.org/gruf/go-kv"
 	"codeberg.org/gruf/go-logger/v2/level"
+	"github.com/gin-contrib/requestid"
 	"github.com/gin-gonic/gin"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 )
@@ -35,7 +36,7 @@ import (
 func Logger() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Initialize the logging fields
-		fields := make(kv.Fields, 6, 7)
+		fields := make(kv.Fields, 7, 8)
 
 		// Determine pre-handler time
 		before := time.Now()
@@ -73,6 +74,7 @@ func Logger() gin.HandlerFunc {
 			fields[3] = kv.Field{"method", c.Request.Method}
 			fields[4] = kv.Field{"statusCode", code}
 			fields[5] = kv.Field{"path", path}
+			fields[6] = kv.Field{RequestIDKey, requestid.Get(c)}
 
 			// Create log entry with fields
 			l := log.WithFields(fields...)

--- a/internal/middleware/requestid.go
+++ b/internal/middleware/requestid.go
@@ -1,0 +1,16 @@
+package middleware
+
+import (
+	"github.com/gin-contrib/requestid"
+	"github.com/gin-gonic/gin"
+)
+
+// RequestIDKey is a string to use as a map key, for example a logger field
+const RequestIDKey = "requestID"
+
+// RequestID returns a gin middleware which adds a unique ID for each request
+// to the context. It currently directly wraps the upstream library but this
+// makes it easier to set any custom options later on.
+func RequestID() gin.HandlerFunc {
+	return requestid.New()
+}

--- a/vendor/github.com/gin-contrib/requestid/.gitignore
+++ b/vendor/github.com/gin-contrib/requestid/.gitignore
@@ -1,0 +1,15 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/vendor/github.com/gin-contrib/requestid/.golangci.yml
+++ b/vendor/github.com/gin-contrib/requestid/.golangci.yml
@@ -1,0 +1,43 @@
+linters:
+  enable-all: false
+  disable-all: true
+  fast: false
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - rowserrcheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    - gofumpt
+
+run:
+  timeout: 3m

--- a/vendor/github.com/gin-contrib/requestid/.goreleaser.yaml
+++ b/vendor/github.com/gin-contrib/requestid/.goreleaser.yaml
@@ -1,0 +1,57 @@
+project_name: queue
+
+builds:
+  -
+    # If true, skip the build.
+    # Useful for library projects.
+    # Default is false
+    skip: true
+
+changelog:
+  # Set it to true if you wish to skip the changelog generation.
+  # This may result in an empty release notes on GitHub/GitLab/Gitea.
+  skip: false
+
+  # Changelog generation implementation to use.
+  #
+  # Valid options are:
+  # - `git`: uses `git log`;
+  # - `github`: uses the compare GitHub API, appending the author login to the changelog.
+  # - `gitlab`: uses the compare GitLab API, appending the author name and email to the changelog.
+  # - `github-native`: uses the GitHub release notes generation API, disables the groups feature.
+  #
+  # Defaults to `git`.
+  use: git
+
+  # Sorts the changelog by the commit's messages.
+  # Could either be asc, desc or empty
+  # Default is empty
+  sort: asc
+
+  # Group commits messages by given regex and title.
+  # Order value defines the order of the groups.
+  # Proving no regex means all commits will be grouped under the default group.
+  # Groups are disabled when using github-native, as it already groups things by itself.
+  #
+  # Default is no groups.
+  groups:
+    - title: Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: 'Bug fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: 'Enhancements'
+      regexp: "^.*chore[(\\w)]*:+.*$"
+      order: 2
+    - title: Others
+      order: 999
+
+  filters:
+    # Commit messages matching the regexp listed here will be removed from
+    # the changelog
+    # Default is empty
+    exclude:
+      - '^docs'
+      - 'CICD'
+      - typo

--- a/vendor/github.com/gin-contrib/requestid/LICENSE
+++ b/vendor/github.com/gin-contrib/requestid/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Gin-Gonic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/gin-contrib/requestid/README.md
+++ b/vendor/github.com/gin-contrib/requestid/README.md
@@ -1,0 +1,76 @@
+# RequestID
+
+[![Run Tests](https://github.com/gin-contrib/requestid/actions/workflows/go.yml/badge.svg?branch=master)](https://github.com/gin-contrib/requestid/actions/workflows/go.yml)
+[![codecov](https://codecov.io/gh/gin-contrib/requestid/branch/master/graph/badge.svg)](https://codecov.io/gh/gin-contrib/requestid)
+[![Go Report Card](https://goreportcard.com/badge/github.com/gin-contrib/requestid)](https://goreportcard.com/report/github.com/gin-contrib/requestid)
+[![GoDoc](https://godoc.org/github.com/gin-contrib/requestid?status.svg)](https://godoc.org/github.com/gin-contrib/requestid)
+[![Join the chat at https://gitter.im/gin-gonic/gin](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/gin-gonic/gin)
+
+Request ID middleware for Gin Framework. Adds an indentifier to the response using the `X-Request-ID` header. Passes the `X-Request-ID` value back to the caller if it's sent in the request headers.
+
+## Config
+
+define your custom generator function:
+
+```go
+func main() {
+
+  r := gin.New()
+
+  r.Use(
+    requestid.New(
+      requestid.WithGenerator(func() string {
+        return "test"
+      }),
+      requestid.WithCustomHeaderStrKey("your-customer-key"),
+    ),
+  )
+
+  // Example ping request.
+  r.GET("/ping", func(c *gin.Context) {
+    c.String(http.StatusOK, "pong "+fmt.Sprint(time.Now().Unix()))
+  })
+
+  // Listen and Server in 0.0.0.0:8080
+  r.Run(":8080")
+}
+```
+
+## Example
+
+```go
+package main
+
+import (
+  "fmt"
+  "net/http"
+  "time"
+
+  "github.com/gin-contrib/requestid"
+  "github.com/gin-gonic/gin"
+)
+
+func main() {
+
+  r := gin.New()
+
+  r.Use(requestid.New())
+
+  // Example ping request.
+  r.GET("/ping", func(c *gin.Context) {
+    c.String(http.StatusOK, "pong "+fmt.Sprint(time.Now().Unix()))
+  })
+
+  // Listen and Server in 0.0.0.0:8080
+  r.Run(":8080")
+}
+```
+
+How to get the request identifier:
+
+```go
+// Example / request.
+r.GET("/", func(c *gin.Context) {
+  c.String(http.StatusOK, "id:"+requestid.Get(c))
+})
+```

--- a/vendor/github.com/gin-contrib/requestid/options.go
+++ b/vendor/github.com/gin-contrib/requestid/options.go
@@ -1,0 +1,36 @@
+package requestid
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// Option for queue system
+type Option func(*config)
+
+type (
+	Generator func() string
+	Handler   func(c *gin.Context, requestID string)
+)
+
+type HeaderStrKey string
+
+// WithGenerator set generator function
+func WithGenerator(g Generator) Option {
+	return func(cfg *config) {
+		cfg.generator = g
+	}
+}
+
+// WithCustomeHeaderStrKey set custom header key for request id
+func WithCustomHeaderStrKey(s HeaderStrKey) Option {
+	return func(cfg *config) {
+		cfg.headerKey = s
+	}
+}
+
+// WithHandler set handler function for request id with context
+func WithHandler(handler Handler) Option {
+	return func(cfg *config) {
+		cfg.handler = handler
+	}
+}

--- a/vendor/github.com/gin-contrib/requestid/requestid.go
+++ b/vendor/github.com/gin-contrib/requestid/requestid.go
@@ -1,0 +1,55 @@
+package requestid
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+var headerXRequestID string
+
+// Config defines the config for RequestID middleware
+type config struct {
+	// Generator defines a function to generate an ID.
+	// Optional. Default: func() string {
+	//   return uuid.New().String()
+	// }
+	generator Generator
+	headerKey HeaderStrKey
+	handler   Handler
+}
+
+// New initializes the RequestID middleware.
+func New(opts ...Option) gin.HandlerFunc {
+	cfg := &config{
+		generator: func() string {
+			return uuid.New().String()
+		},
+		headerKey: "X-Request-ID",
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	headerXRequestID = string(cfg.headerKey)
+
+	return func(c *gin.Context) {
+		// Get id from request
+		rid := c.GetHeader(headerXRequestID)
+		if rid == "" {
+			rid = cfg.generator()
+			c.Request.Header.Add(headerXRequestID, rid)
+		}
+		if cfg.handler != nil {
+			cfg.handler(c, rid)
+		}
+		// Set the id to ensure that the requestid is in the response
+		c.Header(headerXRequestID, rid)
+		c.Next()
+	}
+}
+
+// Get returns the request identifier
+func Get(c *gin.Context) string {
+	return c.Writer.Header().Get(headerXRequestID)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -151,6 +151,9 @@ github.com/gin-contrib/cors
 # github.com/gin-contrib/gzip v0.0.6
 ## explicit; go 1.13
 github.com/gin-contrib/gzip
+# github.com/gin-contrib/requestid v0.0.6
+## explicit; go 1.15
+github.com/gin-contrib/requestid
 # github.com/gin-contrib/sessions v0.0.5
 ## explicit; go 1.18
 github.com/gin-contrib/sessions

--- a/web/template/404.tmpl
+++ b/web/template/404.tmpl
@@ -29,7 +29,8 @@
 		</p>
 		<p>
 			If you believe this 404 was an error, you can contact
-			the instance admin.
+			the instance admin. Provide them with the following request
+			Request ID: <code>{{.requestID}}</code>.
 		</p>
 	</section>
 </main>

--- a/web/template/error.tmpl
+++ b/web/template/error.tmpl
@@ -20,6 +20,7 @@
     <main>
         <section class="error">
           <span>❌</span> <pre>{{.error}}</pre>
+		  <span>Request ID</span> <code>{{.requestID}}</code>
         </section>
     </main>
 {{ template "footer.tmpl" .}}


### PR DESCRIPTION
# Description

This is the revival of #1145. Irrespective of what else we may want to do as part of #1230, having a unique identifier per request will be necessary.

Getting this in place now would let us add Prometheus metrics on the HTTP side and tack on an Exemplar for the request ID. That gets us the first step between being able to correlate metrics + logs if you ingest them somewhere centrally without the cardinality explosion of the request ID being a label on the metric.

After that, we can take a look at OpenTelemetry tracing. That's a bit complicated and has its own TraceID (which is a `[16]byte`). I don't think there's any way for us to directly map the Request ID to the Trace ID and we can't use the Trace ID as the Request ID since tracing can be sampled (meaning not each request would have a Trace ID).

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
