### PR TITLE
[chore] Update more log calls to include context

### DIFF
--- a/internal/concurrency/workers.go
+++ b/internal/concurrency/workers.go
@@ -119,10 +119,11 @@ func (w *WorkerPool[MsgType]) Queue(msg MsgType) {
 	// Create new process function for msg
 	process := func(ctx context.Context) {
 		if err := w.process(ctx, msg); err != nil {
-			log.WithFields(kv.Fields{
-				kv.Field{K: "type", V: w.wtype},
-				kv.Field{K: "error", V: err},
-			}...).Error("message processing error")
+			log.WithContext(ctx).
+				WithFields(kv.Fields{
+					kv.Field{K: "type", V: w.wtype},
+					kv.Field{K: "error", V: err},
+				}...).Error("message processing error")
 		}
 	}
 

--- a/internal/federation/federatingdb/accept.go
+++ b/internal/federation/federatingdb/accept.go
@@ -39,7 +39,8 @@ func (f *federatingDB) Accept(ctx context.Context, accept vocab.ActivityStreamsA
 		if err != nil {
 			return err
 		}
-		l := log.WithField("accept", i)
+		l := log.WithContext(ctx).
+			WithField("accept", i)
 		l.Debug("entering Accept")
 	}
 

--- a/internal/federation/federatingdb/announce.go
+++ b/internal/federation/federatingdb/announce.go
@@ -35,7 +35,8 @@ func (f *federatingDB) Announce(ctx context.Context, announce vocab.ActivityStre
 		if err != nil {
 			return err
 		}
-		l := log.WithField("announce", i)
+		l := log.WithContext(ctx).
+			WithField("announce", i)
 		l.Debug("entering Announce")
 	}
 

--- a/internal/federation/federatingdb/reject.go
+++ b/internal/federation/federatingdb/reject.go
@@ -38,7 +38,8 @@ func (f *federatingDB) Reject(ctx context.Context, reject vocab.ActivityStreamsR
 		if err != nil {
 			return err
 		}
-		l := log.WithField("reject", i)
+		l := log.WithContext(ctx).
+			WithField("reject", i)
 		l.Debug("entering Reject")
 	}
 

--- a/internal/federation/federatingdb/undo.go
+++ b/internal/federation/federatingdb/undo.go
@@ -32,7 +32,7 @@ import (
 )
 
 func (f *federatingDB) Undo(ctx context.Context, undo vocab.ActivityStreamsUndo) error {
-	l := log.Entry{}
+	l := log.Entry{}.WithContext(ctx)
 
 	if log.Level() >= level.DEBUG {
 		i, err := marshalItem(undo)

--- a/internal/federation/federatingdb/update.go
+++ b/internal/federation/federatingdb/update.go
@@ -42,7 +42,7 @@ import (
 //
 // The library makes this call only after acquiring a lock first.
 func (f *federatingDB) Update(ctx context.Context, asType vocab.Type) error {
-	l := log.Entry{}
+	l := log.Entry{}.WithContext(ctx)
 
 	if log.Level() >= level.DEBUG {
 		i, err := marshalItem(asType)

--- a/internal/federation/federatingdb/util.go
+++ b/internal/federation/federatingdb/util.go
@@ -69,7 +69,8 @@ func (f *federatingDB) NewID(ctx context.Context, t vocab.Type) (idURL *url.URL,
 		if err != nil {
 			return nil, err
 		}
-		l := log.WithField("newID", i)
+		l := log.WithContext(ctx).
+			WithField("newID", i)
 		l.Debug("entering NewID")
 	}
 

--- a/internal/media/manager.go
+++ b/internal/media/manager.go
@@ -319,7 +319,8 @@ func (m *manager) PreProcessEmoji(ctx context.Context, data DataFunc, postData P
 				}
 			}
 
-			l := log.WithField("shortcode@domain", emoji.Shortcode+"@"+emoji.Domain)
+			l := log.WithContext(ctx).
+				WithField("shortcode@domain", emoji.Shortcode+"@"+emoji.Domain)
 			l.Debug("postData: cleaning up old emoji files for refreshed emoji")
 			if err := m.state.Storage.Delete(innerCtx, originalImagePath); err != nil && !errors.Is(err, storage.ErrNotFound) {
 				l.Errorf("postData: error cleaning up old emoji image at %s for refreshed emoji: %s", originalImagePath, err)

--- a/internal/typeutils/astointernal.go
+++ b/internal/typeutils/astointernal.go
@@ -243,7 +243,8 @@ func (c *converter) ASStatusToStatus(ctx context.Context, statusable ap.Statusab
 	}
 	status.URI = uriProp.GetIRI().String()
 
-	l := log.WithField("statusURI", status.URI)
+	l := log.WithContext(ctx).
+		WithField("statusURI", status.URI)
 
 	// web url for viewing this status
 	if statusURL, err := ap.ExtractURL(statusable); err == nil {


### PR DESCRIPTION
# Description

In #1476 we updated `log.WithFields()` but we forgot about `log.WithField()`. Also updates a few explicit `log.Entry{}` creations.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
