### PR TITLE
[bug] Pass context in logging middleware

### DIFF
--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -57,7 +57,8 @@ func Logger() gin.HandlerFunc {
 
 				// Dump a stacktrace to error log
 				callers := errors.GetCallers(3, 10)
-				log.WithField("stacktrace", callers).Error(err)
+				log.WithContext(c.Request.Context()).
+					WithField("stacktrace", callers).Error(err)
 			}
 
 			// NOTE:
@@ -75,7 +76,8 @@ func Logger() gin.HandlerFunc {
 			fields[5] = kv.Field{"path", path}
 
 			// Create log entry with fields
-			l := log.WithFields(fields...)
+			l := log.WithContext(c.Request.Context()).
+				WithFields(fields...)
 
 			// Default is info
 			lvl := level.INFO


### PR DESCRIPTION
# Description

This updates the middleware `log.WithField` calls that create new loggers to include the context the first time around. Without it the requestID does not get logged.

Fixup from #1476

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
