### PR TITLE
[docs] Clarify email requirement for OIDC

### DIFF
--- a/docs/configuration/oidc.md
+++ b/docs/configuration/oidc.md
@@ -10,6 +10,9 @@ This is very convenient in the following cases:
 - You want to delegate management of users, accounts, passwords etc. to an external service to make admin easier for yourself.
 - You already have a lot of users in an external system and you don't want to have to recreate them all in GoToSocial manually.
 
+!!! tip
+    If a user doesn't exist yet, login will fail if your IdP doesn't return a non-empty `email` as part of the claims. The email needs to be unique on this instance. Though we use the `sub` claim to associate the external identity with a GtS user, when a user is created it needs an email associated with it.
+
 ## Settings
 
 GoToSocial exposes the following configuration settings for OIDC, shown below with their default values.


### PR DESCRIPTION
# Description

Updates the docs to specify that the claims received from an OIDC provider need to contain a non-zero and unique email address as that's used as part of user creation.

This came up in the support chat on Matrix. Someone was trying to use OIDC but some folks couldn't log in. Turns out they didn't have an email address set.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
