### PR TITLE
Replacing Pinafore with Semaphore

### DIFF
--- a/web/template/index.tmpl
+++ b/web/template/index.tmpl
@@ -36,15 +36,15 @@
 		</p>
 		<div class="applist">
 			<div class="entry">
-				<svg role="img" aria-labelledby="pinaforeTitle pinaforeDesc" class="logo redraw" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10000 10000">
-					<title id="pinaforeTitle">The Pinafore logo</title>
-					<desc id="pinaforeDesc">A stylised boat in flat design</desc>
-					<path d="M9212 5993H5987V823c1053 667 2747 2177 3225 5170zM3100 2690A12240 12240 0 01939 6035h2161zm676 7210h2448a3067 3067 0 003067-3067H5052V627a527 527 0 00-1052 0v6206H709a3067 3067 0 003067 3067z"></path>
+				<svg role="img" aria-labelledby="semaphoreTitle semaphoreDesc" class="logo redraw" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 146 120">
+					<title id="semaphoreTitle">The Semaphore logo</title>
+					<desc id="semaphoreDesc">A waving flag</desc>
+					<path d="M68.13 0C53.94 0 42.81 20 13.9 27.1l-2.23-5.29a6.5 6.5 0 0 0-5.17-10.4 6.5 6.5 0 0 0-.81 12.95L46.2 120l5.99-2.5-14.42-33.33c22.8-6.86 32.51-22.16 49.83-20.58 9.9.9 4.87 19.56 8.11 17.93 16.22-8.15 32.44-11.41 50.29-11.41-7.96-9.78-17.38-20.55-22.71-31.74L120.8 32c-2.32-7.33-2.56-14.75.87-22.22-9.74-3.26-21.1 0-32.45 4.9C82.2 9.77 79.5 0 68.13 0zM15.26 30.42c8.95 6.63 13.63 13.86 16.07 20.94l1.62 6.32c1.24 6.58 1.07 12.8 1.27 18.03z"></path>
 				</svg>
 				<div>
-					<h2>Pinafore</h2>
-					<p>Pinafore is a web client designed for speed and simplicity.</p>
-					<a href="https://pinafore.social/" target="_blank" rel="noopener">Use Pinafore</a>
+					<h2>Semaphore</h2>
+					<p>Semaphore is a web client designed for speed and simplicity.</p>
+					<a href="https://semaphore.social/" target="_blank" rel="noopener">Use Semaphore</a>
 				</div>
 			</div>
 			<div class="entry">


### PR DESCRIPTION
# Description

As Pinafore is now unmaintained: https://nolanlawson.com/2023/01/09/retiring-pinafore/
And that a fork that looks serious is created: https://github.com/NickColley/semaphore

I have changed the mentions of Pirafore to its successor, Semaphore.

This change has been tested and can be seen here: https://gts-test.oniricorpe.eu/

Closes #1343

Also, it maybe be relevant to add this web client too (or replacing Pinafore in place of Semaphore), which seems to be well compatible with GTS: https://github.com/elk-zone/elk

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.