### PR TITLE
[bugfix] Fix remaining mangled URI escaping issues in statuses + accounts

### DIFF
--- a/internal/ap/extract.go
+++ b/internal/ap/extract.go
@@ -56,10 +56,13 @@ func ExtractName(i WithName) string {
 		return ""
 	}
 
-	// take the first name string we can find
+	// Take the first useful value for the name string we can find.
 	for iter := nameProp.Begin(); iter != nameProp.End(); iter = iter.Next() {
-		if iter.IsXMLSchemaString() && iter.GetXMLSchemaString() != "" {
+		switch {
+		case iter.IsXMLSchemaString():
 			return iter.GetXMLSchemaString()
+		case iter.IsIRI():
+			return iter.GetIRI().String()
 		}
 	}
 
@@ -253,10 +256,10 @@ func ExtractSummary(i WithSummary) string {
 
 	for iter := summaryProp.Begin(); iter != summaryProp.End(); iter = iter.Next() {
 		switch {
-		case iter.IsIRI():
-			return iter.GetIRI().String()
 		case iter.IsXMLSchemaString():
 			return iter.GetXMLSchemaString()
+		case iter.IsIRI():
+			return iter.GetIRI().String()
 		}
 	}
 
@@ -354,10 +357,10 @@ func ExtractContent(i WithContent) string {
 	}
 
 	for iter := contentProperty.Begin(); iter != contentProperty.End(); iter = iter.Next() {
-		if iter.IsXMLSchemaString() {
+		switch {
+		case iter.IsXMLSchemaString():
 			return iter.GetXMLSchemaString()
-		}
-		if iter.IsIRI() && iter.GetIRI() != nil {
+		case iter.IsIRI():
 			return iter.GetIRI().String()
 		}
 	}

--- a/internal/ap/interfaces.go
+++ b/internal/ap/interfaces.go
@@ -51,7 +51,9 @@ type Statusable interface {
 	WithTypeName
 
 	WithSummary
+	WithSetSummary
 	WithName
+	WithSetName
 	WithInReplyTo
 	WithPublished
 	WithURL

--- a/internal/ap/interfaces.go
+++ b/internal/ap/interfaces.go
@@ -73,6 +73,7 @@ type Attachmentable interface {
 	WithMediaType
 	WithURL
 	WithName
+	WithSetName
 	WithBlurhash
 }
 
@@ -191,6 +192,11 @@ type WithIcon interface {
 // WithName represents an activity with ActivityStreamsNameProperty
 type WithName interface {
 	GetActivityStreamsName() vocab.ActivityStreamsNameProperty
+}
+
+// WithSetName represents an activity with a settable ActivityStreamsNameProperty
+type WithSetName interface {
+	SetActivityStreamsName(vocab.ActivityStreamsNameProperty)
 }
 
 // WithImage represents an activity with ActivityStreamsImageProperty

--- a/internal/ap/interfaces.go
+++ b/internal/ap/interfaces.go
@@ -30,6 +30,7 @@ type Accountable interface {
 	WithName
 	WithImage
 	WithSummary
+	WithSetSummary
 	WithDiscoverable
 	WithURL
 	WithPublicKey
@@ -207,6 +208,11 @@ type WithImage interface {
 // WithSummary represents an activity with ActivityStreamsSummaryProperty
 type WithSummary interface {
 	GetActivityStreamsSummary() vocab.ActivityStreamsSummaryProperty
+}
+
+// WithSetSummary represents an activity that can have summary set on it.
+type WithSetSummary interface {
+	SetActivityStreamsSummary(vocab.ActivityStreamsSummaryProperty)
 }
 
 // WithDiscoverable represents an activity with TootDiscoverableProperty

--- a/internal/ap/normalize.go
+++ b/internal/ap/normalize.go
@@ -114,3 +114,25 @@ func NormalizeStatusableContent(statusable Statusable, rawStatusable map[string]
 	contentProp.AppendXMLSchemaString(rawContent)
 	statusable.SetActivityStreamsContent(contentProp)
 }
+
+func NormalizeStatusableAttachments(statusable Statusable, rawStatusable map[string]interface{}) {
+	attachmentProperty := statusable.GetActivityStreamsAttachment()
+	if attachmentProperty.Len() == 0 {
+		// No attachments.
+		return
+	}
+
+	
+
+	for iter := attachmentProperty.Begin(); iter != attachmentProperty.End(); iter = iter.Next() {
+
+	}
+}
+
+func NormalizeAccountableSummary(accountable Accountable, rawAccountable map[string]interface{}) {
+
+}
+
+func NormalizeAttachmentableName(attachmentable Attachmentable, rawAttachmentable map[string]interface{}) {
+
+}

--- a/internal/ap/resolve.go
+++ b/internal/ap/resolve.go
@@ -27,8 +27,7 @@ import (
 )
 
 // ResolveStatusable tries to resolve the given bytes into an ActivityPub Statusable representation.
-// It will then perform normalization on the Statusable by calling NormalizeStatusable, so that
-// callers don't need to bother doing extra steps.
+// It will then perform normalization on the Statusable.
 //
 // Works for: Article, Document, Image, Video, Note, Page, Event, Place, Profile
 func ResolveStatusable(ctx context.Context, b []byte) (Statusable, error) {
@@ -73,12 +72,16 @@ func ResolveStatusable(ctx context.Context, b []byte) (Statusable, error) {
 		return nil, newErrWrongType(err)
 	}
 
-	NormalizeStatusableContent(statusable, rawStatusable)
-	NormalizeStatusableAttachments(statusable, rawStatusable)
+	NormalizeContent(statusable, rawStatusable)
+	NormalizeAttachments(statusable, rawStatusable)
+	NormalizeSummary(statusable, rawStatusable)
+	NormalizeName(statusable, rawStatusable)
+
 	return statusable, nil
 }
 
 // ResolveStatusable tries to resolve the given bytes into an ActivityPub Accountable representation.
+// It will then perform normalization on the Accountable.
 //
 // Works for: Application, Group, Organization, Person, Service
 func ResolveAccountable(ctx context.Context, b []byte) (Accountable, error) {
@@ -115,6 +118,7 @@ func ResolveAccountable(ctx context.Context, b []byte) (Accountable, error) {
 		return nil, newErrWrongType(err)
 	}
 
-	NormalizeAccountableSummary(accountable, rawAccountable)
+	NormalizeSummary(accountable, rawAccountable)
+
 	return accountable, nil
 }

--- a/internal/ap/resolve.go
+++ b/internal/ap/resolve.go
@@ -74,6 +74,7 @@ func ResolveStatusable(ctx context.Context, b []byte) (Statusable, error) {
 	}
 
 	NormalizeStatusableContent(statusable, rawStatusable)
+	NormalizeStatusableAttachments(statusable, rawStatusable)
 	return statusable, nil
 }
 
@@ -114,5 +115,6 @@ func ResolveAccountable(ctx context.Context, b []byte) (Accountable, error) {
 		return nil, newErrWrongType(err)
 	}
 
+	NormalizeAccountableSummary(accountable, rawAccountable)
 	return accountable, nil
 }

--- a/internal/processing/fromfederator.go
+++ b/internal/processing/fromfederator.go
@@ -373,15 +373,11 @@ func (p *Processor) processUpdateAccountFromFederator(ctx context.Context, feder
 		return errors.New("profile was not parseable as *gtsmodel.Account")
 	}
 
-	incomingAccountURL, err := url.Parse(incomingAccount.URI)
-	if err != nil {
-		return err
-	}
-
-	// further database updates occur inside getremoteaccount
-	if _, err := p.federator.GetAccountByURI(ctx,
+	// Call UpdateAccount with force to reflect that
+	// we want to fetch new bio, avatar, header, etc.
+	if _, err := p.federator.UpdateAccount(ctx,
 		federatorMsg.ReceivingAccount.Username,
-		incomingAccountURL,
+		incomingAccount,
 		true,
 	); err != nil {
 		return fmt.Errorf("error enriching updated account from federator: %s", err)


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request implements further normalization of the following:

- status summary (used as content warning)
- status name (used as backup content warning)
- status attachment name (used as image description)
- account summary (used as bio)

This should resolve remaining issues with URI strings being parsed and funky escaping happening. 

closes https://github.com/superseriousbusiness/gotosocial/issues/1698

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
