### PR TITLE
[docs] remove nginx trailing slash

### DIFF
--- a/docs/installation_guide/nginx.md
+++ b/docs/installation_guide/nginx.md
@@ -154,7 +154,7 @@ server {
   server_name example.org;
   location / {
     # set to 127.0.0.1 instead of localhost to work around https://stackoverflow.com/a/52550758
-    proxy_pass http://127.0.0.1:8080/;
+    proxy_pass http://127.0.0.1:8080;
     proxy_set_header Host $host;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Just bring the 'finished' nginx example in line with the one further up the page; that trailing slash is significant.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
