### PR TITLE
[chore/performance] simplify storage driver to use storage.Storage directly

### DIFF
--- a/internal/api/client/media/mediacreate_test.go
+++ b/internal/api/client/media/mediacreate_test.go
@@ -136,15 +136,13 @@ func (suite *MediaCreateTestSuite) TestMediaCreateSuccessful() {
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 
 	// see what's in storage *before* the request
-	storageKeysBeforeRequest := []string{}
-	iter, err := suite.storage.KVStore.Iterator(context.Background(), nil)
-	if err != nil {
+	var storageKeysBeforeRequest []string
+	if err := suite.storage.WalkKeys(ctx, func(ctx context.Context, key string) error {
+		storageKeysBeforeRequest = append(storageKeysBeforeRequest, key)
+		return nil
+	}); err != nil {
 		panic(err)
 	}
-	for iter.Next() {
-		storageKeysBeforeRequest = append(storageKeysBeforeRequest, iter.Key())
-	}
-	iter.Release()
 
 	// create the request
 	buf, w, err := testrig.CreateMultipartFormData("file", "../../../../testrig/media/test-jpeg.jpg", map[string]string{
@@ -163,15 +161,13 @@ func (suite *MediaCreateTestSuite) TestMediaCreateSuccessful() {
 	suite.mediaModule.MediaCreatePOSTHandler(ctx)
 
 	// check what's in storage *after* the request
-	storageKeysAfterRequest := []string{}
-	iter, err = suite.storage.KVStore.Iterator(context.Background(), nil)
-	if err != nil {
+	var storageKeysAfterRequest []string
+	if err := suite.storage.WalkKeys(ctx, func(ctx context.Context, key string) error {
+		storageKeysAfterRequest = append(storageKeysAfterRequest, key)
+		return nil
+	}); err != nil {
 		panic(err)
 	}
-	for iter.Next() {
-		storageKeysAfterRequest = append(storageKeysAfterRequest, iter.Key())
-	}
-	iter.Release()
 
 	// check response
 	suite.EqualValues(http.StatusOK, recorder.Code)
@@ -225,15 +221,13 @@ func (suite *MediaCreateTestSuite) TestMediaCreateSuccessfulV2() {
 	ctx.Set(oauth.SessionAuthorizedAccount, suite.testAccounts["local_account_1"])
 
 	// see what's in storage *before* the request
-	storageKeysBeforeRequest := []string{}
-	iter, err := suite.storage.KVStore.Iterator(context.Background(), nil)
-	if err != nil {
+	var storageKeysBeforeRequest []string
+	if err := suite.storage.WalkKeys(ctx, func(ctx context.Context, key string) error {
+		storageKeysBeforeRequest = append(storageKeysBeforeRequest, key)
+		return nil
+	}); err != nil {
 		panic(err)
 	}
-	for iter.Next() {
-		storageKeysBeforeRequest = append(storageKeysBeforeRequest, iter.Key())
-	}
-	iter.Release()
 
 	// create the request
 	buf, w, err := testrig.CreateMultipartFormData("file", "../../../../testrig/media/test-jpeg.jpg", map[string]string{
@@ -252,15 +246,13 @@ func (suite *MediaCreateTestSuite) TestMediaCreateSuccessfulV2() {
 	suite.mediaModule.MediaCreatePOSTHandler(ctx)
 
 	// check what's in storage *after* the request
-	storageKeysAfterRequest := []string{}
-	iter, err = suite.storage.KVStore.Iterator(context.Background(), nil)
-	if err != nil {
+	var storageKeysAfterRequest []string
+	if err := suite.storage.WalkKeys(ctx, func(ctx context.Context, key string) error {
+		storageKeysAfterRequest = append(storageKeysAfterRequest, key)
+		return nil
+	}); err != nil {
 		panic(err)
 	}
-	for iter.Next() {
-		storageKeysAfterRequest = append(storageKeysAfterRequest, iter.Key())
-	}
-	iter.Release()
 
 	// check response
 	suite.EqualValues(http.StatusOK, recorder.Code)

--- a/internal/media/manager_test.go
+++ b/internal/media/manager_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"codeberg.org/gruf/go-store/v2/kv"
 	"codeberg.org/gruf/go-store/v2/storage"
 	"github.com/stretchr/testify/suite"
 	gtsmodel "github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
@@ -1196,7 +1195,6 @@ func (suite *ManagerTestSuite) TestSimpleJpegProcessBlockingWithDiskStorage() {
 	defer state.Workers.Stop()
 
 	storage := &gtsstorage.Driver{
-		KVStore: kv.New(disk),
 		Storage: disk,
 	}
 	state.Storage = storage

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -94,6 +94,10 @@ func (d *Driver) WalkKeys(ctx context.Context, walk func(context.Context, string
 	})
 }
 
+func (d *Driver) Close() error {
+	return d.Storage.Close()
+}
+
 // URL will return a presigned GET object URL, but only if running on S3 storage with proxying disabled.
 func (d *Driver) URL(ctx context.Context, key string) *PresignedURL {
 	// Check whether S3 *without* proxying is enabled

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -62,30 +62,37 @@ type Driver struct {
 	PresignedCache *ttl.Cache[string, PresignedURL]
 }
 
+// Get returns the byte value for key in storage.
 func (d *Driver) Get(ctx context.Context, key string) ([]byte, error) {
 	return d.Storage.ReadBytes(ctx, key)
 }
 
+// GetStream returns an io.ReadCloser for the value bytes at key in the storage.
 func (d *Driver) GetStream(ctx context.Context, key string) (io.ReadCloser, error) {
 	return d.Storage.ReadStream(ctx, key)
 }
 
+// Put writes the supplied value bytes at key in the storage
 func (d *Driver) Put(ctx context.Context, key string, value []byte) (int, error) {
 	return d.Storage.WriteBytes(ctx, key, value)
 }
 
+// PutStream writes the bytes from supplied reader at key in the storage
 func (d *Driver) PutStream(ctx context.Context, key string, r io.Reader) (int64, error) {
 	return d.Storage.WriteStream(ctx, key, r)
 }
 
+// Remove attempts to remove the supplied key (and corresponding value) from storage.
 func (d *Driver) Delete(ctx context.Context, key string) error {
 	return d.Storage.Remove(ctx, key)
 }
 
+// Has checks if the supplied key is in the storage.
 func (d *Driver) Has(ctx context.Context, key string) (bool, error) {
 	return d.Storage.Stat(ctx, key)
 }
 
+// WalkKeys walks the keys in the storage.
 func (d *Driver) WalkKeys(ctx context.Context, walk func(context.Context, string) error) error {
 	return d.Storage.WalkKeys(ctx, storage.WalkKeysOptions{
 		WalkFn: func(ctx context.Context, entry storage.Entry) error {
@@ -94,6 +101,7 @@ func (d *Driver) WalkKeys(ctx context.Context, walk func(context.Context, string
 	})
 }
 
+// Close will close the storage, releasing any file locks.
 func (d *Driver) Close() error {
 	return d.Storage.Close()
 }

--- a/testrig/storage.go
+++ b/testrig/storage.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path"
 
-	"codeberg.org/gruf/go-store/v2/kv"
 	"codeberg.org/gruf/go-store/v2/storage"
 	gtsstorage "github.com/superseriousbusiness/gotosocial/internal/storage"
 )
@@ -33,7 +32,6 @@ import (
 func NewInMemoryStorage() *gtsstorage.Driver {
 	storage := storage.OpenMemory(200, false)
 	return &gtsstorage.Driver{
-		KVStore: kv.New(storage),
 		Storage: storage,
 	}
 }
@@ -95,30 +93,18 @@ func StandardStorageSetup(storage *gtsstorage.Driver, relativePath string) {
 	}
 }
 
-// StandardStorageTeardown deletes everything in storage so that it's clean for
-// the next test
-// nolint:gocritic // complains about the type switch, but it's the cleanest solution
+// StandardStorageTeardown deletes everything in storage so that it's clean for the next test.
 func StandardStorageTeardown(storage *gtsstorage.Driver) {
 	defer os.RemoveAll(path.Join(os.TempDir(), "gotosocial"))
 
-	// Open a storage iterator
-	iter, err := storage.Iterator(context.Background(), nil)
-	if err != nil {
-		panic(err)
-	}
-
 	var keys []string
 
-	for iter.Next() {
-		// Collate all of the storage keys
-		keys = append(keys, iter.Key())
-	}
-
-	// Done with iter
-	iter.Release()
+	_ = storage.WalkKeys(context.Background(), func(ctx context.Context, key string) error {
+		keys = append(keys, key)
+		return nil
+	})
 
 	for _, key := range keys {
-		// Ignore errors, we just want to attempt delete all
-		_ = storage.Delete(context.Background(), key)
+		storage.Delete(context.Background(), key)
 	}
 }

--- a/testrig/storage.go
+++ b/testrig/storage.go
@@ -105,6 +105,6 @@ func StandardStorageTeardown(storage *gtsstorage.Driver) {
 	})
 
 	for _, key := range keys {
-		storage.Delete(context.Background(), key)
+		_ = storage.Delete(context.Background(), key)
 	}
 }


### PR DESCRIPTION
This simplifies our storage driver to directly use the interface type `storage.Storage` instead of the wrapping type `kv.KVStore{}`. We are using this is an adaptable media storage interface, but `kv.KVStore{}` is more intended for use as a key-value store, and as such uses a per-key mutex locking system which we don't need. This PR instead just updates us to use the underlying storage interface type directly, though using `kv.KVStore{}` like wrapper functions to prevent a huge number of required code changes.

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
