### PR TITLE
[bugfix] fix account role structure to enable fedilab login

### DIFF
--- a/internal/api/client/admin/reportsget_test.go
+++ b/internal/api/client/admin/reportsget_test.go
@@ -156,7 +156,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet1() {
       "ips": [],
       "locale": "",
       "invite_request": null,
-      "role": "user",
+      "role": {
+        "name": "user"
+      },
       "confirmed": false,
       "approved": false,
       "disabled": false,
@@ -195,7 +197,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet1() {
       "ips": [],
       "locale": "en",
       "invite_request": "",
-      "role": "user",
+      "role": {
+        "name": "user"
+      },
       "confirmed": true,
       "approved": true,
       "disabled": false,
@@ -222,7 +226,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet1() {
         "last_status_at": "2021-10-20T10:40:37.000Z",
         "emojis": [],
         "fields": [],
-        "role": "user"
+        "role": {
+          "name": "user"
+        }
       },
       "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
     },
@@ -236,7 +242,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet1() {
       "ips": [],
       "locale": "en",
       "invite_request": "",
-      "role": "admin",
+      "role": {
+        "name": "admin"
+      },
       "confirmed": true,
       "approved": true,
       "disabled": false,
@@ -264,7 +272,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet1() {
         "emojis": [],
         "fields": [],
         "enable_rss": true,
-        "role": "admin"
+        "role": {
+          "name": "admin"
+        }
       },
       "created_by_application_id": "01F8MGXQRHYF5QPMTMXP78QC2F"
     },
@@ -278,7 +288,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet1() {
       "ips": [],
       "locale": "en",
       "invite_request": "",
-      "role": "admin",
+      "role": {
+        "name": "admin"
+      },
       "confirmed": true,
       "approved": true,
       "disabled": false,
@@ -306,7 +318,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet1() {
         "emojis": [],
         "fields": [],
         "enable_rss": true,
-        "role": "admin"
+        "role": {
+          "name": "admin"
+        }
       },
       "created_by_application_id": "01F8MGXQRHYF5QPMTMXP78QC2F"
     },
@@ -333,7 +347,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet1() {
       "ips": [],
       "locale": "en",
       "invite_request": "",
-      "role": "user",
+      "role": {
+        "name": "user"
+      },
       "confirmed": true,
       "approved": true,
       "disabled": false,
@@ -360,7 +376,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet1() {
         "last_status_at": "2021-10-20T10:40:37.000Z",
         "emojis": [],
         "fields": [],
-        "role": "user"
+        "role": {
+          "name": "user"
+        }
       },
       "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
     },
@@ -374,7 +392,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet1() {
       "ips": [],
       "locale": "",
       "invite_request": null,
-      "role": "user",
+      "role": {
+        "name": "user"
+      },
       "confirmed": false,
       "approved": false,
       "disabled": false,
@@ -528,7 +548,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet2() {
       "ips": [],
       "locale": "en",
       "invite_request": "",
-      "role": "user",
+      "role": {
+        "name": "user"
+      },
       "confirmed": true,
       "approved": true,
       "disabled": false,
@@ -555,7 +577,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet2() {
         "last_status_at": "2021-10-20T10:40:37.000Z",
         "emojis": [],
         "fields": [],
-        "role": "user"
+        "role": {
+          "name": "user"
+        }
       },
       "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
     },
@@ -569,7 +593,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet2() {
       "ips": [],
       "locale": "",
       "invite_request": null,
-      "role": "user",
+      "role": {
+        "name": "user"
+      },
       "confirmed": false,
       "approved": false,
       "disabled": false,
@@ -723,7 +749,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet3() {
       "ips": [],
       "locale": "en",
       "invite_request": "",
-      "role": "user",
+      "role": {
+        "name": "user"
+      },
       "confirmed": true,
       "approved": true,
       "disabled": false,
@@ -750,7 +778,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet3() {
         "last_status_at": "2021-10-20T10:40:37.000Z",
         "emojis": [],
         "fields": [],
-        "role": "user"
+        "role": {
+          "name": "user"
+        }
       },
       "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
     },
@@ -764,7 +794,9 @@ func (suite *ReportsGetTestSuite) TestReportsGet3() {
       "ips": [],
       "locale": "",
       "invite_request": null,
-      "role": "user",
+      "role": {
+        "name": "user"
+      },
       "confirmed": false,
       "approved": false,
       "disabled": false,

--- a/internal/api/client/instance/instancepatch_test.go
+++ b/internal/api/client/instance/instancepatch_test.go
@@ -151,7 +151,9 @@ func (suite *InstancePatchTestSuite) TestInstancePatch1() {
     "emojis": [],
     "fields": [],
     "enable_rss": true,
-    "role": "admin"
+    "role": {
+      "name": "admin"
+    }
   },
   "max_toot_chars": 5000
 }`, dst.String())
@@ -247,7 +249,9 @@ func (suite *InstancePatchTestSuite) TestInstancePatch2() {
     "emojis": [],
     "fields": [],
     "enable_rss": true,
-    "role": "admin"
+    "role": {
+      "name": "admin"
+    }
   },
   "max_toot_chars": 5000
 }`, dst.String())
@@ -343,7 +347,9 @@ func (suite *InstancePatchTestSuite) TestInstancePatch3() {
     "emojis": [],
     "fields": [],
     "enable_rss": true,
-    "role": "admin"
+    "role": {
+      "name": "admin"
+    }
   },
   "max_toot_chars": 5000
 }`, dst.String())
@@ -490,7 +496,9 @@ func (suite *InstancePatchTestSuite) TestInstancePatch6() {
     "emojis": [],
     "fields": [],
     "enable_rss": true,
-    "role": "admin"
+    "role": {
+      "name": "admin"
+    }
   },
   "max_toot_chars": 5000
 }`, dst.String())
