### PR TITLE
[bugfix] update go-cache to v3.3.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	codeberg.org/gruf/go-bytesize v1.0.2
 	codeberg.org/gruf/go-byteutil v1.1.2
-	codeberg.org/gruf/go-cache/v3 v3.3.2
+	codeberg.org/gruf/go-cache/v3 v3.3.3
 	codeberg.org/gruf/go-debug v1.3.0
 	codeberg.org/gruf/go-errors/v2 v2.2.0
 	codeberg.org/gruf/go-fastcopy v1.1.2

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	codeberg.org/gruf/go-bytesize v1.0.2
 	codeberg.org/gruf/go-byteutil v1.1.2
-	codeberg.org/gruf/go-cache/v3 v3.3.0
+	codeberg.org/gruf/go-cache/v3 v3.3.1
 	codeberg.org/gruf/go-debug v1.3.0
 	codeberg.org/gruf/go-errors/v2 v2.2.0
 	codeberg.org/gruf/go-fastcopy v1.1.2

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	codeberg.org/gruf/go-bytesize v1.0.2
 	codeberg.org/gruf/go-byteutil v1.1.2
-	codeberg.org/gruf/go-cache/v3 v3.3.1
+	codeberg.org/gruf/go-cache/v3 v3.3.2
 	codeberg.org/gruf/go-debug v1.3.0
 	codeberg.org/gruf/go-errors/v2 v2.2.0
 	codeberg.org/gruf/go-fastcopy v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ codeberg.org/gruf/go-bytesize v1.0.2/go.mod h1:n/GU8HzL9f3UNp/mUKyr1qVmTlj7+xacp
 codeberg.org/gruf/go-byteutil v1.0.0/go.mod h1:cWM3tgMCroSzqoBXUXMhvxTxYJp+TbCr6ioISRY5vSU=
 codeberg.org/gruf/go-byteutil v1.1.2 h1:TQLZtTxTNca9xEfDIndmo7nBYxeS94nrv/9DS3Nk5Tw=
 codeberg.org/gruf/go-byteutil v1.1.2/go.mod h1:cWM3tgMCroSzqoBXUXMhvxTxYJp+TbCr6ioISRY5vSU=
-codeberg.org/gruf/go-cache/v3 v3.3.1 h1:Y4flVtwTyrLFQwB9EY7gUxiaGE8RsP/NmWC5SLK/sdM=
-codeberg.org/gruf/go-cache/v3 v3.3.1/go.mod h1:pTeVPEb9DshXUkd8Dg76UcsLpU6EC/tXQ2qb+JrmxEc=
+codeberg.org/gruf/go-cache/v3 v3.3.2 h1:tAS0PTB6SMBua6J97D0o4koGphFJ5qbJwhtNLw5FXUs=
+codeberg.org/gruf/go-cache/v3 v3.3.2/go.mod h1:pTeVPEb9DshXUkd8Dg76UcsLpU6EC/tXQ2qb+JrmxEc=
 codeberg.org/gruf/go-debug v1.3.0 h1:PIRxQiWUFKtGOGZFdZ3Y0pqyfI0Xr87j224IYe2snZs=
 codeberg.org/gruf/go-debug v1.3.0/go.mod h1:N+vSy9uJBQgpQcJUqjctvqFz7tBHJf+S/PIjLILzpLg=
 codeberg.org/gruf/go-errors/v2 v2.0.0/go.mod h1:ZRhbdhvgoUA3Yw6e56kd9Ox984RrvbEFC2pOXyHDJP4=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ codeberg.org/gruf/go-bytesize v1.0.2/go.mod h1:n/GU8HzL9f3UNp/mUKyr1qVmTlj7+xacp
 codeberg.org/gruf/go-byteutil v1.0.0/go.mod h1:cWM3tgMCroSzqoBXUXMhvxTxYJp+TbCr6ioISRY5vSU=
 codeberg.org/gruf/go-byteutil v1.1.2 h1:TQLZtTxTNca9xEfDIndmo7nBYxeS94nrv/9DS3Nk5Tw=
 codeberg.org/gruf/go-byteutil v1.1.2/go.mod h1:cWM3tgMCroSzqoBXUXMhvxTxYJp+TbCr6ioISRY5vSU=
