### PR TITLE
[chore] Update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -9,6 +9,16 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report! Please be cautious with the sensitive information/logs while filing the issue.
+  - type: markdown
+    attributes:
+      value: |
+        ⚠️ If you're reporting an interoperability issue with a **closed source**
+        ActivityPub/Mastodon client or server, please report the issue to the
+        developers of that client or server instead. Without access to their
+        source debugging the issue is difficult for us. Since GoToSocial is
+        open source, developers of closed source implementations can run a copy
+        and autonomously debug the issue. We'll gladly address any bugs they
+        raise with us.
   - type: textarea
     id: desc
     attributes:


### PR DESCRIPTION
# Description

> Beware. Controversy

There's been a recent increase in new ActivityPub clients. Unfortunately most clients are coded directly against the Mastodon API and make deep rooted assumptions about it in their implementations. This leads to those clients not working with GTS. Though GTS implements a good chunk of the Mastodon API, it's always in catch-up mode. The Mastodon Client API is not part of the ActivityPub spec.

This change aims to add some gentle language to the bug report template to direct folks that are reporting compatibility issues with closed source clients to go talk to those developers instead. GTS developers can reasonably help debug an issue if they have access to the source code on both ends, but when the client is closed source the burden of ensuring compatibility can't be on GTS developers.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
