### PR TITLE
[bugfix] Reorder web view logic, other small fixes

### DIFF
--- a/internal/api/util/parsequery.go
+++ b/internal/api/util/parsequery.go
@@ -43,6 +43,11 @@ const (
 	SearchResolveKey           = "resolve"
 	SearchTypeKey              = "type"
 
+	/* Web endpoint keys */
+
+	WebUsernameKey = "username"
+	WebStatusIDKey = "status"
+
 	/* Domain block keys */
 
 	DomainBlockExportKey = "export"
@@ -73,6 +78,14 @@ func ParseLimit(value string, defaultValue int, max, min int) (int, gtserror.Wit
 
 func ParseLocal(value string, defaultValue bool) (bool, gtserror.WithCode) {
 	return parseBool(value, defaultValue, LocalKey)
+}
+
+func ParseMaxID(value string, defaultValue string) string {
+	if value == "" {
+		return defaultValue
+	}
+
+	return value
 }
 
 func ParseSearchExcludeUnreviewed(value string, defaultValue bool) (bool, gtserror.WithCode) {
@@ -125,6 +138,26 @@ func ParseSearchLookup(value string) (string, gtserror.WithCode) {
 
 func ParseSearchQuery(value string) (string, gtserror.WithCode) {
 	key := SearchQueryKey
+
+	if value == "" {
+		return "", requiredError(key)
+	}
+
+	return value, nil
+}
+
+func ParseWebUsername(value string) (string, gtserror.WithCode) {
+	key := WebUsernameKey
+
+	if value == "" {
+		return "", requiredError(key)
+	}
+
+	return value, nil
+}
+
+func ParseWebStatusID(value string) (string, gtserror.WithCode) {
+	key := WebStatusIDKey
 
 	if value == "" {
 		return "", requiredError(key)

--- a/internal/federation/dereferencing/dereferencer.go
+++ b/internal/federation/dereferencing/dereferencer.go
@@ -95,7 +95,7 @@ type deref struct {
 	derefEmojis         map[string]*media.ProcessingEmoji
 	derefEmojisMu       mutexes.Mutex
 	handshakes          map[string][]*url.URL
-	handshakeSync       sync.Mutex // mutex to lock/unlock when checking or updating the handshakes map
+	handshakesMu        sync.Mutex // mutex to lock/unlock when checking or updating the handshakes map
 }
 
 // NewDereferencer returns a Dereferencer initialized with the given parameters.

--- a/internal/processing/account/statuses.go
+++ b/internal/processing/account/statuses.go
@@ -197,3 +197,9 @@ func (p *Processor) WebStatusesGet(ctx context.Context, targetAccountID string, 
 		NextMaxIDValue: nextMaxIDValue,
 	})
 }
+
+// PinnedStatusesGet is a shortcut for getting just an account's pinned statuses.
+// Under the hood, it just calls StatusesGet using mostly default parameters.
+func (p *Processor) PinnedStatusesGet(ctx context.Context, requestingAccount *gtsmodel.Account, targetAccountID string) (*apimodel.PageableResponse, gtserror.WithCode) {
+	return p.StatusesGet(ctx, requestingAccount, targetAccountID, 0, false, false, "", "", true, false, false)
+}

--- a/internal/processing/fedi/common.go
+++ b/internal/processing/fedi/common.go
@@ -19,41 +19,61 @@ package fedi
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"net/url"
 
+	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtscontext"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 )
 
-func (p *Processor) authenticate(ctx context.Context, requestedUsername string) (requestedAccount, requestingAccount *gtsmodel.Account, errWithCode gtserror.WithCode) {
+func (p *Processor) authenticate(ctx context.Context, requestedUsername string) (
+	*gtsmodel.Account, // requestedAccount
+	*gtsmodel.Account, // requestingAccount
+	gtserror.WithCode,
+) {
+	// Get LOCAL account with the requested username.
 	requestedAccount, err := p.state.DB.GetAccountByUsernameDomain(ctx, requestedUsername, "")
 	if err != nil {
-		errWithCode = gtserror.NewErrorNotFound(fmt.Errorf("database error getting account with username %s: %s", requestedUsername, err))
-		return
+		if !errors.Is(err, db.ErrNoEntries) {
+			// Real db error.
+			err = gtserror.Newf("db error getting account %s: %w", requestedUsername, err)
+			return nil, nil, gtserror.NewErrorInternalError(err)
+		}
+
+		// Account just not found in the db.
+		return nil, nil, gtserror.NewErrorNotFound(err)
 	}
 
-	var requestingAccountURI *url.URL
-	requestingAccountURI, errWithCode = p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
+	// Ensure request signed, and use signature URI to
+	// get requesting account, dereferencing if necessary.
+	requestingAccountURI, errWithCode := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
 	if errWithCode != nil {
-		return
+		return nil, nil, errWithCode
 	}
 
-	if requestingAccount, _, err = p.federator.GetAccountByURI(gtscontext.SetFastFail(ctx), requestedUsername, requestingAccountURI); err != nil {
-		errWithCode = gtserror.NewErrorUnauthorized(err)
-		return
+	requestingAccount, _, err := p.federator.GetAccountByURI(
+		gtscontext.SetFastFail(ctx),
+		requestedUsername,
+		requestingAccountURI,
+	)
+	if err != nil {
+		err = gtserror.Newf("error getting account %s: %w", requestingAccountURI, err)
+		return nil, nil, gtserror.NewErrorUnauthorized(err)
 	}
 
+	// Ensure no block exists between requester + requested.
 	blocked, err := p.state.DB.IsEitherBlocked(ctx, requestedAccount.ID, requestingAccount.ID)
 	if err != nil {
-		errWithCode = gtserror.NewErrorInternalError(err)
-		return
+		err = gtserror.Newf("db error getting checking block: %w", err)
+		return nil, nil, gtserror.NewErrorInternalError(err)
 	}
 
 	if blocked {
-		errWithCode = gtserror.NewErrorUnauthorized(fmt.Errorf("block exists between accounts %s and %s", requestedAccount.ID, requestingAccount.ID))
+		err = fmt.Errorf("block exists between accounts %s and %s", requestedAccount.ID, requestingAccount.ID)
+		return nil, nil, gtserror.NewErrorUnauthorized(err)
 	}
 
-	return
+	return requestedAccount, requestingAccount, nil
 }

--- a/internal/processing/fedi/user.go
+++ b/internal/processing/fedi/user.go
@@ -19,65 +19,110 @@ package fedi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 
 	"github.com/superseriousbusiness/activity/streams/vocab"
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtscontext"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/uris"
 )
 
-// UserGet handles the getting of a fedi/activitypub representation of a user/account, performing appropriate authentication
-// before returning a JSON serializable interface to the caller.
+// UserGet handles the getting of a fedi/activitypub representation of a user/account,
+// performing authentication before returning a JSON serializable interface to the caller.
 func (p *Processor) UserGet(ctx context.Context, requestedUsername string, requestURL *url.URL) (interface{}, gtserror.WithCode) {
-	// Get the instance-local account the request is referring to.
+	// (Try to) get the requested local account from the db.
 	requestedAccount, err := p.state.DB.GetAccountByUsernameDomain(ctx, requestedUsername, "")
 	if err != nil {
-		return nil, gtserror.NewErrorNotFound(fmt.Errorf("database error getting account with username %s: %s", requestedUsername, err))
-	}
+		if errors.Is(err, db.ErrNoEntries) {
+			// Account just not found w/ this username.
+			err := fmt.Errorf("account with username %s not found in the db", requestedUsername)
+			return nil, gtserror.NewErrorNotFound(err)
+		}
 
-	var requestedPerson vocab.ActivityStreamsPerson
+		// Real db error.
+		err := fmt.Errorf("db error getting account with username %s: %w", requestedUsername, err)
+		return nil, gtserror.NewErrorInternalError(err)
+	}
 
 	if uris.IsPublicKeyPath(requestURL) {
-		// if it's a public key path, we don't need to authenticate but we'll only serve the bare minimum user profile needed for the public key
-		requestedPerson, err = p.tc.AccountToASMinimal(ctx, requestedAccount)
+		// If request is on a public key path, we don't need to
+		// authenticate this request. However, we'll only serve
+		// the bare minimum user profile needed for the pubkey.
+		//
+		// TODO: https://github.com/superseriousbusiness/gotosocial/issues/1186
+		minimalPerson, err := p.tc.AccountToASMinimal(ctx, requestedAccount)
 		if err != nil {
 			return nil, gtserror.NewErrorInternalError(err)
 		}
-	} else {
-		// if it's any other path, we want to fully authenticate the request before we serve any data, and then we can serve a more complete profile
-		requestingAccountURI, errWithCode := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
-		if errWithCode != nil {
-			return nil, errWithCode
-		}
 
-		// if we're not already handshaking/dereferencing a remote account, dereference it now
-		if !p.federator.Handshaking(requestedUsername, requestingAccountURI) {
-			requestingAccount, _, err := p.federator.GetAccountByURI(gtscontext.SetFastFail(ctx), requestedUsername, requestingAccountURI)
-			if err != nil {
-				return nil, gtserror.NewErrorUnauthorized(err)
-			}
-
-			blocked, err := p.state.DB.IsEitherBlocked(ctx, requestedAccount.ID, requestingAccount.ID)
-			if err != nil {
-				return nil, gtserror.NewErrorInternalError(err)
-			}
-
-			if blocked {
-				return nil, gtserror.NewErrorUnauthorized(fmt.Errorf("block exists between accounts %s and %s", requestedAccount.ID, requestingAccount.ID))
-			}
-		}
-
-		requestedPerson, err = p.tc.AccountToAS(ctx, requestedAccount)
-		if err != nil {
-			return nil, gtserror.NewErrorInternalError(err)
-		}
+		// Return early with bare minimum data.
+		return data(minimalPerson)
 	}
 
+	// If the request is not on a public key path, we want to
+	// try to authenticate it before we serve any data, so that
+	// we can serve a more complete profile.
+	requestingAccountURI, errWithCode := p.federator.AuthenticateFederatedRequest(ctx, requestedUsername)
+	if errWithCode != nil {
+		return nil, errWithCode // likely 401
+	}
+
+	// Auth passed, generate the proper AP representation.
+	person, err := p.tc.AccountToAS(ctx, requestedAccount)
+	if err != nil {
+		return nil, gtserror.NewErrorInternalError(err)
+	}
+
+	// If we are currently handshaking with the remote account
+	// making the request, then don't be coy: just serve the AP
+	// representation of the target account.
+	//
+	// This handshake check ensures that we don't get stuck in
+	// a loop with another GtS instance, where each instance is
+	// trying repeatedly to dereference the other account that's
+	// making the request before it will reveal its own account.
+	//
+	// Instead, we end up in an 'I'll show you mine if you show me
+	// yours' situation, where we sort of agree to reveal each
+	// other's profiles at the same time.
+	if p.federator.Handshaking(requestedUsername, requestingAccountURI) {
+		return data(person)
+	}
+
+	// We're not currently handshaking with the requestingAccountURI,
+	// so fetch its details and ensure it's up to date + not blocked.
+	requestingAccount, _, err := p.federator.GetAccountByURI(
+		// On a hot path so fail quickly.
+		gtscontext.SetFastFail(ctx),
+		requestedUsername, requestingAccountURI,
+	)
+	if err != nil {
+		err := gtserror.Newf("error getting account %s: %w", requestingAccountURI, err)
+		return nil, gtserror.NewErrorUnauthorized(err)
+	}
+
+	blocked, err := p.state.DB.IsBlocked(ctx, requestedAccount.ID, requestingAccount.ID)
+	if err != nil {
+		err := gtserror.Newf("error checking block from account %s to account %s: %w", requestedAccount.ID, requestingAccount.ID, err)
+		return nil, gtserror.NewErrorInternalError(err)
+	}
+
+	if blocked {
+		err := fmt.Errorf("account %s blocks account %s", requestedAccount.ID, requestingAccount.ID)
+		return nil, gtserror.NewErrorUnauthorized(err)
+	}
+
+	return data(person)
+}
+
+func data(requestedPerson vocab.ActivityStreamsPerson) (interface{}, gtserror.WithCode) {
 	data, err := ap.Serialize(requestedPerson)
 	if err != nil {
+		err := gtserror.Newf("error serializing person: %w", err)
 		return nil, gtserror.NewErrorInternalError(err)
 	}
 

--- a/internal/web/profile.go
+++ b/internal/web/profile.go
@@ -20,7 +20,6 @@ package web
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -33,91 +32,117 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
 
-const (
-	// MaxStatusIDKey is for specifying the maximum ID of the status to retrieve.
-	MaxStatusIDKey = "max_id"
-)
-
 func (m *Module) profileGETHandler(c *gin.Context) {
 	ctx := c.Request.Context()
 
+	// We'll need the instance later, and we can also use it
+	// before then to make it easier to return a web error.
+	instance, errWithCode := m.processor.InstanceGetV1(ctx)
+	if errWithCode != nil {
+		apiutil.WebErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
+		return
+	}
+
+	// Return instance we already got from the db,
+	// don't try to fetch it again when erroring.
+	instanceGet := func(ctx context.Context) (*apimodel.InstanceV1, gtserror.WithCode) {
+		return instance, nil
+	}
+
+	// Parse account targetUsername from the URL.
+	targetUsername, errWithCode := apiutil.ParseWebUsername(c.Param(apiutil.WebUsernameKey))
+	if errWithCode != nil {
+		apiutil.WebErrorHandler(c, errWithCode, instanceGet)
+		return
+	}
+
+	// Normalize requested username:
+	//
+	//   - Usernames on our instance are (currently) always lowercase.
+	//
+	// todo: Update this logic when different username patterns
+	// are allowed, and/or when status slugs are introduced.
+	targetUsername = strings.ToLower(targetUsername)
+
+	// Check what type of content is being requested. If we're getting an AP
+	// request on this endpoint we should render the AP representation instead.
+	accept, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
+	if err != nil {
+		apiutil.WebErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), instanceGet)
+		return
+	}
+
+	if accept == string(apiutil.AppActivityJSON) || accept == string(apiutil.AppActivityLDJSON) {
+		// AP account representation has been requested.
+		m.returnAPAccount(c, targetUsername, accept, instanceGet)
+		return
+	}
+
+	// text/html has been requested. Proceed with getting the web view of the account.
+
+	// Don't require auth for web endpoints, but do take it if it was provided.
+	// authed.Account might end up nil here, but that's fine in case of public pages.
 	authed, err := oauth.Authed(c, false, false, false, false)
 	if err != nil {
 		apiutil.WebErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return
 	}
 
-	username := strings.ToLower(c.Param(usernameKey))
-	if username == "" {
-		err := errors.New("no account username specified")
-		apiutil.WebErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
-		return
-	}
-
-	instance, err := m.processor.InstanceGetV1(ctx)
-	if err != nil {
-		apiutil.WebErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
-		return
-	}
-
-	instanceGet := func(ctx context.Context) (*apimodel.InstanceV1, gtserror.WithCode) {
-		return instance, nil
-	}
-
-	account, errWithCode := m.processor.Account().GetLocalByUsername(ctx, authed.Account, username)
+	// Fetch the target account so we can do some checks on it.
+	targetAccount, errWithCode := m.processor.Account().GetLocalByUsername(ctx, authed.Account, targetUsername)
 	if errWithCode != nil {
 		apiutil.WebErrorHandler(c, errWithCode, instanceGet)
 		return
 	}
 
-	// if we're getting an AP request on this endpoint we
-	// should render the account's AP representation instead
-	accept := apiutil.NegotiateFormat(c, string(apiutil.TextHTML), string(apiutil.AppActivityJSON), string(apiutil.AppActivityLDJSON))
-	if accept == string(apiutil.AppActivityJSON) || accept == string(apiutil.AppActivityLDJSON) {
-		m.returnAPProfile(c, username, accept)
+	// If target account is suspended, this page should not be visible.
+	// TODO: change this to 410?
+	if targetAccount.Suspended {
+		err := fmt.Errorf("target account %s is suspended", targetUsername)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorNotFound(err), instanceGet)
 		return
 	}
 
+	// Only generate RSS link if account has RSS enabled.
 	var rssFeed string
-	if account.EnableRSS {
-		rssFeed = "/@" + account.Username + "/feed.rss"
+	if targetAccount.EnableRSS {
+		rssFeed = "/@" + targetAccount.Username + "/feed.rss"
 	}
 
-	// only allow search engines / robots to view this page if account is discoverable
+	// Only allow search engines / robots to
+	// index if account is discoverable.
 	var robotsMeta string
-	if account.Discoverable {
+	if targetAccount.Discoverable {
 		robotsMeta = robotsMetaAllowSome
 	}
 
 	// We need to change our response slightly if the
 	// profile visitor is paging through statuses.
 	var (
-		paging      bool
-		pinnedResp  = &apimodel.PageableResponse{}
-		maxStatusID string
+		maxStatusID    = apiutil.ParseMaxID(c.Query(apiutil.MaxIDKey), "")
+		paging         = maxStatusID != ""
+		pinnedStatuses *apimodel.PageableResponse
 	)
 
-	if maxStatusIDString := c.Query(MaxStatusIDKey); maxStatusIDString != "" {
-		maxStatusID = maxStatusIDString
-		paging = true
-	}
-
-	statusResp, errWithCode := m.processor.Account().WebStatusesGet(ctx, account.ID, maxStatusID)
-	if errWithCode != nil {
-		apiutil.WebErrorHandler(c, errWithCode, instanceGet)
-		return
-	}
-
-	// If we're not paging, then the profile visitor
-	// is currently just opening the bare profile, so
-	// load pinned statuses so we can show them at the
-	// top of the profile.
 	if !paging {
-		pinnedResp, errWithCode = m.processor.Account().StatusesGet(ctx, authed.Account, account.ID, 0, false, false, "", "", true, false, false)
+		// Client opened bare profile (from the top)
+		// so load + display pinned statuses.
+		pinnedStatuses, errWithCode = m.processor.Account().PinnedStatusesGet(ctx, authed.Account, targetAccount.ID)
 		if errWithCode != nil {
 			apiutil.WebErrorHandler(c, errWithCode, instanceGet)
 			return
 		}
+	} else {
+		// Don't load pinned statuses at
+		// the top of profile while paging.
+		pinnedStatuses = new(apimodel.PageableResponse)
+	}
+
+	// Get statuses from maxStatusID onwards (or from top if empty string).
+	statusResp, errWithCode := m.processor.Account().WebStatusesGet(ctx, targetAccount.ID, maxStatusID)
+	if errWithCode != nil {
+		apiutil.WebErrorHandler(c, errWithCode, instanceGet)
+		return
 	}
 
 	stylesheets := []string{
@@ -126,34 +151,41 @@ func (m *Module) profileGETHandler(c *gin.Context) {
 		distPathPrefix + "/profile.css",
 	}
 	if config.GetAccountsAllowCustomCSS() {
-		stylesheets = append(stylesheets, "/@"+account.Username+"/custom.css")
+		stylesheets = append(stylesheets, "/@"+targetAccount.Username+"/custom.css")
 	}
 
 	c.HTML(http.StatusOK, "profile.tmpl", gin.H{
 		"instance":         instance,
-		"account":          account,
-		"ogMeta":           ogBase(instance).withAccount(account),
+		"account":          targetAccount,
+		"ogMeta":           ogBase(instance).withAccount(targetAccount),
 		"rssFeed":          rssFeed,
 		"robotsMeta":       robotsMeta,
 		"statuses":         statusResp.Items,
 		"statuses_next":    statusResp.NextLink,
-		"pinned_statuses":  pinnedResp.Items,
+		"pinned_statuses":  pinnedStatuses.Items,
 		"show_back_to_top": paging,
 		"stylesheets":      stylesheets,
 		"javascript":       []string{distPathPrefix + "/frontend.js"},
 	})
 }
 
-func (m *Module) returnAPProfile(c *gin.Context, username string, accept string) {
-	user, errWithCode := m.processor.Fedi().UserGet(c.Request.Context(), username, c.Request.URL)
+// returnAPAccount returns an ActivityPub representation of
+// target account. It will do http signature authentication.
+func (m *Module) returnAPAccount(
+	c *gin.Context,
+	targetUsername string,
+	accept string,
+	instanceGet func(ctx context.Context) (*apimodel.InstanceV1, gtserror.WithCode),
+) {
+	user, errWithCode := m.processor.Fedi().UserGet(c.Request.Context(), targetUsername, c.Request.URL)
 	if errWithCode != nil {
 		apiutil.WebErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
 	}
 
-	b, mErr := json.Marshal(user)
-	if mErr != nil {
-		err := fmt.Errorf("could not marshal json: %s", mErr)
+	b, err := json.Marshal(user)
+	if err != nil {
+		err := gtserror.Newf("could not marshal json: %w", err)
 		apiutil.WebErrorHandler(c, gtserror.NewErrorInternalError(err), m.processor.InstanceGetV1)
 		return
 	}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates some of our web view status / account stuff:

- Reorder web view auth logic so that if an AP request comes in on a status URL, the AP representation can be served properly even if it's not a public status (assuming requester has permission to view it). Previously, we only served AP representations of public statuses that were requested using the URL rather than the AP URI, but this is not quite right.
- Serve 404 for local accounts that have been suspended, instead of showing a web view of an empty profile.
- Comment and tidy up for readability.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
