### PR TITLE
docs: local docs hacking howto

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,17 @@ The process for documentation pull requests is a bit looser than the process for
 
 If you see something in the documentation that's missing, wrong, or unclear, feel free to open a pull request addressing it; you don't necessarily need to open an issue first, but please explain why you're opening the PR in the PR comment.
 
+We support a [Conda](https://docs.conda.io/en/latest/)-based workflow for hacking, building & publishing the documentation. Here's how you can get started locally:
+
+* Install [`miniconda`](https://docs.conda.io/en/latest/miniconda.html)
+* Create your conda environment: `conda env create -f ./docs/environment.yml`
+* Activate the environment: `conda activate gotosocial-docs`
+* Serve locally: `mkdocs serve`
+
+Then you can visit [localhost:8000](http://127.0.0.1:8000/) in your browser to view.
+
+If you don't use Conda, you can read the `docs/environment.yml` to see which dependencies are required and `pip install` them manually.
+
 ## Development
 
 ### Golang forking quirks


### PR DESCRIPTION
# Description

HOWTO on how to set things up locally for docs hacking.

Alternatively, we could commit a `requirements.txt` to root so that folks can `pip install -r requirements.txt` and maintainers can `pip freeze > requirements.txt` when things get updated / added. Happy to re-work this PR with that change if desired.

> [Rendered](https://github.com/decentral1se/gotosocial/blob/65b328c075c3336e36f3301cc87105a7909087c2/CONTRIBUTING.md)

This is my `requirements.txt` atm:

```
beautifulsoup4==4.12.2
cairocffi==1.5.1
CairoSVG==2.7.0
certifi==2023.5.7
cffi==1.15.1
charset-normalizer==3.1.0
click==8.1.3
colorama==0.4.6
cssselect2==0.7.0
defusedxml==0.7.1
ghp-import==2.1.0
idna==3.4
importlib-metadata==6.6.0
Jinja2==3.1.2
Markdown==3.3.7
MarkupSafe==2.1.2
mergedeep==1.3.4
mkdocs==1.4.3
mkdocs-material==9.1.14
mkdocs-material-extensions==1.1.1
mkdocs-swagger-ui-tag==0.6.1
packaging==23.1
Pillow==9.5.0
pycparser==2.21
Pygments==2.15.1
pymdown-extensions==10.0.1
python-dateutil==2.8.2
PyYAML==6.0
pyyaml-env-tag==0.1
regex==2023.5.5
requests==2.31.0
six==1.16.0
soupsieve==2.4.1
tinycss2==1.2.1
urllib3==2.0.2
watchdog==3.0.0
webencodings==0.5.1
zipp==3.15.0
```

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).