### PR TITLE
[bugfix] Serve correct 'application/jrd+json' content type for webfinger requests

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -2582,7 +2582,7 @@ paths:
                 See: https://webfinger.net/
             operationId: webfingerGet
             produces:
-                - application/json
+                - application/jrd+json
             responses:
                 "200":
                     description: ""

--- a/internal/api/util/mime.go
+++ b/internal/api/util/mime.go
@@ -20,7 +20,6 @@ package util
 // MIME represents a mime-type.
 type MIME string
 
-// MIME type
 const (
 	AppJSON           MIME = `application/json`
 	AppXML            MIME = `application/xml`
@@ -28,6 +27,7 @@ const (
 	AppRSSXML         MIME = `application/rss+xml`
 	AppActivityJSON   MIME = `application/activity+json`
 	AppActivityLDJSON MIME = `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`
+	AppJRDJSON        MIME = `application/jrd+json` // https://www.rfc-editor.org/rfc/rfc7033#section-10.2
 	AppForm           MIME = `application/x-www-form-urlencoded`
 	MultipartForm     MIME = `multipart/form-data`
 	TextXML           MIME = `text/xml`

--- a/internal/api/util/negotiate.go
+++ b/internal/api/util/negotiate.go
@@ -35,6 +35,15 @@ var JSONAcceptHeaders = []MIME{
 	AppJSON,
 }
 
+// WebfingerJSONAcceptHeaders is a slice of offers that prefers the
+// jrd+json content type, but will be chill and fall back to app/json.
+// This is to be used specifically for webfinger responses.
+// See https://www.rfc-editor.org/rfc/rfc7033#section-10.2
+var WebfingerJSONAcceptHeaders = []MIME{
+	AppJRDJSON,
+	AppJSON,
+}
+
 // HTMLOrJSONAcceptHeaders is a slice of offers that prefers TextHTML and will
 // fall back to JSON if necessary. This is useful for error handling, since it can
 // be used to serve a nice HTML page if the caller accepts that, or just JSON if not.

--- a/internal/api/wellknown/webfinger/webfinger_test.go
+++ b/internal/api/wellknown/webfinger/webfinger_test.go
@@ -18,12 +18,7 @@
 package webfinger_test
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
-	"time"
-
 	"github.com/stretchr/testify/suite"
-	"github.com/superseriousbusiness/gotosocial/internal/ap"
 	"github.com/superseriousbusiness/gotosocial/internal/api/wellknown/webfinger"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/email"
@@ -102,35 +97,4 @@ func (suite *WebfingerStandardTestSuite) TearDownTest() {
 	testrig.StandardDBTeardown(suite.db)
 	testrig.StandardStorageTeardown(suite.storage)
 	testrig.StopWorkers(&suite.state)
-}
-
-func accountDomainAccount() *gtsmodel.Account {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		panic(err)
-	}
-	publicKey := &privateKey.PublicKey
-
-	acct := &gtsmodel.Account{
-		ID:                    "01FG1K8EA7SYHEC7V6XKVNC4ZA",
-		CreatedAt:             time.Now(),
-		UpdatedAt:             time.Now(),
-		Username:              "aaaaa",
-		Domain:                "",
-		Privacy:               gtsmodel.VisibilityDefault,
-		Language:              "en",
-		URI:                   "http://gts.example.org/users/aaaaa",
-		URL:                   "http://gts.example.org/@aaaaa",
-		InboxURI:              "http://gts.example.org/users/aaaaa/inbox",
-		OutboxURI:             "http://gts.example.org/users/aaaaa/outbox",
-		FollowingURI:          "http://gts.example.org/users/aaaaa/following",
-		FollowersURI:          "http://gts.example.org/users/aaaaa/followers",
-		FeaturedCollectionURI: "http://gts.example.org/users/aaaaa/collections/featured",
-		ActorType:             ap.ActorPerson,
-		PrivateKey:            privateKey,
-		PublicKey:             publicKey,
-		PublicKeyURI:          "http://gts.example.org/users/aaaaa/main-key",
-	}
-
-	return acct
 }

--- a/internal/transport/finger.go
+++ b/internal/transport/finger.go
@@ -59,8 +59,10 @@ func prepWebfingerReq(ctx context.Context, loc, domain, username string) (*http.
 	value := url.QueryEscape("acct:" + username + "@" + domain)
 	req.URL.RawQuery = "resource=" + value
 
+	// Prefer application/jrd+json, fall back to application/json.
+	// See https://www.rfc-editor.org/rfc/rfc7033#section-10.2.
+	req.Header.Add("Accept", string(apiutil.AppJRDJSON))
 	req.Header.Add("Accept", string(apiutil.AppJSON))
-	req.Header.Add("Accept", "application/jrd+json")
 	req.Header.Set("Host", req.URL.Host)
 
 	return req, nil


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates the webfinger endpoint to correctly return `application/jrd+json` for content-type, regardless of whether `application/jrd+json` or `application/json` was negotiated.

closes https://github.com/superseriousbusiness/gotosocial/issues/1736

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
