### PR TITLE
[performance] tweak http client error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	codeberg.org/gruf/go-bytesize v1.0.2
 	codeberg.org/gruf/go-byteutil v1.1.2
-	codeberg.org/gruf/go-cache/v3 v3.2.5
+	codeberg.org/gruf/go-cache/v3 v3.2.6
 	codeberg.org/gruf/go-debug v1.3.0
 	codeberg.org/gruf/go-errors/v2 v2.2.0
 	codeberg.org/gruf/go-fastcopy v1.1.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	codeberg.org/gruf/go-byteutil v1.1.2
 	codeberg.org/gruf/go-cache/v3 v3.2.5
 	codeberg.org/gruf/go-debug v1.3.0
-	codeberg.org/gruf/go-errors/v2 v2.1.1
+	codeberg.org/gruf/go-errors/v2 v2.2.0
 	codeberg.org/gruf/go-fastcopy v1.1.2
 	codeberg.org/gruf/go-kv v1.6.1
 	codeberg.org/gruf/go-logger/v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ codeberg.org/gruf/go-bytesize v1.0.2/go.mod h1:n/GU8HzL9f3UNp/mUKyr1qVmTlj7+xacp
 codeberg.org/gruf/go-byteutil v1.0.0/go.mod h1:cWM3tgMCroSzqoBXUXMhvxTxYJp+TbCr6ioISRY5vSU=
 codeberg.org/gruf/go-byteutil v1.1.2 h1:TQLZtTxTNca9xEfDIndmo7nBYxeS94nrv/9DS3Nk5Tw=
 codeberg.org/gruf/go-byteutil v1.1.2/go.mod h1:cWM3tgMCroSzqoBXUXMhvxTxYJp+TbCr6ioISRY5vSU=
-codeberg.org/gruf/go-cache/v3 v3.2.5 h1:C+JwTR4uxjuE6qwqB48d3NCRJejsbzxRpfFEBReaViA=
-codeberg.org/gruf/go-cache/v3 v3.2.5/go.mod h1:up7za8FtNdtttcx6AJ8ffqkrSkXDGTilsd9yJ0IyhfM=
+codeberg.org/gruf/go-cache/v3 v3.2.6 h1:PtAGOvCTGwhqOqIEFBP4M0F6xbaAWYe3t/7QYGNzulI=
+codeberg.org/gruf/go-cache/v3 v3.2.6/go.mod h1:pTeVPEb9DshXUkd8Dg76UcsLpU6EC/tXQ2qb+JrmxEc=
 codeberg.org/gruf/go-debug v1.3.0 h1:PIRxQiWUFKtGOGZFdZ3Y0pqyfI0Xr87j224IYe2snZs=
 codeberg.org/gruf/go-debug v1.3.0/go.mod h1:N+vSy9uJBQgpQcJUqjctvqFz7tBHJf+S/PIjLILzpLg=
 codeberg.org/gruf/go-errors/v2 v2.0.0/go.mod h1:ZRhbdhvgoUA3Yw6e56kd9Ox984RrvbEFC2pOXyHDJP4=

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ codeberg.org/gruf/go-cache/v3 v3.2.5/go.mod h1:up7za8FtNdtttcx6AJ8ffqkrSkXDGTils
 codeberg.org/gruf/go-debug v1.3.0 h1:PIRxQiWUFKtGOGZFdZ3Y0pqyfI0Xr87j224IYe2snZs=
 codeberg.org/gruf/go-debug v1.3.0/go.mod h1:N+vSy9uJBQgpQcJUqjctvqFz7tBHJf+S/PIjLILzpLg=
 codeberg.org/gruf/go-errors/v2 v2.0.0/go.mod h1:ZRhbdhvgoUA3Yw6e56kd9Ox984RrvbEFC2pOXyHDJP4=
-codeberg.org/gruf/go-errors/v2 v2.1.1 h1:oj7JUIvUBafF60HrwN74JrCMol1Ouh3gq1ggrH5hGTw=
-codeberg.org/gruf/go-errors/v2 v2.1.1/go.mod h1:LfzD9nkAAJpEDbkUqOZQ2jdaQ8VrK0pnR36zLOMFq6Y=
+codeberg.org/gruf/go-errors/v2 v2.2.0 h1:CxnTtR4+BqRGeBHuG/FdCKM4m3otMdfPVez6ReBebkM=
+codeberg.org/gruf/go-errors/v2 v2.2.0/go.mod h1:LfzD9nkAAJpEDbkUqOZQ2jdaQ8VrK0pnR36zLOMFq6Y=
 codeberg.org/gruf/go-fastcopy v1.1.2 h1:YwmYXPsyOcRBxKEE2+w1bGAZfclHVaPijFsOVOcnNcw=
 codeberg.org/gruf/go-fastcopy v1.1.2/go.mod h1:GDDYR0Cnb3U/AIfGM3983V/L+GN+vuwVMvrmVABo21s=
 codeberg.org/gruf/go-fastpath v1.0.1/go.mod h1:edveE/Kp3Eqi0JJm0lXYdkVrB28cNUkcb/bRGFTPqeI=

