### PR TITLE
[frogend/chore] Update backnextlinks

### DIFF
--- a/web/source/css/profile.css
+++ b/web/source/css/profile.css
@@ -219,6 +219,15 @@
 			border-bottom-right-radius: $br;
 		}
 	}
+
+	.backnextlinks {
+		display: flex;
+		justify-content: space-between;
+
+		.next {
+			margin-left: auto;
+		}
+	}
 }
 
 .profile .about-user {


### PR DESCRIPTION
v. small fix to restore previous behavior of back/next links on profiles, so that 'show older' always appears on the right, and 'back to top' always appears on the left