### PR TITLE
[bugfix] Always serialize `orderedItems` as array in `OrderedCollection`

### DIFF
--- a/docs/federation/federating_with_gotosocial.md
+++ b/docs/federation/federating_with_gotosocial.md
@@ -236,13 +236,15 @@ Example of a featured collection of a user who has pinned multiple `Note`s:
 }
 ```
 
-Example of a user who has pinned one `Note` (`orderedItems` is just a URL string now!):
+Example of a user who has pinned one `Note`:
 
 ```json
 {
   "@context": "https://www.w3.org/ns/activitystreams",
   "id": "https://example.org/users/some_user/collections/featured",
-  "orderedItems": "https://example.org/users/some_user/statuses/01GS7VTYH0S77NNXTP6W4G9EAG",
+  "orderedItems": [
+    "https://example.org/users/some_user/statuses/01GS7VTYH0S77NNXTP6W4G9EAG"
+  ],
   "totalItems": 1,
   "type": "OrderedCollection"
 }

--- a/internal/ap/serialize.go
+++ b/internal/ap/serialize.go
@@ -1,0 +1,64 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package ap
+
+import (
+	"errors"
+
+	"github.com/superseriousbusiness/activity/streams"
+	"github.com/superseriousbusiness/activity/streams/vocab"
+)
+
+// SerializeOrderedCollection is a custom serializer for an ActivityStreamsOrderedCollection.
+// Unlike the standard streams.Serialize function, this serializer normalizes the orderedItems
+// value to always be an array/slice, regardless of how many items are contained therein.
+//
+// TODO: Remove this function if we can fix the underlying issue in Go-Fed.
+//
+// See:
+//   - https://github.com/go-fed/activity/issues/139
+//   - https://github.com/mastodon/mastodon/issues/24225
+func SerializeOrderedCollection(orderedCollection vocab.ActivityStreamsOrderedCollection) (map[string]interface{}, error) {
+	data, err := streams.Serialize(orderedCollection)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, normalizeOrderedCollectionData(data)
+}
+
+func normalizeOrderedCollectionData(rawOrderedCollection map[string]interface{}) error {
+	orderedItems, ok := rawOrderedCollection["orderedItems"]
+	if !ok {
+		return errors.New("no orderedItems set on OrderedCollection")
+	}
+
+	if _, ok := orderedItems.([]interface{}); ok {
+		// Already slice.
+		return nil
+	}
+
+	orderedItemsString, ok := orderedItems.(string)
+	if !ok {
+		return errors.New("orderedItems was neither slice nor string")
+	}
+
+	rawOrderedCollection["orderedItems"] = []string{orderedItemsString}
+
+	return nil
+}

--- a/internal/processing/fedi/collections.go
+++ b/internal/processing/fedi/collections.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 
 	"github.com/superseriousbusiness/activity/streams"
+	"github.com/superseriousbusiness/gotosocial/internal/ap"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 )
@@ -172,7 +173,7 @@ func (p *Processor) FeaturedCollectionGet(ctx context.Context, requestedUsername
 		return nil, gtserror.NewErrorInternalError(err)
 	}
 
-	data, err := streams.Serialize(collection)
+	data, err := ap.SerializeOrderedCollection(collection)
 	if err != nil {
 		return nil, gtserror.NewErrorInternalError(err)
 	}

--- a/internal/typeutils/internaltoas_test.go
+++ b/internal/typeutils/internaltoas_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/activity/streams"
+	"github.com/superseriousbusiness/gotosocial/internal/ap"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/testrig"
@@ -669,7 +670,7 @@ func (suite *InternalToASTestSuite) TestPinnedStatusesToASSomeItems() {
 		suite.FailNow(err.Error())
 	}
 
-	ser, err := streams.Serialize(collection)
+	ser, err := ap.SerializeOrderedCollection(collection)
 	suite.NoError(err)
 
 	bytes, err := json.MarshalIndent(ser, "", "  ")
@@ -701,7 +702,7 @@ func (suite *InternalToASTestSuite) TestPinnedStatusesToASNoItems() {
 		suite.FailNow(err.Error())
 	}
 
-	ser, err := streams.Serialize(collection)
+	ser, err := ap.SerializeOrderedCollection(collection)
 	suite.NoError(err)
 
 	bytes, err := json.MarshalIndent(ser, "", "  ")
@@ -730,7 +731,7 @@ func (suite *InternalToASTestSuite) TestPinnedStatusesToASOneItem() {
 		suite.FailNow(err.Error())
 	}
 
-	ser, err := streams.Serialize(collection)
+	ser, err := ap.SerializeOrderedCollection(collection)
 	suite.NoError(err)
 
 	bytes, err := json.MarshalIndent(ser, "", "  ")
@@ -739,7 +740,9 @@ func (suite *InternalToASTestSuite) TestPinnedStatusesToASOneItem() {
 	suite.Equal(`{
   "@context": "https://www.w3.org/ns/activitystreams",
   "id": "http://localhost:8080/users/1happyturtle/collections/featured",
-  "orderedItems": "http://localhost:8080/users/1happyturtle/statuses/01G20ZM733MGN8J344T4ZDDFY1",
+  "orderedItems": [
+    "http://localhost:8080/users/1happyturtle/statuses/01G20ZM733MGN8J344T4ZDDFY1"
+  ],
   "totalItems": 1,
   "type": "OrderedCollection"
 }`, string(bytes))


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request implements a workaround for an issue where orderedItems in a featured/pinned collection would be serialized as a string (instead of a string array) if there was only one entry. This was causing issues with other implementations that assume that orderedItems will always be an array (which is apparently the correct behavior).

See https://github.com/mastodon/mastodon/issues/24225 and https://github.com/go-fed/activity/issues/139

Note: while this code gets us moving for now, it is far from a perfect solution because a) it's confusing and b) it's inefficient. We should definitely pull this code out if/when we get it fixed in go-fed.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
