### PR TITLE
docs: support copy/pasta for code blocks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ theme:
   font: false
   features:
     - header.autohide
+    - content.code.copy
   palette:
     - scheme: slate
       toggle:


### PR DESCRIPTION
# Description

From https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-copy-button

Before:
![before](https://github.com/superseriousbusiness/gotosocial/assets/1991377/770771e7-85b5-434a-8445-534f8770e030)

After:
![with-copy](https://github.com/superseriousbusiness/gotosocial/assets/1991377/c9c86b9c-a99a-4980-a197-8706585456c7)

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).