-codeberg.org/gruf/go-cache/v3 v3.3.0 h1:Bor75j4MYJIDqH22/aQvmwA7hMqBOzDOWdSQz25Lq+8=
-codeberg.org/gruf/go-cache/v3 v3.3.0/go.mod h1:pTeVPEb9DshXUkd8Dg76UcsLpU6EC/tXQ2qb+JrmxEc=
+codeberg.org/gruf/go-cache/v3 v3.3.1 h1:Y4flVtwTyrLFQwB9EY7gUxiaGE8RsP/NmWC5SLK/sdM=
+codeberg.org/gruf/go-cache/v3 v3.3.1/go.mod h1:pTeVPEb9DshXUkd8Dg76UcsLpU6EC/tXQ2qb+JrmxEc=
 codeberg.org/gruf/go-debug v1.3.0 h1:PIRxQiWUFKtGOGZFdZ3Y0pqyfI0Xr87j224IYe2snZs=
 codeberg.org/gruf/go-debug v1.3.0/go.mod h1:N+vSy9uJBQgpQcJUqjctvqFz7tBHJf+S/PIjLILzpLg=
 codeberg.org/gruf/go-errors/v2 v2.0.0/go.mod h1:ZRhbdhvgoUA3Yw6e56kd9Ox984RrvbEFC2pOXyHDJP4=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ codeberg.org/gruf/go-bytesize v1.0.2/go.mod h1:n/GU8HzL9f3UNp/mUKyr1qVmTlj7+xacp
 codeberg.org/gruf/go-byteutil v1.0.0/go.mod h1:cWM3tgMCroSzqoBXUXMhvxTxYJp+TbCr6ioISRY5vSU=
 codeberg.org/gruf/go-byteutil v1.1.2 h1:TQLZtTxTNca9xEfDIndmo7nBYxeS94nrv/9DS3Nk5Tw=
 codeberg.org/gruf/go-byteutil v1.1.2/go.mod h1:cWM3tgMCroSzqoBXUXMhvxTxYJp+TbCr6ioISRY5vSU=
-codeberg.org/gruf/go-cache/v3 v3.3.2 h1:tAS0PTB6SMBua6J97D0o4koGphFJ5qbJwhtNLw5FXUs=
-codeberg.org/gruf/go-cache/v3 v3.3.2/go.mod h1:pTeVPEb9DshXUkd8Dg76UcsLpU6EC/tXQ2qb+JrmxEc=
+codeberg.org/gruf/go-cache/v3 v3.3.3 h1:CzOFg6JV+typ8Jst1rrYDbZjxEV7bUxKggkbfN5Y79o=
+codeberg.org/gruf/go-cache/v3 v3.3.3/go.mod h1:pTeVPEb9DshXUkd8Dg76UcsLpU6EC/tXQ2qb+JrmxEc=
 codeberg.org/gruf/go-debug v1.3.0 h1:PIRxQiWUFKtGOGZFdZ3Y0pqyfI0Xr87j224IYe2snZs=
 codeberg.org/gruf/go-debug v1.3.0/go.mod h1:N+vSy9uJBQgpQcJUqjctvqFz7tBHJf+S/PIjLILzpLg=
 codeberg.org/gruf/go-errors/v2 v2.0.0/go.mod h1:ZRhbdhvgoUA3Yw6e56kd9Ox984RrvbEFC2pOXyHDJP4=

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,8 +5,7 @@ set -eu
 # DEBUG returns whether DEBUG build is enabled.
 DEBUG() { [ ! -z "${DEBUG-}" ]; }
 
