### PR TITLE
[bugfix] Fix first item of thread dereferencing always being skipped

### DIFF
--- a/internal/federation/dereferencing/thread.go
+++ b/internal/federation/dereferencing/thread.go
@@ -229,23 +229,24 @@ stackLoop:
 
 				// Start off the item iterator
 				current.itemIter = items.Begin()
-				if current.itemIter == nil {
-					continue stackLoop
-				}
-			} else {
-				// Get next item iterator object
-				current.itemIter = current.itemIter.Next()
 			}
 
 		itemLoop:
 			for {
+				// Check for remaining iter
 				if current.itemIter == nil {
 					break itemLoop
 				}
 
-				itemIRI, _ := pub.ToId(current.itemIter)
+				// Get current item iterator
+				itemIter := current.itemIter
+
+				// Set the next available iterator
+				current.itemIter = itemIter.Next()
+
+				// Check for available IRI on item
+				itemIRI, _ := pub.ToId(itemIter)
 				if itemIRI == nil {
-					// Unusable iter object
 					continue itemLoop
 				}
 


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request fixes a bug in our thread dereferencing where we were always skipping the first item in replies by calling Begin() on the iter and then calling Next() immediately, skipping to the second item (which is mostly empty).

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
