### PR TITLE
[performance] replace domain block cache with an in-memory radix trie

### DIFF
--- a/internal/cache/domain/domain_test.go
+++ b/internal/cache/domain/domain_test.go
@@ -20,13 +20,12 @@ package domain_test
 import (
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/superseriousbusiness/gotosocial/internal/cache/domain"
 )
 
 func TestBlockCache(t *testing.T) {
-	c := domain.New(100, time.Second)
+	c := new(domain.BlockCache)
 
 	blocks := []string{
 		"google.com",

--- a/internal/cache/gts.go
+++ b/internal/cache/gts.go
@@ -72,12 +72,6 @@ func (c *GTSCaches) Init() {
 func (c *GTSCaches) Start() {
 	tryStart(c.account, config.GetCacheGTSAccountSweepFreq())
 	tryStart(c.block, config.GetCacheGTSBlockSweepFreq())
-	tryUntil("starting domain block cache", 5, func() bool {
-		if sweep := config.GetCacheGTSDomainBlockSweepFreq(); sweep > 0 {
-			return c.domainBlock.Start(sweep)
-		}
-		return true
-	})
 	tryStart(c.emoji, config.GetCacheGTSEmojiSweepFreq())
 	tryStart(c.emojiCategory, config.GetCacheGTSEmojiCategorySweepFreq())
 	tryStart(c.follow, config.GetCacheGTSFollowSweepFreq())
@@ -102,7 +96,6 @@ func (c *GTSCaches) Start() {
 func (c *GTSCaches) Stop() {
 	tryStop(c.account, config.GetCacheGTSAccountSweepFreq())
 	tryStop(c.block, config.GetCacheGTSBlockSweepFreq())
-	tryUntil("stopping domain block cache", 5, c.domainBlock.Stop)
 	tryStop(c.emoji, config.GetCacheGTSEmojiSweepFreq())
 	tryStop(c.emojiCategory, config.GetCacheGTSEmojiCategorySweepFreq())
 	tryStop(c.follow, config.GetCacheGTSFollowSweepFreq())
@@ -233,10 +226,7 @@ func (c *GTSCaches) initBlock() {
 }
 
 func (c *GTSCaches) initDomainBlock() {
-	c.domainBlock = domain.New(
-		config.GetCacheGTSDomainBlockMaxSize(),
-		config.GetCacheGTSDomainBlockTTL(),
-	)
+	c.domainBlock = new(domain.BlockCache)
 }
 
 func (c *GTSCaches) initEmoji() {


### PR DESCRIPTION
# Description
Replaces the original domain-block cache, which was an in-memory list backed up by a faster hashmap TTL cache. This replaces that entire complex system with a singular in-memory radix tree, that searches the individual children of a node using a binary search, since we can sort the tree beforehand.

Code and dependency-wise, this is a much simpler solution. It also has the added benefit that it relies only on atomic operations, no mutexes, so it should be a little faster! It may be a bit slower during the procedure of adding new domains, but considering this cache will be 95% of the time read-from, and 5% written-to, this is an acceptable trade-off.

See: https://en.wikipedia.org/wiki/Radix_tree

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
