### PR TITLE
[bugfix] Fix multiple "updated_at" columns for media updates

### DIFF
--- a/internal/media/prune.go
+++ b/internal/media/prune.go
@@ -328,10 +328,8 @@ func (m *manager) uncacheAttachment(ctx context.Context, attachment *gtsmodel.Me
 	}
 
 	// Update attachment to reflect that we no longer have it cached.
-	attachment.UpdatedAt = time.Now()
-	cached := false
-	attachment.Cached = &cached
-	return m.state.DB.UpdateAttachment(ctx, attachment, "updated_at", "cached")
+	attachment.Cached = func() *bool { i := false; return &i }()
+	return m.state.DB.UpdateAttachment(ctx, attachment, "cached")
 }
 
 func (m *manager) removeFiles(ctx context.Context, keys ...string) (int, error) {

--- a/internal/processing/account_test.go
+++ b/internal/processing/account_test.go
@@ -88,7 +88,7 @@ func (suite *AccountTestSuite) TestAccountDeleteLocal() {
 
 	if !testrig.WaitFor(func() bool {
 		dbAccount, _ := suite.db.GetAccountByID(ctx, deletingAccount.ID)
-		return suite.WithinDuration(dbAccount.SuspendedAt, time.Now(), 30*time.Second)
+		return !dbAccount.SuspendedAt.IsZero()
 	}) {
 		suite.FailNow("timed out waiting for account to be deleted")
 	}

--- a/internal/processing/media/unattach.go
+++ b/internal/processing/media/unattach.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
@@ -44,11 +43,9 @@ func (p *Processor) Unattach(ctx context.Context, account *gtsmodel.Account, med
 		return nil, gtserror.NewErrorNotFound(errors.New("attachment not owned by requesting account"))
 	}
 
-	updatingColumns := []string{"updated_at", "status_id"}
-	attachment.UpdatedAt = time.Now()
 	attachment.StatusID = ""
 
-	if err := p.state.DB.UpdateAttachment(ctx, attachment, updatingColumns...); err != nil {
+	if err := p.state.DB.UpdateAttachment(ctx, attachment, "status_id"); err != nil {
 		return nil, gtserror.NewErrorNotFound(fmt.Errorf("db error updating attachment: %s", err))
 	}
 


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request fixes an issue where the column `updated_at` was being passed into media attachment updates as an extra column. This was causing double `updated_at` columns to be used when making db queries. SQLite doesn't mind this, but postgres does.

closes https://github.com/superseriousbusiness/gotosocial/issues/1645

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
