### PR TITLE
[bugfix] only attempt to populate account/statuses from DB if already exist

### DIFF
--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -116,6 +116,15 @@ func (d *deref) getStatusByURI(ctx context.Context, requestUser string, uri *url
 		}, nil)
 	}
 
+	// Check whether needs update.
+	if statusUpToDate(status) {
+		// This is existing up-to-date status, ensure it is populated.
+		if err := d.state.DB.PopulateStatus(ctx, status); err != nil {
+			log.Errorf(ctx, "error populating existing status: %v", err)
+		}
+		return status, nil, nil
+	}
+
 	// Try to update + deref existing status model.
 	latest, apubStatus, err := d.enrichStatus(ctx,
 		requestUser,

--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -27,6 +27,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/gtscontext"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/id"
@@ -80,15 +81,23 @@ func (d *deref) getStatusByURI(ctx context.Context, requestUser string, uri *url
 		err    error
 	)
 
-	// Search the database for existing status with ID URI.
-	status, err = d.state.DB.GetStatusByURI(ctx, uriStr)
+	// Search the database for existing status with URI.
+	status, err = d.state.DB.GetStatusByURI(
+		// request a barebones object, it may be in the
+		// db but with related models not yet dereferenced.
+		gtscontext.SetBarebones(ctx),
+		uriStr,
+	)
 	if err != nil && !errors.Is(err, db.ErrNoEntries) {
 		return nil, nil, gtserror.Newf("error checking database for status %s by uri: %w", uriStr, err)
 	}
 
 	if status == nil {
-		// Else, search the database for existing by ID URL.
-		status, err = d.state.DB.GetStatusByURL(ctx, uriStr)
+		// Else, search the database for existing by URL.
+		status, err = d.state.DB.GetStatusByURL(
+			gtscontext.SetBarebones(ctx),
+			uriStr,
+		)
 		if err != nil && !errors.Is(err, db.ErrNoEntries) {
 			return nil, nil, gtserror.Newf("error checking database for status %s by url: %w", uriStr, err)
 		}


### PR DESCRIPTION
# Description
Only populate account / status models in the dereferencer when we *know* it is an *existing* up-to-date model, otherwise errors may be returned for related models not yet dereferenced.

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
