### PR TITLE
[bugfix] Fix single author threads not appearing in home timeline

### DIFF
--- a/internal/visibility/home_timeline.go
+++ b/internal/visibility/home_timeline.go
@@ -98,7 +98,7 @@ func (f *Filter) isStatusHomeTimelineable(ctx context.Context, owner *gtsmodel.A
 
 	var (
 		next      *gtsmodel.Status
-		oneAuthor bool
+		oneAuthor = true // Assume one author until proven otherwise.
 		included  bool
 		converstn bool
 	)
@@ -149,7 +149,7 @@ func (f *Filter) isStatusHomeTimelineable(ctx context.Context, owner *gtsmodel.A
 		}
 
 		if oneAuthor {
-			// Check if this is a single-author status thread.
+			// Check if this continues to be a single-author thread.
 			oneAuthor = (next.AccountID == status.AccountID)
 		}
 	}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request fixes an issue where single-author thread replies were not appearing in the home timeline.

We were assuming that threads were not single author, by default, but then never checking that boolean again to possibly set it to true.

Now, instead, we assume single-author threads and only change the boolean once if we see otherwise.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
