### PR TITLE
[docs] Activate the edit feature

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ theme:
   features:
     - header.autohide
     - content.code.copy
+    - content.action.edit
   palette:
     - scheme: slate
       toggle:


### PR DESCRIPTION
# Description

We already set edit_uri, but we forgot to enable the feature flag. By turning it on each page now gets an edit button on the right hand side of the page header. This'll open the edit view in GitHub.

Hopefully this makes it easier for folks to make (small) doc changes.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