-CGO_ENABLED=0 go build -trimpath -v \
-                       -tags "netgo osusergo static_build kvformat notracing $(DEBUG && echo 'debugenv')" \
+CGO_ENABLED=0 go build -trimpath \
+                       -tags "netgo osusergo static_build kvformat $(DEBUG && echo 'debugenv')" \
                        -ldflags="-s -w -extldflags '-static' -X 'main.Version=${VERSION:-$(git describe --tags --abbrev=0)}'" \
-                       -gcflags=all='-B -C -l=4' \
                        ./cmd/gotosocial

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,7 +5,8 @@ set -eu
 # DEBUG returns whether DEBUG build is enabled.
 DEBUG() { [ ! -z "${DEBUG-}" ]; }
 
-CGO_ENABLED=0 go build -trimpath \
-                       -tags "netgo osusergo static_build kvformat $(DEBUG && echo 'debugenv')" \
+CGO_ENABLED=0 go build -trimpath -v \
+                       -tags "netgo osusergo static_build kvformat notracing $(DEBUG && echo 'debugenv')" \
                        -ldflags="-s -w -extldflags '-static' -X 'main.Version=${VERSION:-$(git describe --tags --abbrev=0)}'" \
+                       -gcflags=all='-B -C -l=4' \
                        ./cmd/gotosocial

--- a/vendor/codeberg.org/gruf/go-cache/v3/cache.go
+++ b/vendor/codeberg.org/gruf/go-cache/v3/cache.go
@@ -15,10 +15,10 @@ type Cache[Key comparable, Value any] interface {
 	Stop() bool
 
 	// SetEvictionCallback sets the eviction callback to the provided hook.
-	SetEvictionCallback(hook func(*ttlcache.Entry[Key, Value]))
+	SetEvictionCallback(hook func(Key, Value))
 
 	// SetInvalidateCallback sets the invalidate callback to the provided hook.
-	SetInvalidateCallback(hook func(*ttlcache.Entry[Key, Value]))
+	SetInvalidateCallback(hook func(Key, Value))
 
 	// SetTTL sets the cache item TTL. Update can be specified to force updates of existing items in the cache, this will simply add the change in TTL to their current expiry time.
 	SetTTL(ttl time.Duration, update bool)
@@ -43,6 +43,9 @@ type Cache[Key comparable, Value any] interface {
 
 	// Invalidate deletes a value from the cache, calling the invalidate callback.
 	Invalidate(key Key) bool
+
+	// InvalidateAll is equivalent to multiple Invalidate calls.
+	InvalidateAll(keys ...Key) bool
 
 	// Clear empties the cache, calling the invalidate callback on each entry.
 	Clear()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ codeberg.org/gruf/go-bytesize
 # codeberg.org/gruf/go-byteutil v1.1.2
 ## explicit; go 1.16
 codeberg.org/gruf/go-byteutil
-# codeberg.org/gruf/go-cache/v3 v3.3.1
+# codeberg.org/gruf/go-cache/v3 v3.3.2
 ## explicit; go 1.19
 codeberg.org/gruf/go-cache/v3
 codeberg.org/gruf/go-cache/v3/result

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ codeberg.org/gruf/go-bytesize
 # codeberg.org/gruf/go-byteutil v1.1.2
 ## explicit; go 1.16
 codeberg.org/gruf/go-byteutil
-# codeberg.org/gruf/go-cache/v3 v3.3.0
+# codeberg.org/gruf/go-cache/v3 v3.3.1
 ## explicit; go 1.19
 codeberg.org/gruf/go-cache/v3
 codeberg.org/gruf/go-cache/v3/result

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ codeberg.org/gruf/go-bytesize
 # codeberg.org/gruf/go-byteutil v1.1.2
 ## explicit; go 1.16
 codeberg.org/gruf/go-byteutil
-# codeberg.org/gruf/go-cache/v3 v3.3.2
+# codeberg.org/gruf/go-cache/v3 v3.3.3
 ## explicit; go 1.19
 codeberg.org/gruf/go-cache/v3
 codeberg.org/gruf/go-cache/v3/result


### PR DESCRIPTION
# Description
Updates go-cache library to v3.3.2 to fix possible race condition between invalidate hooks holding locks.

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
