### PR TITLE
[chore] Refactor timeline Get, other small fixes

### DIFF
--- a/internal/processing/statustimeline.go
+++ b/internal/processing/statustimeline.go
@@ -253,7 +253,7 @@ func (p *Processor) FavedTimelineGet(ctx context.Context, authed *oauth.Auth, ma
 		return util.EmptyPageableResponse(), nil
 	}
 
-	items := make([]interface{}, 0, len(filtered))
+	items := make([]interface{}, len(filtered))
 	for i, item := range filtered {
 		items[i] = item
 	}

--- a/internal/timeline/get.go
+++ b/internal/timeline/get.go
@@ -51,7 +51,7 @@ func (t *timeline) Get(ctx context.Context, amount int, maxID string, sinceID st
 	// last time Get was called for this timeline
 	t.Lock()
 	t.lastGot = time.Now()
-	t.Unlock()
+	t.Unlock()aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 	var items []Preparable
 	var err error

--- a/internal/timeline/get.go
+++ b/internal/timeline/get.go
@@ -358,11 +358,7 @@ func (t *timeline) getXBetweenID(ctx context.Context, amount int, behindID strin
 			items = append(items, entry.prepared)
 
 			served++
-			if served >= amount {
-				return false
-			}
-
-			return true
+			return served < amount
 		}
 	} else {
 		// Iterate through the list from the top, until

--- a/internal/timeline/get_test.go
+++ b/internal/timeline/get_test.go
@@ -53,7 +53,7 @@ func (suite *GetTestSuite) SetupTest() {
 	testrig.StandardDBSetup(suite.db, nil)
 
 	// let's take local_account_1 as the timeline owner
-	tl, err := timeline.NewTimeline(
+	tl := timeline.NewTimeline(
 		context.Background(),
 		suite.testAccounts["local_account_1"].ID,
 		processing.StatusGrabFunction(suite.db),
@@ -61,9 +61,6 @@ func (suite *GetTestSuite) SetupTest() {
 		processing.StatusPrepareFunction(suite.db, suite.tc),
 		processing.StatusSkipInsertFunction(),
 	)
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
 
 	// put the status IDs in a determinate order since we can't trust a map to keep its order
 	statuses := []*gtsmodel.Status{}

--- a/internal/timeline/index.go
+++ b/internal/timeline/index.go
@@ -210,7 +210,7 @@ func (t *timeline) IndexAndPrepareOne(ctx context.Context, statusID string, boos
 		return false, nil
 	}
 
-	return inserted, t.prepare(ctx, statusID)
+	return inserted, t.prepareOne(ctx, statusID)
 }
 
 func (t *timeline) OldestIndexedItemID(ctx context.Context) (string, error) {

--- a/internal/timeline/index_test.go
+++ b/internal/timeline/index_test.go
@@ -52,7 +52,7 @@ func (suite *IndexTestSuite) SetupTest() {
 	testrig.StandardDBSetup(suite.db, nil)
 
 	// let's take local_account_1 as the timeline owner, and start with an empty timeline
-	tl, err := timeline.NewTimeline(
+	suite.timeline = timeline.NewTimeline(
 		context.Background(),
 		suite.testAccounts["local_account_1"].ID,
 		processing.StatusGrabFunction(suite.db),
@@ -60,10 +60,6 @@ func (suite *IndexTestSuite) SetupTest() {
 		processing.StatusPrepareFunction(suite.db, suite.tc),
 		processing.StatusSkipInsertFunction(),
 	)
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
-	suite.timeline = tl
 }
 
 func (suite *IndexTestSuite) TearDownTest() {

--- a/internal/timeline/indexeditems.go
+++ b/internal/timeline/indexeditems.go
@@ -20,7 +20,9 @@ package timeline
 import (
 	"container/list"
 	"context"
-	"errors"
+	"fmt"
+
+	"github.com/superseriousbusiness/gotosocial/internal/log"
 )
 
 type indexedItems struct {
@@ -36,50 +38,84 @@ type indexedItemsEntry struct {
 }
 
 func (i *indexedItems) insertIndexed(ctx context.Context, newEntry *indexedItemsEntry) (bool, error) {
+	// Lazily init indexed items.
 	if i.data == nil {
 		i.data = &list.List{}
+		i.data.Init()
 	}
 
-	// if we have no entries yet, this is both the newest and oldest entry, so just put it in the front
 	if i.data.Len() == 0 {
+		// We have no entries yet, meaning this is both the
+		// newest + oldest entry, so just put it in the front.
 		i.data.PushFront(newEntry)
 		return true, nil
 	}
 
-	var insertMark *list.Element
-	var position int
-	// We need to iterate through the index to make sure we put this item in the appropriate place according to when it was created.
-	// We also need to make sure we're not inserting a duplicate item -- this can happen sometimes and it's not nice UX (*shudder*).
+	var (
+		insertMark      *list.Element
+		currentPosition int
+	)
+
+	// We need to iterate through the index to make sure we put
+	// this item in the appropriate place according to its id.
+	// We also need to make sure we're not inserting a duplicate
+	// item -- this can happen sometimes and it's sucky UX.
 	for e := i.data.Front(); e != nil; e = e.Next() {
-		position++
+		currentPosition++
 
-		entry, ok := e.Value.(*indexedItemsEntry)
+		currentEntry, ok := e.Value.(*indexedItemsEntry)
 		if !ok {
-			return false, errors.New("insertIndexed: could not parse e as an indexedItemsEntry")
+			log.Panic(ctx, "could not parse e as indexedItemsEntry")
 		}
 
-		skip, err := i.skipInsert(ctx, newEntry.itemID, newEntry.accountID, newEntry.boostOfID, newEntry.boostOfAccountID, entry.itemID, entry.accountID, entry.boostOfID, entry.boostOfAccountID, position)
-		if err != nil {
-			return false, err
-		}
-		if skip {
+		// Check if we need to skip inserting this item based on
+		// the current item.
+		//
+		// For example, if the new item is a boost, and the current
+		// item is the original, we may not want to insert the boost
+		// if it would appear very shortly after the original.
+		if skip, err := i.skipInsert(
+			ctx,
+			newEntry.itemID,
+			newEntry.accountID,
+			newEntry.boostOfID,
+			newEntry.boostOfAccountID,
+			currentEntry.itemID,
+			currentEntry.accountID,
+			currentEntry.boostOfID,
+			currentEntry.boostOfAccountID,
+			currentPosition,
+		); err != nil {
+			return false, fmt.Errorf("insertIndexed: error calling skipInsert: %w", err)
+		} else if skip {
+			// We don't need to insert this at all,
+			// so we can safely bail.
 			return false, nil
 		}
 
-		// if the item to index is newer than e, insert it before e in the list
-		if insertMark == nil {
-			if newEntry.itemID > entry.itemID {
-				insertMark = e
-			}
+		if insertMark != nil {
+			// We already found our mark.
+			continue
 		}
+
+		if currentEntry.itemID > newEntry.itemID {
+			// We're still in items newer than
+			// the one we're trying to insert.
+			continue
+		}
+
+		// We found our spot!
+		insertMark = e
 	}
 
-	if insertMark != nil {
-		i.data.InsertBefore(newEntry, insertMark)
+	if insertMark == nil {
+		// We looked through the whole timeline and didn't find
+		// a mark, so the new item is the oldest item we've seen;
+		// insert it at the back.
+		i.data.PushBack(newEntry)
 		return true, nil
 	}
 
-	// if we reach this point it's the oldest item we've seen so put it at the back
-	i.data.PushBack(newEntry)
+	i.data.InsertBefore(newEntry, insertMark)
 	return true, nil
 }

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -193,7 +193,7 @@ func (m *manager) GetOldestIndexedID(ctx context.Context, accountID string) (str
 }
 
 func (m *manager) PrepareXFromTop(ctx context.Context, accountID string, limit int) error {
-	return m.getOrCreateTimeline(ctx, accountID).PrepareFromTop(ctx, limit)
+	return m.getOrCreateTimeline(ctx, accountID).PrepareXFromTop(ctx, limit)
 }
 
 func (m *manager) WipeItemFromAllTimelines(ctx context.Context, statusID string) error {

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -52,7 +52,7 @@ type Manager interface {
 	// The returned bool indicates whether the item was actually put in the timeline. This could be false in cases where
 	// the item is a boosted status, but a boost of the original status or the status itself already exists recently in the timeline.
 	Ingest(ctx context.Context, item Timelineable, timelineAccountID string) (bool, error)
-	
+
 	// IngestAndPrepare takes one timelineable and indexes it into the timeline for the given account ID, and then immediately prepares it for serving.
 	// This is useful in cases where we know the item will need to be shown at the top of a user's timeline immediately (eg., a new status is created).
 	//
@@ -61,32 +61,32 @@ type Manager interface {
 	// The returned bool indicates whether the item was actually put in the timeline. This could be false in cases where
 	// a status is a boost, but a boost of the original status or the status itself already exists recently in the timeline.
 	IngestAndPrepare(ctx context.Context, item Timelineable, accountID string) (bool, error)
-	
+
 	// GetTimeline returns limit n amount of prepared entries from the timeline of the given account ID, in descending chronological order.
 	// If maxID is provided, it will return prepared entries from that maxID onwards, inclusive.
 	GetTimeline(ctx context.Context, accountID string, maxID string, sinceID string, minID string, limit int, local bool) ([]Preparable, error)
-	
+
 	// GetIndexedLength returns the amount of items that have been *indexed* for the given account ID.
 	GetIndexedLength(ctx context.Context, accountID string) int
-	
+
 	// GetOldestIndexedID returns the id ID for the oldest item that we have indexed for the given account.
 	GetOldestIndexedID(ctx context.Context, accountID string) (string, error)
-	
+
 	// PrepareXFromTop prepares limit n amount of items, based on their indexed representations, from the top of the index.
 	PrepareXFromTop(ctx context.Context, accountID string, limit int) error
-	
+
 	// Remove removes one item from the timeline of the given timelineAccountID
 	Remove(ctx context.Context, accountID string, itemID string) (int, error)
-	
+
 	// WipeItemFromAllTimelines removes one item from the index and prepared items of all timelines
 	WipeItemFromAllTimelines(ctx context.Context, itemID string) error
-	
+
 	// WipeStatusesFromAccountID removes all items by the given accountID from the timelineAccountID's timelines.
 	WipeItemsFromAccountID(ctx context.Context, timelineAccountID string, accountID string) error
-	
+
 	// Start starts hourly cleanup jobs for this timeline manager.
 	Start() error
-	
+
 	// Stop stops the timeline manager (currently a stub, doesn't do anything).
 	Stop() error
 }
@@ -243,6 +243,6 @@ func (m *manager) getOrCreateTimeline(ctx context.Context, accountID string) Tim
 	// Create + store it.
 	timeline := NewTimeline(ctx, accountID, m.grabFunction, m.filterFunction, m.prepareFunction, m.skipInsertFunction)
 	m.accountTimelines.Store(accountID, timeline)
-	
+
 	return timeline
 }

--- a/internal/timeline/prepare.go
+++ b/internal/timeline/prepare.go
@@ -148,7 +148,7 @@ prepareloop:
 		if preparing {
 			if err := t.prepare(ctx, entry.itemID); err != nil {
 				// there's been an error
-				if err != db.ErrNoEntries {
+				if !errors.Is(err, db.ErrNoEntries) {
 					// it's a real error
 					return fmt.Errorf("prepareBehind: error preparing item with id %s: %s", entry.itemID, err)
 				}

--- a/internal/timeline/prune.go
+++ b/internal/timeline/prune.go
@@ -21,11 +21,6 @@ import (
 	"container/list"
 )
 
-const (
-	defaultDesiredIndexedItemsLength  = 400
-	defaultDesiredPreparedItemsLength = 50
-)
-
 func (t *timeline) Prune(desiredPreparedItemsLength int, desiredIndexedItemsLength int) int {
 	t.Lock()
 	defer t.Unlock()

--- a/internal/timeline/prune_test.go
+++ b/internal/timeline/prune_test.go
@@ -52,7 +52,7 @@ func (suite *PruneTestSuite) SetupTest() {
 	testrig.StandardDBSetup(suite.db, nil)
 
 	// let's take local_account_1 as the timeline owner
-	tl, err := timeline.NewTimeline(
+	tl := timeline.NewTimeline(
 		context.Background(),
 		suite.testAccounts["local_account_1"].ID,
 		processing.StatusGrabFunction(suite.db),
@@ -60,9 +60,6 @@ func (suite *PruneTestSuite) SetupTest() {
 		processing.StatusPrepareFunction(suite.db, suite.tc),
 		processing.StatusSkipInsertFunction(),
 	)
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
 
 	// put the status IDs in a determinate order since we can't trust a map to keep its order
 	statuses := []*gtsmodel.Status{}

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -83,12 +83,14 @@ type Timeline interface {
 	// The returned bool indicates whether or not the item was actually inserted into the timeline. This will be false
 	// if the item is a boost and the original item or another boost of it already exists < boostReinsertionDepth back in the timeline.
 	IndexOne(ctx context.Context, itemID string, boostOfID string, accountID string, boostOfAccountID string) (bool, error)
+
 	// IndexAndPrepareOne puts a item into the timeline at the appropriate place according to its 'createdAt' property,
 	// and then immediately prepares it.
 	//
 	// The returned bool indicates whether or not the item was actually inserted into the timeline. This will be false
 	// if the item is a boost and the original item or another boost of it already exists < boostReinsertionDepth back in the timeline.
 	IndexAndPrepareOne(ctx context.Context, itemID string, boostOfID string, accountID string, boostOfAccountID string) (bool, error)
+
 	// PrepareXFromTop instructs the timeline to prepare x amount of items from the top of the timeline, useful during init.
 	PrepareFromTop(ctx context.Context, amount int) error
 
@@ -98,11 +100,14 @@ type Timeline interface {
 
 	// AccountID returns the id of the account this timeline belongs to.
 	AccountID() string
+
 	// ItemIndexLength returns the length of the item index at this point in time.
 	ItemIndexLength(ctx context.Context) int
+
 	// OldestIndexedItemID returns the id of the rearmost (ie., the oldest) indexed item, or an error if something goes wrong.
 	// If nothing goes wrong but there's no oldest item, an empty string will be returned so make sure to check for this.
 	OldestIndexedItemID(ctx context.Context) (string, error)
+
 	// NewestIndexedItemID returns the id of the frontmost (ie., the newest) indexed item, or an error if something goes wrong.
 	// If nothing goes wrong but there's no newest item, an empty string will be returned so make sure to check for this.
 	NewestIndexedItemID(ctx context.Context) (string, error)
@@ -113,17 +118,20 @@ type Timeline interface {
 
 	// LastGot returns the time that Get was last called.
 	LastGot() time.Time
+
 	// Prune prunes preparedItems and indexedItems in this timeline to the desired lengths.
 	// This will be a no-op if the lengths are already < the desired values.
 	// Prune acquires a lock on the timeline before pruning.
 	// The return value is the combined total of items pruned from preparedItems and indexedItems.
 	Prune(desiredPreparedItemsLength int, desiredIndexedItemsLength int) int
+
 	// Remove removes a item from both the index and prepared items.
 	//
 	// If a item has multiple entries in a timeline, they will all be removed.
 	//
 	// The returned int indicates the amount of entries that were removed.
 	Remove(ctx context.Context, itemID string) (int, error)
+
 	// RemoveAllBy removes all items by the given accountID, from both the index and prepared items.
 	//
 	// The returned int indicates the amount of entries that were removed.

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -96,7 +96,9 @@ type Timeline interface {
 		INFO FUNCTIONS
 	*/
 
-	// ActualPostIndexLength returns the actual length of the item index at this point in time.
+	// AccountID returns the id of the account this timeline belongs to.
+	AccountID() string
+	// ItemIndexLength returns the length of the item index at this point in time.
 	ItemIndexLength(ctx context.Context) int
 	// OldestIndexedItemID returns the id of the rearmost (ie., the oldest) indexed item, or an error if something goes wrong.
 	// If nothing goes wrong but there's no oldest item, an empty string will be returned so make sure to check for this.
@@ -140,6 +142,10 @@ type timeline struct {
 	sync.Mutex
 }
 
+func (t *timeline) AccountID() string {
+	return t.accountID
+}
+
 // NewTimeline returns a new Timeline for the given account ID
 func NewTimeline(
 	ctx context.Context,
@@ -148,7 +154,7 @@ func NewTimeline(
 	filterFunction FilterFunction,
 	prepareFunction PrepareFunction,
 	skipInsertFunction SkipInsertFunction,
-) (Timeline, error) {
+) Timeline {
 	return &timeline{
 		indexedItems: &indexedItems{
 			skipInsert: skipInsertFunction,
@@ -161,5 +167,5 @@ func NewTimeline(
 		prepareFunction: prepareFunction,
 		accountID:       timelineAccountID,
 		lastGot:         time.Time{},
-	}, nil
+	}
 }

--- a/internal/timeline/timeline.go
+++ b/internal/timeline/timeline.go
@@ -92,7 +92,7 @@ type Timeline interface {
 	IndexAndPrepareOne(ctx context.Context, itemID string, boostOfID string, accountID string, boostOfAccountID string) (bool, error)
 
 	// PrepareXFromTop instructs the timeline to prepare x amount of items from the top of the timeline, useful during init.
-	PrepareFromTop(ctx context.Context, amount int) error
+	PrepareXFromTop(ctx context.Context, amount int) error
 
 	/*
 		INFO FUNCTIONS

--- a/internal/timeline/timeline_test.go
+++ b/internal/timeline/timeline_test.go
@@ -34,8 +34,10 @@ type TimelineStandardTestSuite struct {
 	tc     typeutils.TypeConverter
 	filter *visibility.Filter
 
-	testAccounts map[string]*gtsmodel.Account
-	testStatuses map[string]*gtsmodel.Status
+	testAccounts    map[string]*gtsmodel.Account
+	testStatuses    map[string]*gtsmodel.Status
+	highestStatusID string
+	lowestStatusID  string
 
 	timeline timeline.Timeline
 	manager  timeline.Manager


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request does some v. necessary refactoring on our timeline code, mostly updating `internal/timeline/get.go` to make it more readable, remove some cruft, and add some comments that better explain what's actually happening, since it's not easy code to understand.

The PR also distinguishes properly between `minID` and `sinceID`, which have slightly different uses and indicate the direction that paging should be performed in. This is explained in the comments, but essentially sinceID means 'return from the top' and minID means 'return from the mark upwards'. It's likely that not distinguishing properly between these two things was causing users to miss statuses / not be able to fill gaps in their timeline properly.

We still ought to go through the rest of the `timeline` package and clean up other functions, but this is a start and I don't want to turn it into another massive, difficult-to-review refactor :')

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
