### PR TITLE
[bugfix] Add idempotency-key to allowed CORS headers

### DIFF
--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -54,6 +54,11 @@ func CORS() gin.HandlerFunc {
 			// needed to pass oauth bearer tokens
 			"Authorization",
 
+			// Some clients require this; see:
+			//   - https://docs.joinmastodon.org/methods/statuses/#headers
+			//   - https://github.com/superseriousbusiness/gotosocial/issues/1664
+			"Idempotency-Key",
+
 			// needed for websocket upgrade requests
 			"Upgrade",
 			"Sec-WebSocket-Extensions",


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Add `Idempotency-Key` to allowed CORS headers. Although we don't currently use this, some clients require this header to be allowed through, and it is in the mastodon API spec so we'd better do it.

closes https://github.com/superseriousbusiness/gotosocial/issues/1664

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation. -- n/a
- [ ] I/we have added tests that cover new code. -- n/a
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
