### PR TITLE
[bugfix] Rework notifs to use `min_id` for paging up

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -4574,6 +4574,18 @@ paths:
                 ````
             operationId: notifications
             parameters:
+                - description: Return only notifications *OLDER* than the given max notification ID. The notification with the specified ID will not be included in the response.
+                  in: query
+                  name: max_id
+                  type: string
+                - description: Return only notifications *newer* than the given since notification ID. The notification with the specified ID will not be included in the response.
+                  in: query
+                  name: since_id
+                  type: string
+                - description: Return only notifications *immediately newer* than the given since notification ID. The notification with the specified ID will not be included in the response.
+                  in: query
+                  name: min_id
+                  type: string
                 - default: 20
                   description: Number of notifications to return.
                   in: query
@@ -4584,16 +4596,6 @@ paths:
                     type: string
                   name: exclude_types
                   type: array
-                - description: Return only notifications *OLDER* than the given max status ID. The status with the specified ID will not be included in the response.
-                  in: query
-                  name: max_id
-                  type: string
-                - description: |-
-                    Return only notifications *NEWER* than the given since status ID.
-                    The status with the specified ID will not be included in the response.
-                  in: query
-                  name: since_id
-                  type: string
             produces:
                 - application/json
             responses:

--- a/internal/api/client/notifications/notifications.go
+++ b/internal/api/client/notifications/notifications.go
@@ -36,12 +36,10 @@ const (
 
 	// ExcludeTypes is an array specifying notification types to exclude
 	ExcludeTypesKey = "exclude_types[]"
-	// MaxIDKey is the url query for setting a max notification ID to return
-	MaxIDKey = "max_id"
-	// LimitKey is for specifying maximum number of notifications to return.
-	LimitKey = "limit"
-	// SinceIDKey is for specifying the minimum notification ID to return.
-	SinceIDKey = "since_id"
+	MaxIDKey        = "max_id"
+	LimitKey        = "limit"
+	SinceIDKey      = "since_id"
+	MinIDKey        = "min_id"
 )
 
 type Module struct {

--- a/internal/api/client/notifications/notificationsget.go
+++ b/internal/api/client/notifications/notificationsget.go
@@ -50,6 +50,29 @@ import (
 //
 //	parameters:
 //	-
+//		name: max_id
+//		type: string
+//		description: >-
+//			Return only notifications *OLDER* than the given max notification ID.
+//			The notification with the specified ID will not be included in the response.
+//		in: query
+//		required: false
+//	-
+//		name: since_id
+//		type: string
+//		description: >-
+//			Return only notifications *newer* than the given since notification ID.
+//			The notification with the specified ID will not be included in the response.
+//		in: query
+//	-
+//		name: min_id
+//		type: string
+//		description: >-
+//			Return only notifications *immediately newer* than the given since notification ID.
+//			The notification with the specified ID will not be included in the response.
+//		in: query
+//		required: false
+//	-
 //		name: limit
 //		type: integer
 //		description: Number of notifications to return.
@@ -62,22 +85,6 @@ import (
 //		items:
 //			type: string
 //			description: Array of types of notifications to exclude (follow, favourite, reblog, mention, poll, follow_request)
-//		in: query
-//		required: false
-//	-
-//		name: max_id
-//		type: string
-//		description: >-
-//			Return only notifications *OLDER* than the given max status ID.
-//			The status with the specified ID will not be included in the response.
-//		in: query
-//		required: false
-//	-
-//		name: since_id
-//		type: string
-//		description: |-
-//			Return only notifications *NEWER* than the given since status ID.
-//			The status with the specified ID will not be included in the response.
 //		in: query
 //		required: false
 //
@@ -131,21 +138,15 @@ func (m *Module) NotificationsGETHandler(c *gin.Context) {
 		limit = int(i)
 	}
 
-	maxID := ""
-	maxIDString := c.Query(MaxIDKey)
-	if maxIDString != "" {
-		maxID = maxIDString
-	}
-
-	sinceID := ""
-	sinceIDString := c.Query(SinceIDKey)
-	if sinceIDString != "" {
-		sinceID = sinceIDString
-	}
-
-	excludeTypes := c.QueryArray(ExcludeTypesKey)
-
-	resp, errWithCode := m.processor.NotificationsGet(c.Request.Context(), authed, excludeTypes, limit, maxID, sinceID)
+	resp, errWithCode := m.processor.NotificationsGet(
+		c.Request.Context(),
+		authed,
+		c.Query(MaxIDKey),
+		c.Query(SinceIDKey),
+		c.Query(MinIDKey),
+		limit,
+		c.QueryArray(ExcludeTypesKey),
+	)
 	if errWithCode != nil {
 		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return

--- a/internal/db/bundb/notification_test.go
+++ b/internal/db/bundb/notification_test.go
@@ -89,7 +89,7 @@ func (suite *NotificationTestSuite) TestGetAccountNotificationsWithSpam() {
 	suite.spamNotifs()
 	testAccount := suite.testAccounts["local_account_1"]
 	before := time.Now()
-	notifications, err := suite.db.GetAccountNotifications(context.Background(), testAccount.ID, []string{}, 20, id.Highest, id.Lowest)
+	notifications, err := suite.db.GetAccountNotifications(context.Background(), testAccount.ID, id.Highest, id.Lowest, "", 20, nil)
 	suite.NoError(err)
 	timeTaken := time.Since(before)
 	fmt.Printf("\n\n\n withSpam: got %d notifications in %s\n\n\n", len(notifications), timeTaken)
@@ -103,7 +103,7 @@ func (suite *NotificationTestSuite) TestGetAccountNotificationsWithSpam() {
 func (suite *NotificationTestSuite) TestGetAccountNotificationsWithoutSpam() {
 	testAccount := suite.testAccounts["local_account_1"]
 	before := time.Now()
-	notifications, err := suite.db.GetAccountNotifications(context.Background(), testAccount.ID, []string{}, 20, id.Highest, id.Lowest)
+	notifications, err := suite.db.GetAccountNotifications(context.Background(), testAccount.ID, id.Highest, id.Lowest, "", 20, nil)
 	suite.NoError(err)
 	timeTaken := time.Since(before)
 	fmt.Printf("\n\n\n withoutSpam: got %d notifications in %s\n\n\n", len(notifications), timeTaken)
@@ -120,9 +120,9 @@ func (suite *NotificationTestSuite) TestDeleteNotificationsWithSpam() {
 	err := suite.db.DeleteNotifications(context.Background(), nil, testAccount.ID, "")
 	suite.NoError(err)
 
-	notifications, err := suite.db.GetAccountNotifications(context.Background(), testAccount.ID, []string{}, 20, id.Highest, id.Lowest)
+	notifications, err := suite.db.GetAccountNotifications(context.Background(), testAccount.ID, id.Highest, id.Lowest, "", 20, nil)
 	suite.NoError(err)
-	suite.NotNil(notifications)
+	suite.Nil(notifications)
 	suite.Empty(notifications)
 }
 
@@ -132,9 +132,9 @@ func (suite *NotificationTestSuite) TestDeleteNotificationsWithTwoAccounts() {
 	err := suite.db.DeleteNotifications(context.Background(), nil, testAccount.ID, "")
 	suite.NoError(err)
 
-	notifications, err := suite.db.GetAccountNotifications(context.Background(), testAccount.ID, []string{}, 20, id.Highest, id.Lowest)
+	notifications, err := suite.db.GetAccountNotifications(context.Background(), testAccount.ID, id.Highest, id.Lowest, "", 20, nil)
 	suite.NoError(err)
-	suite.NotNil(notifications)
+	suite.Nil(notifications)
 	suite.Empty(notifications)
 
 	notif := []*gtsmodel.Notification{}

--- a/internal/db/notification.go
+++ b/internal/db/notification.go
@@ -28,7 +28,7 @@ type Notification interface {
 	// GetNotifications returns a slice of notifications that pertain to the given accountID.
 	//
 	// Returned notifications will be ordered ID descending (ie., highest/newest to lowest/oldest).
-	GetAccountNotifications(ctx context.Context, accountID string, excludeTypes []string, limit int, maxID string, sinceID string) ([]*gtsmodel.Notification, Error)
+	GetAccountNotifications(ctx context.Context, accountID string, maxID string, sinceID string, minID string, limit int, excludeTypes []string) ([]*gtsmodel.Notification, Error)
 
 	// GetNotification returns one notification according to its id.
 	GetNotificationByID(ctx context.Context, id string) (*gtsmodel.Notification, Error)

--- a/internal/processing/notification_test.go
+++ b/internal/processing/notification_test.go
@@ -32,7 +32,7 @@ type NotificationTestSuite struct {
 // get a notification where someone has liked our status
 func (suite *NotificationTestSuite) TestGetNotifications() {
 	receivingAccount := suite.testAccounts["local_account_1"]
-	notifsResponse, err := suite.processor.NotificationsGet(context.Background(), suite.testAutheds["local_account_1"], []string{}, 10, "", "")
+	notifsResponse, err := suite.processor.NotificationsGet(context.Background(), suite.testAutheds["local_account_1"], "", "", "", 10, nil)
 	suite.NoError(err)
 	suite.Len(notifsResponse.Items, 1)
 	notif, ok := notifsResponse.Items[0].(*apimodel.Notification)
@@ -44,7 +44,7 @@ func (suite *NotificationTestSuite) TestGetNotifications() {
 	suite.NotNil(notif.Status)
 	suite.NotNil(notif.Status.Account)
 	suite.Equal(receivingAccount.ID, notif.Status.Account.ID)
-	suite.Equal(`<http://localhost:8080/api/v1/notifications?limit=10&max_id=01F8Q0ANPTWW10DAKTX7BRPBJP>; rel="next", <http://localhost:8080/api/v1/notifications?limit=10&since_id=01F8Q0ANPTWW10DAKTX7BRPBJP>; rel="prev"`, notifsResponse.LinkHeader)
+	suite.Equal(`<http://localhost:8080/api/v1/notifications?limit=10&max_id=01F8Q0ANPTWW10DAKTX7BRPBJP>; rel="next", <http://localhost:8080/api/v1/notifications?limit=10&min_id=01F8Q0ANPTWW10DAKTX7BRPBJP>; rel="prev"`, notifsResponse.LinkHeader)
 }
 
 func TestNotificationTestSuite(t *testing.T) {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request brings our notification serving (using `min_id` to page up) in line with what we do for home + public status timelines.

Also adds filters for notifications so that notifs about accounts or statuses which should not be visible are no longer shown to the requester (though they can still be seen if the id is known).

closes https://github.com/superseriousbusiness/gotosocial/issues/1720

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
