### PR TITLE
[bug] Fix nginx fileserver caching example

### DIFF
--- a/docs/installation_guide/advanced.md
+++ b/docs/installation_guide/advanced.md
@@ -403,7 +403,7 @@ server {
     alias storage-local-base-path/;
     autoindex off;
     expires max;
-    add_header Cache-Control "public, immutable";
+    add_header Cache-Control "private, immutable";
     try_files $uri @fileserver;
   }
 


### PR DESCRIPTION
# Description

This updates the example to ensure the nginx proxies the request on to GTS if the file is not found on disk. This can happen due to media pruning.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
