### PR TITLE
[chore] Change time comparison in webfinger test

### DIFF
--- a/internal/transport/finger_test.go
+++ b/internal/transport/finger_test.go
@@ -87,9 +87,12 @@ func (suite *FingerTestSuite) TestFingerWithHostMetaCacheStrategy() {
 
 	// the TTL of the entry should have extended because we did a second
 	// successful finger
-	suite.NotEqual(initialTime, repeatTime, "expected webfinger cache entry to have different expiry times")
+	if repeatTime.Equal(initialTime) {
+		suite.FailNowf("expected webfinger cache entry to have different expiry times", "initial: '%s', repeat: '%s'", initialTime, repeatTime)
+	}
+
 	if repeatTime.Before(initialTime) {
-		suite.FailNow("expected webfinger cache entry to not be a time traveller")
+		suite.FailNowf("expected webfinger cache entry to not be a time traveller", "initial: '%s', repeat: '%s'", initialTime, repeatTime)
 	}
 
 	// finger a non-existing user on that same instance which will return an error


### PR DESCRIPTION
# Description

Every now and then the `TestFingerWithHostMetaCacheStrategy` would fail on a time related error. I suspect `suite.Equal` doesn't quite work as expected when given two `time.Time`'s, so instead explicitly check with the `time.Equal`.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
