### PR TITLE
[feature] Provide .well-known/host-meta endpoint

### DIFF
--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -43,6 +43,9 @@ host: "localhost"
 # to "gts.example.org/.well-known/webfinger" so that GtS can handle them properly.
 #
 # You should also redirect requests at "example.org/.well-known/nodeinfo" in the same way.
+#
+# You should also redirect requests at "example.org/.well-known/host-meta" in the same way. This endpoint is used by a number of clients to discover the API endpoint to use when the host and account domain are different.
+#
 # An empty string (ie., not set) means that the same value as 'host' will be used.
 #
 # DO NOT change this after your server has already run once, or you will break things!

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -55,6 +55,11 @@ host: "localhost"
 # to "gts.example.org/.well-known/webfinger" so that GtS can handle them properly.
 #
 # You should also redirect requests at "example.org/.well-known/nodeinfo" in the same way.
+#
+# You should also redirect requests at "example.org/.well-known/host-meta" in the same way. This endpoint
+# is used by a number of clients to discover the API endpoint to use when the host and account domain are
+# different.
+#
 # An empty string (ie., not set) means that the same value as 'host' will be used.
 #
 # DO NOT change this after your server has already run once, or you will break things!

--- a/internal/api/util/negotiate.go
+++ b/internal/api/util/negotiate.go
@@ -58,6 +58,11 @@ var HTMLOrActivityPubHeaders = []MIME{
 	AppActivityLDJSON,
 }
 
+var HostMetaHeaders = []MIME{
+	AppXMLXRD,
+	AppXML,
+}
+
 // NegotiateAccept takes the *gin.Context from an incoming request, and a
 // slice of Offers, and performs content negotiation for the given request
 // with the given content-type offers. It will return a string representation

--- a/internal/api/wellknown.go
+++ b/internal/api/wellknown.go
@@ -20,6 +20,7 @@ package api
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api/wellknown/hostmeta"
 	"github.com/superseriousbusiness/gotosocial/internal/api/wellknown/nodeinfo"
 	"github.com/superseriousbusiness/gotosocial/internal/api/wellknown/webfinger"
 	"github.com/superseriousbusiness/gotosocial/internal/middleware"
