### PR TITLE
[chore] License sloth logo + default avatars under CC by-sa 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Here's a screenshot of the instance landing page!
 - [Contact](#contact)
 - [Credits](#credits)
   - [Libraries](#libraries)
-  - [Image Attribution](#image-attribution)
+  - [Image Attribution and Licensing](#image-attribution-and-licensing)
   - [Team](#team)
   - [Special Thanks](#special-thanks)
 - [Sponsorship + Funding](#sponsorship--funding)
@@ -262,9 +262,22 @@ The following libraries and frameworks are used by GoToSocial, with gratitude �
 - [wagslane/go-password-validator](https://github.com/wagslane/go-password-validator); password strength validation. [MIT License](https://spdx.org/licenses/MIT.html).
 - [ulule/limiter](https://github.com/ulule/limiter); http rate limit middleware. [MIT License](https://spdx.org/licenses/MIT.html).
 
-### Image Attribution
+### Image Attribution and Licensing
 
-Sloth logo by [Anna Abramek](https://abramek.art/), Copyright (C) 2021-2023 the GoToSocial Authors.
+Sloth logo by [Anna Abramek](https://abramek.art/).
+
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />The GoToSocial sloth mascot is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+
+The Creative Commons Attribution-ShareAlike 4.0 International License license applies specifically to the following files and subdirectories of this repository:
+
+- [sloth logo png](./web/assets/logo.png)
+- [sloth logo svg](./web/assets/logo.svg)
+- [all default avatars](./web/assets/default_avatars)
+
+Under the terms of the license, you are free to:
+
+- Share — copy and redistribute the abovementioned material in any medium or format.
+- Adapt — remix, transform, and build upon the abovementioned material for any purpose, even commercially.
 
 ### Team
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,9 +60,13 @@ For bugs and feature requests, please check to see if there's [already an issue]
 
 ## Credits
 
-### Image Attribution
+### Image Attribution and Licensing
 
-Sloth logo by [Anna Abramek](https://abramek.art/), Copyright (C) 2021-2023 the GoToSocial Authors.
+Sloth logo by [Anna Abramek](https://abramek.art/).
+
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />The GoToSocial sloth mascot is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+
+For more information on GoToSocial image licensing, see [here](https://github.com/superseriousbusiness/gotosocial#image-attribution-and-licensing).
 
 ### Developers
 

--- a/web/assets/LICENSE
+++ b/web/assets/LICENSE
@@ -1,0 +1,7 @@
+The following files and subdirectories in this directory are licensed under the Creative Commons Attribution-ShareAlike 4.0 International License:
+
+- logo.png (sloth logo)
+- logo.svg (sloth logo)
+- ./default_avatars/* (all default avatars)
+
+To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This PR updates some of our licensing to explicitly license the sloth logo and derived images as [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).

Other licenses in the repo are not changed.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).