### PR TITLE
[bugfix] Allow usernames of length 1

### DIFF
--- a/internal/regexes/regexes.go
+++ b/internal/regexes/regexes.go
@@ -47,8 +47,8 @@ const (
 	mentionFinder            = `(?:^|\s)(@` + usernameGrp + `+(?:@` + domainGrp + `+)?)` // Extract all mentions from a text, each mention may include domain.
 	emojiShortcode           = `\w{2,30}`                                                // Pattern for emoji shortcodes. maximumEmojiShortcodeLength = 30
 	emojiFinder              = `(?:\b)?:(` + emojiShortcode + `):(?:\b)?`                // Extract all emoji shortcodes from a text.
-	usernameStrict           = `^[a-z0-9_]{2,64}$`                                       // Pattern for usernames on THIS instance. maximumUsernameLength = 64
-	usernameRelaxed          = `[a-z0-9_\.]{2,}`                                         // Relaxed version of username that can match instance accounts too.
+	usernameStrict           = `^[a-z0-9_]{1,64}$`                                       // Pattern for usernames on THIS instance. maximumUsernameLength = 64
+	usernameRelaxed          = `[a-z0-9_\.]{1,}`                                         // Relaxed version of username that can match instance accounts too.
 	misskeyReportNotesFinder = `(?m)(?:^Note: ((?:http|https):\/\/.*)$)`                 // Extract reported Note URIs from the text of a Misskey report/flag.
 	ulid                     = `[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}`                  // Pattern for ULID.
 	ulidValidate             = `^` + ulid + `$`                                          // Validate one ULID.

--- a/internal/validate/formvalidation_test.go
+++ b/internal/validate/formvalidation_test.go
@@ -93,6 +93,7 @@ func (suite *ValidationTestSuite) TestValidateUsername() {
 	trailingSpace := "thisusername_ends_with_a_space "
 	newlines := "this_is\n_almost_ok"
 	goodUsername := "this_is_a_good_username"
+	singleChar := "s"
 	var err error
 
 	err = validate.Username(empty)
@@ -117,6 +118,9 @@ func (suite *ValidationTestSuite) TestValidateUsername() {
 	suite.EqualError(err, fmt.Sprintf("given username %s was invalid: must contain only lowercase letters, numbers, and underscores, max 64 characters", newlines))
 
 	err = validate.Username(goodUsername)
+	suite.NoError(err)
+
+	err = validate.Username(singleChar)
 	suite.NoError(err)
 }
 


### PR DESCRIPTION
# Description

Allows usernames of length 1.

Closes https://github.com/superseriousbusiness/gotosocial/issues/1691.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
