### PR TITLE
[bugfix] Add `ON CONFLICT` statements to status updates

### DIFF
--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -200,7 +200,9 @@ func (s *statusDB) PutStatus(ctx context.Context, status *gtsmodel.Status) db.Er
 					Model(&gtsmodel.StatusToEmoji{
 						StatusID: status.ID,
 						EmojiID:  i,
-					}).Exec(ctx); err != nil {
+					}).
+					On("CONFLICT (?, ?) DO NOTHING", bun.Ident("status_id"), bun.Ident("emoji_id")).
+					Exec(ctx); err != nil {
 					err = s.conn.ProcessError(err)
 					if !errors.Is(err, db.ErrAlreadyExists) {
 						return err
@@ -215,7 +217,9 @@ func (s *statusDB) PutStatus(ctx context.Context, status *gtsmodel.Status) db.Er
 					Model(&gtsmodel.StatusToTag{
 						StatusID: status.ID,
 						TagID:    i,
-					}).Exec(ctx); err != nil {
+					}).
+					On("CONFLICT (?, ?) DO NOTHING", bun.Ident("status_id"), bun.Ident("tag_id")).
+					Exec(ctx); err != nil {
 					err = s.conn.ProcessError(err)
 					if !errors.Is(err, db.ErrAlreadyExists) {
 						return err
@@ -261,7 +265,9 @@ func (s *statusDB) UpdateStatus(ctx context.Context, status *gtsmodel.Status, co
 				Model(&gtsmodel.StatusToEmoji{
 					StatusID: status.ID,
 					EmojiID:  i,
-				}).Exec(ctx); err != nil {
+				}).
+				On("CONFLICT (?, ?) DO NOTHING", bun.Ident("status_id"), bun.Ident("emoji_id")).
+				Exec(ctx); err != nil {
 				err = s.conn.ProcessError(err)
 				if !errors.Is(err, db.ErrAlreadyExists) {
 					return err
@@ -276,7 +282,9 @@ func (s *statusDB) UpdateStatus(ctx context.Context, status *gtsmodel.Status, co
 				Model(&gtsmodel.StatusToTag{
 					StatusID: status.ID,
 					TagID:    i,
-				}).Exec(ctx); err != nil {
+				}).
+				On("CONFLICT (?, ?) DO NOTHING", bun.Ident("status_id"), bun.Ident("tag_id")).
+				Exec(ctx); err != nil {
 				err = s.conn.ProcessError(err)
 				if !errors.Is(err, db.ErrAlreadyExists) {
 					return err
@@ -300,7 +308,7 @@ func (s *statusDB) UpdateStatus(ctx context.Context, status *gtsmodel.Status, co
 			}
 		}
 
-		// Finally, insert the status
+		// Finally, update the status
 		_, err := tx.
 			NewUpdate().
 			Model(status).


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request adds some `ON CONFLICT DO NOTHING` clauses to our queries, to prevent postgres transactions from being aborted even though we're catching errors nicely. Postgres considers a transaction in which errors have occurred to be a bad transaction, and will refuse further queries against it with `current transaction is aborted, commands ignored until end of transaction block`. We were running into this in our status update statements specifically, because we create new status_to_emoji and status_to_tag entries in there, but often those exist already.

Also added a test case to catch this, and instructions for running this specific test against postgres.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