@@ -609,7 +617,9 @@ func (suite *InstancePatchTestSuite) TestInstancePatch8() {
     "emojis": [],
     "fields": [],
     "enable_rss": true,
-    "role": "admin"
+    "role": {
+      "name": "admin"
+    }
   },
   "max_toot_chars": 5000
 }`, dst.String())
@@ -740,7 +750,9 @@ func (suite *InstancePatchTestSuite) TestInstancePatch9() {
     "emojis": [],
     "fields": [],
     "enable_rss": true,
-    "role": "admin"
+    "role": {
+      "name": "admin"
+    }
   },
   "max_toot_chars": 5000
 }`, dst.String())

--- a/internal/api/model/account.go
+++ b/internal/api/model/account.go
@@ -97,7 +97,7 @@ type Account struct {
 	// Role of the account on this instance.
 	// Omitted for remote accounts.
 	// example: user
-	Role AccountRole `json:"role,omitempty"`
+	Role *AccountRole `json:"role,omitempty"`
 }
 
 // AccountCreateRequest models account creation parameters.
@@ -215,13 +215,20 @@ type AccountDeleteRequest struct {
 
 // AccountRole models the role of an account.
 //
+// swagger:model role
+type AccountRole struct {
+	Name AccountRoleName `form:"-" json:"name,omitempty" xml:"-"`
+}
+
+// AccountRoleName represent the name of the role of an account.
+//
 // swagger:enum accountRole
 // swagger:type string
-type AccountRole string
+type AccountRoleName string
 
 const (
-	AccountRoleUser      AccountRole = "user"      // Standard user
-	AccountRoleModerator AccountRole = "moderator" // Moderator privileges
-	AccountRoleAdmin     AccountRole = "admin"     // Instance admin
-	AccountRoleUnknown   AccountRole = ""          // We don't know / remote account
+	AccountRoleUser      AccountRoleName = "user"      // Standard user
+	AccountRoleModerator AccountRoleName = "moderator" // Moderator privileges
+	AccountRoleAdmin     AccountRoleName = "admin"     // Instance admin
+	AccountRoleUnknown   AccountRoleName = ""          // We don't know / remote account
 )

--- a/internal/api/model/admin.go
+++ b/internal/api/model/admin.go
@@ -56,7 +56,7 @@ type AdminAccountInfo struct {
 	// example: Pleaaaaaaaaaaaaaaase!!
 	InviteRequest *string `json:"invite_request"`
 	// The current role of the account.
-	Role string `json:"role"`
+	Role AccountRole `json:"role,omitempty"`
 	// Whether the account has confirmed their email address.
 	Confirmed bool `json:"confirmed"`
 	// Whether the account is currently approved.

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -167,10 +167,8 @@ func (c *converter) AccountToAPIAccountPublic(ctx context.Context, a *gtsmodel.A
 		log.Errorf(ctx, "error converting account emojis: %v", err)
 	}
 
-	var (
-		acct string
-		role = apimodel.AccountRoleUnknown
-	)
+	var acct string
+	var role *apimodel.AccountRole
 
 	if a.Domain != "" {
 		// this is a remote user
@@ -185,11 +183,11 @@ func (c *converter) AccountToAPIAccountPublic(ctx context.Context, a *gtsmodel.A
 
 		switch {
 		case *user.Admin:
-			role = apimodel.AccountRoleAdmin
+			role = &apimodel.AccountRole{Name: apimodel.AccountRoleAdmin}
 		case *user.Moderator:
-			role = apimodel.AccountRoleModerator
+			role = &apimodel.AccountRole{Name: apimodel.AccountRoleModerator}
 		default:
-			role = apimodel.AccountRoleUser
+			role = &apimodel.AccountRole{Name: apimodel.AccountRoleUser}
 		}
 	}
 
@@ -270,7 +268,7 @@ func (c *converter) AccountToAdminAPIAccount(ctx context.Context, a *gtsmodel.Ac
 		disabled               bool
 		silenced               bool
 		suspended              bool
-		role                   apimodel.AccountRole = apimodel.AccountRoleUser // assume user by default
+		role                   apimodel.AccountRole = apimodel.AccountRole{Name: apimodel.AccountRoleUser} // assume user by default
 		createdByApplicationID string
 	)
 
@@ -296,9 +294,9 @@ func (c *converter) AccountToAdminAPIAccount(ctx context.Context, a *gtsmodel.Ac
 		locale = user.Locale
 		inviteRequest = &user.Account.Reason
 		if *user.Admin {
-			role = apimodel.AccountRoleAdmin
+			role = apimodel.AccountRole{Name: apimodel.AccountRoleAdmin}
 		} else if *user.Moderator {
-			role = apimodel.AccountRoleModerator
+			role = apimodel.AccountRole{Name: apimodel.AccountRoleModerator}
 		}
 		confirmed = !user.ConfirmedAt.IsZero()
 		approved = *user.Approved
@@ -323,7 +321,7 @@ func (c *converter) AccountToAdminAPIAccount(ctx context.Context, a *gtsmodel.Ac
 		IPs:                    []interface{}{}, // not implemented,
 		Locale:                 locale,
 		InviteRequest:          inviteRequest,
-		Role:                   string(role),
+		Role:                   role,
 		Confirmed:              confirmed,
 		Approved:               approved,
 		Disabled:               disabled,

--- a/internal/typeutils/internaltofrontend_test.go
+++ b/internal/typeutils/internaltofrontend_test.go
@@ -63,7 +63,9 @@ func (suite *InternalToFrontendTestSuite) TestAccountToFrontend() {
   "emojis": [],
   "fields": [],
   "enable_rss": true,
-  "role": "user"
+  "role": {
+    "name": "user"
+  }
 }`, string(b))
 }
 
@@ -109,7 +111,9 @@ func (suite *InternalToFrontendTestSuite) TestAccountToFrontendWithEmojiStruct()
   ],
   "fields": [],
   "enable_rss": true,
-  "role": "user"
+  "role": {
+    "name": "user"
+  }
 }`, string(b))
 }
 
@@ -155,7 +159,9 @@ func (suite *InternalToFrontendTestSuite) TestAccountToFrontendWithEmojiIDs() {
   ],
   "fields": [],
   "enable_rss": true,
-  "role": "user"
+  "role": {
+    "name": "user"
+  }
 }`, string(b))
 }
 
@@ -198,7 +204,9 @@ func (suite *InternalToFrontendTestSuite) TestAccountToFrontendSensitive() {
     "follow_requests_count": 0
   },
   "enable_rss": true,
-  "role": "user"
+  "role": {
+    "name": "user"
+  }
 }`, string(b))
 }
 