@@ -30,6 +31,7 @@ import (
 type WellKnown struct {
 	nodeInfo  *nodeinfo.Module
 	webfinger *webfinger.Module
+	hostMeta  *hostmeta.Module
 }
 
 func (w *WellKnown) Route(r router.Router, m ...gin.HandlerFunc) {
@@ -45,11 +47,13 @@ func (w *WellKnown) Route(r router.Router, m ...gin.HandlerFunc) {
 
 	w.nodeInfo.Route(wellKnownGroup.Handle)
 	w.webfinger.Route(wellKnownGroup.Handle)
+	w.hostMeta.Route(wellKnownGroup.Handle)
 }
 
 func NewWellKnown(p *processing.Processor) *WellKnown {
 	return &WellKnown{
 		nodeInfo:  nodeinfo.New(p),
 		webfinger: webfinger.New(p),
+		hostMeta:  hostmeta.New(p),
 	}
 }

--- a/internal/api/wellknown/hostmeta/hostmeta.go
+++ b/internal/api/wellknown/hostmeta/hostmeta.go
@@ -16,22 +16,30 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package util
+package hostmeta
 
-// MIME represents a mime-type.
-type MIME string
+import (
+	"net/http"
 
-// MIME type
-const (
-	AppJSON           MIME = `application/json`
-	AppXML            MIME = `application/xml`
-	AppXMLXRD         MIME = `application/xrd+xml`
-	AppRSSXML         MIME = `application/rss+xml`
-	AppActivityJSON   MIME = `application/activity+json`
-	AppActivityLDJSON MIME = `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`
-	AppForm           MIME = `application/x-www-form-urlencoded`
-	MultipartForm     MIME = `multipart/form-data`
-	TextXML           MIME = `text/xml`
-	TextHTML          MIME = `text/html`
-	TextCSS           MIME = `text/css`
+	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/processing"
 )
+
+const (
+	HostMetaContentType = "application/xrd+xml"
+	HostMetaPath        = "/host-meta"
+)
+
+type Module struct {
+	processor *processing.Processor
+}
+
+func New(processor *processing.Processor) *Module {
+	return &Module{
+		processor: processor,
+	}
+}
+
+func (m *Module) Route(attachHandler func(method string, path string, f ...gin.HandlerFunc) gin.IRoutes) {
+	attachHandler(http.MethodGet, HostMetaPath, m.HostMetaGETHandler)
+}

--- a/internal/api/wellknown/hostmeta/hostmetaget.go
+++ b/internal/api/wellknown/hostmeta/hostmetaget.go
@@ -1,0 +1,73 @@
+/*
+   GoToSocial
+   Copyright (C) 2021-2023 GoToSocial Authors admin@gotosocial.org
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package hostmeta
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/xml"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+)
+
+// HostMetaGETHandler swagger:operation GET /.well-known/host-meta hostMetaGet
+//
+// Returns a compliant hostmeta response to web host metadata queries.
+//
+// See: https://www.rfc-editor.org/rfc/rfc6415.html
+//
+//	---
+//	tags:
+//	- .well-known
+//
+//	produces:
+//	- application/xrd+xml"
+//
+//	responses:
+//		'200':
+//			schema:
+//				"$ref": "#/definitions/hostmeta"
+func (m *Module) HostMetaGETHandler(c *gin.Context) {
+	if _, err := apiutil.NegotiateAccept(c, apiutil.HostMetaHeaders...); err != nil {
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
+		return
+	}
+
+	hostMeta := m.processor.Fedi().HostMetaGet()
+
+	// this setup with a separate buffer we encode into is used because
+	// xml.Marshal does not emit xml.Header by itself
+	var b bytes.Buffer
+	data := bufio.NewWriter(&b)
+	if _, err := data.Write([]byte(xml.Header)); err != nil {
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
+		return
+	}
+
+	enc := xml.NewEncoder(data)
+	if err := enc.Encode(hostMeta); err != nil {
+		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
+		return
+	}
+
+	c.Data(http.StatusOK, HostMetaContentType, b.Bytes())
+}

--- a/internal/processing/fedi/wellknown.go
+++ b/internal/processing/fedi/wellknown.go
@@ -28,6 +28,10 @@ import (
 )
 
 const (
+	hostMetaXMLNS                   = "http://docs.oasis-open.org/ns/xri/xrd-1.0"
+	hostMetaRel                     = "lrdd"
+	hostMetaType                    = "application/xrd+xml"
+	hostMetaTemplate                = ".well-known/webfinger?resource={uri}"
 	nodeInfoVersion                 = "2.0"
 	nodeInfoSoftwareName            = "gotosocial"
 	nodeInfoRel                     = "http://nodeinfo.diaspora.software/ns/schema/" + nodeInfoVersion
@@ -94,6 +98,22 @@ func (p *Processor) NodeInfoGet(ctx context.Context) (*apimodel.Nodeinfo, gtserr
 		},
 		Metadata: nodeInfoMetadata,
 	}, nil
+}
+
+// HostMetaGet returns a host-meta struct in response to a host-meta request.
+func (p *Processor) HostMetaGet() *apimodel.HostMeta {
+	protocol := config.GetProtocol()
+	host := config.GetHost()
+	return &apimodel.HostMeta{
+		XMLNS: hostMetaXMLNS,
+		Link: []apimodel.Link{
+			{
+				Rel:      hostMetaRel,
+				Type:     hostMetaType,
+				Template: fmt.Sprintf("%s://%s/%s", protocol, host, hostMetaTemplate),
+			},
+		},
+	}
 }
 
 // WebfingerGet handles the GET for a webfinger resource. Most commonly, it will be used for returning account lookups.


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Host-meta is back baby!

So it turns out, when the account and instance domain aren't the same (say pixie.town vs social.pixie.town), the official Mastodon Android client uses the `host-meta` endpoint to discover what the "actual" domain is. Currently this fallback isn't happening for GtS instances because we don't provide `host-meta` making a number of Mastodon apps not work.

The iOS client doesn't do this but (yet) but that's tracked in https://github.com/mastodon/mastodon-ios/issues/967 for now.

I suspect a number of other clients might do this too and having `host-meta` would make more things work with GtS than what we initially thought.


## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
