### PR TITLE
Make webfinger find actors for queries on actor URIs and URLs.

### DIFF
--- a/internal/regexes/regexes.go
+++ b/internal/regexes/regexes.go
@@ -91,6 +91,10 @@ var (
 	// UserPath parses a path that validates and captures the username part from eg /users/example_username
 	UserPath = regexp.MustCompile(userPathString)
 
+	userAliasString = fmt.Sprintf(`^https?://([\w\-\.:]+)/(?:users/|@)(%s)$`, usernameStringRelaxed)
+	// UserAlias captures the username and domain part from a user URL or URI
+	UserAlias = regexp.MustCompile(userAliasString)
+
 	publicKeyPath = fmt.Sprintf(`^/?%s/(%s)/%s`, users, usernameStringRelaxed, publicKey)
 	// PublicKeyPath parses a path that validates and captures the username part from eg /users/example_username/main-key
 	PublicKeyPath = regexp.MustCompile(publicKeyPath)

--- a/internal/util/namestring.go
+++ b/internal/util/namestring.go
@@ -49,9 +49,9 @@ func ExtractAliasstringParts(alias string) (username, host string, err error) {
 	matches := regexes.UserAlias.FindStringSubmatch(alias)
 	if len(matches) == 3 {
 		return matches[2], matches[1], nil
-	} else {
-		return "", "", fmt.Errorf("couldn't match alias %s", alias)
 	}
+
+	return "", "", fmt.Errorf("couldn't match alias %s", alias)
 }
 
 // ExtractWebfingerParts returns username test_user and
@@ -62,14 +62,14 @@ func ExtractAliasstringParts(alias string) (username, host string, err error) {
 func ExtractWebfingerParts(webfinger string) (username, host string, err error) {
 	if strings.HasPrefix(webfinger, "https://") || strings.HasPrefix(webfinger, "http://") {
 		return ExtractAliasstringParts(webfinger)
-	} else {
-		webfinger = strings.TrimPrefix(webfinger, "acct:")
-
-		// prepend an @ if necessary
-		if webfinger[0] != '@' {
-			webfinger = "@" + webfinger
-		}
-
-		return ExtractNamestringParts(webfinger)
 	}
+
+	webfinger = strings.TrimPrefix(webfinger, "acct:")
+
+	// prepend an @ if necessary
+	if webfinger[0] != '@' {
+		webfinger = "@" + webfinger
+	}
+
+	return ExtractNamestringParts(webfinger)
 }


### PR DESCRIPTION
# Description

Make webfinger queries on actor URIs and URLs (which are returned as aliases on typical actor webfinger responses) return the corresponding actor. This matches existing functionality on Mastodon and Pleroma and Misskey.

This should not change behavior of any existing queries or behavior, (tests were ran to make sure) just adds additional valid behavior for certain types of queries. However if a URL is passed that does not match a URI or URL regex, a new, distinct error message will be returned. But I didn't find any tests relying on this behavior.

The changes were tested against the local test harness server, but not a live server just FYI.

closes #1415

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.

I go fmt'ed my changes, but after some effort I failed to figure out how to do "golangci-lint run", I'm sorry.