### PR TITLE
[bugfix] Fix relationship not updating 'following' on accept follow request

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -102,6 +102,9 @@ func (c *Caches) setuphooks() {
 		// Invalidate follow request target account ID cached visibility.
 		c.Visibility.Invalidate("ItemID", followReq.TargetAccountID)
 		c.Visibility.Invalidate("RequesterID", followReq.TargetAccountID)
+
+		// Invalidate any cached follow corresponding to this request.
+		c.GTS.Follow().Invalidate("AccountID.TargetAccountID", followReq.AccountID, followReq.TargetAccountID)
 	})
 
 	c.GTS.Status().SetInvalidateCallback(func(status *gtsmodel.Status) {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

We introduced a small issue where the follow cache wasn't being invalidated when a follow request was accepted, leading to a case where you could follow someone, have them accept, and still have your relationship show that you aren't following them.

This PR fixes this by just invalidating the follow cache when a follow request is accepted.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
