### PR TITLE
[chore] Inform user on how to get testrig

### DIFF
--- a/cmd/gotosocial/main.go
+++ b/cmd/gotosocial/main.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"log"
+	"os"
 	godebug "runtime/debug"
 	"strings"
 
@@ -66,6 +67,8 @@ func main() {
 	if debug.DEBUG {
 		// only add testrig if debug enabled.
 		rootCmd.AddCommand(testrigCommands())
+	} else if len(os.Args) > 1 && os.Args[1] == "testrig" {
+		log.Fatalln("gotosocial must be built and run with the DEBUG enviroment variable set to enable and access testrig")
 	}
 
 	// run


### PR DESCRIPTION
# Description

This adds a dummy testrig subcommand when we're not building with DEBUG set. Now any invocation of gotosocial testrig, plain or with any kind of subcommands or arguments will result in that error message getting returned.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
