### PR TITLE
[bugfix] don't INFO level log DMs

### DIFF
--- a/internal/federation/federatingactor.go
+++ b/internal/federation/federatingactor.go
@@ -68,7 +68,7 @@ func newFederatingActor(c pub.CommonBehavior, s2s pub.FederatingProtocol, db pub
 }
 
 func (f *federatingActor) Send(c context.Context, outbox *url.URL, t vocab.Type) (pub.Activity, error) {
-	log.Infof(c, "send activity %s via outbox %s", t.GetTypeName(), outbox)
+	log.Debugf(c, "send activity %s via outbox %s", t.GetTypeName(), outbox)
 	return f.wrapped.Send(c, outbox, t)
 }
 

--- a/internal/processing/fromclientapi.go
+++ b/internal/processing/fromclientapi.go
@@ -50,7 +50,7 @@ func (p *Processor) ProcessFromClientAPI(ctx context.Context, clientMsg messages
 
 	// Log this federated message
 	l := log.WithContext(ctx).WithFields(fields...)
-	l.Info("processing from client")
+	l.Debug("processing from client")
 
 	switch clientMsg.APActivityType {
 	case ap.ActivityCreate:

--- a/internal/processing/fromfederator.go
+++ b/internal/processing/fromfederator.go
@@ -59,7 +59,7 @@ func (p *Processor) ProcessFromFederator(ctx context.Context, federatorMsg messa
 
 	// Log this federated message
 	l := log.WithContext(ctx).WithFields(fields...)
-	l.Info("processing from federator")
+	l.Debug("processing from federator")
 
 	switch federatorMsg.APActivityType {
 	case ap.ActivityCreate:


### PR DESCRIPTION
# Description

Only log DMs on DEBUG log level. I've tested this locally following the steps to reproduce in https://github.com/superseriousbusiness/gotosocial/issues/1412 and see no other INFO level logging of DMs after this change. From my reading of #1412 this is deemed the appropriate solution for this issue. Closes https://github.com/superseriousbusiness/gotosocial/issues/1412.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
