### PR TITLE
[bugfix] internal server error on search not found

### DIFF
--- a/internal/federation/authenticate.go
+++ b/internal/federation/authenticate.go
@@ -25,6 +25,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -226,7 +227,7 @@ func (f *federator) AuthenticateFederatedRequest(ctx context.Context, requestedU
 		// The actual http call to the remote server is made right here in the Dereference function.
 		b, err := trans.Dereference(ctx, requestingPublicKeyID)
 		if err != nil {
-			if errors.Is(err, transport.ErrGone) {
+			if gtserror.StatusCode(err) == http.StatusGone {
 				// if we get a 410 error it means the account that owns this public key has been deleted;
 				// we should add a tombstone to our database so that we can avoid trying to deref it in future
 				if err := f.HandleGone(ctx, requestingPublicKeyID); err != nil {

--- a/internal/federation/federatingprotocol.go
+++ b/internal/federation/federatingprotocol.go
@@ -31,6 +31,7 @@ import (
 	"github.com/superseriousbusiness/activity/streams/vocab"
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/transport"
@@ -210,7 +211,7 @@ func (f *federator) AuthenticatePostInbox(ctx context.Context, w http.ResponseWr
 		transport.WithFastfail(ctx), username, publicKeyOwnerURI, false,
 	)
 	if err != nil {
-		if errors.Is(err, transport.ErrGone) {
+		if gtserror.StatusCode(err) == http.StatusGone {
 			// This is the same case as the http.StatusGone check above.
 			// It can happen here and not there because there's a race
 			// where the sending server starts sending account deletion

--- a/internal/gtserror/error.go
+++ b/internal/gtserror/error.go
@@ -1,0 +1,49 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2023 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package gtserror
+
+import (
+	"codeberg.org/gruf/go-errors/v2"
+)
+
+type errkey int
+
+const (
+	_ errkey = iota
+	statusCodeKey
+	notFoundKey
+)
+
+func StatusCode(err error) int {
+	i, _ := errors.Value(err, statusCodeKey).(int)
+	return i
+}
+
+func WithStatusCode(err error, code int) error {
+	return errors.WithValue(err, statusCodeKey, code)
+}
+
+func NotFound(err error) bool {
+	_, ok := errors.Value(err, notFoundKey).(struct{})
+	return ok
+}
+
+func SetNotFound(err error) error {
+	return errors.WithValue(err, notFoundKey, struct{}{})
+}

--- a/internal/gtserror/error.go
+++ b/internal/gtserror/error.go
@@ -22,28 +22,39 @@ import (
 	"codeberg.org/gruf/go-errors/v2"
 )
 
+// package private error key type.
 type errkey int
 
 const (
+	// error value keys.
 	_ errkey = iota
 	statusCodeKey
 	notFoundKey
 )
 
+// StatusCode checks error for a stored status code value. For example
+// an error from an outgoing HTTP request may be stored, or an API handler
+// expected response status code may be stored.
 func StatusCode(err error) int {
 	i, _ := errors.Value(err, statusCodeKey).(int)
 	return i
 }
 
+// WithStatusCode will wrap the given error to store provided status code,
+// returning wrapped error. See StatusCode() for example use-cases.
 func WithStatusCode(err error, code int) error {
 	return errors.WithValue(err, statusCodeKey, code)
 }
 
+// NotFound checks error for a stored "not found" flag. For example
+// an error from an outgoing HTTP request due to DNS lookup.
 func NotFound(err error) bool {
 	_, ok := errors.Value(err, notFoundKey).(struct{})
 	return ok
 }
 
+// SetNotFound will wrap the given error to store a "not found" flag,
+// returning wrapped error. See NotFound() for example use-cases.
 func SetNotFound(err error) error {
 	return errors.WithValue(err, notFoundKey, struct{}{})
 }

--- a/internal/transport/deliver.go
+++ b/internal/transport/deliver.go
@@ -29,6 +29,7 @@ import (
 	"codeberg.org/gruf/go-byteutil"
 	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 )
 
 func (t *transport) BatchDeliver(ctx context.Context, b []byte, recipients []*url.URL) error {
@@ -96,7 +97,8 @@ func (t *transport) Deliver(ctx context.Context, b []byte, to *url.URL) error {
 
 	if code := resp.StatusCode; code != http.StatusOK &&
 		code != http.StatusCreated && code != http.StatusAccepted {
-		return fmt.Errorf("POST request to %s failed: %s", urlStr, resp.Status)
+		err := fmt.Errorf("POST request to %s failed: %s", urlStr, resp.Status)
+		return gtserror.WithStatusCode(err, resp.StatusCode)
 	}
 
 	return nil

--- a/internal/transport/derefinstance.go
+++ b/internal/transport/derefinstance.go
@@ -30,6 +30,7 @@ import (
 
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/id"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
@@ -102,7 +103,8 @@ func dereferenceByAPIV1Instance(ctx context.Context, t *transport, iri *url.URL)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET request to %s failed: %s", iriStr, resp.Status)
+		err := fmt.Errorf("GET request to %s failed: %s", iriStr, resp.Status)
+		return nil, gtserror.WithStatusCode(err, resp.StatusCode)
 	}
 
 	b, err := io.ReadAll(resp.Body)
@@ -252,7 +254,8 @@ func callNodeInfoWellKnown(ctx context.Context, t *transport, iri *url.URL) (*ur
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("callNodeInfoWellKnown: GET request to %s failed: %s", iriStr, resp.Status)
+		err := fmt.Errorf("GET request to %s failed: %s", iriStr, resp.Status)
+		return nil, gtserror.WithStatusCode(err, resp.StatusCode)
 	}
 
 	b, err := io.ReadAll(resp.Body)
@@ -303,7 +306,8 @@ func callNodeInfo(ctx context.Context, t *transport, iri *url.URL) (*apimodel.No
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("callNodeInfo: GET request to %s failed: %s", iriStr, resp.Status)
+		err := fmt.Errorf("GET request to %s failed: %s", iriStr, resp.Status)
+		return nil, gtserror.WithStatusCode(err, resp.StatusCode)
 	}
 
 	b, err := io.ReadAll(resp.Body)

--- a/internal/transport/derefmedia.go
+++ b/internal/transport/derefmedia.go
@@ -24,6 +24,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 )
 
 func (t *transport) DereferenceMedia(ctx context.Context, iri *url.URL) (io.ReadCloser, int64, error) {
@@ -46,7 +48,8 @@ func (t *transport) DereferenceMedia(ctx context.Context, iri *url.URL) (io.Read
 
 	// Check for an expected status code
 	if rsp.StatusCode != http.StatusOK {
-		return nil, 0, fmt.Errorf("GET request to %s failed: %s", iriStr, rsp.Status)
+		err := fmt.Errorf("GET request to %s failed: %s", iriStr, rsp.Status)
+		return nil, 0, gtserror.WithStatusCode(err, rsp.StatusCode)
 	}
 
 	return rsp.Body, rsp.ContentLength, nil


### PR DESCRIPTION
Changes:
- return early on DNS lookup not-found error in transport
- wrap transport errors to include HTTP status code, and "not found" on DNS lookup error
- update error checking to look for status codes (e.g. 401, 404) instead of transport.ErrGone
- update not-retrievable error checking to look for "not found" and "gone" (both HTTP status code and DNS lookup)

Checklist:
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
