### PR TITLE
[bugfix] Add proper constraints on status faves, dedupe

### DIFF
--- a/internal/db/bundb/migrations/20230405130021_status_fave_unique_constraints.go
+++ b/internal/db/bundb/migrations/20230405130021_status_fave_unique_constraints.go
@@ -1,0 +1,166 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		// To update fave constraints, we need to migrate faves into a new table.
+		// See section 7 here: https://www.sqlite.org/lang_altertable.html
+
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			// Remove any duplicate faves that were created before constraints.
+			// We need to ensure that we don't just delete all faves that are
+			// duplicates--we should keep the original, non-duplicate fave.
+			// So, produced query will look something like this:
+			//
+			//	DELETE FROM "status_faves"
+			//	WHERE id IN (
+			//		WITH cte AS (
+			//			SELECT
+			//				"id",
+			//				ROW_NUMBER() OVER(
+			//					PARTITION BY "account_id", "status_id"
+			//					ORDER BY "account_id", "status_id"
+			//				) AS "row_number"
+			//			FROM status_faves
+			//		)
+			//		SELECT "id" FROM cte
+			//		WHERE "row_number" > 1
+			//	)
+			//
+			// The above query only deletes status_faves with ids that are
+			// in the subquery. The subquery selects the IDs of all duplicate
+			// status faves past the first one, where 'duplicate' means 'has
+			// the same account id and status id'.
+			overQ := tx.NewRaw(
+				"PARTITION BY ?, ? ORDER BY ?, ?",
+				bun.Ident("account_id"),
+				bun.Ident("status_id"),
+				bun.Ident("account_id"),
+				bun.Ident("status_id"),
+			)
+
+			rowNumberQ := tx.NewRaw(
+				"SELECT ?, ROW_NUMBER() OVER(?) AS ? FROM status_faves",
+				bun.Ident("id"),
+				overQ,
+				bun.Ident("row_number"),
+			)
+
+			inQ := tx.NewRaw(
+				"WITH cte AS (?) SELECT ? FROM cte WHERE ? > 1",
+				rowNumberQ,
+				bun.Ident("id"),
+				bun.Ident("row_number"),
+			)
+
+			if _, err := tx.
+				NewDelete().
+				Table("status_faves").
+				Where("id IN (?)", inQ).
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			// Create the new faves table.
+			if _, err := tx.
+				NewCreateTable().
+				ModelTableExpr("new_status_faves").
+				Model(&gtsmodel.StatusFave{}).
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			// Specify columns explicitly to
+			// avoid any Postgres shenanigans.
+			columns := []string{
+				"id",
+				"created_at",
+				"updated_at",
+				"account_id",
+				"target_account_id",
+				"status_id",
+				"uri",
+			}
+
+			// Copy remaining faves to the new table.
+			if _, err := tx.
+				NewInsert().
+				Table("new_status_faves").
+				Table("status_faves").
+				Column(columns...).
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			// Drop the old table.
+			if _, err := tx.
+				NewDropTable().
+				Table("status_faves").
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			// Rename new table to old table.
+			if _, err := tx.
+				ExecContext(
+					ctx,
+					"ALTER TABLE ? RENAME TO ?",
+					bun.Ident("new_status_faves"),
+					bun.Ident("status_faves"),
+				); err != nil {
+				return err
+			}
+
+			// Add indexes to the new table.
+			for index, columns := range map[string][]string{
+				"status_faves_id_idx":         {"id"},
+				"status_faves_account_id_idx": {"account_id"},
+				"status_faves_status_id_idx":  {"status_id"},
+			} {
+				if _, err := tx.
+					NewCreateIndex().
+					Table("status_faves").
+					Index(index).
+					Column(columns...).
+					Exec(ctx); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}

