### PR TITLE
[feature] More flexible OIDC attribute matching

### DIFF
--- a/example/config.yaml
+++ b/example/config.yaml
@@ -689,14 +689,14 @@ oidc-client-secret: ""
 # Array of string. Scopes to request from the OIDC provider. The returned values will be used to
 # populate users created in GtS as a result of the authentication flow. 'openid' and 'email' are required.
 # 'profile' is used to extract a username for the newly created user.
-# 'groups' is optional and can be used to determine if a user is an admin based on oidc-admin-groups.
+# You can add any additional scopes, such as whichever scope returns the account or admin claims that are
+# used in oidc-admin-required-claims and oidc-account-required-claims.
 # Examples: See eg., https://auth0.com/docs/scopes/openid-connect-scopes
-# Default: ["openid", "email", "profile", "groups"]
+# Default: ["openid", "email", "profile"]
 oidc-scopes:
   - "openid"
   - "email"
   - "profile"
-  - "groups"
 
 # Bool. Link OIDC authenticated users to existing ones based on their email address.
 # This is mostly intended for migration purposes if you were running previous versions of GTS
@@ -705,10 +705,31 @@ oidc-scopes:
 # Default: false
 oidc-link-existing: false
 
-# Array of string. If the returned ID token contains a 'groups' claim that matches one of the
-# groups in oidc-admin-groups, then this user will be granted admin rights on the GtS instance
+# Array of claim/value objects. The returned ID token will be tested against the specified
+# claims and required value. Only if all required claims match is the account granted admin
+# rights on the GtS instance. The tested claims cannot be a part of the claims returned by the
+# openid, profile, email, address or phone scopes.
+# If this list is empty, then admin access is never granted. At least one condition needs to
+# be present.
+# The claim(s) on the ID token can either be a single string or a list of string. If the
+# specified claim is of a different type, a list of integers for example, the claim is ignored
+# and as such a test against it will always fail.
+# Just because someone has claims that grant them admin access does not automatically mean they
+# can login/create an account. Their account will still be tested against the conditions in
+# oidc-account-required-claims too.
+# Examples: [{claim: groups, value: admin}]
 # Default: []
-oidc-admin-groups: []
+oidc-admin-required-claims: []
+
+# Array of claim:value objects. The returned ID token will be tested against the specified
+# claims and required value. If it matches, the user will be allowed to login and have their
+# account created. The tested claims cannot be a part of the claims returned by the openid,
+# profile, email, address or phone scopes.
+# If this list is empty, then this test is not performed at all and as such any user with an
+# otherwise valid token will be allowed to create an account or login.
+# Examples: [{claim: roles, value: gtsUser}]
+# Default: []
+oidc-account-required-claims: []
 
 #######################
 ##### SMTP CONFIG #####

