### PR TITLE
[feature] Add instance stats to /about

### DIFF
--- a/web/template/about.tmpl
+++ b/web/template/about.tmpl
@@ -81,6 +81,15 @@
 				{{end}}
 			</p>
 		</div>
+
+		<div>
+			<h2>Instance Statistics</h2>
+				<ul>
+					<li>Users: <span class="count">{{.instance.Stats.user_count}}</span></li>
+					<li>Posts: <span class="count">{{.instance.Stats.status_count}}</span></li>
+					<li>Federates with: <span class="count">{{.instance.Stats.domain_count}}</span> instances</li>
+				</ul>
+		</div>
 	</section>
 </main>
 {{ template "footer.tmpl" .}}


### PR DESCRIPTION
# Description

When you configure the `landing-page-user` redirect, you lose access to the one page that displays server stats. This adds the same stats as we have on `/` to `/about` to bring those back.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
