### PR TITLE
[chore/performance] Make sender multiplier configurable

### DIFF
--- a/docs/configuration/advanced.md
+++ b/docs/configuration/advanced.md
@@ -79,4 +79,36 @@ advanced-rate-limit-requests: 300
 # Examples: [8, 4, 9, 0]
 # Default: 8
 advanced-throttling-multiplier: 8
+
+# Int. CPU multiplier for the amount of goroutines to spawn in order to send messages via ActivityPub.
+# Messages will be batched so that at most multiplier * CPU count messages will be sent out at once.
+# This can be tuned to limit concurrent POSTing to remote inboxes, preventing your instance CPU
+# usage from skyrocketing when an account with many followers posts a new status.
+#
+# Messages are split among available senders, and each sender processes its assigned messages in serial.
+# For example, say a user with 1000 followers is on an instance with 2 CPUs. With the default multiplier
+# of 2, this means 4 senders would be in process at once on this instance. When the user creates a new post,
+# each sender would end up iterating through about 250 Create messages + delivering them to remote instances.
+#
+# If you set this to 0 or less, only 1 sender will be used regardless of CPU count. This may be
+# useful in cases where you are working with very tight network or CPU constraints.
+#
+# Example values for multiplier 2 (default):
+#
+# 1 cpu = 2 concurrent senders
+# 2 cpu = 4 concurrent senders
+# 4 cpu = 8 concurrent senders
+#
+# Example values for multiplier 4:
+#
+# 1 cpu = 4 concurrent senders
+# 2 cpu = 8 concurrent senders
+# 4 cpu = 16 concurrent senders
+#
+# Example values for multiplier <1:
+#
+# 1 cpu = 1 concurrent sender
+# 2 cpu = 1 concurrent sender
+# 4 cpu = 1 concurrent sender
+advanced-sender-multiplier: 2
 ```

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -848,3 +848,35 @@ advanced-throttling-multiplier: 8
 # Examples: [30s, 10s, 5s, 1m]
 # Default: 30s
 advanced-throttling-retry-after: "30s"
+
+# Int. CPU multiplier for the amount of goroutines to spawn in order to send messages via ActivityPub.
+# Messages will be batched so that at most multiplier * CPU count messages will be sent out at once.
+# This can be tuned to limit concurrent POSTing to remote inboxes, preventing your instance CPU
+# usage from skyrocketing when an account with many followers posts a new status.
+#
+# Messages are split among available senders, and each sender processes its assigned messages in serial.
+# For example, say a user with 1000 followers is on an instance with 2 CPUs. With the default multiplier
+# of 2, this means 4 senders would be in process at once on this instance. When the user creates a new post,
+# each sender would end up iterating through about 250 Create messages + delivering them to remote instances.
+#
+# If you set this to 0 or less, only 1 sender will be used regardless of CPU count. This may be
+# useful in cases where you are working with very tight network or CPU constraints.
+#
+# Example values for multiplier 2 (default):
+#
+# 1 cpu = 2 concurrent senders
+# 2 cpu = 4 concurrent senders
+# 4 cpu = 8 concurrent senders
+#
+# Example values for multiplier 4:
+#
+# 1 cpu = 4 concurrent senders
+# 2 cpu = 8 concurrent senders
+# 4 cpu = 16 concurrent senders
+#
+# Example values for multiplier <1:
+#
+# 1 cpu = 1 concurrent sender
+# 2 cpu = 1 concurrent sender
+# 4 cpu = 1 concurrent sender
+advanced-sender-multiplier: 2

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,6 +141,7 @@ type Configuration struct {
 	AdvancedRateLimitRequests    int           `name:"advanced-rate-limit-requests" usage:"Amount of HTTP requests to permit within a 5 minute window. 0 or less turns rate limiting off."`
 	AdvancedThrottlingMultiplier int           `name:"advanced-throttling-multiplier" usage:"Multiplier to use per cpu for http request throttling. 0 or less turns throttling off."`
 	AdvancedThrottlingRetryAfter time.Duration `name:"advanced-throttling-retry-after" usage:"Retry-After duration response to send for throttled requests."`
+	AdvancedSenderMultiplier     int           `name:"advanced-sender-multiplier" usage:"Multiplier to use per cpu for batching outgoing fedi messages. 0 or less turns batching off (not recommended)."`
 
 	// Cache configuration vars.
 	Cache CacheConfiguration `name:"cache"`

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -116,6 +116,7 @@ var Defaults = Configuration{
 	AdvancedCookiesSamesite:      "lax",
 	AdvancedRateLimitRequests:    300, // 1 per second per 5 minutes
 	AdvancedThrottlingMultiplier: 8,   // 8 open requests per CPU
+	AdvancedSenderMultiplier:     2,   // 2 senders per CPU
 
 	Cache: CacheConfiguration{
 		GTS: GTSCacheConfiguration{

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -144,6 +144,7 @@ func (s *ConfigState) AddServerFlags(cmd *cobra.Command) {
 		cmd.Flags().Int(AdvancedRateLimitRequestsFlag(), cfg.AdvancedRateLimitRequests, fieldtag("AdvancedRateLimitRequests", "usage"))
 		cmd.Flags().Int(AdvancedThrottlingMultiplierFlag(), cfg.AdvancedThrottlingMultiplier, fieldtag("AdvancedThrottlingMultiplier", "usage"))
 		cmd.Flags().Duration(AdvancedThrottlingRetryAfterFlag(), cfg.AdvancedThrottlingRetryAfter, fieldtag("AdvancedThrottlingRetryAfter", "usage"))
+		cmd.Flags().Int(AdvancedSenderMultiplierFlag(), cfg.AdvancedSenderMultiplier, fieldtag("AdvancedSenderMultiplier", "usage"))
 
 		cmd.Flags().String(RequestIDHeaderFlag(), cfg.RequestIDHeader, fieldtag("RequestIDHeader", "usage"))
 	})

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -2124,6 +2124,31 @@ func GetAdvancedThrottlingRetryAfter() time.Duration { return global.GetAdvanced
 // SetAdvancedThrottlingRetryAfter safely sets the value for global configuration 'AdvancedThrottlingRetryAfter' field
 func SetAdvancedThrottlingRetryAfter(v time.Duration) { global.SetAdvancedThrottlingRetryAfter(v) }
 
+// GetAdvancedSenderMultiplier safely fetches the Configuration value for state's 'AdvancedSenderMultiplier' field
+func (st *ConfigState) GetAdvancedSenderMultiplier() (v int) {
+	st.mutex.Lock()
+	v = st.config.AdvancedSenderMultiplier
+	st.mutex.Unlock()
+	return
+}
+
+// SetAdvancedSenderMultiplier safely sets the Configuration value for state's 'AdvancedSenderMultiplier' field
+func (st *ConfigState) SetAdvancedSenderMultiplier(v int) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.AdvancedSenderMultiplier = v
+	st.reloadToViper()
+}
+
+// AdvancedSenderMultiplierFlag returns the flag name for the 'AdvancedSenderMultiplier' field
+func AdvancedSenderMultiplierFlag() string { return "advanced-sender-multiplier" }
+
+// GetAdvancedSenderMultiplier safely fetches the value for global configuration 'AdvancedSenderMultiplier' field
+func GetAdvancedSenderMultiplier() int { return global.GetAdvancedSenderMultiplier() }
+
+// SetAdvancedSenderMultiplier safely sets the value for global configuration 'AdvancedSenderMultiplier' field
+func SetAdvancedSenderMultiplier(v int) { global.SetAdvancedSenderMultiplier(v) }
+
 // GetCacheGTSAccountMaxSize safely fetches the Configuration value for state's 'Cache.GTS.AccountMaxSize' field
 func (st *ConfigState) GetCacheGTSAccountMaxSize() (v int) {
 	st.mutex.Lock()

--- a/test/envparsing.sh
+++ b/test/envparsing.sh
@@ -11,6 +11,7 @@ EXPECT=$(cat <<"EOF"
     "accounts-registration-open": true,
     "advanced-cookies-samesite": "strict",
     "advanced-rate-limit-requests": 6969,
+    "advanced-sender-multiplier": -1,
     "advanced-throttling-multiplier": -1,
     "advanced-throttling-retry-after": 10000000000,
     "application-name": "gts",
@@ -241,6 +242,7 @@ GTS_SYSLOG_PROTOCOL='udp' \
 GTS_SYSLOG_ADDRESS='127.0.0.1:6969' \
 GTS_ADVANCED_COOKIES_SAMESITE='strict' \
 GTS_ADVANCED_RATE_LIMIT_REQUESTS=6969 \
+GTS_ADVANCED_SENDER_MULTIPLIER=-1 \
 GTS_ADVANCED_THROTTLING_MULTIPLIER=-1 \
 GTS_ADVANCED_THROTTLING_RETRY_AFTER='10s' \
 GTS_REQUEST_ID_HEADER='X-Trace-Id' \

--- a/testrig/config.go
+++ b/testrig/config.go
@@ -120,6 +120,7 @@ var testDefaults = config.Configuration{
 	AdvancedCookiesSamesite:      "lax",
 	AdvancedRateLimitRequests:    0, // disabled
 	AdvancedThrottlingMultiplier: 0, // disabled
+	AdvancedSenderMultiplier:     0, // 1 sender only, regardless of CPU
 
 	SoftwareVersion: "0.0.0-testrig",
 


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request implements a configuration option for number of senders per CPU, while keeping the default multiplier of 2 * CPU.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
