### PR TITLE
[bugfix] Set cache-control max-age dynamically for s3

### DIFF
--- a/internal/api/fileserver.go
+++ b/internal/api/fileserver.go
@@ -31,11 +31,6 @@ type Fileserver struct {
 	fileserver *fileserver.Module
 }
 
-func maxAge() string {
-
-	return "max-age=604800" // 7d
-}
-
 func (f *Fileserver) Route(r router.Router, m ...gin.HandlerFunc) {
 	fileserverGroup := r.AttachGroup("fileserver")
 

--- a/internal/api/fileserver.go
+++ b/internal/api/fileserver.go
@@ -53,7 +53,7 @@ func (f *Fileserver) Route(r router.Router, m ...gin.HandlerFunc) {
 	// it expires. This ensures that clients won't cache expired
 	// links. This is done within fileserver/servefile.go.
 	if config.GetStorageBackend() == "local" || config.GetStorageS3Proxy() {
-		fileserverGroup.Use(middleware.CacheControl("private", "max-age=86400")) // 7d
+		fileserverGroup.Use(middleware.CacheControl("private", "max-age=604800")) // 7d
 	}
 
 	f.fileserver.Route(fileserverGroup.Handle)

--- a/internal/api/fileserver/servefile.go
+++ b/internal/api/fileserver/servefile.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"codeberg.org/gruf/go-fastcopy"
 	"github.com/gin-gonic/gin"
@@ -89,6 +90,10 @@ func (m *Module) ServeFile(c *gin.Context) {
 
 	if content.URL != nil {
 		// This is a non-local, non-proxied S3 file we're redirecting to.
+		// Derive the max-age value from how long the link has left until
+		// it expires.
+		maxAge := int(content.URL.Expiry.Sub(time.Now()).Seconds())
+		c.Header("Cache-Control", "private,max-age="+strconv.Itoa(maxAge))
 		c.Redirect(http.StatusFound, content.URL.String())
 		return
 	}

--- a/internal/api/fileserver/servefile.go
+++ b/internal/api/fileserver/servefile.go
@@ -92,7 +92,7 @@ func (m *Module) ServeFile(c *gin.Context) {
 		// This is a non-local, non-proxied S3 file we're redirecting to.
 		// Derive the max-age value from how long the link has left until
 		// it expires.
-		maxAge := int(content.URL.Expiry.Sub(time.Now()).Seconds())
+		maxAge := int(time.Until(content.URL.Expiry).Seconds())
 		c.Header("Cache-Control", "private,max-age="+strconv.Itoa(maxAge))
 		c.Redirect(http.StatusFound, content.URL.String())
 		return

--- a/internal/api/model/content.go
+++ b/internal/api/model/content.go
@@ -20,8 +20,9 @@ package model
 
 import (
 	"io"
-	"net/url"
 	"time"
+
+	"github.com/superseriousbusiness/gotosocial/internal/storage"
 )
 
 // Content wraps everything needed to serve a blob of content (some kind of media) through the API.
@@ -35,7 +36,7 @@ type Content struct {
 	// Actual content
 	Content io.ReadCloser
 	// Resource URL to forward to if the file can be fetched from the storage directly (e.g signed S3 URL)
-	URL *url.URL
+	URL *storage.PresignedURL
 }
 
 // GetContentRequestForm describes a piece of content desired by the caller of the fileserver API.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -41,6 +41,13 @@ const (
 	urlCacheExpiryFrequency = time.Minute * 5
 )
 
+// PresignedURL represents a pre signed S3 URL with
+// an expiry time.
+type PresignedURL struct {
+	*url.URL
+	Expiry time.Time // link expires at this time
+}
+
 // ErrAlreadyExists is a ptr to underlying storage.ErrAlreadyExists,
 // to put the related errors in the same package as our storage wrapper.
 var ErrAlreadyExists = storage.ErrAlreadyExists
@@ -54,11 +61,11 @@ type Driver struct {
 	// S3-only parameters
 	Proxy          bool
 	Bucket         string
-	PresignedCache *ttl.Cache[string, *url.URL]
+	PresignedCache *ttl.Cache[string, PresignedURL]
 }
 
 // URL will return a presigned GET object URL, but only if running on S3 storage with proxying disabled.
-func (d *Driver) URL(ctx context.Context, key string) *url.URL {
+func (d *Driver) URL(ctx context.Context, key string) *PresignedURL {
 	// Check whether S3 *without* proxying is enabled
 	s3, ok := d.Storage.(*storage.S3Storage)
 	if !ok || d.Proxy {
@@ -72,18 +79,24 @@ func (d *Driver) URL(ctx context.Context, key string) *url.URL {
 	d.PresignedCache.Unlock()
 
 	if ok {
-		return e.Value
+		return &e.Value
 	}
 
 	u, err := s3.Client().PresignedGetObject(ctx, d.Bucket, key, urlCacheTTL, url.Values{
 		"response-content-type": []string{mime.TypeByExtension(path.Ext(key))},
 	})
+
+	psu := PresignedURL{
+		URL:    u,
+		Expiry: time.Now().Add(urlCacheTTL), // link expires in 24h time
+	}
+
 	if err != nil {
 		// If URL request fails, fallback is to fetch the file. So ignore the error here
 		return nil
 	}
-	d.PresignedCache.Set(key, u)
-	return u
+	d.PresignedCache.Set(key, psu)
+	return &psu
 }
 
 func AutoConfig() (*Driver, error) {
@@ -151,7 +164,7 @@ func NewS3Storage() (*Driver, error) {
 	}
 
 	// ttl should be lower than the expiry used by S3 to avoid serving invalid URLs
-	presignedCache := ttl.New[string, *url.URL](0, 1000, urlCacheTTL-urlCacheExpiryFrequency)
+	presignedCache := ttl.New[string, PresignedURL](0, 1000, urlCacheTTL-urlCacheExpiryFrequency)
 	presignedCache.Start(urlCacheExpiryFrequency)
 
 	return &Driver{

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -85,16 +85,16 @@ func (d *Driver) URL(ctx context.Context, key string) *PresignedURL {
 	u, err := s3.Client().PresignedGetObject(ctx, d.Bucket, key, urlCacheTTL, url.Values{
 		"response-content-type": []string{mime.TypeByExtension(path.Ext(key))},
 	})
+	if err != nil {
+		// If URL request fails, fallback is to fetch the file. So ignore the error here
+		return nil
+	}
 
 	psu := PresignedURL{
 		URL:    u,
 		Expiry: time.Now().Add(urlCacheTTL), // link expires in 24h time
 	}
 
-	if err != nil {
-		// If URL request fails, fallback is to fetch the file. So ignore the error here
-		return nil
-	}
 	d.PresignedCache.Set(key, psu)
 	return &psu
 }


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This PR fixes a case where an s3 url could return a cache-control max age of 24h when the url actually does not have 24h of validity left. Instead, cache-control max-age is now set depending on how long the link has left until expiry.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code. -- n/a, we still need a way of testing s3 stuff nicely
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
