### PR TITLE
[bugfix] fix file range length calculation being off by 1

### DIFF
--- a/internal/api/fileserver/servefile.go
+++ b/internal/api/fileserver/servefile.go
@@ -218,8 +218,9 @@ func serveFileRange(rw http.ResponseWriter, src io.Reader, rng string, size int6
 		return
 	}
 
-	// Determine content len
-	length := end - start
+	// Determine new content length
+	// after slicing to given range.
+	length := end - start + 1
 
 	if end < size-1 {
 		// Range end < file end, limit the reader

--- a/internal/processing/media/delete.go
+++ b/internal/processing/media/delete.go
@@ -39,10 +39,8 @@ func (p *processor) Delete(ctx context.Context, mediaAttachmentID string) gtserr
 	}
 
 	// delete the attachment
-	if err := p.db.DeleteByID(ctx, mediaAttachmentID, attachment); err != nil {
-		if err != db.ErrNoEntries {
-			errs = append(errs, fmt.Sprintf("remove attachment: %s", err))
-		}
+	if err := p.db.DeleteByID(ctx, mediaAttachmentID, attachment); err != nil && !errors.Is(err, db.ErrNoEntries) {
+		errs = append(errs, fmt.Sprintf("remove attachment: %s", err))
 	}
 
 	if len(errs) != 0 {


### PR DESCRIPTION
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
