### PR TITLE
[bugfix] Fix oob token route, update templates+css for oob and errors

### DIFF
--- a/internal/oauth/server.go
+++ b/internal/oauth/server.go
@@ -53,7 +53,7 @@ const (
 	// OOBURI is the out-of-band oauth token uri
 	OOBURI = "urn:ietf:wg:oauth:2.0:oob"
 	// OOBTokenPath is the path to redirect out-of-band token requests to.
-	OOBTokenPath = "/oob"
+	OOBTokenPath = "/oauth/oob" // #nosec G101 else we get a hardcoded credentials warning
 	// HelpfulAdvice is a handy hint to users;
 	// particularly important during the login flow
 	HelpfulAdvice = "If you arrived at this error during a login/oauth flow, please try clearing your session cookies and logging in again; if problems persist, make sure you're using the correct credentials"

--- a/web/source/css/base.css
+++ b/web/source/css/base.css
@@ -277,23 +277,24 @@ section.login {
 
 section.error {
 	word-break: break-word;
-	display: flex;
-	flex-direction: row;
-	align-items: center;
 	margin-bottom: 0.5rem;
-
-	span {
-		font-size: 2em;
-	}
 
 	pre {
 		border: 1px solid #ff000080;
-		margin-left: 1em;
-		padding: 0 0.7em;
+		padding: 0.5rem;
 		border-radius: 0.5em;
 		background-color: #ff000010;
 		font-size: 1.3em;
 		white-space: pre-wrap;
+	}
+}
+
+section.oob-token {
+	code {
+		background: $gray1;
+		padding: 0.5rem;
+		margin: 0;
+		border-radius: 0.3rem;
 	}
 }
 

--- a/web/template/error.tmpl
+++ b/web/template/error.tmpl
@@ -17,10 +17,15 @@
 */ -}}
 
 {{ template "header.tmpl" .}}
-    <main>
-        <section class="error">
-          <span>❌</span> <pre>{{.error}}</pre>
-          <span>Request ID</span> <code>{{.requestID}}</code>
-        </section>
-    </main>
+<main>
+	<section class="error">
+		<h1>An error occured:</h1>
+		<pre>{{.error}}</pre>
+		{{if .requestID}}
+		<div>
+			<span>Request ID:</span> <code>{{.requestID}}</code>
+		</div>
+		{{end}}
+	</section>
+</main>
 {{ template "footer.tmpl" .}}

--- a/web/template/oob.tmpl
+++ b/web/template/oob.tmpl
@@ -17,10 +17,11 @@
 */ -}}
 
 {{ template "header.tmpl" .}}
-    <main>
-        <h1>Hi {{ .user }}!</h1>
-        <p>Here's your out-of-band token with scope <em>{{.scope}}</em>:</p>
-        <p><code>{{ .oobToken }}</code><p>
-        <p>Use it wisely!</p>
-    </main>
+<main>
+	<section class="oob-token">
+		<h1>Hi {{ .user }}!</h1>
+		<p>Here's your out-of-band token with scope "<em>{{.scope}}</em>", use it wisely:</p>
+		<code>{{ .oobToken }}</code>
+	</section>
+</main>
 {{ template "footer.tmpl" .}}


### PR DESCRIPTION
# Description

Our `oob.tmpl` was served on `/oauth/oob` but the flow redirected to `/oob`. Flow now redirects correctly to `/oauth/oob`.
Also took the opportunity to update the layout/style for the oob and error templates.

closes https://github.com/superseriousbusiness/gotosocial/issues/1518

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
