### PR TITLE
[chore] Update vscode launch configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,14 +2,18 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"name": "Launch Package",
+			"name": "Debug Package",
 			"type": "go",
 			"request": "launch",
-			"mode": "auto",
+			"mode": "debug",
 			"program": "${workspaceFolder}/cmd/gotosocial",
 			"args": [
 				"testrig", "start"
 			],
+			"buildFlags": "-tags='netgo osusergo static_build kvformat debugenv'",
+			"env": {
+				"DEBUG": "1",
+			},
 			"cwd": "${workspaceFolder}"
 		}
 	]


### PR DESCRIPTION
# Description

In order to get testrig we have to build with the debugenv tag and run with the DEBUG environment variable. Since this is a Debug build this also updates the launch configuration name to reflect that.

We do not build with `-ldflags="-s -w"` since that strips debug info.

This makes it possible to launch GtS from VS Code in debug mode, set breakpoints in the editor etc.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
