### PR TITLE
[chore] Move request validation earlier in client

### DIFF
--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -153,6 +153,11 @@ func New(cfg Config) *Client {
 // as the standard http.Client{}.Do() implementation except that response body will
 // be wrapped by an io.LimitReader() to limit response body sizes.
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	// Ensure this is a valid request
+	if err := ValidateRequest(req); err != nil {
+		return nil, err
+	}
+
 	// Get host's wait queue
 	wait := c.wait(req.Host)
 
@@ -196,11 +201,6 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		case wait <- struct{}{}:
 			defer func() { <-wait }()
 		}
-	}
-
-	// Firstly, ensure this is a valid request
-	if err := ValidateRequest(req); err != nil {
-		return nil, err
 	}
 
 	// Perform the HTTP request


### PR DESCRIPTION
# Description

This moves checking if the request is valid as early as possible in the chain. This should ensure that for an invalid request we never bother acquiring the wait queue and taking up a spot in it.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
