### PR TITLE
[bugfix] Overwrite API client closed errors with `499 - Client Closed Request`

### DIFF
--- a/internal/api/util/errorhandling.go
+++ b/internal/api/util/errorhandling.go
@@ -109,7 +109,7 @@ func ErrorHandler(c *gin.Context, errWithCode gtserror.WithCode, instanceGet fun
 		// Requester probably left already. Wrap original error
 		// with a less alarming one. We can return early here
 		// because it doesn't matter what we send to the client.
-		errWithCode = gtserror.NewErrorClientClosedRequest(errWithCode.Original())
+		errWithCode = gtserror.NewErrorClientClosedRequest(errWithCode.Unwrap())
 		c.AbortWithStatus(errWithCode.Code())
 		return
 	}

--- a/internal/gtserror/withcode.go
+++ b/internal/gtserror/withcode.go
@@ -23,15 +23,20 @@ import (
 	"strings"
 )
 
+const (
+	StatusClientClosedRequest     = 499
+	StatusTextClientClosedRequest = "Client Closed Request"
+)
+
 // WithCode wraps an internal error with an http code, and a 'safe' version of
 // the error that can be served to clients without revealing internal business logic.
 //
 // A typical use of this error would be to first log the Original error, then return
 // the Safe error and the StatusCode to an API caller.
 type WithCode interface {
-	// Original returns the original error.
+	// Unwrap returns the original error.
 	// This should *NEVER* be returned to a client as it may contain sensitive information.
-	Original() error
+	Unwrap() error
 	// Error serializes the original internal error for debugging within the GoToSocial logs.
 	// This should *NEVER* be returned to a client as it may contain sensitive information.
 	Error() string
@@ -48,7 +53,7 @@ type withCode struct {
 	code     int
 }
 
-func (e withCode) Original() error {
+func (e withCode) Unwrap() error {
 	return e.original
 }
 
@@ -187,7 +192,7 @@ func NewErrorGone(original error, helpText ...string) WithCode {
 func NewErrorClientClosedRequest(original error) WithCode {
 	return withCode{
 		original: original,
-		safe:     errors.New("Client Closed Request"),
-		code:     499,
+		safe:     errors.New(StatusTextClientClosedRequest),
+		code:     StatusClientClosedRequest,
 	}
 }

--- a/internal/gtserror/withcode.go
+++ b/internal/gtserror/withcode.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 )
 
+// Custom http response codes + text that
+// aren't included in the net/http package.
 const (
 	StatusClientClosedRequest     = 499
 	StatusTextClientClosedRequest = "Client Closed Request"

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -27,6 +27,7 @@ import (
 	"codeberg.org/gruf/go-kv"
 	"codeberg.org/gruf/go-logger/v2/level"
 	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 )
 
@@ -91,11 +92,23 @@ func Logger(logClientIP bool) gin.HandlerFunc {
 				l = l.WithField("error", c.Errors)
 			}
 
+			// Get appropriate text for this code.
+			statusText := http.StatusText(code)
+			if statusText == "" {
+				// Look for custom codes.
+				switch code {
+				case gtserror.StatusClientClosedRequest:
+					statusText = gtserror.StatusTextClientClosedRequest
+				default:
+					statusText = "Unknown Status"
+				}
+			}
+
 			// Generate a nicer looking bytecount
 			size := bytesize.Size(c.Writer.Size())
 
-			// Finally, write log entry with status text body size
-			l.Logf(lvl, "%s: wrote %s", http.StatusText(code), size)
+			// Finally, write log entry with status text + body size.
+			l.Logf(lvl, "%s: wrote %s", statusText, size)
 		}()
 
 		// Process request


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates error logging in aputil to check if the error came about because the requester hung up the request before it could be completed. If so, whatever errWithCode was given is replaced with a less alarming error, that indicates that the client already closed the request before we could process it.

Not a standard error code, but then again it doesn't really matter because the client isn't going to see it anyway...

This should make it easier to debug GtS, since the logs won't show so many superfluous error messages.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
