### PR TITLE
[chore] improve opengraph descripiton tag

### DIFF
--- a/internal/web/opengraph.go
+++ b/internal/web/opengraph.go
@@ -134,11 +134,11 @@ func parseTitle(account *apimodel.Account, accountDomain string) string {
 // parseDescription returns a string description which is
 // safe to use as a template.HTMLAttr inside templates.
 func parseDescription(in string) string {
-	i := html.UnescapeString(in)
-	i = text.SanitizePlaintext(i)
-	i = strings.ReplaceAll(i, "\"", "'")
-	i = strings.ReplaceAll(i, `\`, "")
+	i := text.SanitizePlaintext(in)
 	i = strings.ReplaceAll(i, "\n", " ")
+	i = strings.Join(strings.Fields(i), " ")
+	i = html.EscapeString(i)
+	i = strings.ReplaceAll(i, `\`, "&bsol;")
 	i = trim(i, maxOGDescriptionLength)
 	return `content="` + i + `"`
 }

--- a/internal/web/opengraph_test.go
+++ b/internal/web/opengraph_test.go
@@ -1,0 +1,50 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2023 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package web
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type OpenGraphTestSuite struct {
+	suite.Suite
+}
+
+func (suite *OpenGraphTestSuite) TestParseDescription() {
+	tests := []struct {
+		name, in, exp string
+	}{
+		{name: "shellcmd", in: `echo '\e]8;;http://example.com\e\This is a link\e]8;;\e'`, exp: `echo &#39;&bsol;e]8;;http://example.com&bsol;e&bsol;This is a link&bsol;e]8;;&bsol;e&#39;`},
+		{name: "newlines", in: "test\n\ntest\ntest", exp: "test test test"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		suite.Run(tt.name, func() {
+			suite.Equal(fmt.Sprintf("content=\"%s\"", tt.exp), parseDescription(tt.in))
+		})
+	}
+}
+
+func TestOpenGraphTestSuite(t *testing.T) {
+	suite.Run(t, &OpenGraphTestSuite{})
+}


### PR DESCRIPTION
# Description

This changes parseDescription to properly encode things to be safe for usage without removing things like backslashes that may be relevant.

* text.SanitizePlaintext already calls html.UnescapeString so we don't have to do that
* Replace `\n` with space early
* Remove duplicate white-space by splitting on fields and joining
* HTML-escape the string we have
* For extra certainty, encode the backslash as `&bsol;`

Fixes #1549

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