--- a/internal/api/auth/callback.go
+++ b/internal/api/auth/callback.go
@@ -286,7 +286,7 @@ func (m *Module) createUserFromOIDC(ctx context.Context, claims *oidc.Claims, ex
 	adminGroups := config.GetOIDCAdminGroups()
 	var admin bool
 LOOP:
-	for _, g := range claims.Groups {
+	for _, g := range claims.Attrs["groups"] {
 		for _, ag := range adminGroups {
 			if strings.EqualFold(g, ag) {
 				admin = true

--- a/internal/api/auth/callback_test.go
+++ b/internal/api/auth/callback_test.go
@@ -1,0 +1,107 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/oidc"
+)
+
+type CallbackTestSuite struct {
+	// standard suite interfaces
+	suite.Suite
+}
+
+func (suite *CallbackTestSuite) TestAllowedByClaims() {
+	tests := []struct {
+		name   string
+		claims *oidc.Claims
+		rules  []config.OIDCRequirement
+		pass   bool
+	}{
+		{
+			name:   "fail closed",
+			claims: &oidc.Claims{},
+			rules:  nil,
+			pass:   false,
+		},
+		{
+			name: "single claim and no matching rules",
+			claims: &oidc.Claims{Attrs: map[string][]string{
+				"apple": {"pie"},
+			}},
+			rules: nil,
+			pass:  false,
+		},
+		{
+			name: "single claim and matching rule",
+			claims: &oidc.Claims{Attrs: map[string][]string{
+				"apple": {"pie"},
+			}},
+			rules: []config.OIDCRequirement{
+				{Claim: "apple", Value: "pie"},
+			},
+			pass: true,
+		},
+		{
+			name: "single claim and multiple rules",
+			claims: &oidc.Claims{Attrs: map[string][]string{
+				"apple": {"pie"},
+			}},
+			rules: []config.OIDCRequirement{
+				{Claim: "apple", Value: "pie"},
+				{Claim: "blueberry", Value: "muffin"},
+			},
+			pass: false,
+		},
+		{
+			name: "multiple claims and single matching rule",
+			claims: &oidc.Claims{Attrs: map[string][]string{
+				"apple":     {"pie"},
+				"blueberry": {"muffin"},
+			}},
+			rules: []config.OIDCRequirement{
+				{Claim: "blueberry", Value: "muffin"},
+			},
+			pass: true,
+		},
+		{
+			name: "multiple claims and multiple matching rules",
+			claims: &oidc.Claims{Attrs: map[string][]string{
+				"apple":     {"pie"},
+				"blueberry": {"muffin"},
+			}},
+			rules: []config.OIDCRequirement{
+				{Claim: "apple", Value: "pie"},
+				{Claim: "blueberry", Value: "muffin"},
+			},
+			pass: true,
+		},
+		{
+			name: "multiple claims and only partial matching rule",
+			claims: &oidc.Claims{Attrs: map[string][]string{
+				"apple":     {"pie"},
+				"blueberry": {"muffin"},
+			}},
+			rules: []config.OIDCRequirement{
+				{Claim: "apple", Value: "pie"},
+				{Claim: "blueberry", Value: "cobbler"},
+			},
+			pass: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		suite.Run(tt.name, func() {
+			res := allowedByClaims(tt.claims, tt.rules)
+			if tt.pass != res {
+				suite.FailNowf("rule evaluation incorrect", "expected: %t, got: %t", tt.pass, res)
+			}
+		})
+	}
+}
+
+func TestCallbackTestSuite(t *testing.T) {
+	suite.Run(t, &CallbackTestSuite{})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,15 +118,17 @@ type Configuration struct {
 	TLSCertificateChain string `name:"tls-certificate-chain" usage:"Filesystem path to the certificate chain including any intermediate CAs and the TLS public key"`
 	TLSCertificateKey   string `name:"tls-certificate-key" usage:"Filesystem path to the TLS private key"`
 
-	OIDCEnabled          bool     `name:"oidc-enabled" usage:"Enabled OIDC authorization for this instance. If set to true, then the other OIDC flags must also be set."`
-	OIDCIdpName          string   `name:"oidc-idp-name" usage:"Name of the OIDC identity provider. Will be shown to the user when logging in."`
-	OIDCSkipVerification bool     `name:"oidc-skip-verification" usage:"Skip verification of tokens returned by the OIDC provider. Should only be set to 'true' for testing purposes, never in a production environment!"`
-	OIDCIssuer           string   `name:"oidc-issuer" usage:"Address of the OIDC issuer. Should be the web address, including protocol, at which the issuer can be reached. Eg., 'https://example.org/auth'"`
-	OIDCClientID         string   `name:"oidc-client-id" usage:"ClientID of GoToSocial, as registered with the OIDC provider."`
-	OIDCClientSecret     string   `name:"oidc-client-secret" usage:"ClientSecret of GoToSocial, as registered with the OIDC provider."`
-	OIDCScopes           []string `name:"oidc-scopes" usage:"OIDC scopes."`
-	OIDCLinkExisting     bool     `name:"oidc-link-existing" usage:"link existing user accounts to OIDC logins based on the stored email value"`
-	OIDCAdminGroups      []string `name:"oidc-admin-groups" usage:"Membership of one of the listed groups makes someone a GtS admin"`
+	OIDCEnabled               bool              `name:"oidc-enabled" usage:"Enabled OIDC authorization for this instance. If set to true, then the other OIDC flags must also be set."`
+	OIDCIdpName               string            `name:"oidc-idp-name" usage:"Name of the OIDC identity provider. Will be shown to the user when logging in."`
+	OIDCSkipVerification      bool              `name:"oidc-skip-verification" usage:"Skip verification of tokens returned by the OIDC provider. Should only be set to 'true' for testing purposes, never in a production environment!"`
+	OIDCIssuer                string            `name:"oidc-issuer" usage:"Address of the OIDC issuer. Should be the web address, including protocol, at which the issuer can be reached. Eg., 'https://example.org/auth'"`
+	OIDCClientID              string            `name:"oidc-client-id" usage:"ClientID of GoToSocial, as registered with the OIDC provider."`
+	OIDCClientSecret          string            `name:"oidc-client-secret" usage:"ClientSecret of GoToSocial, as registered with the OIDC provider."`
+	OIDCScopes                []string          `name:"oidc-scopes" usage:"OIDC scopes."`
+	OIDCLinkExisting          bool              `name:"oidc-link-existing" usage:"link existing user accounts to OIDC logins based on the stored email value"`
+	OIDCAdminGroups           []string          `name:"oidc-admin-groups" usage:"Membership of one of the listed groups makes someone a GtS admin"`
+	OIDCAdminRequiredClaims   []OIDCRequirement `name:"oidc-admin-required-claims" usage:"Having the listed claims and required values makes someone a GtS admin"`
+	OIDCAccountRequiredCliams []OIDCRequirement `name:"oidc-account-required-claims" usage:"Having the listed claims and required values allows someone to login/create an account"`
 
 	TracingEnabled           bool   `name:"tracing-enabled" usage:"Enable OTLP Tracing"`
 	TracingTransport         string `name:"tracing-transport" usage:"grpc or jaeger"`
@@ -164,6 +166,11 @@ type Configuration struct {
 	AdminMediaPruneDryRun bool   `name:"dry-run" usage:"perform a dry run and only log number of items eligible for pruning"`
 
 	RequestIDHeader string `name:"request-id-header" usage:"Header to extract the Request ID from. Eg.,'X-Request-Id'."`
+}
+
+type OIDCRequirement struct {
+	Claim string `name:"claim"`
+	Value string `name:"value"`
 }
 
 type HTTPClientConfiguration struct {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -100,7 +100,7 @@ var Defaults = Configuration{
 	OIDCIssuer:           "",
 	OIDCClientID:         "",
 	OIDCClientSecret:     "",
-	OIDCScopes:           []string{oidc.ScopeOpenID, "profile", "email", "groups"},
+	OIDCScopes:           []string{oidc.ScopeOpenID, "profile", "email"},
 	OIDCLinkExisting:     false,
 
 	SMTPHost:               "",

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -1849,6 +1849,56 @@ func GetOIDCAdminGroups() []string { return global.GetOIDCAdminGroups() }
 // SetOIDCAdminGroups safely sets the value for global configuration 'OIDCAdminGroups' field
 func SetOIDCAdminGroups(v []string) { global.SetOIDCAdminGroups(v) }
 
+// GetOIDCAdminRequiredClaims safely fetches the Configuration value for state's 'OIDCAdminRequiredClaims' field
+func (st *ConfigState) GetOIDCAdminRequiredClaims() (v []OIDCRequirement) {
+	st.mutex.Lock()
+	v = st.config.OIDCAdminRequiredClaims
+	st.mutex.Unlock()
+	return
+}
+
+// SetOIDCAdminRequiredClaims safely sets the Configuration value for state's 'OIDCAdminRequiredClaims' field
+func (st *ConfigState) SetOIDCAdminRequiredClaims(v []OIDCRequirement) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.OIDCAdminRequiredClaims = v
+	st.reloadToViper()
+}
+
+// OIDCAdminRequiredClaimsFlag returns the flag name for the 'OIDCAdminRequiredClaims' field
+func OIDCAdminRequiredClaimsFlag() string { return "oidc-admin-required-claims" }
+
+// GetOIDCAdminRequiredClaims safely fetches the value for global configuration 'OIDCAdminRequiredClaims' field
+func GetOIDCAdminRequiredClaims() []OIDCRequirement { return global.GetOIDCAdminRequiredClaims() }
+
+// SetOIDCAdminRequiredClaims safely sets the value for global configuration 'OIDCAdminRequiredClaims' field
+func SetOIDCAdminRequiredClaims(v []OIDCRequirement) { global.SetOIDCAdminRequiredClaims(v) }
+
+// GetOIDCAccountRequiredCliams safely fetches the Configuration value for state's 'OIDCAccountRequiredCliams' field
+func (st *ConfigState) GetOIDCAccountRequiredCliams() (v []OIDCRequirement) {
+	st.mutex.Lock()
+	v = st.config.OIDCAccountRequiredCliams
+	st.mutex.Unlock()
+	return
+}
+
+// SetOIDCAccountRequiredCliams safely sets the Configuration value for state's 'OIDCAccountRequiredCliams' field
+func (st *ConfigState) SetOIDCAccountRequiredCliams(v []OIDCRequirement) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.OIDCAccountRequiredCliams = v
+	st.reloadToViper()
+}
+
+// OIDCAccountRequiredCliamsFlag returns the flag name for the 'OIDCAccountRequiredCliams' field
+func OIDCAccountRequiredCliamsFlag() string { return "oidc-account-required-claims" }
+
+// GetOIDCAccountRequiredCliams safely fetches the value for global configuration 'OIDCAccountRequiredCliams' field
+func GetOIDCAccountRequiredCliams() []OIDCRequirement { return global.GetOIDCAccountRequiredCliams() }
+
+// SetOIDCAccountRequiredCliams safely sets the value for global configuration 'OIDCAccountRequiredCliams' field
+func SetOIDCAccountRequiredCliams(v []OIDCRequirement) { global.SetOIDCAccountRequiredCliams(v) }
+
 // GetTracingEnabled safely fetches the Configuration value for state's 'TracingEnabled' field
 func (st *ConfigState) GetTracingEnabled() (v bool) {
 	st.mutex.Lock()

--- a/internal/oidc/claims.go
+++ b/internal/oidc/claims.go
@@ -17,16 +17,77 @@
 
 package oidc
 
-import "encoding/gob"
+import (
+	"encoding/gob"
+	"encoding/json"
+	"fmt"
+)
 
 // Claims represents claims as found in an id_token returned from an OIDC flow.
+//
+// All known claims are stored in their respective field. All unknown claims, as
+// long as they were either a string or a list of string, are stored keyed by the
+// claim in the Attrs map.
 type Claims struct {
-	Sub               string   `json:"sub"`
-	Email             string   `json:"email"`
-	EmailVerified     bool     `json:"email_verified"`
-	Groups            []string `json:"groups"`
-	Name              string   `json:"name"`
-	PreferredUsername string   `json:"preferred_username"`
+	Sub               string              `json:"sub"`
+	Email             string              `json:"email"`
+	EmailVerified     bool                `json:"email_verified"`
+	Name              string              `json:"name"`
+	PreferredUsername string              `json:"preferred_username"`
+	Attrs             map[string][]string `json:"-"`
+}
+
+// UnmarshalJSON implements the necessary logic to store any unknown
+// keys in the Attrs map
+func (c *Claims) UnmarshalJSON(data []byte) error {
+	// Create a new type so we don't recursively call UnmarshalJSON, but
+	// can reuse the type and decode based on the existing struct tags
+	type claims2 Claims
+	if err := json.Unmarshal(data, (*claims2)(c)); err != nil {
+		return fmt.Errorf("failed to decode JSON as a claims object: %s", err)
+	}
+
+	// Decode again, but now as json.RawMessage. Though we decode twice
+	// json.RawMessage is just []byte, so no actual decoding occurs. Only
+	// the keys in the top level object are collected
+	tmp := map[string]json.RawMessage{}
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		// Given that we already successfully unmarshalled into Claims, this error
+		// can realistically never occur as we know it's an object and keys in JSON
+		// must be strings
+		return fmt.Errorf("failed to decode as JSON object: %s", err)
+	}
+
+	// Remove any known fields, so all that is left are fields that we
+	// didn't have a direct struct mapping for. Delete is a no-op for
+	// keys that don't exist or are nil so can be safely called for all
+	// known fields even if some weren't present
+	delete(tmp, "sub")
+	delete(tmp, "email")
+	delete(tmp, "email_verified")
+	delete(tmp, "name")
+	delete(tmp, "preferred_username")
+
+	// initialise the Attrs map so we can set values on it
+	c.Attrs = map[string][]string{}
+
+	for key, value := range tmp {
+		var ls []string
+		if err := json.Unmarshal(value, &ls); err != nil {
+			var s string
+			if nerr := json.Unmarshal(value, &s); nerr != nil {
+				// The value couldn't be unmarshalled as either a string or a slice of
+				// string. Whatever it is, it's in a format we don't know or understand
+				// so we won't be able to use it. Move on to the next key.
+				continue
+			}
+			c.Attrs[key] = []string{s}
+			// The value decoded successfully as a string, move on to the next key
+			continue
+		}
+		c.Attrs[key] = ls
+	}
+	return nil
 }
 
 func init() {

--- a/internal/oidc/claims_test.go
+++ b/internal/oidc/claims_test.go
@@ -1,0 +1,69 @@
+package oidc
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type OIDCTestSuite struct {
+	// standard suite interfaces
+	suite.Suite
+}
+
+func (suite *OIDCTestSuite) TestOIDCClaimsUnmarshall() {
+	tests := []struct {
+		name string
+		in   string
+		err  bool
+		res  Claims
+	}{
+		{
+			name: "no unknown claims",
+			in:   `{"sub":"a", "email":"b", "email_verified": true, "name": "c", "preferred_username": "c"}`,
+			res:  Claims{Sub: "a", Email: "b", EmailVerified: true, Name: "c", PreferredUsername: "c", Attrs: map[string][]string{}},
+		},
+		{
+			name: "unknown claim with string value",
+			in:   `{"sub":"a", "email":"b", "email_verified": true, "name": "c", "preferred_username": "c", "groups": "test"}`,
+			res: Claims{Sub: "a", Email: "b", EmailVerified: true, Name: "c", PreferredUsername: "c", Attrs: map[string][]string{
+				"groups": {"test"},
+			}},
+		},
+		{
+			name: "unknown claim with list of string value",
+			in:   `{"sub":"a", "email":"b", "email_verified": true, "name": "c", "preferred_username": "c", "groups": ["test1", "test2"]}`,
+			res: Claims{Sub: "a", Email: "b", EmailVerified: true, Name: "c", PreferredUsername: "c", Attrs: map[string][]string{
+				"groups": {"test1", "test2"},
+			}},
+		},
+		{
+			name: "unknown claim with list of int value",
+			in:   `{"sub":"a", "email":"b", "email_verified": true, "name": "c", "preferred_username": "c", "groups": [1, 2]}`,
+			res:  Claims{Sub: "a", Email: "b", EmailVerified: true, Name: "c", PreferredUsername: "c", Attrs: map[string][]string{}},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		suite.Run(tt.name, func() {
+			var c Claims
+			err := json.Unmarshal([]byte(tt.in), &c)
+			if !tt.err && err != nil {
+				suite.FailNowf("expected success unmarshalling", "got error: %s", err.Error())
+			}
+			if tt.err && err == nil {
+				suite.FailNowf("expected failed unmarshalling", "got no error")
+			}
+			if !reflect.DeepEqual(tt.res, c) {
+				suite.T().Log(c.Attrs)
+				suite.FailNow("expected structs to be identical")
+			}
+		})
+	}
+}
+
+func TestOIDCTestSuite(t *testing.T) {
+	suite.Run(t, &OIDCTestSuite{})
+}

--- a/test/envparsing.sh
+++ b/test/envparsing.sh
@@ -123,9 +123,11 @@ EXPECT=$(cat <<"EOF"
     "media-image-max-size": 420,
     "media-remote-cache-days": 30,
     "media-video-max-size": 420,
+    "oidc-account-required-claims": null,
     "oidc-admin-groups": [
         "steamy"
     ],
+    "oidc-admin-required-claims": null,
     "oidc-client-id": "1234",
     "oidc-client-secret": "shhhh its a secret",
     "oidc-enabled": true,
@@ -253,6 +255,8 @@ GTS_OIDC_CLIENT_SECRET='shhhh its a secret' \
 GTS_OIDC_SCOPES='read,write' \
 GTS_OIDC_LINK_EXISTING=true \
 GTS_OIDC_ADMIN_GROUPS='steamy' \
+GTS_OIDC_ACCOUNT_REQUIRED_CLAIMS='' \
+GTS_OIDC_ADMIN_REQUIRED_CLAIMS='' \
 GTS_SMTP_HOST='example.com' \
 GTS_SMTP_PORT=4269 \
 GTS_SMTP_USERNAME='sex-haver' \


### PR DESCRIPTION
# Description

In order to solve #1914 and #1915 we need to make our matching on OIDC claims more flexible. Unfortunately, there is no well-defined and supported scope amongst all IdPs to expose membership information using defined claims. So far we've expected a groups claim to exist, but this is implementation dependent.

By commit:
* This changes our claims implementation so that for standardised claims defined by a well-known scope we retain a struct field. Any other keys in the claims object are stored by their key in the new Attrs field instead, as a list of strings. A custom UnmarshalJSON is implemented for this purpose in order to ensure we have type safety once the decoding is done.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.