### PR TITLE
[docs] Add site_url for absolute 404 page assets

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: GoToSocial Documentation
+site_url: https://docs.gotosocial.org
 theme:
   name: material
   language: en


### PR DESCRIPTION
# Description

Weird mkdocs/read-the-docs issue for 404 pages, seems setting the site_url might fix the asset links for the 404 pages.