### PR TITLE
[bugfix] Remove initial storage cleanup

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -33,7 +33,6 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
-	"github.com/superseriousbusiness/gotosocial/internal/log"
 )
 
 const (
@@ -126,11 +125,6 @@ func NewFileStorage() (*Driver, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error opening disk storage: %w", err)
-	}
-
-	// Perform an initial storage clean to delete old dirs.
-	if err := disk.Clean(context.Background()); err != nil {
-		log.Errorf(nil, "error performing storage cleanup: %v", err)
 	}
 
 	return &Driver{


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request removes the initial disk storage cleanup, which was likely what was causing minutes-long delays for some people when restarting their instance. The cleanup is already part of the nightly media prune cycle, so the startup clean wasn't really needed anymore anyways.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
