### PR TITLE
[frogend/chore] remove break-all on profile fields

### DIFF
--- a/web/source/css/profile.css
+++ b/web/source/css/profile.css
@@ -242,7 +242,6 @@
 			display: flex;
 			flex-direction: column;
 			border-bottom: 0.1rem solid $gray2;
-			word-break: break-all;
 
 			&:first-child {
 				border-top: 0.1rem solid $gray2;


### PR DESCRIPTION
Teeny fix to remove break-all on profile fields; it was causing lines to split unpleasantly, making them difficult to read.