### PR TITLE
[chore] update account statuses paging logic

### DIFF
--- a/internal/db/bundb/account_test.go
+++ b/internal/db/bundb/account_test.go
@@ -45,6 +45,34 @@ func (suite *AccountTestSuite) TestGetAccountStatuses() {
 	suite.Len(statuses, 5)
 }
 
+func (suite *AccountTestSuite) TestGetAccountStatusesPageDown() {
+	// get the first page
+	statuses, err := suite.db.GetAccountStatuses(context.Background(), suite.testAccounts["local_account_1"].ID, 2, false, false, "", "", false, false)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+	suite.Len(statuses, 2)
+
+	// get the second page
+	statuses, err = suite.db.GetAccountStatuses(context.Background(), suite.testAccounts["local_account_1"].ID, 2, false, false, statuses[len(statuses)-1].ID, "", false, false)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+	suite.Len(statuses, 2)
+
+	// get the third page
+	statuses, err = suite.db.GetAccountStatuses(context.Background(), suite.testAccounts["local_account_1"].ID, 2, false, false, statuses[len(statuses)-1].ID, "", false, false)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+	suite.Len(statuses, 1)
+
+	// try to get the last page (should be empty)
+	statuses, err = suite.db.GetAccountStatuses(context.Background(), suite.testAccounts["local_account_1"].ID, 2, false, false, statuses[len(statuses)-1].ID, "", false, false)
+	suite.ErrorIs(err, db.ErrNoEntries)
+	suite.Empty(statuses)
+}
+
 func (suite *AccountTestSuite) TestGetAccountStatusesExcludeRepliesAndReblogs() {
 	statuses, err := suite.db.GetAccountStatuses(context.Background(), suite.testAccounts["local_account_1"].ID, 20, true, true, "", "", false, false)
 	suite.NoError(err)

--- a/internal/util/paging_test.go
+++ b/internal/util/paging_test.go
@@ -1,0 +1,139 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package util_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
+)
+
+type PagingSuite struct {
+	suite.Suite
+}
+
+func (suite *PagingSuite) TestPagingStandard() {
+	config.SetHost("example.org")
+
+	params := util.PageableResponseParams{
+		Items:          make([]interface{}, 10, 10),
+		Path:           "/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses",
+		NextMaxIDValue: "01H11KA1DM2VH3747YDE7FV5HN",
+		PrevMinIDValue: "01H11KBBVRRDYYC5KEPME1NP5R",
+		Limit:          10,
+	}
+
+	resp, errWithCode := util.PackagePageableResponse(params)
+	if errWithCode != nil {
+		suite.FailNow(errWithCode.Error())
+	}
+
+	suite.Equal(make([]interface{}, 10, 10), resp.Items)
+	suite.Equal(`<https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?limit=10&max_id=01H11KA1DM2VH3747YDE7FV5HN>; rel="next", <https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?limit=10&min_id=01H11KBBVRRDYYC5KEPME1NP5R>; rel="prev"`, resp.LinkHeader)
+	suite.Equal(`https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?limit=10&max_id=01H11KA1DM2VH3747YDE7FV5HN`, resp.NextLink)
+	suite.Equal(`https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?limit=10&min_id=01H11KBBVRRDYYC5KEPME1NP5R`, resp.PrevLink)
+}
+
+func (suite *PagingSuite) TestPagingNoLimit() {
+	config.SetHost("example.org")
+
+	params := util.PageableResponseParams{
+		Items:          make([]interface{}, 10, 10),
+		Path:           "/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses",
+		NextMaxIDValue: "01H11KA1DM2VH3747YDE7FV5HN",
+		PrevMinIDValue: "01H11KBBVRRDYYC5KEPME1NP5R",
+	}
+
+	resp, errWithCode := util.PackagePageableResponse(params)
+	if errWithCode != nil {
+		suite.FailNow(errWithCode.Error())
+	}
+
+	suite.Equal(make([]interface{}, 10, 10), resp.Items)
+	suite.Equal(`<https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?max_id=01H11KA1DM2VH3747YDE7FV5HN>; rel="next", <https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?min_id=01H11KBBVRRDYYC5KEPME1NP5R>; rel="prev"`, resp.LinkHeader)
+	suite.Equal(`https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?max_id=01H11KA1DM2VH3747YDE7FV5HN`, resp.NextLink)
+	suite.Equal(`https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?min_id=01H11KBBVRRDYYC5KEPME1NP5R`, resp.PrevLink)
+}
+
+func (suite *PagingSuite) TestPagingNoNextID() {
+	config.SetHost("example.org")
+
+	params := util.PageableResponseParams{
+		Items:          make([]interface{}, 10, 10),
+		Path:           "/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses",
+		PrevMinIDValue: "01H11KBBVRRDYYC5KEPME1NP5R",
+		Limit:          10,
+	}
+
+	resp, errWithCode := util.PackagePageableResponse(params)
+	if errWithCode != nil {
+		suite.FailNow(errWithCode.Error())
+	}
+
+	suite.Equal(make([]interface{}, 10, 10), resp.Items)
+	suite.Equal(`<https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?limit=10&min_id=01H11KBBVRRDYYC5KEPME1NP5R>; rel="prev"`, resp.LinkHeader)
+	suite.Equal(``, resp.NextLink)
+	suite.Equal(`https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?limit=10&min_id=01H11KBBVRRDYYC5KEPME1NP5R`, resp.PrevLink)
+}
+
+func (suite *PagingSuite) TestPagingNoPrevID() {
+	config.SetHost("example.org")
+
+	params := util.PageableResponseParams{
+		Items:          make([]interface{}, 10, 10),
+		Path:           "/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses",
+		NextMaxIDValue: "01H11KA1DM2VH3747YDE7FV5HN",
+		Limit:          10,
+	}
+
+	resp, errWithCode := util.PackagePageableResponse(params)
+	if errWithCode != nil {
+		suite.FailNow(errWithCode.Error())
+	}
+
+	suite.Equal(make([]interface{}, 10, 10), resp.Items)
+	suite.Equal(`<https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?limit=10&max_id=01H11KA1DM2VH3747YDE7FV5HN>; rel="next"`, resp.LinkHeader)
+	suite.Equal(`https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?limit=10&max_id=01H11KA1DM2VH3747YDE7FV5HN`, resp.NextLink)
+	suite.Equal(``, resp.PrevLink)
+}
+
+func (suite *PagingSuite) TestPagingNoItems() {
+	config.SetHost("example.org")
+
+	params := util.PageableResponseParams{
+		NextMaxIDValue: "01H11KA1DM2VH3747YDE7FV5HN",
+		PrevMinIDValue: "01H11KBBVRRDYYC5KEPME1NP5R",
+		Limit:          10,
+	}
+
+	resp, errWithCode := util.PackagePageableResponse(params)
+	if errWithCode != nil {
+		suite.FailNow(errWithCode.Error())
+	}
+
+	suite.Empty(resp.Items)
+	suite.Empty(resp.LinkHeader)
+	suite.Empty(resp.NextLink)
+	suite.Empty(resp.PrevLink)
+}
+
+func TestPagingSuite(t *testing.T) {
+	suite.Run(t, &PagingSuite{})
+}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request tidies up some of the account status paging logic (for both api statuses and web ones), removing some unused WhereEmptyOrNull checks, and ensuring that paging goes in the correct order if min_id is supplied.

Also updates the pageable response building logic a little bit, and omits next or prev queries where the id for those is not set.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
