### PR TITLE
[bugfix] Federate status Delete using just the URI, update Delete addressing

### DIFF
--- a/internal/typeutils/converter.go
+++ b/internal/typeutils/converter.go
@@ -148,6 +148,9 @@ type TypeConverter interface {
 	AccountToASMinimal(ctx context.Context, a *gtsmodel.Account) (vocab.ActivityStreamsPerson, error)
 	// StatusToAS converts a gts model status into an activity streams note, suitable for federation
 	StatusToAS(ctx context.Context, s *gtsmodel.Status) (vocab.ActivityStreamsNote, error)
+	// StatusToASDelete converts a gts model status into a Delete of that status, using just the
+	// URI of the status as object, and addressing the Delete appropriately.
+	StatusToASDelete(ctx context.Context, status *gtsmodel.Status) (vocab.ActivityStreamsDelete, error)
 	// FollowToASFollow converts a gts model Follow into an activity streams Follow, suitable for federation
 	FollowToAS(ctx context.Context, f *gtsmodel.Follow, originAccount *gtsmodel.Account, targetAccount *gtsmodel.Account) (vocab.ActivityStreamsFollow, error)
 	// MentionToAS converts a gts model mention into an activity streams Mention, suitable for federation

--- a/internal/typeutils/converter_test.go
+++ b/internal/typeutils/converter_test.go
@@ -477,6 +477,7 @@ type TypeUtilsTestSuite struct {
 	testPeople      map[string]vocab.ActivityStreamsPerson
 	testEmojis      map[string]*gtsmodel.Emoji
 	testReports     map[string]*gtsmodel.Report
+	testMentions    map[string]*gtsmodel.Mention
 
 	typeconverter typeutils.TypeConverter
 }
@@ -495,6 +496,7 @@ func (suite *TypeUtilsTestSuite) SetupSuite() {
 	suite.testPeople = testrig.NewTestFediPeople()
 	suite.testEmojis = testrig.NewTestEmojis()
 	suite.testReports = testrig.NewTestReports()
+	suite.testMentions = testrig.NewTestMentions()
 	suite.typeconverter = typeutils.NewConverter(suite.db)
 }
 

--- a/internal/typeutils/internaltoas_test.go
+++ b/internal/typeutils/internaltoas_test.go
@@ -430,6 +430,116 @@ func (suite *InternalToASTestSuite) TestStatusToASWithMentions() {
 }`, string(bytes))
 }
 
+func (suite *InternalToASTestSuite) TestStatusToASDeletePublicReply() {
+	testStatus := suite.testStatuses["admin_account_status_3"]
+	ctx := context.Background()
+
+	asDelete, err := suite.typeconverter.StatusToASDelete(ctx, testStatus)
+	suite.NoError(err)
+
+	ser, err := streams.Serialize(asDelete)
+	suite.NoError(err)
+
+	bytes, err := json.MarshalIndent(ser, "", "  ")
+	suite.NoError(err)
+
+	suite.Equal(`{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "actor": "http://localhost:8080/users/admin",
+  "cc": [
+    "http://localhost:8080/users/admin/followers",
+    "http://localhost:8080/users/the_mighty_zork"
+  ],
+  "object": "http://localhost:8080/users/admin/statuses/01FF25D5Q0DH7CHD57CTRS6WK0",
+  "to": "https://www.w3.org/ns/activitystreams#Public",
+  "type": "Delete"
+}`, string(bytes))
+}
+
+func (suite *InternalToASTestSuite) TestStatusToASDeletePublicReplyOriginalDeleted() {
+	testStatus := suite.testStatuses["admin_account_status_3"]
+	ctx := context.Background()
+
+  // Delete the status this replies to.
+  if err := suite.db.DeleteStatusByID(ctx, testStatus.ID); err != nil {
+    suite.FailNow(err.Error())
+  }
+
+  // Delete the mention the reply created.
+  mention := suite.testMentions["admin_account_mention_zork"]
+  if err := suite.db.DeleteByID(ctx, mention.ID, mention); err != nil {
+    suite.FailNow(err.Error())
+  }
+
+  // The delete should still be created OK.
+	asDelete, err := suite.typeconverter.StatusToASDelete(ctx, testStatus)
+	suite.NoError(err)
+
+	ser, err := streams.Serialize(asDelete)
+	suite.NoError(err)
+
+	bytes, err := json.MarshalIndent(ser, "", "  ")
+	suite.NoError(err)
+
+	suite.Equal(`{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "actor": "http://localhost:8080/users/admin",
+  "cc": [
+    "http://localhost:8080/users/admin/followers",
+    "http://localhost:8080/users/the_mighty_zork"
+  ],
+  "object": "http://localhost:8080/users/admin/statuses/01FF25D5Q0DH7CHD57CTRS6WK0",
+  "to": "https://www.w3.org/ns/activitystreams#Public",
+  "type": "Delete"
+}`, string(bytes))
+}
+
+func (suite *InternalToASTestSuite) TestStatusToASDeletePublic() {
+	testStatus := suite.testStatuses["admin_account_status_1"]
+	ctx := context.Background()
+
+	asDelete, err := suite.typeconverter.StatusToASDelete(ctx, testStatus)
+	suite.NoError(err)
+
+	ser, err := streams.Serialize(asDelete)
+	suite.NoError(err)
+
+	bytes, err := json.MarshalIndent(ser, "", "  ")
+	suite.NoError(err)
+
+	suite.Equal(`{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "actor": "http://localhost:8080/users/admin",
+  "cc": "http://localhost:8080/users/admin/followers",
+  "object": "http://localhost:8080/users/admin/statuses/01F8MH75CBF9JFX4ZAD54N0W0R",
+  "to": "https://www.w3.org/ns/activitystreams#Public",
+  "type": "Delete"
+}`, string(bytes))
+}
+
+func (suite *InternalToASTestSuite) TestStatusToASDeleteDirectMessage() {
+	testStatus := suite.testStatuses["local_account_2_status_6"]
+	ctx := context.Background()
+
+	asDelete, err := suite.typeconverter.StatusToASDelete(ctx, testStatus)
+	suite.NoError(err)
+
+	ser, err := streams.Serialize(asDelete)
+	suite.NoError(err)
+
+	bytes, err := json.MarshalIndent(ser, "", "  ")
+	suite.NoError(err)
+
+	suite.Equal(`{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "actor": "http://localhost:8080/users/1happyturtle",
+  "cc": [],
+  "object": "http://localhost:8080/users/1happyturtle/statuses/01FN3VJGFH10KR7S2PB0GFJZYG",
+  "to": "http://localhost:8080/users/the_mighty_zork",
+  "type": "Delete"
+}`, string(bytes))
+}
+
 func (suite *InternalToASTestSuite) TestStatusesToASOutboxPage() {
 	testAccount := suite.testAccounts["admin_account"]
 	ctx := context.Background()


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates some of our status delete logic to federate the Delete using only the URI of the status.

It also updates the addressing of the Delete to always include the ActivityPub public URI in the `to` field unless the deleted post was a direct message, and also to always CC the replied-to user (if present) with the delete.

This should help to ensure that Deletes are federated a bit more widely. The trade off is that remote instances might become aware of the URI of now-deleted posts that were not originally addressed to them (but which they might have seen through some other method). Since it's just the URI and not the status itself, which can't possibly now be dereferenced, this seems a worthy tradeoff.

In future, we should also look at addressing deletes of non-direct messages to all known sharedInboxes, a little bit like mastodon does, but for now this is better than nothing :)

The PR also adds some documentation about how GtS handles deletes, under the 'federating with gotosocial' section.

closes https://github.com/superseriousbusiness/gotosocial/issues/1526

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
