### PR TITLE
[bugfix] Fix invalid `og:description` on account w/ empty note

### DIFF
--- a/internal/web/opengraph.go
+++ b/internal/web/opengraph.go
@@ -91,7 +91,7 @@ func (og *ogMeta) withAccount(account *apimodel.Account) *ogMeta {
 	if account.Note != "" {
 		og.Description = parseDescription(account.Note)
 	} else {
-		og.Description = "This GoToSocial user hasn't written a bio yet!"
+		og.Description = `content="This GoToSocial user hasn't written a bio yet!"`
 	}
 
 	og.Image = account.Avatar

--- a/internal/web/opengraph_test.go
+++ b/internal/web/opengraph_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 )
 
 type OpenGraphTestSuite struct {
@@ -42,6 +43,72 @@ func (suite *OpenGraphTestSuite) TestParseDescription() {
 			suite.Equal(fmt.Sprintf("content=\"%s\"", tt.exp), parseDescription(tt.in))
 		})
 	}
+}
+
+func (suite *OpenGraphTestSuite) TestWithAccountWithNote() {
+	baseMeta := ogBase(&apimodel.InstanceV1{
+		AccountDomain: "example.org",
+		Languages:     []string{"en"},
+	})
+
+	accountMeta := baseMeta.withAccount(&apimodel.Account{
+		Acct:        "example_account",
+		DisplayName: "example person!!",
+		URL:         "https://example.org/@example_account",
+		Note:        "<p>This is my profile, read it and weep! Weep then!</p>",
+		Username:    "example_account",
+	})
+
+	suite.EqualValues(ogMeta{
+		Title:                "example person!! (@example_account@example.org)",
+		Type:                 "profile",
+		Locale:               "en",
+		URL:                  "https://example.org/@example_account",
+		SiteName:             "example.org",
+		Description:          "content=\"This is my profile, read it and weep! Weep then!\"",
+		Image:                "",
+		ImageWidth:           "",
+		ImageHeight:          "",
+		ImageAlt:             "Avatar for example_account",
+		ArticlePublisher:     "",
+		ArticleAuthor:        "",
+		ArticleModifiedTime:  "",
+		ArticlePublishedTime: "",
+		ProfileUsername:      "example_account",
+	}, *accountMeta)
+}
+
+func (suite *OpenGraphTestSuite) TestWithAccountNoNote() {
+	baseMeta := ogBase(&apimodel.InstanceV1{
+		AccountDomain: "example.org",
+		Languages:     []string{"en"},
+	})
+
+	accountMeta := baseMeta.withAccount(&apimodel.Account{
+		Acct:        "example_account",
+		DisplayName: "example person!!",
+		URL:         "https://example.org/@example_account",
+		Note:        "", // <- empty
+		Username:    "example_account",
+	})
+
+	suite.EqualValues(ogMeta{
+		Title:                "example person!! (@example_account@example.org)",
+		Type:                 "profile",
+		Locale:               "en",
+		URL:                  "https://example.org/@example_account",
+		SiteName:             "example.org",
+		Description:          "content=\"This GoToSocial user hasn't written a bio yet!\"",
+		Image:                "",
+		ImageWidth:           "",
+		ImageHeight:          "",
+		ImageAlt:             "Avatar for example_account",
+		ArticlePublisher:     "",
+		ArticleAuthor:        "",
+		ArticleModifiedTime:  "",
+		ArticlePublishedTime: "",
+		ProfileUsername:      "example_account",
+	}, *accountMeta)
 }
 
 func TestOpenGraphTestSuite(t *testing.T) {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request fixes a little bug where accounts with empty notes ended up with an invalid og:description tag, and adds tests for same.

closes https://github.com/superseriousbusiness/gotosocial/issues/1715

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