@@ -258,7 +266,9 @@ func (suite *InternalToFrontendTestSuite) TestStatusToFrontend() {
     "emojis": [],
     "fields": [],
     "enable_rss": true,
-    "role": "admin"
+    "role": {
+      "name": "admin"
+    }
   },
   "media_attachments": [
     {
@@ -371,7 +381,9 @@ func (suite *InternalToFrontendTestSuite) TestStatusToFrontendUnknownLanguage() 
     "emojis": [],
     "fields": [],
     "enable_rss": true,
-    "role": "admin"
+    "role": {
+      "name": "admin"
+    }
   },
   "media_attachments": [
     {
@@ -553,7 +565,9 @@ func (suite *InternalToFrontendTestSuite) TestInstanceV1ToFrontend() {
     "emojis": [],
     "fields": [],
     "enable_rss": true,
-    "role": "admin"
+    "role": {
+      "name": "admin"
+    }
   },
   "max_toot_chars": 5000
 }`, string(b))
@@ -660,7 +674,9 @@ func (suite *InternalToFrontendTestSuite) TestInstanceV2ToFrontend() {
       "emojis": [],
       "fields": [],
       "enable_rss": true,
-      "role": "admin"
+      "role": {
+        "name": "admin"
+      }
     }
   },
   "rules": []
@@ -811,7 +827,9 @@ func (suite *InternalToFrontendTestSuite) TestReportToFrontend2() {
     "last_status_at": "2021-10-20T10:40:37.000Z",
     "emojis": [],
     "fields": [],
-    "role": "user"
+    "role": {
+      "name": "user"
+    }
   }
 }`, string(b))
 }
