### PR TITLE
[chore/bugfix] Demote 'failed' inbox forwarding to warn log rather than error return

### DIFF
--- a/internal/federation/federatingactor.go
+++ b/internal/federation/federatingactor.go
@@ -231,8 +231,9 @@ func (f *federatingActor) PostInboxScheme(ctx context.Context, w http.ResponseWr
 		// is updated, and/or federating callbacks are handled
 		// properly.
 		if !errors.Is(err, db.ErrAlreadyExists) {
-			err = fmt.Errorf("PostInboxScheme: error calling sideEffectActor.InboxForwarding: %w", err)
-			return false, gtserror.NewErrorInternalError(err)
+			// Failed inbox forwarding is not a show-stopper,
+			// and doesn't even necessarily denote a real error.
+			l.Warnf("error calling sideEffectActor.InboxForwarding: %q", err)
 		}
 	}
 


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Currently, side effect actor inbox forwarding unfortunately handles some of the necessary side effects of creating activities and whatnot (see https://github.com/superseriousbusiness/gotosocial/issues/1891). However, this often causes annoying errors to pop up, especially when doing things like receiving Likes from Misskey instances that target statuses our instance doesn't know about yet. This causes a db error which then results in a 500 being returned to the remote server.

As a temporary workaround before we fix the actual issue, we can at least tone down the error message here so that it doesn't return 500 to the caller, and just does a warn log instead, since it's unlikely that failed inbox forwarding indicates an actual error.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
