### PR TITLE
[bugfix] Don't stretch on very wide status'es

### DIFF
--- a/web/source/css/profile.css
+++ b/web/source/css/profile.css
@@ -181,6 +181,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 0.4rem;
+	min-width: 0%;
 
 	.col-header {
 		display: grid;


### PR DESCRIPTION
# Description

If someone makes a post with a long, uninterrupted piece of text in a code snippet, we would stretch the column to fit it, resulting in the UI going a bit whacky.

By setting min-width: 0% this fixes it, and we now automatically get a scrollbar on overflow instead.

Fixes: #1952

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