@@ -843,7 +861,9 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend1() {
     "ips": [],
     "locale": "",
     "invite_request": null,
-    "role": "user",
+    "role": {
+      "name": "user"
+    },
     "confirmed": false,
     "approved": false,
     "disabled": false,
@@ -882,7 +902,9 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend1() {
     "ips": [],
     "locale": "en",
     "invite_request": "",
-    "role": "user",
+    "role": {
+      "name": "user"
+    },
     "confirmed": true,
     "approved": true,
     "disabled": false,
@@ -909,7 +931,9 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend1() {
       "last_status_at": "2021-10-20T10:40:37.000Z",
       "emojis": [],
       "fields": [],
-      "role": "user"
+      "role": {
+        "name": "user"
+      }
     },
     "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
   },
@@ -923,7 +947,9 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend1() {
     "ips": [],
     "locale": "en",
     "invite_request": "",
-    "role": "admin",
+    "role": {
+      "name": "admin"
+    },
     "confirmed": true,
     "approved": true,
     "disabled": false,
@@ -951,7 +977,9 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend1() {
       "emojis": [],
       "fields": [],
       "enable_rss": true,
-      "role": "admin"
+      "role": {
+        "name": "admin"
+      }
     },
     "created_by_application_id": "01F8MGXQRHYF5QPMTMXP78QC2F"
   },
@@ -965,7 +993,9 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend1() {
     "ips": [],
     "locale": "en",
     "invite_request": "",
-    "role": "admin",
+    "role": {
+      "name": "admin"
+    },
     "confirmed": true,
     "approved": true,
     "disabled": false,
@@ -993,7 +1023,9 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend1() {
       "emojis": [],
       "fields": [],
       "enable_rss": true,
-      "role": "admin"
+      "role": {
+        "name": "admin"
+      }
     },
     "created_by_application_id": "01F8MGXQRHYF5QPMTMXP78QC2F"
   },
@@ -1030,7 +1062,9 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend2() {
     "ips": [],
     "locale": "en",
     "invite_request": "",
-    "role": "user",
+    "role": {
+      "name": "user"
+    },
     "confirmed": true,
     "approved": true,
     "disabled": false,
@@ -1057,7 +1091,9 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend2() {
       "last_status_at": "2021-10-20T10:40:37.000Z",
       "emojis": [],
       "fields": [],
-      "role": "user"
+      "role": {
+        "name": "user"
+      }
     },
     "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
   },
@@ -1071,7 +1107,9 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend2() {
     "ips": [],
     "locale": "",
     "invite_request": null,
-    "role": "user",
+    "role": {
+      "name": "user"
+    },
     "confirmed": false,
     "approved": false,
     "disabled": false,

--- a/web/source/settings/index.js
+++ b/web/source/settings/index.js
@@ -55,7 +55,7 @@ const nav = {
 const { sidebar, panelRouter } = require("./lib/get-views")(nav);
 
 function App({ account }) {
-	const isAdmin = account.role == "admin";
+	const isAdmin = account.role.name == "admin";
 	const [logoutQuery] = query.useLogoutMutation();
 
 	return (

--- a/web/source/settings/user/profile.js
+++ b/web/source/settings/user/profile.js
@@ -90,7 +90,7 @@ function UserProfileForm({ data: profile }) {
 					header={form.header.previewValue ?? profile.header}
 					display_name={form.displayName.value ?? profile.username}
 					username={profile.username}
-					role={profile.role}
+					role={profile.role.name}
 				/>
 				<div className="files">
 					<div>

--- a/web/template/profile.tmpl
+++ b/web/template/profile.tmpl
@@ -34,7 +34,7 @@
             <div class="usernamecontainer">
                 <div class="username">@{{ .account.Username }}@{{ .instance.AccountDomain }}</div>
                 {{- /* Only render account role if 1. it's present and 2. it's not equal to the standard 'user' role */ -}}
-                {{ if and (.account.Role) (ne .account.Role "user") }}<div class="role {{ .account.Role }}">{{ .account.Role }}</div>{{ end }}
+                {{ if and (.account.Role) (ne .account.Role.Name "user") }}<div class="role {{ .account.Role.Name }}">{{ .account.Role.Name }}</div>{{ end }}
             </div>
         </div>
         <div class="detailed">


### PR DESCRIPTION
- Change account role from string to object
- Update tests

# Description

Fedilab was unable to login due to an issue with parsing the `role` value. Account Role was changed to an object instead of a string to more closely match the Mastodon API with the current value of the role being used as the name of the role.
In API response `"role": "admin` is now `"role": {"name": "admin"}` which satisfies the Fedilab parsing and enables login.

closes #1479

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
