### PR TITLE
[bugfix] Return empty result rather than 500 error when searching for blocked domains

### DIFF
--- a/internal/api/client/search/searchget_test.go
+++ b/internal/api/client/search/searchget_test.go
@@ -252,6 +252,34 @@ func (suite *SearchGetTestSuite) TestSearchStatusByURL() {
 	suite.NotNil(gotStatus)
 }
 
+func (suite *SearchGetTestSuite) TestSearchBlockedDomainURL() {
+	query := "https://replyguys.com/@someone"
+	resolve := true
+
+	searchResult, err := suite.testSearch(query, resolve, http.StatusOK)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Len(searchResult.Accounts, 0)
+	suite.Len(searchResult.Statuses, 0)
+	suite.Len(searchResult.Hashtags, 0)
+}
+
+func (suite *SearchGetTestSuite) TestSearchBlockedDomainNamestring() {
+	query := "@someone@replyguys.com"
+	resolve := true
+
+	searchResult, err := suite.testSearch(query, resolve, http.StatusOK)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Len(searchResult.Accounts, 0)
+	suite.Len(searchResult.Statuses, 0)
+	suite.Len(searchResult.Hashtags, 0)
+}
+
 func TestSearchGetTestSuite(t *testing.T) {
 	suite.Run(t, &SearchGetTestSuite{})
 }


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request adds a quick domain block check in the search function of the processor to ensure that items being searched aren't currently domain blocked.

When we do https://github.com/superseriousbusiness/gotosocial/issues/1497 we should consider removing these checks and doing them in the dereferencer instead.

closes https://github.com/superseriousbusiness/gotosocial/issues/1462

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