--- a/internal/federation/federatingdb/create.go
+++ b/internal/federation/federatingdb/create.go
@@ -288,13 +288,19 @@ func (f *federatingDB) activityLike(ctx context.Context, asType vocab.Type, rece
 
 	fave, err := f.typeConverter.ASLikeToFave(ctx, like)
 	if err != nil {
-		return fmt.Errorf("activityLike: could not convert Like to fave: %s", err)
+		return fmt.Errorf("activityLike: could not convert Like to fave: %w", err)
 	}
 
 	fave.ID = id.NewULID()
 
-	if err := f.state.DB.Put(ctx, fave); err != nil {
-		return fmt.Errorf("activityLike: database error inserting fave: %s", err)
+	if err := f.state.DB.PutStatusFave(ctx, fave); err != nil {
+		if errors.Is(err, db.ErrAlreadyExists) {
+			// The Like already exists in the database, which
+			// means we've already handled side effects. We can
+			// just return nil here and be done with it.
+			return nil
+		}
+		return fmt.Errorf("activityLike: database error inserting fave: %w", err)
 	}
 
 	f.state.Workers.EnqueueFederator(ctx, messages.FromFederator{

--- a/internal/federation/federatingdb/undo.go
+++ b/internal/federation/federatingdb/undo.go
@@ -26,11 +26,12 @@ import (
 	"github.com/superseriousbusiness/activity/streams/vocab"
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 )
 
 func (f *federatingDB) Undo(ctx context.Context, undo vocab.ActivityStreamsUndo) error {
-	l := log.Entry{}.WithContext(ctx)
+	l := log.WithContext(ctx)
 
 	if log.Level() >= level.DEBUG {
 		i, err := marshalItem(undo)
@@ -55,70 +56,163 @@ func (f *federatingDB) Undo(ctx context.Context, undo vocab.ActivityStreamsUndo)
 	}
 
 	for iter := undoObject.Begin(); iter != undoObject.End(); iter = iter.Next() {
-		if iter.GetType() == nil {
+		t := iter.GetType()
+		if t == nil {
 			continue
 		}
-		switch iter.GetType().GetTypeName() {
+
+		switch t.GetTypeName() {
 		case ap.ActivityFollow:
-			// UNDO FOLLOW
-			ASFollow, ok := iter.GetType().(vocab.ActivityStreamsFollow)
-			if !ok {
-				return errors.New("UNDO: couldn't parse follow into vocab.ActivityStreamsFollow")
+			if err := f.undoFollow(ctx, receivingAccount, undo, t); err != nil {
+				return err
 			}
-			// make sure the actor owns the follow
-			if !sameActor(undo.GetActivityStreamsActor(), ASFollow.GetActivityStreamsActor()) {
-				return errors.New("UNDO: follow actor and activity actor not the same")
-			}
-			// convert the follow to something we can understand
-			gtsFollow, err := f.typeConverter.ASFollowToFollow(ctx, ASFollow)
-			if err != nil {
-				return fmt.Errorf("UNDO: error converting asfollow to gtsfollow: %s", err)
-			}
-			// make sure the addressee of the original follow is the same as whatever inbox this landed in
-			if gtsFollow.TargetAccountID != receivingAccount.ID {
-				return errors.New("UNDO: follow object account and inbox account were not the same")
-			}
-			// delete any existing FOLLOW
-			if err := f.state.DB.DeleteFollowByURI(ctx, gtsFollow.URI); err != nil && !errors.Is(err, db.ErrNoEntries) {
-				return fmt.Errorf("UNDO: db error removing follow: %s", err)
-			}
-			// delete any existing FOLLOW REQUEST
-			if err := f.state.DB.DeleteFollowRequestByURI(ctx, gtsFollow.URI); err != nil && !errors.Is(err, db.ErrNoEntries) {
-				return fmt.Errorf("UNDO: db error removing follow request: %s", err)
-			}
-			l.Debug("follow undone")
-			return nil
 		case ap.ActivityLike:
-			// UNDO LIKE
+			if err := f.undoLike(ctx, receivingAccount, undo, t); err != nil {
+				return err
+			}
 		case ap.ActivityAnnounce:
-			// UNDO BOOST/REBLOG/ANNOUNCE
+			// todo: UNDO BOOST/REBLOG/ANNOUNCE
 		case ap.ActivityBlock:
-			// UNDO BLOCK
-			ASBlock, ok := iter.GetType().(vocab.ActivityStreamsBlock)
-			if !ok {
-				return errors.New("UNDO: couldn't parse block into vocab.ActivityStreamsBlock")
+			if err := f.undoBlock(ctx, receivingAccount, undo, t); err != nil {
+				return err
 			}
-			// make sure the actor owns the follow
-			if !sameActor(undo.GetActivityStreamsActor(), ASBlock.GetActivityStreamsActor()) {
-				return errors.New("UNDO: block actor and activity actor not the same")
-			}
-			// convert the block to something we can understand
-			gtsBlock, err := f.typeConverter.ASBlockToBlock(ctx, ASBlock)
-			if err != nil {
-				return fmt.Errorf("UNDO: error converting asblock to gtsblock: %s", err)
-			}
-			// make sure the addressee of the original block is the same as whatever inbox this landed in
-			if gtsBlock.TargetAccountID != receivingAccount.ID {
-				return errors.New("UNDO: block object account and inbox account were not the same")
-			}
-			// delete any existing BLOCK
-			if err := f.state.DB.DeleteBlockByURI(ctx, gtsBlock.URI); err != nil {
-				return fmt.Errorf("UNDO: db error removing block: %s", err)
-			}
-			l.Debug("block undone")
-			return nil
 		}
 	}
 
+	return nil
+}
+
+func (f *federatingDB) undoFollow(
+	ctx context.Context,
+	receivingAccount *gtsmodel.Account,
+	undo vocab.ActivityStreamsUndo,
+	t vocab.Type,
+) error {
+	Follow, ok := t.(vocab.ActivityStreamsFollow)
+	if !ok {
+		return errors.New("undoFollow: couldn't parse vocab.Type into vocab.ActivityStreamsFollow")
+	}
+
+	// Make sure the undo actor owns the target.
+	if !sameActor(undo.GetActivityStreamsActor(), Follow.GetActivityStreamsActor()) {
+		// Ignore this Activity.
+		return nil
+	}
+
+	follow, err := f.typeConverter.ASFollowToFollow(ctx, Follow)
+	if err != nil {
+		return fmt.Errorf("undoFollow: error converting ActivityStreams Follow to follow: %w", err)
+	}
+
+	// Ensure addressee is follow target.
+	if follow.TargetAccountID != receivingAccount.ID {
+		// Ignore this Activity.
+		return nil
+	}
+
+	// Delete any existing follow.
+	if err := f.state.DB.DeleteFollowByURI(ctx, follow.URI); err != nil && !errors.Is(err, db.ErrNoEntries) {
+		return fmt.Errorf("undoFollow: db error removing follow: %w", err)
+	}
+
+	// Delete any existing follow request.
+	if err := f.state.DB.DeleteFollowRequestByURI(ctx, follow.URI); err != nil && !errors.Is(err, db.ErrNoEntries) {
+		return fmt.Errorf("undoFollow: db error removing follow request: %w", err)
+	}
+
+	log.Debug(ctx, "follow undone")
+	return nil
+}
+
+func (f *federatingDB) undoLike(
+	ctx context.Context,
+	receivingAccount *gtsmodel.Account,
+	undo vocab.ActivityStreamsUndo,
+	t vocab.Type,
+) error {
+	Like, ok := t.(vocab.ActivityStreamsLike)
+	if !ok {
+		return errors.New("undoLike: couldn't parse vocab.Type into vocab.ActivityStreamsLike")
+	}
+
+	// Make sure the undo actor owns the target.
+	if !sameActor(undo.GetActivityStreamsActor(), Like.GetActivityStreamsActor()) {
+		// Ignore this Activity.
+		return nil
+	}
+
+	fave, err := f.typeConverter.ASLikeToFave(ctx, Like)
+	if err != nil {
+		return fmt.Errorf("undoLike: error converting ActivityStreams Like to fave: %w", err)
+	}
+
+	// Ensure addressee is follow target.
+	if fave.TargetAccountID != receivingAccount.ID {
+		// Ignore this Activity.
+		return nil
+	}
+
+	// Ignore URI on likes, since we often
+	// get multiple likes with the same target
+	// with different URIs. Instead, we'll
+	// select using account and target status.
+	fave, err = f.state.DB.GetStatusFave(ctx, fave.AccountID, fave.StatusID)
+	if err != nil {
+		if errors.Is(err, db.ErrNoEntries) {
+			// We didn't have a like/fave
+			// for this combo anyway, ignore.
+			return nil
+		}
+		aaaaaaaaaa
+	}
+
+	// Delete any existing FOLLOW.
+	if err := f.state.DB.DeleteFollowByURI(ctx, fave.URI); err != nil && !errors.Is(err, db.ErrNoEntries) {
+		return fmt.Errorf("undoFollow: db error removing follow: %w", err)
+	}
+
+	// Delete any existing FOLLOW REQUEST.
+	if err := f.state.DB.DeleteFollowRequestByURI(ctx, fave.URI); err != nil && !errors.Is(err, db.ErrNoEntries) {
+		return fmt.Errorf("undoFollow: db error removing follow request: %w", err)
+	}
+
+	log.Debug(ctx, "like undone")
+	return nil
+}
+
+func (f *federatingDB) undoBlock(
+	ctx context.Context,
+	receivingAccount *gtsmodel.Account,
+	undo vocab.ActivityStreamsUndo,
+	t vocab.Type,
+) error {
+	Block, ok := t.(vocab.ActivityStreamsBlock)
+	if !ok {
+		return errors.New("undoBlock: couldn't parse vocab.Type into vocab.ActivityStreamsBlock")
+	}
+
+	// Make sure the undo actor owns the target.
+	if !sameActor(undo.GetActivityStreamsActor(), Block.GetActivityStreamsActor()) {
+		// Ignore this Activity.
+		return nil
+	}
+
+	block, err := f.typeConverter.ASBlockToBlock(ctx, Block)
+	if err != nil {
+		return fmt.Errorf("undoBlock: error converting ActivityStreams Block to block: %w", err)
+	}
+
+	// Ensure addressee is block target.
+	if block.TargetAccountID != receivingAccount.ID {
+		// Ignore this Activity.
+		return nil
+	}
+
+	// Delete any existing BLOCK
+	if err := f.state.DB.DeleteBlockByURI(ctx, block.URI); err != nil && !errors.Is(err, db.ErrNoEntries) {
+		return fmt.Errorf("undoBlock: db error removing block: %w", err)
+	}
+
+	log.Debug(ctx, "block undone")
 	return nil
 }

--- a/internal/federation/federatingdb/util.go
+++ b/internal/federation/federatingdb/util.go
@@ -36,23 +36,27 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/uris"
 )
 
-func sameActor(activityActor vocab.ActivityStreamsActorProperty, followActor vocab.ActivityStreamsActorProperty) bool {
-	if activityActor == nil || followActor == nil {
+func sameActor(actor1 vocab.ActivityStreamsActorProperty, actor2 vocab.ActivityStreamsActorProperty) bool {
+	if actor1 == nil || actor2 == nil {
 		return false
 	}
-	for aIter := activityActor.Begin(); aIter != activityActor.End(); aIter = aIter.Next() {
-		for fIter := followActor.Begin(); fIter != followActor.End(); fIter = fIter.Next() {
-			if aIter.GetIRI() == nil {
+
+	for a1Iter := actor1.Begin(); a1Iter != actor1.End(); a1Iter = a1Iter.Next() {
+		for a2Iter := actor2.Begin(); a2Iter != actor2.End(); a2Iter = a2Iter.Next() {
+			if a1Iter.GetIRI() == nil {
 				return false
 			}
-			if fIter.GetIRI() == nil {
+
+			if a2Iter.GetIRI() == nil {
 				return false
 			}
-			if aIter.GetIRI().String() == fIter.GetIRI().String() {
+
+			if a1Iter.GetIRI().String() == a2Iter.GetIRI().String() {
 				return true
 			}
 		}
 	}
+
 	return false
 }
 

--- a/internal/gtsmodel/statusfave.go
+++ b/internal/gtsmodel/statusfave.go
@@ -21,14 +21,14 @@ import "time"
 
 // StatusFave refers to a 'fave' or 'like' in the database, from one account, targeting the status of another account
 type StatusFave struct {
-	ID              string    `validate:"required,ulid" bun:"type:CHAR(26),pk,nullzero,notnull,unique"`                  // id of this item in the database
-	CreatedAt       time.Time `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"`           // when was item created
-	UpdatedAt       time.Time `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"`           // when was item last updated
-	AccountID       string    `validate:"required,ulid" bun:"type:CHAR(26),unique:statusfavesrctarget,nullzero,notnull"` // id of the account that created ('did') the fave
-	Account         *Account  `validate:"-" bun:"-"`                                                                     // account that created the fave
-	TargetAccountID string    `validate:"required,ulid" bun:"type:CHAR(26),unique:statusfavesrctarget,nullzero,notnull"` // id the account owning the faved status
-	TargetAccount   *Account  `validate:"-" bun:"-"`                                                                     // account owning the faved status
-	StatusID        string    `validate:"required,ulid" bun:"type:CHAR(26),nullzero,notnull"`                            // database id of the status that has been 'faved'
-	Status          *Status   `validate:"-" bun:"-"`                                                                     // the faved status
-	URI             string    `validate:"required,url" bun:",nullzero,notnull,unique"`                                   // ActivityPub URI of this fave
+	ID              string    `validate:"required,ulid" bun:"type:CHAR(26),pk,nullzero,notnull,unique"`                      // id of this item in the database
+	CreatedAt       time.Time `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"`               // when was item created
+	UpdatedAt       time.Time `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"`               // when was item last updated
+	AccountID       string    `validate:"required,ulid" bun:"type:CHAR(26),unique:statusfaveaccountstatus,nullzero,notnull"` // id of the account that created ('did') the fave
+	Account         *Account  `validate:"-" bun:"-"`                                                                         // account that created the fave
+	TargetAccountID string    `validate:"required,ulid" bun:"type:CHAR(26),nullzero,notnull"`                                // id the account owning the faved status
+	TargetAccount   *Account  `validate:"-" bun:"-"`                                                                         // account owning the faved status
+	StatusID        string    `validate:"required,ulid" bun:"type:CHAR(26),unique:statusfaveaccountstatus,nullzero,notnull"` // database id of the status that has been 'faved'
+	Status          *Status   `validate:"-" bun:"-"`                                                                         // the faved status
+	URI             string    `validate:"required,url" bun:",nullzero,notnull,unique"`                                       // ActivityPub URI of this fave
 }

--- a/internal/gtsmodel/statusfave.go
+++ b/internal/gtsmodel/statusfave.go
@@ -21,14 +21,14 @@ import "time"
 
 // StatusFave refers to a 'fave' or 'like' in the database, from one account, targeting the status of another account
 type StatusFave struct {
-	ID              string    `validate:"required,ulid" bun:"type:CHAR(26),pk,nullzero,notnull,unique"`        // id of this item in the database
-	CreatedAt       time.Time `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"` // when was item created
-	UpdatedAt       time.Time `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"` // when was item last updated
-	AccountID       string    `validate:"required,ulid" bun:"type:CHAR(26),nullzero,notnull"`                  // id of the account that created ('did') the fave
-	Account         *Account  `validate:"-" bun:"rel:belongs-to"`                                              // account that created the fave
-	TargetAccountID string    `validate:"required,ulid" bun:"type:CHAR(26),nullzero,notnull"`                  // id the account owning the faved status
-	TargetAccount   *Account  `validate:"-" bun:"rel:belongs-to"`                                              // account owning the faved status
-	StatusID        string    `validate:"required,ulid" bun:"type:CHAR(26),nullzero,notnull"`                  // database id of the status that has been 'faved'
-	Status          *Status   `validate:"-" bun:"rel:belongs-to"`                                              // the faved status
-	URI             string    `validate:"required,url" bun:",nullzero,notnull"`                                // ActivityPub URI of this fave
+	ID              string    `validate:"required,ulid" bun:"type:CHAR(26),pk,nullzero,notnull,unique"`                  // id of this item in the database
+	CreatedAt       time.Time `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"`           // when was item created
+	UpdatedAt       time.Time `validate:"-" bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"`           // when was item last updated
+	AccountID       string    `validate:"required,ulid" bun:"type:CHAR(26),unique:statusfavesrctarget,nullzero,notnull"` // id of the account that created ('did') the fave
+	Account         *Account  `validate:"-" bun:"-"`                                                                     // account that created the fave
+	TargetAccountID string    `validate:"required,ulid" bun:"type:CHAR(26),unique:statusfavesrctarget,nullzero,notnull"` // id the account owning the faved status
+	TargetAccount   *Account  `validate:"-" bun:"-"`                                                                     // account owning the faved status
+	StatusID        string    `validate:"required,ulid" bun:"type:CHAR(26),nullzero,notnull"`                            // database id of the status that has been 'faved'
+	Status          *Status   `validate:"-" bun:"-"`                                                                     // the faved status
+	URI             string    `validate:"required,url" bun:",nullzero,notnull,unique"`                                   // ActivityPub URI of this fave
 }


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request:

- Introduces proper constraints on status faves -- now, an account can only like a status once.
- Includes a migration to delete duplicate status faves, before adding constraints to status fave table.
- Implements federating undo logic for status likes -- we didn't have this before for some reason???
- Does some v. small tidying up in the bits of the codebase that had to be touched :hand: 

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code. -- tested the migration on both sqlite and postgres, seems OK
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
