### PR TITLE
[chore] Split the bug template in two

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_frontend.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_frontend.yaml
@@ -1,7 +1,7 @@
-name: Bug Report
-description: Create a report to help us improve
+name: Frontend Bug Report
+description: Report an issue related to the web frontend
 title: "[bug] Issue Title"
-labels: [bug]
+labels: ["bug", "frontend"]
 assignees: []
 
 body:
@@ -9,20 +9,11 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report! Please be cautious with the sensitive information/logs while filing the issue.
-  - type: markdown
-    attributes:
-      value: |
-        ⚠️ If you're reporting an interoperability issue with a **closed source**
-        ActivityPub/Mastodon client or server, please report the issue to the
-        developers of that client or server instead. Without access to their
-        source debugging the issue is difficult for us. Since GoToSocial is
-        open source, developers of closed source implementations can run a copy
-        and autonomously debug the issue. We'll gladly address any bugs they
-        raise with us.
+
   - type: textarea
     id: desc
     attributes:
-      label: Describe the bug with a clear and concise description of what the bug is.
+      label: Describe the bug with a clear and concise description of what the bug is. Please include screenshots of any visual issues.
     validations:
       required: true
 
@@ -36,13 +27,13 @@ body:
       required: true
 
   - type: input
-    id: GoToSocial-Arch
+    id: Browser-Version
     attributes:
-      label: GoToSocial Arch
-      description: What architecture do you use and did you do a Binary or Docker installation?
-      placeholder: e.g. arm64 Docker or arm64 Binary
+      label: Browser version
+      description: What browser(s) and versions are you using that show this bug?
+      placeholder: Firefox 103.0b9 (64-bit)
     validations:
-      required: false
+      required: true
 
   - type: textarea
     id: what-happened


### PR DESCRIPTION


# Description

Based on the idea in https://github.com/superseriousbusiness/gotosocial/issues/1438#issuecomment-1429852161.

Have a separate template for:
* Frontend, with labels bug and frontend and requiring the browser field
* Regular/backend, for other bugs with only the bug label and removal of the browser field

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
