### PR TITLE
[bugfix] Fix up `error getting account avatar/header` errors, other small fixes

### DIFF
--- a/cmd/gotosocial/action/admin/media/prune/common.go
+++ b/cmd/gotosocial/action/admin/media/prune/common.go
@@ -33,6 +33,7 @@ type prune struct {
 	dbService db.DB
 	storage   *gtsstorage.Driver
 	manager   media.Manager
+	state     *state.State
 }
 
 func setupPrune(ctx context.Context) (*prune, error) {
@@ -44,6 +45,7 @@ func setupPrune(ctx context.Context) (*prune, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating dbservice: %w", err)
 	}
+	state.DB = dbService
 
 	//nolint:contextcheck
 	storage, err := gtsstorage.AutoConfig()
@@ -61,6 +63,7 @@ func setupPrune(ctx context.Context) (*prune, error) {
 		dbService: dbService,
 		storage:   storage,
 		manager:   manager,
+		state:     &state,
 	}, nil
 }
 
@@ -72,6 +75,9 @@ func (p *prune) shutdown(ctx context.Context) error {
 	if err := p.dbService.Stop(ctx); err != nil {
 		return fmt.Errorf("error closing dbservice: %w", err)
 	}
+
+	p.state.Caches.Stop()
+	p.state.Workers.Stop()
 
 	return nil
 }

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -41,9 +41,7 @@ type accountDB struct {
 func (a *accountDB) newAccountQ(account *gtsmodel.Account) *bun.SelectQuery {
 	return a.conn.
 		NewSelect().
-		Model(account).
-		Relation("AvatarMediaAttachment").
-		Relation("HeaderMediaAttachment")
+		Model(account)
 }
 
 func (a *accountDB) GetAccountByID(ctx context.Context, id string) (*gtsmodel.Account, db.Error) {

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -178,7 +178,8 @@ func NewBunDBService(ctx context.Context, state *state.State) (db.DB, error) {
 			conn: conn,
 		},
 		Media: &mediaDB{
-			conn: conn,
+			conn:  conn,
+			state: state,
 		},
 		Mention: &mentionDB{
 			conn:  conn,

--- a/internal/db/bundb/media.go
+++ b/internal/db/bundb/media.go
@@ -58,7 +58,7 @@ func (m *mediaDB) getAttachments(ctx context.Context, ids []string) ([]*gtsmodel
 		// Attempt fetch from DB
 		attachment, err := m.GetAttachmentByID(ctx, id)
 		if err != nil {
-			log.Errorf("GetAttachments: error getting attachment %q: %v", id, err)
+			log.Errorf("error getting attachment %q: %v", id, err)
 			continue
 		}
 

--- a/internal/db/bundb/media.go
+++ b/internal/db/bundb/media.go
@@ -24,38 +24,58 @@ import (
 
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/superseriousbusiness/gotosocial/internal/state"
 	"github.com/uptrace/bun"
 )
 
 type mediaDB struct {
-	conn *DBConn
+	conn  *DBConn
+	state *state.State
 }
 
-func (m *mediaDB) newMediaQ(i interface{}) *bun.SelectQuery {
+func (m *mediaDB) newMediaQ(i *gtsmodel.MediaAttachment) *bun.SelectQuery {
 	return m.conn.
 		NewSelect().
-		Model(i).
-		Relation("Account")
+		Model(i)
 }
 
 func (m *mediaDB) GetAttachmentByID(ctx context.Context, id string) (*gtsmodel.MediaAttachment, db.Error) {
-	attachment := &gtsmodel.MediaAttachment{}
+	return m.getAttachment(
+		ctx,
+		"ID",
+		func(attachment *gtsmodel.MediaAttachment) error {
+			return m.newMediaQ(attachment).Where("? = ?", bun.Ident("media_attachment.id"), id).Scan(ctx)
+		},
+		id,
+	)
+}
 
-	q := m.newMediaQ(attachment).
-		Where("? = ?", bun.Ident("media_attachment.id"), id)
+func (m *mediaDB) getAttachments(ctx context.Context, ids []string) ([]*gtsmodel.MediaAttachment, db.Error) {
+	attachments := make([]*gtsmodel.MediaAttachment, 0, len(ids))
 
-	if err := q.Scan(ctx); err != nil {
-		return nil, m.conn.ProcessError(err)
+	for _, id := range ids {
+		// Attempt fetch from DB
+		attachment, err := m.GetAttachmentByID(ctx, id)
+		if err != nil {
+			log.Errorf("GetAttachments: error getting attachment %q: %v", id, err)
+			continue
+		}
+
+		// Append attachment
+		attachments = append(attachments, attachment)
 	}
-	return attachment, nil
+
+	return attachments, nil
 }
 
 func (m *mediaDB) GetRemoteOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, db.Error) {
-	attachments := []*gtsmodel.MediaAttachment{}
+	attachmentIDs := []string{}
 
 	q := m.conn.
 		NewSelect().
-		Model(&attachments).
+		TableExpr("? AS ?", bun.Ident("media_attachments"), bun.Ident("media_attachment")).
+		Column("media_attachment.id").
 		Where("? = ?", bun.Ident("media_attachment.cached"), true).
 		Where("? < ?", bun.Ident("media_attachment.created_at"), olderThan).
 		WhereGroup(" AND ", whereNotEmptyAndNotNull("media_attachment.remote_url")).
@@ -65,11 +85,11 @@ func (m *mediaDB) GetRemoteOlderThan(ctx context.Context, olderThan time.Time, l
 		q = q.Limit(limit)
 	}
 
-	if err := q.Scan(ctx); err != nil {
+	if err := q.Scan(ctx, &attachmentIDs); err != nil {
 		return nil, m.conn.ProcessError(err)
 	}
 
-	return attachments, nil
+	return m.getAttachments(ctx, attachmentIDs)
 }
 
 func (m *mediaDB) CountRemoteOlderThan(ctx context.Context, olderThan time.Time) (int, db.Error) {
@@ -90,9 +110,11 @@ func (m *mediaDB) CountRemoteOlderThan(ctx context.Context, olderThan time.Time)
 }
 
 func (m *mediaDB) GetAvatarsAndHeaders(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, db.Error) {
-	attachments := []*gtsmodel.MediaAttachment{}
+	attachmentIDs := []string{}
 
-	q := m.newMediaQ(&attachments).
+	q := m.conn.NewSelect().
+		TableExpr("? AS ?", bun.Ident("media_attachments"), bun.Ident("media_attachment")).
+		Column("media_attachment.id").
 		WhereGroup(" AND ", func(innerQ *bun.SelectQuery) *bun.SelectQuery {
 			return innerQ.
 				WhereOr("? = ?", bun.Ident("media_attachment.avatar"), true).
@@ -108,17 +130,20 @@ func (m *mediaDB) GetAvatarsAndHeaders(ctx context.Context, maxID string, limit 
 		q = q.Limit(limit)
 	}
 
-	if err := q.Scan(ctx); err != nil {
+	if err := q.Scan(ctx, &attachmentIDs); err != nil {
 		return nil, m.conn.ProcessError(err)
 	}
 
-	return attachments, nil
+	return m.getAttachments(ctx, attachmentIDs)
 }
 
 func (m *mediaDB) GetLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, db.Error) {
-	attachments := []*gtsmodel.MediaAttachment{}
+	attachmentIDs := []string{}
 
-	q := m.newMediaQ(&attachments).
+	q := m.conn.
+		NewSelect().
+		TableExpr("? AS ?", bun.Ident("media_attachments"), bun.Ident("media_attachment")).
+		Column("media_attachment.id").
 		Where("? = ?", bun.Ident("media_attachment.cached"), true).
 		Where("? = ?", bun.Ident("media_attachment.avatar"), false).
 		Where("? = ?", bun.Ident("media_attachment.header"), false).
@@ -131,11 +156,11 @@ func (m *mediaDB) GetLocalUnattachedOlderThan(ctx context.Context, olderThan tim
 		q = q.Limit(limit)
 	}
 
-	if err := q.Scan(ctx); err != nil {
+	if err := q.Scan(ctx, &attachmentIDs); err != nil {
 		return nil, m.conn.ProcessError(err)
 	}
 
-	return attachments, nil
+	return m.getAttachments(ctx, attachmentIDs)
 }
 
 func (m *mediaDB) CountLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time) (int, db.Error) {
@@ -156,4 +181,16 @@ func (m *mediaDB) CountLocalUnattachedOlderThan(ctx context.Context, olderThan t
 	}
 
 	return count, nil
+}
+
+func (m *mediaDB) getAttachment(ctx context.Context, lookup string, dbQuery func(*gtsmodel.MediaAttachment) error, keyParts ...any) (*gtsmodel.MediaAttachment, db.Error) {
+	// Fetch attachment from database
+	// todo: cache this lookup
+	attachment := new(gtsmodel.MediaAttachment)
+
+	if err := dbQuery(attachment); err != nil {
+		return nil, m.conn.ProcessError(err)
+	}
+
+	return attachment, nil
 }

--- a/internal/federation/dereferencing/account.go
+++ b/internal/federation/dereferencing/account.go
@@ -239,47 +239,44 @@ func (d *deref) enrichAccount(ctx context.Context, requestUser string, uri *url.
 	latestAcc.HeaderMediaAttachmentID = account.HeaderMediaAttachmentID
 
 	if latestAcc.AvatarRemoteURL != account.AvatarRemoteURL {
+		// Reset the avatar media ID (handles removed).
+		latestAcc.AvatarMediaAttachmentID = ""
+
 		if latestAcc.AvatarRemoteURL != "" {
-			// Account avatar has changed to a new one.
-			// Fetch up-to-date copy and use new media ID.
-			id, err := d.fetchRemoteAccountAvatar(ctx,
+			// Avatar has changed to a new one, fetch up-to-date copy and use new ID.
+			latestAcc.AvatarMediaAttachmentID, err = d.fetchRemoteAccountAvatar(ctx,
 				transport,
 				latestAcc.AvatarRemoteURL,
 				latestAcc.ID,
 			)
 			if err != nil {
 				log.Errorf("error fetching remote avatar for account %s: %v", uri, err)
-				// Keep old avi for now, we'll try again in 2 days.
+
+				// Keep old avatar for now, we'll try again in $interval.
+				latestAcc.AvatarMediaAttachmentID = account.AvatarMediaAttachmentID
 				latestAcc.AvatarRemoteURL = account.AvatarRemoteURL
 			}
-			if id != "" {
-				latestAcc.AvatarMediaAttachmentID = id
-			}
-		} else {
-			// Account avatar has been removed.
-			latestAcc.AvatarMediaAttachmentID = ""
 		}
 	}
 
 	if latestAcc.HeaderRemoteURL != account.HeaderRemoteURL {
+		// Reset the header media ID (handles removed).
+		latestAcc.HeaderMediaAttachmentID = ""
+
 		if latestAcc.HeaderRemoteURL != "" {
-			// Account header has changed to a new one.
-			// Fetch up-to-date copy and use new media ID.
-			id, err := d.fetchRemoteAccountHeader(ctx,
+			// Header has changed to a new one, fetch up-to-date copy and use new ID.
+			latestAcc.HeaderMediaAttachmentID, err = d.fetchRemoteAccountHeader(ctx,
 				transport,
 				latestAcc.HeaderRemoteURL,
 				latestAcc.ID,
 			)
 			if err != nil {
 				log.Errorf("error fetching remote header for account %s: %v", uri, err)
-				// Keep old header for now, we'll try again in 2 days.
+
+				// Keep old header for now, we'll try again in $interval.
+				latestAcc.HeaderMediaAttachmentID = account.HeaderMediaAttachmentID
 				latestAcc.HeaderRemoteURL = account.HeaderRemoteURL
-			} else {
-				latestAcc.HeaderMediaAttachmentID = id // we got it
 			}
-		} else {
-			// Account header has been removed.
-			latestAcc.HeaderMediaAttachmentID = ""
 		}
 	}
 

--- a/internal/gtsmodel/mediaattachment.go
+++ b/internal/gtsmodel/mediaattachment.go
@@ -34,7 +34,6 @@ type MediaAttachment struct {
 	Type              FileType         `validate:"oneof=Image Gifv Audio Video Unknown" bun:",nullzero,notnull"`                       // Type of file (image/gifv/audio/video)
 	FileMeta          FileMeta         `validate:"required" bun:",embed:,nullzero,notnull"`                                            // Metadata about the file
 	AccountID         string           `validate:"required,ulid" bun:"type:CHAR(26),nullzero,notnull"`                                 // To which account does this attachment belong
-	Account           *Account         `validate:"-" bun:"rel:belongs-to,join:account_id=id"`                                          // Account corresponding to accountID
 	Description       string           `validate:"-" bun:""`                                                                           // Description of the attachment (for screenreaders)
 	ScheduledStatusID string           `validate:"omitempty,ulid" bun:"type:CHAR(26),nullzero"`                                        // To which scheduled status does this attachment belong
 	Blurhash          string           `validate:"required_if=Type Image,required_if=Type Gif,required_if=Type Video" bun:",nullzero"` // What is the generated blurhash of this attachment

--- a/internal/media/prune.go
+++ b/internal/media/prune.go
@@ -123,7 +123,7 @@ func (m *manager) PruneUnusedRemote(ctx context.Context, dry bool) (int, error) 
 			// Retrieve owning account if possible.
 			var account *gtsmodel.Account
 			if accountID := attachment.AccountID; accountID != "" {
-				account, err = m.db.GetAccountByID(ctx, attachment.AccountID)
+				account, err = m.state.DB.GetAccountByID(ctx, attachment.AccountID)
 				if err != nil && !errors.Is(err, db.ErrNoEntries) {
 					// Only return on a real error.
 					return 0, fmt.Errorf("PruneUnusedRemote: error fetching account with id %s: %w", accountID, err)

--- a/internal/media/prune.go
+++ b/internal/media/prune.go
@@ -124,9 +124,19 @@ func (m *manager) PruneUnusedRemote(ctx context.Context, dry bool) (int, error) 
 		// - Is a header but isn't the owning account's current header.
 		// - Is an avatar but isn't the owning account's current avatar.
 		for _, attachment := range attachments {
-			if attachment.Account == nil ||
-				(*attachment.Header && attachment.ID != attachment.Account.HeaderMediaAttachmentID) ||
-				(*attachment.Avatar && attachment.ID != attachment.Account.AvatarMediaAttachmentID) {
+			// Retrieve owning account if possible.
+			var account *gtsmodel.Account
+			if accountID := attachment.AccountID; accountID != "" {
+				account, err = m.db.GetAccountByID(ctx, attachment.AccountID)
+				if err != nil && !errors.Is(err, db.ErrNoEntries) {
+					// Only return on a real error.
+					return 0, fmt.Errorf("PruneUnusedRemote: error fetching account with id %s: %w", accountID, err)
+				}
+			}
+
+			if account == nil ||
+				(*attachment.Header && attachment.ID != account.HeaderMediaAttachmentID) ||
+				(*attachment.Avatar && attachment.ID != account.AvatarMediaAttachmentID) {
 				if err := f(ctx, attachment); err != nil {
 					return totalPruned, err
 				}

--- a/internal/media/prune.go
+++ b/internal/media/prune.go
@@ -119,10 +119,6 @@ func (m *manager) PruneUnusedRemote(ctx context.Context, dry bool) (int, error) 
 	for attachments, err = m.state.DB.GetAvatarsAndHeaders(ctx, maxID, selectPruneLimit); err == nil && len(attachments) != 0; attachments, err = m.state.DB.GetAvatarsAndHeaders(ctx, maxID, selectPruneLimit) {
 		maxID = attachments[len(attachments)-1].ID // use the id of the last attachment in the slice as the next 'maxID' value
 
-		// Prune each attachment that meets one of the following criteria:
-		// - Has no owning account in the database.
-		// - Is a header but isn't the owning account's current header.
-		// - Is an avatar but isn't the owning account's current avatar.
 		for _, attachment := range attachments {
 			// Retrieve owning account if possible.
 			var account *gtsmodel.Account
@@ -134,6 +130,10 @@ func (m *manager) PruneUnusedRemote(ctx context.Context, dry bool) (int, error) 
 				}
 			}
 
+			// Prune each attachment that meets one of the following criteria:
+			// - Has no owning account in the database.
+			// - Is a header but isn't the owning account's current header.
+			// - Is an avatar but isn't the owning account's current avatar.
 			if account == nil ||
 				(*attachment.Header && attachment.ID != account.HeaderMediaAttachmentID) ||
 				(*attachment.Avatar && attachment.ID != account.AvatarMediaAttachmentID) {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request:

1. Fixes a bug where avatars were being set as 'avatar=false' by accident, leading to them being pruned and then later not found.
2. Allows for situations where a remote header/avatar url has changed to empty, and should therefore be unset.
3. Fixes the `admin media prune remote` command to initialize db state and caches properly.
4. Updates media attachment select db logic to select a bunch of IDs and then select attachments from those IDs, rather than doing big ol' queries.
5. Removes some unused db relations that were causing us to make bigger queries than we needed to be.

Tested on goblin.technology and seems OK there :)

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
