### PR TITLE
[chore] Fix Swagger paths for lists API endpoints

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -4517,7 +4517,34 @@ paths:
                     description: internal server error
             tags:
                 - instance
-    /api/v1/list:
+    /api/v1/lists:
+        get:
+            operationId: lists
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Array of all lists owned by the requesting user.
+                    schema:
+                        items:
+                            $ref: '#/definitions/list'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:lists
+            summary: Get all lists for owned by authorized user.
+            tags:
+                - lists
         post:
             consumes:
                 - application/json
@@ -4568,61 +4595,7 @@ paths:
             summary: Create a new list.
             tags:
                 - lists
-        put:
-            consumes:
-                - application/json
-                - application/xml
-                - application/x-www-form-urlencoded
-            operationId: listUpdate
-            parameters:
-                - description: ID of the list
-                  example: Cool People
-                  in: path
-                  name: id
-                  required: true
-                  type: string
-                  x-go-name: Title
-                - description: Title of this list.
-                  example: Cool People
-                  in: formData
-                  name: title
-                  type: string
-                  x-go-name: RepliesPolicy
-                - description: |-
-                    RepliesPolicy for this list.
-                    followed = Show replies to any followed user
-                    list = Show replies to members of the list
-                    none = Show replies to no one
-                  example: list
-                  in: formData
-                  name: replies_policy
-                  type: string
-            produces:
-                - application/json
-            responses:
-                "200":
-                    description: The newly updated list.
-                    schema:
-                        $ref: '#/definitions/list'
-                "400":
-                    description: bad request
-                "401":
-                    description: unauthorized
-                "403":
-                    description: forbidden
-                "404":
-                    description: not found
-                "406":
-                    description: not acceptable
-                "500":
-                    description: internal server error
-            security:
-                - OAuth2 Bearer:
-                    - write:lists
-            summary: Update an existing list.
-            tags:
-                - lists
-    /api/v1/list/{id}:
+    /api/v1/lists/{id}:
         delete:
             operationId: listDelete
             parameters:
@@ -4683,7 +4656,61 @@ paths:
             summary: Get a single list with the given ID.
             tags:
                 - lists
-    /api/v1/list/{id}/accounts:
+        put:
+            consumes:
+                - application/json
+                - application/xml
+                - application/x-www-form-urlencoded
+            operationId: listUpdate
+            parameters:
+                - description: ID of the list
+                  example: Cool People
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+                  x-go-name: Title
+                - description: Title of this list.
+                  example: Cool People
+                  in: formData
+                  name: title
+                  type: string
+                  x-go-name: RepliesPolicy
+                - description: |-
+                    RepliesPolicy for this list.
+                    followed = Show replies to any followed user
+                    list = Show replies to members of the list
+                    none = Show replies to no one
+                  example: list
+                  in: formData
+                  name: replies_policy
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The newly updated list.
+                    schema:
+                        $ref: '#/definitions/list'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - write:lists
+            summary: Update an existing list.
+            tags:
+                - lists
+    /api/v1/lists/{id}/accounts:
         delete:
             consumes:
                 - application/json
@@ -4824,34 +4851,6 @@ paths:
                 - OAuth2 Bearer:
                     - read:lists
             summary: Add one or more accounts to the given list.
-            tags:
-                - lists
-    /api/v1/lists:
-        get:
-            operationId: lists
-            produces:
-                - application/json
-            responses:
-                "200":
-                    description: Array of all lists owned by the requesting user.
-                    schema:
-                        items:
-                            $ref: '#/definitions/list'
-                        type: array
-                "400":
-                    description: bad request
-                "401":
-                    description: unauthorized
-                "404":
-                    description: not found
-                "406":
-                    description: not acceptable
-                "500":
-                    description: internal server error
-            security:
-                - OAuth2 Bearer:
-                    - read:lists
-            summary: Get all lists for owned by authorized user.
             tags:
                 - lists
     /api/v1/media/{id}:

--- a/internal/api/client/lists/listaccounts.go
+++ b/internal/api/client/lists/listaccounts.go
@@ -27,7 +27,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
-// ListAccountsGETHandler swagger:operation GET /api/v1/list/{id}/accounts listAccounts
+// ListAccountsGETHandler swagger:operation GET /api/v1/lists/{id}/accounts listAccounts
 //
 // Page through accounts in this list.
 //

--- a/internal/api/client/lists/listaccountsadd.go
+++ b/internal/api/client/lists/listaccountsadd.go
@@ -28,7 +28,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
-// ListAccountsPOSTHandler swagger:operation POST /api/v1/list/{id}/accounts addListAccounts
+// ListAccountsPOSTHandler swagger:operation POST /api/v1/lists/{id}/accounts addListAccounts
 //
 // Add one or more accounts to the given list.
 //

--- a/internal/api/client/lists/listaccountsremove.go
+++ b/internal/api/client/lists/listaccountsremove.go
@@ -28,7 +28,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
-// ListAccountsDELETEHandler swagger:operation DELETE /api/v1/list/{id}/accounts removeListAccounts
+// ListAccountsDELETEHandler swagger:operation DELETE /api/v1/lists/{id}/accounts removeListAccounts
 //
 // Remove one or more accounts from the given list.
 //

--- a/internal/api/client/lists/listcreate.go
+++ b/internal/api/client/lists/listcreate.go
@@ -30,7 +30,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/validate"
 )
 
-// ListCreatePOSTHandler swagger:operation POST /api/v1/list listCreate
+// ListCreatePOSTHandler swagger:operation POST /api/v1/lists listCreate
 //
 // Create a new list.
 //

--- a/internal/api/client/lists/listdelete.go
+++ b/internal/api/client/lists/listdelete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
-// ListDELETEHandler swagger:operation DELETE /api/v1/list/{id} listDelete
+// ListDELETEHandler swagger:operation DELETE /api/v1/lists/{id} listDelete
 //
 // Delete a single list with the given ID.
 //

--- a/internal/api/client/lists/listget.go
+++ b/internal/api/client/lists/listget.go
@@ -27,7 +27,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
-// ListGETHandler swagger:operation GET /api/v1/list/{id} list
+// ListGETHandler swagger:operation GET /api/v1/lists/{id} list
 //
 // Get a single list with the given ID.
 //

--- a/internal/api/client/lists/listupdate.go
+++ b/internal/api/client/lists/listupdate.go
@@ -31,7 +31,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/validate"
 )
 
-// ListUpdatePUTHandler swagger:operation PUT /api/v1/list listUpdate
+// ListUpdatePUTHandler swagger:operation PUT /api/v1/lists/{id} listUpdate
 //
 // Update an existing list.
 //


### PR DESCRIPTION
# Description

This pull request fixes paths for lists API endpoints: `/api/v1/list` → `/api/v1/lists`, adding `{id}`, etc.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
