### PR TITLE
add back removed ValidateRequest() before backoff-retry loop

### DIFF
--- a/internal/gtserror/error.go
+++ b/internal/gtserror/error.go
@@ -34,8 +34,8 @@ const (
 	notFoundKey
 	errorTypeKey
 
-	// error types
-	TypeSMTP ErrorType = "smtp" // smtp (mail) error
+	// Types returnable from Type(...).
+	TypeSMTP ErrorType = "smtp" // smtp (mail)
 )
 
 // StatusCode checks error for a stored status code value. For example

--- a/internal/gtserror/new.go
+++ b/internal/gtserror/new.go
@@ -49,14 +49,14 @@ func NewResponseError(rsp *http.Response) error {
 	// using "fmt", as chances are this will
 	// be used in a hot code path and we
 	// know all the incoming types involved.
-	buf.WriteString(rsp.Request.Method)
-	buf.WriteString(" request to ")
-	buf.WriteString(urlStr)
-	buf.WriteString(" failed: status=\"")
-	buf.WriteString(rsp.Status)
-	buf.WriteString("\" body=\"")
-	buf.WriteString(drainBody(rsp.Body, 256))
-	buf.WriteString("\"")
+	_, _ = buf.WriteString(rsp.Request.Method)
+	_, _ = buf.WriteString(" request to ")
+	_, _ = buf.WriteString(urlStr)
+	_, _ = buf.WriteString(" failed: status=\"")
+	_, _ = buf.WriteString(rsp.Status)
+	_, _ = buf.WriteString("\" body=\"")
+	_, _ = buf.WriteString(drainBody(rsp.Body, 256))
+	_, _ = buf.WriteString("\"")
 
 	// Create new error from msg.
 	err := errors.New(buf.String())

--- a/internal/gtserror/new.go
+++ b/internal/gtserror/new.go
@@ -1,0 +1,66 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package gtserror
+
+import (
+	"errors"
+	"net/http"
+
+	"codeberg.org/gruf/go-byteutil"
+)
+
+// NewResponseError crafts an error from provided HTTP response
+// including the method, status and body (if any provided). This
+// will also wrap the returned error using WithStatusCode().
+func NewResponseError(rsp *http.Response) error {
+	var buf byteutil.Buffer
+
+	// Get URL string ahead of time.
+	urlStr := rsp.Request.URL.String()
+
+	// Alloc guesstimate of required buf size.
+	buf.Guarantee(0 +
+		len(rsp.Request.Method) +
+		12 + //  request to
+		len(urlStr) +
+		17 + //  failed: status="
+		len(rsp.Status) +
+		8 + // " body="
+		256 + // max body size
+		1, // "
+	)
+
+	// Build error message string without
+	// using "fmt", as chances are this will
+	// be used in a hot code path and we
+	// know all the incoming types involved.
+	buf.WriteString(rsp.Request.Method)
+	buf.WriteString(" request to ")
+	buf.WriteString(urlStr)
+	buf.WriteString(" failed: status=\"")
+	buf.WriteString(rsp.Status)
+	buf.WriteString("\" body=\"")
+	buf.WriteString(drainBody(rsp.Body, 256))
+	buf.WriteString("\"")
+
+	// Create new error from msg.
+	err := errors.New(buf.String())
+
+	// Wrap error to provide status code.
+	return WithStatusCode(err, rsp.StatusCode)
+}

--- a/internal/gtserror/new_test.go
+++ b/internal/gtserror/new_test.go
@@ -1,0 +1,91 @@
+package gtserror_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+)
+
+func TestResponseError(t *testing.T) {
+	testResponseError(t, http.Response{
+		Body: toBody(`{"error": "user not found"}`),
+		Request: &http.Request{
+			Method: "GET",
+			URL:    toURL("https://google.com/users/sundar"),
+		},
+		Status: "404 Not Found",
+	})
+	testResponseError(t, http.Response{
+		Body: toBody("Unauthorized"),
+		Request: &http.Request{
+			Method: "POST",
+			URL:    toURL("https://google.com/inbox"),
+		},
+		Status: "401 Unauthorized",
+	})
+	testResponseError(t, http.Response{
+		Body: toBody(""),
+		Request: &http.Request{
+			Method: "GET",
+			URL:    toURL("https://google.com/users/sundar"),
+		},
+		Status: "404 Not Found",
+	})
+}
+
+func testResponseError(t *testing.T, rsp http.Response) {
+	var body string
+	if rsp.Body == http.NoBody {
+		body = "<empty>"
+	} else {
+		var b []byte
+		rsp.Body, b = copyBody(rsp.Body)
+		trunc := len(b)
+		if trunc > 256 {
+			trunc = 256
+		}
+		body = string(b[:trunc])
+	}
+	expect := fmt.Sprintf(
+		"%s request to %s failed: status=\"%s\" body=\"%s\"",
+		rsp.Request.Method,
+		rsp.Request.URL.String(),
+		rsp.Status,
+		body,
+	)
+	err := gtserror.NewResponseError(&rsp)
+	if str := err.Error(); str != expect {
+		t.Errorf("unexpected error string: recv=%q expct=%q", str, expect)
+	}
+}
+
+func toURL(u string) *url.URL {
+	url, err := url.Parse(u)
+	if err != nil {
+		panic(err)
+	}
+	return url
+}
+
+func toBody(s string) io.ReadCloser {
+	if s == "" {
+		return http.NoBody
+	}
+	r := strings.NewReader(s)
+	return io.NopCloser(r)
+}
+
+func copyBody(rc io.ReadCloser) (io.ReadCloser, []byte) {
+	b, err := io.ReadAll(rc)
+	if err != nil {
+		panic(err)
+	}
+	r := bytes.NewReader(b)
+	return io.NopCloser(r), b
+}

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -41,6 +41,9 @@ import (
 )
 
 var (
+	// ErrInvalidRequest is returned if a given HTTP request is invalid and cannot be performed.
+	ErrInvalidRequest = errors.New("invalid http request")
+
 	// ErrInvalidNetwork is returned if the request would not be performed over TCP
 	ErrInvalidNetwork = errors.New("invalid network type")
 
@@ -172,6 +175,11 @@ func (c *Client) DoSigned(r *http.Request, sign SignFunc) (rsp *http.Response, e
 		// starting backoff duration.
 		baseBackoff = 2 * time.Second
 	)
+
+	// First validate incoming request.
+	if err := ValidateRequest(r); err != nil {
+		return nil, err
+	}
 
 	// Get request hostname.
 	host := r.URL.Hostname()

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -242,8 +242,12 @@ func (c *Client) DoSigned(r *http.Request, sign SignFunc) (rsp *http.Response, e
 				return rsp, nil
 			}
 
-			// Generate error from status code for logging
-			err = errors.New(`http response "` + rsp.Status + `"`)
+			// Drain response body for error.
+			body, _ := io.ReadAll(rsp.Body)
+			_ = rsp.Body.Close()
+
+			// Create error from response status code and body (if any).
+			err = fmt.Errorf(`http response "%s" "%s"`, rsp.Status, body)
 
 			// Search for a provided "Retry-After" header value.
 			if after := rsp.Header.Get("Retry-After"); after != "" {

--- a/internal/httpclient/validate.go
+++ b/internal/httpclient/validate.go
@@ -1,0 +1,62 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package httpclient
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"golang.org/x/net/http/httpguts"
+)
+
+// ValidateRequest performs the same request validation logic found in the default
+// net/http.Transport{}.roundTrip() function, but pulls it out into this separate
+// function allowing validation errors to be wrapped under a single error type.
+func ValidateRequest(r *http.Request) error {
+	switch {
+	case r.URL == nil:
+		return fmt.Errorf("%w: nil url", ErrInvalidRequest)
+	case r.Header == nil:
+		return fmt.Errorf("%w: nil header", ErrInvalidRequest)
+	case r.URL.Host == "":
+		return fmt.Errorf("%w: empty url host", ErrInvalidRequest)
+	case r.URL.Scheme != "http" && r.URL.Scheme != "https":
+		return fmt.Errorf("%w: unsupported protocol %q", ErrInvalidRequest, r.URL.Scheme)
+	case strings.IndexFunc(r.Method, func(r rune) bool { return !httpguts.IsTokenRune(r) }) != -1:
+		return fmt.Errorf("%w: invalid method %q", ErrInvalidRequest, r.Method)
+	}
+
+	for key, values := range r.Header {
+		// Check field key name is valid
+		if !httpguts.ValidHeaderFieldName(key) {
+			return fmt.Errorf("%w: invalid header field name %q", ErrInvalidRequest, key)
+		}
+
+		// Check each field value is valid
+		for i := 0; i < len(values); i++ {
+			if !httpguts.ValidHeaderFieldValue(values[i]) {
+				return fmt.Errorf("%w: invalid header field value %q", ErrInvalidRequest, values[i])
+			}
+		}
+	}
+
+	// ps. kim wrote this
+
+	return nil
+}

--- a/internal/transport/deliver.go
+++ b/internal/transport/deliver.go
@@ -19,7 +19,6 @@ package transport
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 	"sync"
@@ -131,8 +130,7 @@ func (t *transport) deliver(ctx context.Context, b []byte, to *url.URL) error {
 
 	if code := rsp.StatusCode; code != http.StatusOK &&
 		code != http.StatusCreated && code != http.StatusAccepted {
-		err := fmt.Errorf("POST request to %s failed: %s", url, rsp.Status)
-		return gtserror.WithStatusCode(err, rsp.StatusCode)
+		return gtserror.NewResponseError(rsp)
 	}
 
 	return nil

--- a/internal/transport/dereference.go
+++ b/internal/transport/dereference.go
@@ -19,7 +19,6 @@ package transport
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -66,8 +65,7 @@ func (t *transport) Dereference(ctx context.Context, iri *url.URL) ([]byte, erro
 	defer rsp.Body.Close()
 
 	if rsp.StatusCode != http.StatusOK {
-		err := fmt.Errorf("GET request to %s failed: %s", iriStr, rsp.Status)
-		return nil, gtserror.WithStatusCode(err, rsp.StatusCode)
+		return nil, gtserror.NewResponseError(rsp)
 	}
 
 	return io.ReadAll(rsp.Body)

--- a/internal/transport/derefinstance.go
+++ b/internal/transport/derefinstance.go
@@ -102,8 +102,7 @@ func dereferenceByAPIV1Instance(ctx context.Context, t *transport, iri *url.URL)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		err := fmt.Errorf("GET request to %s failed: %s", iriStr, resp.Status)
-		return nil, gtserror.WithStatusCode(err, resp.StatusCode)
+		return nil, gtserror.NewResponseError(resp)
 	}
 
 	b, err := io.ReadAll(resp.Body)
@@ -133,7 +132,7 @@ func dereferenceByAPIV1Instance(ctx context.Context, t *transport, iri *url.URL)
 		ID:                     ulid,
 		Domain:                 iri.Host,
 		Title:                  apiResp.Title,
-		URI:                    fmt.Sprintf("%s://%s", iri.Scheme, iri.Host),
+		URI:                    iri.Scheme + "://" + iri.Host,
 		ShortDescription:       apiResp.ShortDescription,
 		Description:            apiResp.Description,
 		ContactEmail:           apiResp.Email,
@@ -253,8 +252,7 @@ func callNodeInfoWellKnown(ctx context.Context, t *transport, iri *url.URL) (*ur
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		err := fmt.Errorf("GET request to %s failed: %s", iriStr, resp.Status)
-		return nil, gtserror.WithStatusCode(err, resp.StatusCode)
+		return nil, gtserror.NewResponseError(resp)
 	}
 
 	b, err := io.ReadAll(resp.Body)
@@ -305,8 +303,7 @@ func callNodeInfo(ctx context.Context, t *transport, iri *url.URL) (*apimodel.No
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		err := fmt.Errorf("GET request to %s failed: %s", iriStr, resp.Status)
-		return nil, gtserror.WithStatusCode(err, resp.StatusCode)
+		return nil, gtserror.NewResponseError(resp)
 	}
 
 	b, err := io.ReadAll(resp.Body)

--- a/internal/transport/finger.go
+++ b/internal/transport/finger.go
@@ -27,6 +27,7 @@ import (
 
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 )
 
 // webfingerURLFor returns the URL to try a webfinger request against, as
@@ -102,14 +103,16 @@ func (t *transport) Finger(ctx context.Context, targetUsername string, targetDom
 	// From here on out, we're handling different failure scenarios and
 	// deciding whether we should do a host-meta based fallback or not
 
-	if (rsp.StatusCode >= 500 && rsp.StatusCode < 600) || cached {
-		// In case we got a 5xx, bail out irrespective of if the value
-		// was cached or not. The target may be broken or be signalling
-		// us to back-off.
-		//
-		// If it's any error but the URL was cached, bail out too
-		return nil, fmt.Errorf("GET request to %s failed: %s", req.URL.String(), rsp.Status)
-	}
+	// Response status codes >= 500 are returned as errors by the wrapped HTTP client.
+	//
+	// if (rsp.StatusCode >= 500 && rsp.StatusCode < 600) || cached {
+	// In case we got a 5xx, bail out irrespective of if the value
+	// was cached or not. The target may be broken or be signalling
+	// us to back-off.
+	//
+	// If it's any error but the URL was cached, bail out too
+	// return nil, gtserror.NewResponseError(rsp)
+	// }
 
 	// So far we've failed to get a successful response from the expected
 	// webfinger endpoint. Lets try and discover the webfinger endpoint
@@ -150,7 +153,7 @@ func (t *transport) Finger(ctx context.Context, targetUsername string, targetDom
 		}
 		// We've reached the end of the line here, both the original request
 		// and our attempt to resolve it through the fallback have failed
-		return nil, fmt.Errorf("GET request to %s failed: %s", req.URL.String(), rsp.Status)
+		return nil, gtserror.NewResponseError(rsp)
 	}
 
 	// Set the URL in cache here, since host-meta told us this should be the

--- a/testrig/transportcontroller.go
+++ b/testrig/transportcontroller.go
@@ -209,6 +209,7 @@ func NewMockHTTPClient(do func(req *http.Request) (*http.Response, error), relat
 		reader := bytes.NewReader(responseBytes)
 		readCloser := io.NopCloser(reader)
 		return &http.Response{
+			Request:       req,
 			StatusCode:    responseCode,
 			Body:          readCloser,
 			ContentLength: int64(responseContentLength),


### PR DESCRIPTION
# Description
- add back ValidateRequest()
- validate request BEFORE backoff-retry loop
- include response body in 4xx HTTP response errors

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.