### PR TITLE
[bugfix] fix old password hash staying in cache

### DIFF
--- a/internal/processing/user/changepassword.go
+++ b/internal/processing/user/changepassword.go
@@ -20,7 +20,6 @@ package user
 
 import (
 	"context"
-	"time"
 
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
@@ -43,10 +42,9 @@ func (p *processor) ChangePassword(ctx context.Context, user *gtsmodel.User, old
 	}
 
 	user.EncryptedPassword = string(newPasswordHash)
-	user.UpdatedAt = time.Now()
 
-	if err := p.db.UpdateByID(ctx, user, user.ID, "encrypted_password", "updated_at"); err != nil {
-		return gtserror.NewErrorInternalError(err, "database error")
+	if err := p.db.UpdateUser(ctx, user, "encrypted_password"); err != nil {
+		return gtserror.NewErrorInternalError(err)
 	}
 
 	return nil


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request implements updates the password change logic to make sure the old user entry is invalidated in the cache. This wasn't done before, which meant the old password hash was still hanging around.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code. n/a
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
