### PR TITLE
Fix failure to look up remote profiles with duplicate emojis in some cases

### DIFF
--- a/internal/ap/extract.go
+++ b/internal/ap/extract.go
@@ -453,6 +453,7 @@ func ExtractHashtag(i Hashtaggable) (*gtsmodel.Tag, error) {
 // ExtractEmojis returns a slice of emojis on the interface.
 func ExtractEmojis(i WithTag) ([]*gtsmodel.Emoji, error) {
 	emojis := []*gtsmodel.Emoji{}
+	emojiMap := make(map[string]*gtsmodel.Emoji)
 	tagsProp := i.GetActivityStreamsTag()
 	if tagsProp == nil {
 		return emojis, nil
@@ -477,6 +478,9 @@ func ExtractEmojis(i WithTag) ([]*gtsmodel.Emoji, error) {
 			continue
 		}
 
+		emojiMap[emoji.URI] = emoji
+	}
+	for _, emoji := range emojiMap {
 		emojis = append(emojis, emoji)
 	}
 	return emojis, nil


### PR DESCRIPTION
# Description

Fix a bug where Misskey could send accounts with duplicate emojis, which we would then fail to process.

Also tidies up the local profile edit logic to make sure we don't set duplicate emojis that way, just in case.

closes #1532

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
