### PR TITLE
[bugfix] AppArmor profile for SQLite

### DIFF
--- a/docs/installation_guide/advanced.md
+++ b/docs/installation_guide/advanced.md
@@ -256,6 +256,9 @@ line under `[Service]`:
 AppArmorProfile=gotosocial
 ```
 
+If you're using SQLite, the AppArmor profile expects the database in
+`/gotosocial/db/` so you'll need to adjust your configuration paths accordingly.
+
 For other deployment methods (e.g. a managed Kubernetes cluster), you should
 review your platform's documentation for how to deploy an application with an
 AppArmor profile.

--- a/example/apparmor/gotosocial
+++ b/example/apparmor/gotosocial
@@ -9,6 +9,7 @@ profile gotosocial flags=(attach_disconnected, mediate_deleted) {
   /usr/local/bin/gotosocial mrix,
 
   owner /gotosocial/{,**} r,
+  owner /gotosocial/db/* wk,
   owner /gotosocial/storage/** wk,
 
   # Allow GoToSocial to write logs


### PR DESCRIPTION
# Description

Our default configuration places the SQLite DB in /gotosocial/, but the AppArmor profile doesn't allow us to write there. Instead of making the whole directory writable, add a writable area in /gotosocial/db/ instead and advise in the docs to move the DB there.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
