### PR TITLE
[frogend/chore] Fix profile domain

### DIFF
--- a/web/template/profile.tmpl
+++ b/web/template/profile.tmpl
@@ -39,7 +39,7 @@
 				<span class="sr-only">.</span>
 			</span>
 			<span class="username text-cutoff">@{{.account.Username}}<span class="sr-only">,
-				</span>{{acctInstance .account.Acct}}</span>
+				</span>@{{.instance.AccountDomain}}</span>
 			{{- /* Only render account role if 1. it's present and 2. it's not equal to the standard 'user' role */ -}}
 			{{ if and (.account.Role) (ne .account.Role.Name "user") }}
 			<div class="role {{ .account.Role.Name }}">
@@ -50,7 +50,7 @@
 		<div class="sr-only">
 			Profile for
 			{{if .account.DisplayName}}{{.account.DisplayName}}{{else}}{{.account.Username}}{{end}}.
-			Username @{{.account.Username}}, {{acctInstance .account.Acct}}.
+			Username @{{.account.Username}}, {{.instance.AccountDomain}}.
 			{{ if and (.account.Role) (ne .account.Role.Name "user") }}
 			Role: {{ .account.Role.Name }}
 			{{ end }}

--- a/web/template/profile.tmpl
+++ b/web/template/profile.tmpl
@@ -36,10 +36,8 @@
 				{{else}}
 				{{.account.Username}}
 				{{end}}
-				<span class="sr-only">.</span>
 			</span>
-			<span class="username text-cutoff">@{{.account.Username}}<span class="sr-only">,
-				</span>@{{.instance.AccountDomain}}</span>
+			<span class="username text-cutoff">@{{.account.Username}}@{{.instance.AccountDomain}}</span>
 			{{- /* Only render account role if 1. it's present and 2. it's not equal to the standard 'user' role */ -}}
 			{{ if and (.account.Role) (ne .account.Role.Name "user") }}
 			<div class="role {{ .account.Role.Name }}">


### PR DESCRIPTION
Fixes the profile templates to include the user's domain (for easy copying), as that's never included in the acct field so didn't work with `acctInstance`