### PR TITLE
[bugfix] Set appropriate cache-control when using presigned s3 links

### DIFF
--- a/internal/api/fileserver/servefile.go
+++ b/internal/api/fileserver/servefile.go
@@ -88,7 +88,12 @@ func (m *Module) ServeFile(c *gin.Context) {
 	}
 
 	if content.URL != nil {
-		// This is a non-local S3 file we're proxying to.
+		// This is a non-local S3 file we're redirecting to.
+		// Rewrite the cache control header to reflect the
+		// TTL of the generated signed link, instead of the
+		// default very long cache.
+		const cacheControl = "private,max-age=86400" // 24h
+		c.Header("Cache-Control", cacheControl)
 		c.Redirect(http.StatusFound, content.URL.String())
 		return
 	}

--- a/internal/processing/media/getfile.go
+++ b/internal/processing/media/getfile.go
@@ -232,10 +232,13 @@ func (p *processor) getEmojiContent(ctx context.Context, fileName string, owning
 }
 
 func (p *processor) retrieveFromStorage(ctx context.Context, storagePath string, content *apimodel.Content) (*apimodel.Content, gtserror.WithCode) {
+	// If running on S3 storage with proxying disabled then
+	// just fetch a pre-signed URL instead of serving the content.
 	if url := p.storage.URL(ctx, storagePath); url != nil {
 		content.URL = url
 		return content, nil
 	}
+
 	reader, err := p.storage.GetStream(ctx, storagePath)
 	if err != nil {
 		return nil, gtserror.NewErrorNotFound(fmt.Errorf("error retrieving from storage: %s", err))


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request fixes some logic that got broken in #1250: we were not setting cache control appropriately for presigned s3 links, leading to old links being cached in browsers. Now, cache control is set to 24h when using s3 presigned URLs, to align with the ttl we set for those.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
