### PR TITLE
[bugfix] Only mark status orphaned on 410 Gone

### DIFF
--- a/internal/federation/dereferencing/thread.go
+++ b/internal/federation/dereferencing/thread.go
@@ -168,11 +168,10 @@ func (d *deref) DereferenceStatusAncestors(
 		// useful with the error. For example, HTTP status code returned
 		// from remote may indicate that the parent has been deleted.
 		switch code := gtserror.StatusCode(err); {
-		case code == http.StatusGone || code == http.StatusNotFound:
+		case code == http.StatusGone:
 			// 410 means the status has definitely been deleted.
-			// 404 means the status has *probably* been deleted.
 			// Update this status to reflect that, then bail.
-			l.Debugf("current status has been orphaned (call to parent returned code %d)", code)
+			l.Debug("current status has been orphaned (call to parent returned code 410 Gone)")
 
 			current.InReplyToURI = ""
 			if err := d.state.DB.UpdateStatus(


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Fix small mistake introduced in previous PR where statuses were marked as orphans if a call to their parent returned 404. Many implementations use 404 as a spicy 403 for followers-only statuses, so we were orphaning statuses unnecessarily.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).

