### PR TITLE
[chore] fix 'steal this look' form, uncheck entries after processing

### DIFF
--- a/web/source/settings/admin/emoji/remote/parse-from-toot.js
+++ b/web/source/settings/admin/emoji/remote/parse-from-toot.js
@@ -115,12 +115,26 @@ function CopyEmojiForm({ localEmojiCodes, type, emojiList }) {
 	const form = {
 		selectedEmoji: useCheckListInput("selectedEmoji", {
 			entries: emojiList,
-			uniqueKey: "shortcode"
+			uniqueKey: "id"
 		}),
 		category: useComboBoxInput("category")
 	};
 
-	const [formSubmit, result] = useFormSubmit(form, query.usePatchRemoteEmojisMutation(), { changedOnly: false });
+	const [formSubmit, result] = useFormSubmit(
+		form,
+		query.usePatchRemoteEmojisMutation(),
+		{
+			changedOnly: false,
+			onFinish: ({ data }) => {
+				if (data != undefined) {
+					form.selectedEmoji.updateMultiple(
+						// uncheck all successfully processed emoji
+						data.map(([id]) => [id, { checked: false }])
+					);
+				}
+			}
+		}
+	);
 
 	const buttonsInactive = form.selectedEmoji.someSelected
 		? {}

--- a/web/source/settings/lib/form/check-list.jsx
+++ b/web/source/settings/lib/form/check-list.jsx
@@ -171,7 +171,7 @@ module.exports = function useCheckListInput({ name }, { entries, uniqueKey = "ke
 			onChange,
 			selectedValues,
 			reset,
-			someSelected: state.someChecked,
+			someSelected: state.selectedEntries.size > 0,
 			updateMultiple,
 			toggleAll: {
 				ref: toggleAllRef,

--- a/web/source/settings/lib/form/submit.js
+++ b/web/source/settings/lib/form/submit.js
@@ -18,10 +18,11 @@
 
 "use strict";
 
+const Promise = require("bluebird");
 const React = require("react");
 const syncpipe = require("syncpipe");
 
-module.exports = function useFormSubmit(form, mutationQuery, { changedOnly = true } = {}) {
+module.exports = function useFormSubmit(form, mutationQuery, { changedOnly = true, onFinish } = {}) {
 	if (!Array.isArray(mutationQuery)) {
 		throw new ("useFormSubmit: mutationQuery was not an Array. Is a valid useMutation RTK Query provided?");
 	}
@@ -64,7 +65,13 @@ module.exports = function useFormSubmit(form, mutationQuery, { changedOnly = tru
 
 			mutationData.action = action;
 
-			return runMutation(mutationData);
+			return Promise.try(() => {
+				return runMutation(mutationData);
+			}).then((res) => {
+				if (onFinish) {
+					return onFinish(res);
+				}
+			});
 		},
 		{
 			...result,

--- a/web/source/settings/lib/query/admin/custom-emoji.js
+++ b/web/source/settings/lib/query/admin/custom-emoji.js
@@ -149,7 +149,7 @@ module.exports = (build) => ({
 						body: body
 					}).then(unwrapRes);
 				}).then((res) => {
-					data.push([emoji.shortcode, res]);
+					data.push([emoji.id, res]);
 				}).catch((e) => {
 					let msg = e.message ?? e;
 					if (e.data.error) {


### PR DESCRIPTION
# Description

"Steal this look" interface buttons disabled/enabled based on 'someSelected' property which wasn't implemented properly after previous useCheckList refactoring. Works again now, also involves some changes to unchecking the emoji that *were* properly copied/modified

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
