### PR TITLE
[bugfix] Fix incorrect default for empty emoji domain

### DIFF
--- a/internal/db/bundb/migrations/20230521105850_emoji_empty_domain_fix.go
+++ b/internal/db/bundb/migrations/20230521105850_emoji_empty_domain_fix.go
@@ -1,0 +1,154 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			// SQLite doesn't mind creating multiple constraints with
+			// the same name, but Postgres balks at it, so remove
+			// constraints before we go editing the emoji tables.
+			if tx.Dialect().Name() == dialect.PG {
+				for _, constraint := range []string{
+					"shortcodedomain", // initial constraint name
+					"domainshortcode", // later constraint name
+				} {
+					if _, err := tx.ExecContext(
+						ctx,
+						"ALTER TABLE ? DROP CONSTRAINT IF EXISTS ?",
+						bun.Ident("emojis"),
+						bun.Safe(constraint),
+					); err != nil {
+						return err
+					}
+				}
+			}
+
+			// Set all existing emoji domains to null
+			// where domain is '', to fix the bug!
+			if _, err := tx.
+				NewUpdate().
+				Table("emojis").
+				Set("? = NULL", bun.Ident("domain")).
+				Where("? = ?", bun.Ident("domain"), "").
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			// Create the new emojis table.
+			if _, err := tx.
+				NewCreateTable().
+				ModelTableExpr("new_emojis").
+				Model(&gtsmodel.Emoji{}).
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			// Specify columns explicitly to
+			// avoid any Postgres shenanigans.
+			columns := []string{
+				"id",
+				"created_at",
+				"updated_at",
+				"shortcode",
+				"domain",
+				"image_remote_url",
+				"image_static_remote_url",
+				"image_url",
+				"image_static_url",
+				"image_path",
+				"image_static_path",
+				"image_content_type",
+				"image_static_content_type",
+				"image_file_size",
+				"image_static_file_size",
+				"image_updated_at",
+				"disabled",
+				"uri",
+				"visible_in_picker",
+				"category_id",
+			}
+
+			// Copy existing emojis to the new table.
+			if _, err := tx.
+				NewInsert().
+				Table("new_emojis").
+				Table("emojis").
+				Column(columns...).
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			// Drop the old table.
+			if _, err := tx.
+				NewDropTable().
+				Table("emojis").
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			// Rename new table to old table.
+			if _, err := tx.
+				ExecContext(
+					ctx,
+					"ALTER TABLE ? RENAME TO ?",
+					bun.Ident("new_emojis"),
+					bun.Ident("emojis"),
+				); err != nil {
+				return err
+			}
+
+			// Add indexes to the new table.
+			for index, columns := range map[string][]string{
+				"emojis_id_idx":               {"id"},
+				"emojis_available_custom_idx": {"visible_in_picker", "disabled", "shortcode"},
+				"emojis_image_static_url_idx": {"image_static_url"},
+				"emojis_uri_idx":              {"uri"},
+			} {
+				if _, err := tx.
+					NewCreateIndex().
+					Table("emojis").
+					Index(index).
+					Column(columns...).
+					Exec(ctx); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request adds a database migration to fix a previous bodged migration, where emoji domains were being set to `''` for local emojis, when they should have been `NULL`.

The migration fixes this by updating all emoji domains to NULL where they were empty strings, then moving all emojis into a new table to ensure that the database default is set correctly.

closes https://github.com/superseriousbusiness/gotosocial/issues/1792

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
