### PR TITLE
[docs]: semaphone ref & DEBUG usage for standalone testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ These contribution guidelines were adapted from / inspired by those of Gitea (ht
     - [Finding your way around the code](#finding-your-way-around-the-code)
   - [Style / Linting / Formatting](#style--linting--formatting)
   - [Testing](#testing)
-    - [Standalone Testrig with Pinafore](#standalone-testrig-with-pinafore)
+    - [Standalone Testrig with Semaphore](#standalone-testrig-with-semaphore)
     - [Running automated tests](#running-automated-tests)
       - [SQLite](#sqlite)
       - [Postgres](#postgres)
@@ -222,6 +222,8 @@ GoToSocial uses Gin templates in the `web/template` folder. Static assets are st
 
 To bundle changes, you need [Node.js](https://nodejs.org/en/download/) and [Yarn](https://classic.yarnpkg.com/en/docs/install).
 
+Using [NVM](https://github.com/nvm-sh/nvm) is one convenient way to install them which also supports managing different Node versions.
+
 To install Yarn dependencies:
 
 ```bash
@@ -370,25 +372,26 @@ GoToSocial provides a [testrig](https://github.com/superseriousbusiness/gotosoci
 
 One thing that *isn't* mocked is the Database interface because it's just easier to use an in-memory SQLite database than to mock everything out.
 
-#### Standalone Testrig with Pinafore
+#### Standalone Testrig with Semaphore
 
-You can launch a testrig as a standalone server running at localhost, which you can connect to using something like [Pinafore](https://github.com/nolanlawson/pinafore).
+You can launch a testrig as a standalone server running at localhost, which you can connect to using something like [Semaphore](https://github.com/NickColley/semaphore/).
 
-To do this, first build the gotosocial binary with `./scripts/build.sh`.
+To do this, first build the gotosocial binary with `DEBUG=1 ./scripts/build.sh`.
 
-Then, launch the testrig by invoking the binary as follows:
+Then, launch the testrig with the `DEBUG` environment variable set by invoking the binary as follows:
 
 ```bash
-./gotosocial testrig start
+DEBUG=1 ./gotosocial testrig start
 ```
 
-To run Pinafore locally in dev mode, first clone the [Pinafore](https://github.com/nolanlawson/pinafore) repository, and then run the following command in the cloned directory:
+To run Semaphore locally in dev mode, first clone the [Semaphore](https://github.com/NickColley/semaphore/) repository, and then run the following commands in the cloned directory:
 
 ```bash
+yarn # install dependencies
 yarn run dev
 ```
 
-The Pinafore instance will start running on `localhost:4002`.
+The Semaphore instance will start running on `localhost:4002`.
 
 To connect to the testrig, navigate to `http://localhost:4002` and enter your instance name as `localhost:8080`.
 


### PR DESCRIPTION
# Description

* Point to semaphore for local testing
* Use `DEBUG=1` when running the testrig
* Use `yarn` to install local dependencies first
* Provide an approach for install yarn

> [Rendered](https://github.com/superseriousbusiness/gotosocial/blob/2fe3f411d3cb7f7693c69bea1030298c4b378f25/CONTRIBUTING.md).

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).