### PR TITLE
[feature] Make client IP logging configurable

### DIFF
--- a/cmd/gotosocial/action/server/server.go
+++ b/cmd/gotosocial/action/server/server.go
@@ -162,7 +162,7 @@ var Start action.GTSAction = func(ctx context.Context) error {
 	middlewares = append(middlewares, []gin.HandlerFunc{
 		// note: hooks adding ctx fields must be ABOVE
 		// the logger, otherwise won't be accessible.
-		middleware.Logger(),
+		middleware.Logger(config.GetLogClientIP()),
 		middleware.UserAgent(),
 		middleware.CORS(),
 		middleware.ExtraHeaders(),

--- a/cmd/gotosocial/action/testrig/testrig.go
+++ b/cmd/gotosocial/action/testrig/testrig.go
@@ -105,7 +105,7 @@ var Start action.GTSAction = func(ctx context.Context) error {
 		middlewares = append(middlewares, tracing.InstrumentGin())
 	}
 	middlewares = append(middlewares, []gin.HandlerFunc{
-		middleware.Logger(),
+		middleware.Logger(config.GetLogClientIP()),
 		middleware.UserAgent(),
 		middleware.CORS(),
 		middleware.ExtraHeaders(),

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -30,6 +30,11 @@ log-level: "info"
 # Default: false
 log-db-queries: false
 
+# Bool. Include the client IP in the emitted log lines
+# Options: [true, false]
+# Default: true
+log-client-ip: true
+
 # String. Application name to use internally.
 # Examples: ["My Application","gotosocial"]
 # Default: "gotosocial"
@@ -765,10 +770,6 @@ syslog-address: "localhost:514"
 ##################################
 ##### OBSERVABILITY SETTINGS #####
 ##################################
-
-# Bool. Enable generation/parsing of a request ID for each received HTTP Request.
-# Default: true
-request-id-enabled: true
 
 # String. Header name to use to extract a request or trace ID from. Typically set by a
 # loadbalancer or proxy.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,7 @@ func fieldtag(field, tag string) string {
 type Configuration struct {
 	LogLevel        string   `name:"log-level" usage:"Log level to run at: [trace, debug, info, warn, fatal]"`
 	LogDbQueries    bool     `name:"log-db-queries" usage:"Log database queries verbosely when log-level is trace or debug"`
+	LogClientIP     bool     `name:"log-client-ip" usage:"Include the client IP in logs"`
 	ApplicationName string   `name:"application-name" usage:"Name of the application, used in various places internally"`
 	LandingPageUser string   `name:"landing-page-user" usage:"the user that should be shown on the instance's landing page"`
 	ConfigPath      string   `name:"config-path" usage:"Path to a file containing gotosocial configuration. Values set in this file will be overwritten by values set as env vars or arguments"`

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -198,4 +198,6 @@ var Defaults = Configuration{
 	AdminMediaPruneDryRun: true,
 
 	RequestIDHeader: "X-Request-Id",
+
+	LogClientIP: true,
 }

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -3679,3 +3679,28 @@ func GetRequestIDHeader() string { return global.GetRequestIDHeader() }
 
 // SetRequestIDHeader safely sets the value for global configuration 'RequestIDHeader' field
 func SetRequestIDHeader(v string) { global.SetRequestIDHeader(v) }
+
+// GetLogClientIP safely fetches the Configuration value for state's 'LogClientIP' field
+func (st *ConfigState) GetLogClientIP() (v bool) {
+	st.mutex.Lock()
+	v = st.config.LogClientIP
+	st.mutex.Unlock()
+	return
+}
+
+// SetLogClientIP safely sets the Configuration value for state's 'LogClientIP' field
+func (st *ConfigState) SetLogClientIP(v bool) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.LogClientIP = v
+	st.reloadToViper()
+}
+
+// LogClientIPFlag returns the flag name for the 'LogClientIP' field
+func LogClientIPFlag() string { return "log-client-ip" }
+
+// GetLogClientIP safely fetches the value for global configuration 'LogClientIP' field
+func GetLogClientIP() bool { return global.GetLogClientIP() }
+
+// SetLogClientIP safely sets the value for global configuration 'LogClientIP' field
+func SetLogClientIP(v bool) { global.SetLogClientIP(v) }

--- a/internal/gtscontext/log_hooks.go
+++ b/internal/gtscontext/log_hooks.go
@@ -34,7 +34,7 @@ func init() {
 		}
 		return kvs
 	})
-	// Client IP middleware hook.
+	// Public Key ID middleware hook.
 	log.Hook(func(ctx context.Context, kvs []kv.Field) []kv.Field {
 		if id := PublicKeyID(ctx); id != "" {
 			return append(kvs, kv.Field{K: "pubKeyID", V: id})

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -31,7 +31,7 @@ import (
 )
 
 // Logger returns a gin middleware which provides request logging and panic recovery.
-func Logger() gin.HandlerFunc {
+func Logger(logClientIP bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Initialize the logging fields
 		fields := make(kv.Fields, 5, 7)
@@ -72,10 +72,7 @@ func Logger() gin.HandlerFunc {
 			fields[2] = kv.Field{"method", c.Request.Method}
 			fields[3] = kv.Field{"statusCode", code}
 			fields[4] = kv.Field{"path", path}
-			if includeClientIP := true; includeClientIP {
-				// TODO: make this configurable.
-				//
-				// Include clientIP if enabled.
+			if logClientIP {
 				fields = append(fields, kv.Field{
 					"clientIP", c.ClientIP(),
 				})

--- a/test/envparsing.sh
+++ b/test/envparsing.sh
@@ -98,6 +98,7 @@ EXPECT=$(cat <<"EOF"
     "letsencrypt-email-address": "",
     "letsencrypt-enabled": true,
     "letsencrypt-port": 80,
+    "log-client-ip": false,
     "log-db-queries": true,
     "log-level": "info",
     "media-description-max-chars": 5000,
@@ -170,6 +171,7 @@ EOF
 # ensure that these are parsed without panic
 OUTPUT=$(GTS_LOG_LEVEL='info' \
 GTS_LOG_DB_QUERIES=true \
+GTS_LOG_CLIENT_IP=false \
 GTS_APPLICATION_NAME=gts \
 GTS_LANDING_PAGE_USER=admin \
 GTS_HOST=example.com \


### PR DESCRIPTION
# Description

Admins can now chose whether client IPs should be present in the logs. By default this is enabled in order to retain the current behaviour and because when running in non-proxied mode this is something admins probably want.

When having an LB in front of GtS this can be disabled as requsets can still be correlated between LB and GtS using the Request ID or the tracing facilities.

Fixes: #1574

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
