### PR TITLE
Prefer JSON errors in API endpoints

### DIFF
--- a/internal/api/util/errorhandling.go
+++ b/internal/api/util/errorhandling.go
@@ -88,7 +88,8 @@ func genericErrorHandler(c *gin.Context, instanceGet func(ctx context.Context) (
 // the caller prefers to see an html page with the error rendered there. If not, or
 // if something goes wrong during the function, it will recover and just try to serve
 // an appropriate application/json content-type error.
-func ErrorHandler(c *gin.Context, errWithCode gtserror.WithCode, instanceGet func(ctx context.Context) (*apimodel.InstanceV1, gtserror.WithCode)) {
+// To override the default response type, specify `offers`.
+func ErrorHandler(c *gin.Context, errWithCode gtserror.WithCode, instanceGet func(ctx context.Context) (*apimodel.InstanceV1, gtserror.WithCode), offers ...MIME) {
 	// set the error on the gin context so that it can be logged
 	// in the gin logger middleware (internal/router/logger.go)
 	c.Error(errWithCode) //nolint:errcheck
@@ -97,7 +98,7 @@ func ErrorHandler(c *gin.Context, errWithCode gtserror.WithCode, instanceGet fun
 	// or if we should just use a json. Normally we would want to
 	// check for a returned error, but if an error occurs here we
 	// can just fall back to default behavior (serve json error).
-	accept, _ := NegotiateAccept(c, HTMLOrJSONAcceptHeaders...)
+	accept, _ := NegotiateAccept(c, JSONOrHTMLAcceptHeaders...)
 
 	if errWithCode.Code() == http.StatusNotFound {
 		// use our special not found handler with useful status text

--- a/internal/api/util/errorhandling.go
+++ b/internal/api/util/errorhandling.go
@@ -108,6 +108,11 @@ func ErrorHandler(c *gin.Context, errWithCode gtserror.WithCode, instanceGet fun
 	}
 }
 
+// WebErrorHandler is like ErrorHandler, but will display HTML over JSON by default.
+func WebErrorHandler(c *gin.Context, errWithCode gtserror.WithCode, instanceGet func(ctx context.Context) (*apimodel.InstanceV1, gtserror.WithCode)) {
+	ErrorHandler(c, errWithCode, instanceGet, TextHTML, AppJSON)
+}
+
 // OAuthErrorHandler is a lot like ErrorHandler, but it specifically returns errors
 // that are compatible with https://datatracker.ietf.org/doc/html/rfc6749#section-5.2,
 // but serializing errWithCode.Error() in the 'error' field, and putting any help text

--- a/internal/api/util/negotiate.go
+++ b/internal/api/util/negotiate.go
@@ -44,12 +44,12 @@ var WebfingerJSONAcceptHeaders = []MIME{
 	AppJSON,
 }
 
-// HTMLOrJSONAcceptHeaders is a slice of offers that prefers TextHTML and will
-// fall back to JSON if necessary. This is useful for error handling, since it can
+// JSONOrHTMLAcceptHeaders is a slice of offers that prefers AppJSON and will
+// fall back to HTML if necessary. This is useful for error handling, since it can
 // be used to serve a nice HTML page if the caller accepts that, or just JSON if not.
-var HTMLOrJSONAcceptHeaders = []MIME{
-	TextHTML,
+var JSONOrHTMLAcceptHeaders = []MIME{
 	AppJSON,
+	TextHTML,
 }
 
 // HTMLAcceptHeaders is a slice of offers that just contains text/html types.

--- a/internal/web/about.go
+++ b/internal/web/about.go
@@ -33,7 +33,7 @@ const (
 func (m *Module) aboutGETHandler(c *gin.Context) {
 	instance, err := m.processor.InstanceGetV1(c.Request.Context())
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/web/base.go
+++ b/internal/web/base.go
@@ -36,7 +36,7 @@ func (m *Module) baseHandler(c *gin.Context) {
 
 	instance, err := m.processor.InstanceGetV1(c.Request.Context())
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/web/confirmemail.go
+++ b/internal/web/confirmemail.go
@@ -32,19 +32,19 @@ func (m *Module) confirmEmailGETHandler(c *gin.Context) {
 	// if there's no token in the query, just serve the 404 web handler
 	token := c.Query(tokenParam)
 	if token == "" {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(errors.New(http.StatusText(http.StatusNotFound))), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorNotFound(errors.New(http.StatusText(http.StatusNotFound))), m.processor.InstanceGetV1)
 		return
 	}
 
 	user, errWithCode := m.processor.User().EmailConfirm(ctx, token)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
 	instance, err := m.processor.InstanceGetV1(ctx)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/web/customcss.go
+++ b/internal/web/customcss.go
@@ -33,12 +33,12 @@ const textCSSUTF8 = string(apiutil.TextCSS + "; charset=utf-8")
 func (m *Module) customCSSGETHandler(c *gin.Context) {
 	if !config.GetAccountsAllowCustomCSS() {
 		err := errors.New("accounts-allow-custom-css is not enabled on this instance")
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorNotFound(err), m.processor.InstanceGetV1)
 		return
 	}
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.TextCSS); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -46,13 +46,13 @@ func (m *Module) customCSSGETHandler(c *gin.Context) {
 	username := strings.ToLower(c.Param(usernameKey))
 	if username == "" {
 		err := errors.New("no account username specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	customCSS, errWithCode := m.processor.Account().GetCustomCSSForUsername(c.Request.Context(), username)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/web/domain-blocklist.go
+++ b/internal/web/domain-blocklist.go
@@ -35,25 +35,25 @@ const (
 func (m *Module) domainBlockListGETHandler(c *gin.Context) {
 	authed, err := oauth.Authed(c, false, false, false, false)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	if !config.GetInstanceExposeSuspendedWeb() && (authed.Account == nil || authed.User == nil) {
 		err := fmt.Errorf("this instance does not expose the list of suspended domains publicly")
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	instance, err := m.processor.InstanceGetV1(c.Request.Context())
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 
 	domainBlocks, errWithCode := m.processor.InstancePeersGet(c.Request.Context(), true, false, false)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/web/profile.go
+++ b/internal/web/profile.go
@@ -44,20 +44,20 @@ func (m *Module) profileGETHandler(c *gin.Context) {
 
 	authed, err := oauth.Authed(c, false, false, false, false)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	username := strings.ToLower(c.Param(usernameKey))
 	if username == "" {
 		err := errors.New("no account username specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	instance, err := m.processor.InstanceGetV1(ctx)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -67,7 +67,7 @@ func (m *Module) profileGETHandler(c *gin.Context) {
 
 	account, errWithCode := m.processor.Account().GetLocalByUsername(ctx, authed.Account, username)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, instanceGet)
+		apiutil.WebErrorHandler(c, errWithCode, instanceGet)
 		return
 	}
 
@@ -105,7 +105,7 @@ func (m *Module) profileGETHandler(c *gin.Context) {
 
 	statusResp, errWithCode := m.processor.Account().WebStatusesGet(ctx, account.ID, maxStatusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, instanceGet)
+		apiutil.WebErrorHandler(c, errWithCode, instanceGet)
 		return
 	}
 
@@ -116,7 +116,7 @@ func (m *Module) profileGETHandler(c *gin.Context) {
 	if !paging {
 		pinnedResp, errWithCode = m.processor.Account().StatusesGet(ctx, authed.Account, account.ID, 0, false, false, "", "", true, false, false)
 		if errWithCode != nil {
-			apiutil.ErrorHandler(c, errWithCode, instanceGet)
+			apiutil.WebErrorHandler(c, errWithCode, instanceGet)
 			return
 		}
 	}
@@ -158,14 +158,14 @@ func (m *Module) returnAPProfile(ctx context.Context, c *gin.Context, username s
 
 	user, errWithCode := m.processor.Fedi().UserGet(ctx, username, c.Request.URL)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1) //nolint:contextcheck
+		apiutil.WebErrorHandler(c, errWithCode, m.processor.InstanceGetV1) //nolint:contextcheck
 		return
 	}
 
 	b, mErr := json.Marshal(user)
 	if mErr != nil {
 		err := fmt.Errorf("could not marshal json: %s", mErr)
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1) //nolint:contextcheck
+		apiutil.WebErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1) //nolint:contextcheck
 		return
 	}
 

--- a/internal/web/rss.go
+++ b/internal/web/rss.go
@@ -83,7 +83,7 @@ func (m *Module) rssFeedGETHandler(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	if _, err := apiutil.NegotiateAccept(c, apiutil.AppRSSXML); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -91,7 +91,7 @@ func (m *Module) rssFeedGETHandler(c *gin.Context) {
 	username := strings.ToLower(c.Param(usernameKey))
 	if username == "" {
 		err := errors.New("no account username specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -100,7 +100,7 @@ func (m *Module) rssFeedGETHandler(c *gin.Context) {
 
 	getRssFeed, accountLastPostedPublic, errWithCode := m.processor.Account().GetRSSFeedForUsername(ctx, username)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
@@ -112,13 +112,13 @@ func (m *Module) rssFeedGETHandler(c *gin.Context) {
 		// we either have no cache entry for this, or we have an expired cache entry; generate a new one
 		rssFeed, errWithCode = getRssFeed()
 		if errWithCode != nil {
-			apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
+			apiutil.WebErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 			return
 		}
 
 		eTag, err := generateEtag(bytes.NewBufferString(rssFeed))
 		if err != nil {
-			apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
+			apiutil.WebErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 			return
 		}
 
@@ -146,7 +146,7 @@ func (m *Module) rssFeedGETHandler(c *gin.Context) {
 		// we had a cache entry already so we didn't call to get the rss feed yet
 		rssFeed, errWithCode = getRssFeed()
 		if errWithCode != nil {
-			apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
+			apiutil.WebErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 			return
 		}
 	}

--- a/internal/web/settings-panel.go
+++ b/internal/web/settings-panel.go
@@ -28,7 +28,7 @@ import (
 func (m *Module) SettingsPanelHandler(c *gin.Context) {
 	instance, err := m.processor.InstanceGetV1(c.Request.Context())
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 

--- a/internal/web/thread.go
+++ b/internal/web/thread.go
@@ -39,7 +39,7 @@ func (m *Module) threadGETHandler(c *gin.Context) {
 
 	authed, err := oauth.Authed(c, false, false, false, false)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -47,7 +47,7 @@ func (m *Module) threadGETHandler(c *gin.Context) {
 	username := strings.ToLower(c.Param(usernameKey))
 	if username == "" {
 		err := errors.New("no account username specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -55,13 +55,13 @@ func (m *Module) threadGETHandler(c *gin.Context) {
 	statusID := strings.ToUpper(c.Param(statusIDKey))
 	if statusID == "" {
 		err := errors.New("no status id specified")
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
 	instance, err := m.processor.InstanceGetV1(ctx)
 	if err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}
 
@@ -72,19 +72,19 @@ func (m *Module) threadGETHandler(c *gin.Context) {
 	// do this check to make sure the status is actually from a local account,
 	// we shouldn't render threads from statuses that don't belong to us!
 	if _, errWithCode := m.processor.Account().GetLocalByUsername(ctx, authed.Account, username); errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, instanceGet)
+		apiutil.WebErrorHandler(c, errWithCode, instanceGet)
 		return
 	}
 
 	status, errWithCode := m.processor.Status().Get(ctx, authed.Account, statusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, instanceGet)
+		apiutil.WebErrorHandler(c, errWithCode, instanceGet)
 		return
 	}
 
 	if !strings.EqualFold(username, status.Account.Username) {
 		err := gtserror.NewErrorNotFound(errors.New("path username not equal to status author username"))
-		apiutil.ErrorHandler(c, gtserror.NewErrorNotFound(err), instanceGet)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorNotFound(err), instanceGet)
 		return
 	}
 
@@ -98,7 +98,7 @@ func (m *Module) threadGETHandler(c *gin.Context) {
 
 	context, errWithCode := m.processor.Status().ContextGet(ctx, authed.Account, statusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, instanceGet)
+		apiutil.WebErrorHandler(c, errWithCode, instanceGet)
 		return
 	}
 
@@ -133,14 +133,14 @@ func (m *Module) returnAPStatus(ctx context.Context, c *gin.Context, username st
 
 	status, errWithCode := m.processor.Fedi().StatusGet(ctx, username, statusID)
 	if errWithCode != nil {
-		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1) //nolint:contextcheck
+		apiutil.WebErrorHandler(c, errWithCode, m.processor.InstanceGetV1) //nolint:contextcheck
 		return
 	}
 
 	b, mErr := json.Marshal(status)
 	if mErr != nil {
 		err := fmt.Errorf("could not marshal json: %s", mErr)
-		apiutil.ErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1) //nolint:contextcheck
+		apiutil.WebErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1) //nolint:contextcheck
 		return
 	}
 


### PR DESCRIPTION

# Description

Fixing a point mentioned in https://github.com/superseriousbusiness/gotosocial/issues/1759#issuecomment-1541690096

- Default to JSON over HTML for error handling
- Change the default error display for web endpoints to html

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
