### PR TITLE
[bugfix] Delete mutual follow (requests) when receiving block from remote

### DIFF
--- a/internal/db/bundb/relationship_test.go
+++ b/internal/db/bundb/relationship_test.go
@@ -836,6 +836,19 @@ func (suite *RelationshipTestSuite) TestGetFollowNotExisting() {
 	suite.Nil(follow)
 }
 
+func (suite *RelationshipTestSuite) TestDeleteFollow() {
+	ctx := context.Background()
+	originAccount := suite.testAccounts["local_account_1"]
+	targetAccount := suite.testAccounts["admin_account"]
+
+	err := suite.db.DeleteFollow(ctx, originAccount.ID, targetAccount.ID)
+	suite.NoError(err)
+
+	follow, err := suite.db.GetFollow(ctx, originAccount.ID, targetAccount.ID)
+	suite.EqualError(err, db.ErrNoEntries.Error())
+	suite.Nil(follow)
+}
+
 func (suite *RelationshipTestSuite) TestUnfollowRequestExisting() {
 	ctx := context.Background()
 	originAccount := suite.testAccounts["admin_account"]

--- a/internal/db/bundb/relationship_test.go
+++ b/internal/db/bundb/relationship_test.go
@@ -734,7 +734,7 @@ func (suite *RelationshipTestSuite) TestRejectFollowRequestNotExisting() {
 	targetAccount := suite.testAccounts["local_account_2"]
 
 	err := suite.db.RejectFollowRequest(ctx, account.ID, targetAccount.ID)
-	suite.ErrorIs(err, db.ErrNoEntries)
+	suite.NoError(err)
 }
 
 func (suite *RelationshipTestSuite) TestGetAccountFollowRequests() {

--- a/internal/db/relationship.go
+++ b/internal/db/relationship.go
@@ -97,11 +97,17 @@ type Relationship interface {
 	// UpdateFollowRequest updates one follow request by ID.
 	UpdateFollowRequest(ctx context.Context, followRequest *gtsmodel.FollowRequest, columns ...string) error
 
+	// DeleteFollow deletes a follow if it exists between source and target accounts.
+	DeleteFollow(ctx context.Context, sourceAccountID string, targetAccountID string) error
+
 	// DeleteFollowByID deletes a follow from the database with the given ID.
 	DeleteFollowByID(ctx context.Context, id string) error
 
 	// DeleteFollowByURI deletes a follow from the database with the given URI.
 	DeleteFollowByURI(ctx context.Context, uri string) error
+
+	// DeleteFollowRequest deletes a follow request if it exists between source and target accounts.
+	DeleteFollowRequest(ctx context.Context, sourceAccountID string, targetAccountID string) error
 
 	// DeleteFollowRequestByID deletes a follow request from the database with the given ID.
 	DeleteFollowRequestByID(ctx context.Context, id string) error


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request implements behavior to ensure that relationships are properly deleted when a block is received from a remote user via the federating API. Previously, we didn't properly delete follow (requests) in either direction, which lead to annoying and weird behavior.

closes https://github.com/superseriousbusiness/gotosocial/issues/1334
closes https://github.com/superseriousbusiness/gotosocial/issues/920

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
