### PR TITLE
[feature] Treat unlisted as public for visibility

### DIFF
--- a/internal/visibility/status.go
+++ b/internal/visibility/status.go
@@ -96,7 +96,7 @@ func (f *Filter) isStatusVisible(ctx context.Context, requester *gtsmodel.Accoun
 		return false, nil
 	}
 
-	if status.Visibility == gtsmodel.VisibilityPublic {
+	if status.Visibility == gtsmodel.VisibilityPublic || status.Visibility == gtsmodel.VisibilityUnlocked {
 		// This status will be visible to all.
 		return true, nil
 	}
@@ -105,11 +105,6 @@ func (f *Filter) isStatusVisible(ctx context.Context, requester *gtsmodel.Accoun
 		// This request is WITHOUT auth, and status is NOT public.
 		log.Trace(ctx, "unauthorized request to non-public status")
 		return false, nil
-	}
-
-	if status.Visibility == gtsmodel.VisibilityUnlocked {
-		// This status is visible to all auth'd accounts.
-		return true, nil
 	}
 
 	if requester.ID == status.AccountID {


### PR DESCRIPTION
# Description

Up to now, GtS has required authentication to view an unlisted/unlocked status. However, looking around other implementations unlisted/unlocked still means public, but with the caveat that it won't show up in local and federated timelines or in hashtag searches. It's very often used to reply to a thread to avoid filling the timelines with replies to a conversation someone might not be interested in following.

Changing this will now make unlisted replies to a status on this instance viewable, which means we get a more complete view in the thread UI in our web UI and should result in a more complete view of a thread in other client applications too.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
