### PR TITLE
[bugfix] Don't try to get user when serializing local instance account

### DIFF
--- a/internal/api/client/search/searchget_test.go
+++ b/internal/api/client/search/searchget_test.go
@@ -235,6 +235,23 @@ func (suite *SearchGetTestSuite) TestSearchLocalAccountByURI() {
 	suite.NotNil(gotAccount)
 }
 
+func (suite *SearchGetTestSuite) TestSearchLocalInstanceAccountByURI() {
+	query := "http://localhost:8080/users/localhost:8080"
+	resolve := false
+
+	searchResult, err := suite.testSearch(query, resolve, http.StatusOK)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	if !suite.Len(searchResult.Accounts, 1) {
+		suite.FailNow("expected 1 account in search results but got 0")
+	}
+
+	gotAccount := searchResult.Accounts[0]
+	suite.NotNil(gotAccount)
+}
+
 func (suite *SearchGetTestSuite) TestSearchLocalAccountByURL() {
 	query := "http://localhost:8080/@the_mighty_zork"
 	resolve := false

--- a/internal/gtsmodel/account.go
+++ b/internal/gtsmodel/account.go
@@ -95,6 +95,12 @@ func (a *Account) IsRemote() bool {
 
 // IsInstance returns whether account is an instance internal actor account.
 func (a *Account) IsInstance() bool {
+	if a.IsLocal() {
+		// Check if our instance account.
+		return a.Username == config.GetHost()
+	}
+
+	// Check if remote instance account.
 	return a.Username == a.Domain ||
 		a.FollowersURI == "" ||
 		a.FollowingURI == "" ||

--- a/internal/typeutils/internaltofrontend_test.go
+++ b/internal/typeutils/internaltofrontend_test.go
@@ -248,6 +248,82 @@ func (suite *InternalToFrontendTestSuite) TestAccountToFrontendPublicPunycode() 
 }`, string(b))
 }
 
+func (suite *InternalToFrontendTestSuite) TestLocalInstanceAccountToFrontendPublic() {
+	ctx := context.Background()
+	testAccount, err := suite.db.GetInstanceAccount(ctx, "")
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	apiAccount, err := suite.typeconverter.AccountToAPIAccountPublic(ctx, testAccount)
+	suite.NoError(err)
+	suite.NotNil(apiAccount)
+
+	b, err := json.MarshalIndent(apiAccount, "", "  ")
+	suite.NoError(err)
+
+	suite.Equal(`{
+  "id": "01AY6P665V14JJR0AFVRT7311Y",
+  "username": "localhost:8080",
+  "acct": "localhost:8080",
+  "display_name": "",
+  "locked": false,
+  "discoverable": true,
+  "bot": false,
+  "created_at": "2020-05-17T13:10:59.000Z",
+  "note": "",
+  "url": "http://localhost:8080/@localhost:8080",
+  "avatar": "",
+  "avatar_static": "",
+  "header": "http://localhost:8080/assets/default_header.png",
+  "header_static": "http://localhost:8080/assets/default_header.png",
+  "followers_count": 0,
+  "following_count": 0,
+  "statuses_count": 0,
+  "last_status_at": null,
+  "emojis": [],
+  "fields": []
+}`, string(b))
+}
+
+func (suite *InternalToFrontendTestSuite) TestLocalInstanceAccountToFrontendBlocked() {
+	ctx := context.Background()
+	testAccount, err := suite.db.GetInstanceAccount(ctx, "")
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	apiAccount, err := suite.typeconverter.AccountToAPIAccountBlocked(ctx, testAccount)
+	suite.NoError(err)
+	suite.NotNil(apiAccount)
+
+	b, err := json.MarshalIndent(apiAccount, "", "  ")
+	suite.NoError(err)
+
+	suite.Equal(`{
+  "id": "01AY6P665V14JJR0AFVRT7311Y",
+  "username": "localhost:8080",
+  "acct": "localhost:8080",
+  "display_name": "",
+  "locked": false,
+  "discoverable": false,
+  "bot": false,
+  "created_at": "2020-05-17T13:10:59.000Z",
+  "note": "",
+  "url": "http://localhost:8080/@localhost:8080",
+  "avatar": "",
+  "avatar_static": "",
+  "header": "",
+  "header_static": "",
+  "followers_count": 0,
+  "following_count": 0,
+  "statuses_count": 0,
+  "last_status_at": null,
+  "emojis": null,
+  "fields": null
+}`, string(b))
+}
+
 func (suite *InternalToFrontendTestSuite) TestStatusToFrontend() {
 	testStatus := suite.testStatuses["admin_account_status_1"]
 	requestingAccount := suite.testAccounts["local_account_1"]


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This PR updates our typeutils logic to skip trying to fetch a local user when dealing with a local instance account. Not that it's a great idea to interact with the instance account, but at least now it won't return 500 when searching for it.

closes https://github.com/superseriousbusiness/gotosocial/issues/1289

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