--- a/internal/cache/util.go
+++ b/internal/cache/util.go
@@ -35,7 +35,7 @@ var SentinelError = errors.New("BUG: error should not be returned") //nolint:rev
 // ignoreErrors is an error ignoring function capable of being passed to
 // caches, which specifically catches and ignores our sentinel error type.
 func ignoreErrors(err error) bool {
-	return errorsv2.Is(
+	return errorsv2.Comparable(
 		SentinelError,
 		context.DeadlineExceeded,
 		context.Canceled,

--- a/internal/media/processingemoji.go
+++ b/internal/media/processingemoji.go
@@ -95,7 +95,7 @@ func (p *ProcessingEmoji) load(ctx context.Context) (*gtsmodel.Emoji, bool, erro
 
 		defer func() {
 			// This is only done when ctx NOT cancelled.
-			done = err == nil || !errors.Is(err,
+			done = err == nil || !errors.Comparable(err,
 				context.Canceled,
 				context.DeadlineExceeded,
 			)

--- a/internal/media/processingmedia.go
+++ b/internal/media/processingmedia.go
@@ -95,7 +95,7 @@ func (p *ProcessingMedia) load(ctx context.Context) (*gtsmodel.MediaAttachment, 
 
 		defer func() {
 			// This is only done when ctx NOT cancelled.
-			done = err == nil || !errors.Is(err,
+			done = err == nil || !errors.Comparable(err,
 				context.Canceled,
 				context.DeadlineExceeded,
 			)

--- a/vendor/codeberg.org/gruf/go-cache/v3/result/cache.go
+++ b/vendor/codeberg.org/gruf/go-cache/v3/result/cache.go
@@ -138,7 +138,7 @@ func (c *Cache[Value]) SetInvalidateCallback(hook func(Value)) {
 func (c *Cache[Value]) IgnoreErrors(ignore func(error) bool) {
 	if ignore == nil {
 		ignore = func(err error) bool {
-			return errors.Is(
+			return errors.Comparable(
 				err,
 				context.Canceled,
 				context.DeadlineExceeded,

--- a/vendor/codeberg.org/gruf/go-errors/v2/errors.go
+++ b/vendor/codeberg.org/gruf/go-errors/v2/errors.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -29,7 +30,7 @@ func Stacktrace(err error) Callers {
 	var e interface {
 		Stacktrace() Callers
 	}
-	if !As(err, &e) {
+	if !errors.As(err, &e) {
 		return nil
 	}
 	return e.Stacktrace()

--- a/vendor/codeberg.org/gruf/go-errors/v2/value.go
+++ b/vendor/codeberg.org/gruf/go-errors/v2/value.go
@@ -1,5 +1,7 @@
 package errors
 
+import "errors"
+
 // WithValue wraps err to store given key-value pair, accessible via Value() function.
 func WithValue(err error, key any, value any) error {
 	if err == nil {
@@ -16,7 +18,7 @@ func WithValue(err error, key any, value any) error {
 func Value(err error, key any) any {
 	var e *errWithValue
 
-	if !As(err, &e) {
+	if !errors.As(err, &e) {
 		return nil
 	}
 
@@ -47,7 +49,7 @@ func (e *errWithValue) Value(key any) any {
 			return e.val
 		}
 
-		if !As(e.err, &e) {
+		if !errors.As(e.err, &e) {
 			return nil
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ codeberg.org/gruf/go-bytesize
 # codeberg.org/gruf/go-byteutil v1.1.2
 ## explicit; go 1.16
 codeberg.org/gruf/go-byteutil
-# codeberg.org/gruf/go-cache/v3 v3.2.5
+# codeberg.org/gruf/go-cache/v3 v3.2.6
 ## explicit; go 1.19
 codeberg.org/gruf/go-cache/v3
 codeberg.org/gruf/go-cache/v3/result

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -21,7 +21,7 @@ codeberg.org/gruf/go-cache/v3/ttl
 # codeberg.org/gruf/go-debug v1.3.0
 ## explicit; go 1.16
 codeberg.org/gruf/go-debug
-# codeberg.org/gruf/go-errors/v2 v2.1.1
+# codeberg.org/gruf/go-errors/v2 v2.2.0
 ## explicit; go 1.19
 codeberg.org/gruf/go-errors/v2
 # codeberg.org/gruf/go-fastcopy v1.1.2


### PR DESCRIPTION
# Description
- improved setting of bad host entries
- update error library for fast multi-checking of errors when you would use `errors.As()`
- catch more x509 errors in httpclient as instant-return

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
