### PR TITLE
[bugfix] Fix deleted status causing issues when getting bookmark

### DIFF
--- a/internal/api/client/bookmarks/bookmarks_test.go
+++ b/internal/api/client/bookmarks/bookmarks_test.go
@@ -141,6 +141,7 @@ func (suite *BookmarkTestSuite) TestGetBookmark() {
 	suite.NoError(err)
 
 	suite.Equal(1, len(statuses))
+	suite.Equal(`<http://localhost:8080/api/v1/bookmarks?limit=30&max_id=01F8MHD2QCZSZ6WQS2ATVPEYJ9>; rel="next", <http://localhost:8080/api/v1/bookmarks?limit=30&min_id=01F8MHD2QCZSZ6WQS2ATVPEYJ9>; rel="prev"`, result.Header.Get("link"))
 }
 
 func TestBookmarkTestSuite(t *testing.T) {

--- a/internal/processing/fromcommon.go
+++ b/internal/processing/fromcommon.go
@@ -456,6 +456,11 @@ func (p *Processor) wipeStatus(ctx context.Context, statusToDelete *gtsmodel.Sta
 		return err
 	}
 
+	// delete all bookmarks that point to this status
+	if err := p.db.DeleteWhere(ctx, []db.Where{{Key: "status_id", Value: statusToDelete.ID}}, &[]*gtsmodel.StatusBookmark{}); err != nil {
+		return err
+	}
+
 	// delete all boosts for this status + remove them from timelines
 	if boosts, err := p.db.GetStatusReblogs(ctx, statusToDelete); err == nil {
 		for _, b := range boosts {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This PR fixes a bug where it was possible for a status to be deleted, but a bookmark to that status to remain, causing a GET to bookmarks to return an internal server error.

Now, bookmarks pointing to a status are deleted when that status is deleted.

The bookmark fetching subprocessor function has also been fine tuned to be a bit neater and more fault tolerant.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
