### PR TITLE
[bugfix] Start + stop caches properly for testrig + pruning

### DIFF
--- a/cmd/gotosocial/action/admin/media/prune/common.go
+++ b/cmd/gotosocial/action/admin/media/prune/common.go
@@ -37,7 +37,10 @@ type prune struct {
 
 func setupPrune(ctx context.Context) (*prune, error) {
 	var state state.State
+
 	state.Caches.Init()
+	state.Caches.Start()
+
 	state.Workers.Start()
 
 	dbService, err := bundb.NewBunDBService(ctx, &state)
@@ -51,8 +54,6 @@ func setupPrune(ctx context.Context) (*prune, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating storage backend: %w", err)
 	}
-
-	state.DB = dbService
 	state.Storage = storage
 
 	//nolint:contextcheck
@@ -75,8 +76,8 @@ func (p *prune) shutdown(ctx context.Context) error {
 		return fmt.Errorf("error closing dbservice: %w", err)
 	}
 
-	p.state.Caches.Stop()
 	p.state.Workers.Stop()
+	p.state.Caches.Stop()
 
 	return nil
 }

--- a/cmd/gotosocial/action/testrig/testrig.go
+++ b/cmd/gotosocial/action/testrig/testrig.go
@@ -56,12 +56,14 @@ var Start action.GTSAction = func(ctx context.Context) error {
 		return fmt.Errorf("error initializing tracing: %w", err)
 	}
 
-	// Initialize caches
-	state.Caches.Init()
-	state.Caches.Start()
+	// Initialize caches and database
+	state.DB = testrig.NewTestDB(&state)
+	
+	// New test db inits caches so we don't need to do
+	// that twice, we can just start the initialized caches.
+	state.Caches.Start() 
 	defer state.Caches.Stop()
 
-	state.DB = testrig.NewTestDB(&state)
 	testrig.StandardDBSetup(state.DB, nil)
 
 	if os.Getenv("GTS_STORAGE_BACKEND") == "s3" {

--- a/cmd/gotosocial/action/testrig/testrig.go
+++ b/cmd/gotosocial/action/testrig/testrig.go
@@ -58,10 +58,10 @@ var Start action.GTSAction = func(ctx context.Context) error {
 
 	// Initialize caches and database
 	state.DB = testrig.NewTestDB(&state)
-	
+
 	// New test db inits caches so we don't need to do
 	// that twice, we can just start the initialized caches.
-	state.Caches.Start() 
+	state.Caches.Start()
 	defer state.Caches.Stop()
 
 	testrig.StandardDBSetup(state.DB, nil)


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

- Ensure caches started properly when pruning, so they are also stopped properly.
- Update testrig initialization to avoid initializing caches twice.

closes https://github.com/superseriousbusiness/gotosocial/issues/1713

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
