### PR TITLE
[feature] Allow exposing lookup without auth

### DIFF
--- a/example/config.yaml
+++ b/example/config.yaml
@@ -380,6 +380,11 @@ instance-expose-suspended: false
 # Default: false
 instance-expose-suspended-web: false
 
+# Bool. Allow unauthenticated users to make queries to /api/v1/lookup. This allows them to
+# determine if a username is available on this instance, or if we're aware of a remote
+# account.
+instance-expose-lookup: false
+
 # Bool. Allow unauthenticated users to make queries to /api/v1/timelines/public in order
 # to see a list of public posts on this server. Even if set to 'false', then authenticated
 # users (members of the instance) will still be able to query the endpoint.

--- a/internal/api/client/accounts/lookup.go
+++ b/internal/api/client/accounts/lookup.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 )
@@ -66,7 +67,16 @@ import (
 //		'500':
 //			description: internal server error
 func (m *Module) AccountLookupGETHandler(c *gin.Context) {
-	authed, err := oauth.Authed(c, true, true, true, true)
+	var authed *oauth.Auth
+	var err error
+	if config.GetInstanceExposeLookup() {
+		// If the lookup endpoint is allowed to be exposed, still check if we
+		// can extract various authentication properties, but don't require them.
+		authed, err = oauth.Authed(c, false, false, false, false)
+	} else {
+		authed, err = oauth.Authed(c, true, true, true, true)
+	}
+
 	if err != nil {
 		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
 		return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,7 @@ type Configuration struct {
 	InstanceExposeSuspended        bool `name:"instance-expose-suspended" usage:"Expose suspended instances via web UI, and allow unauthenticated users to query /api/v1/instance/peers?filter=suspended"`
 	InstanceExposeSuspendedWeb     bool `name:"instance-expose-suspended-web" usage:"Expose list of suspended instances as webpage on /about/suspended"`
 	InstanceExposePublicTimeline   bool `name:"instance-expose-public-timeline" usage:"Allow unauthenticated users to query /api/v1/timelines/public"`
+	InstanceExposeLookup           bool `name:"instance-expose-lookup" usage:"Allow unauthenticated users to query /api/v1/lookup"`
 	InstanceDeliverToSharedInboxes bool `name:"instance-deliver-to-shared-inboxes" usage:"Deliver federated messages to shared inboxes, if they're available."`
 
 	AccountsRegistrationOpen bool `name:"accounts-registration-open" usage:"Allow anyone to submit an account signup request. If false, server will be invite-only."`

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -824,6 +824,31 @@ func GetInstanceExposePublicTimeline() bool { return global.GetInstanceExposePub
 // SetInstanceExposePublicTimeline safely sets the value for global configuration 'InstanceExposePublicTimeline' field
 func SetInstanceExposePublicTimeline(v bool) { global.SetInstanceExposePublicTimeline(v) }
 
+// GetInstanceExposeLookup safely fetches the Configuration value for state's 'InstanceExposeLookup' field
+func (st *ConfigState) GetInstanceExposeLookup() (v bool) {
+	st.mutex.RLock()
+	v = st.config.InstanceExposeLookup
+	st.mutex.RUnlock()
+	return
+}
+
+// SetInstanceExposeLookup safely sets the Configuration value for state's 'InstanceExposeLookup' field
+func (st *ConfigState) SetInstanceExposeLookup(v bool) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.InstanceExposeLookup = v
+	st.reloadToViper()
+}
+
+// InstanceExposeLookupFlag returns the flag name for the 'InstanceExposeLookup' field
+func InstanceExposeLookupFlag() string { return "instance-expose-lookup" }
+
+// GetInstanceExposeLookup safely fetches the value for global configuration 'InstanceExposeLookup' field
+func GetInstanceExposeLookup() bool { return global.GetInstanceExposeLookup() }
+
+// SetInstanceExposeLookup safely sets the value for global configuration 'InstanceExposeLookup' field
+func SetInstanceExposeLookup(v bool) { global.SetInstanceExposeLookup(v) }
+
 // GetInstanceDeliverToSharedInboxes safely fetches the Configuration value for state's 'InstanceDeliverToSharedInboxes' field
 func (st *ConfigState) GetInstanceDeliverToSharedInboxes() (v bool) {
 	st.mutex.RLock()

--- a/test/envparsing.sh
+++ b/test/envparsing.sh
@@ -104,6 +104,7 @@ EXPECT=$(cat <<"EOF"
         "timeout": 10000000000
     },
     "instance-deliver-to-shared-inboxes": false,
+    "instance-expose-lookup": true,
     "instance-expose-peers": true,
     "instance-expose-public-timeline": true,
     "instance-expose-suspended": true,
@@ -210,6 +211,7 @@ GTS_TLS_MODE='' \
 GTS_DB_TLS_CA_CERT='' \
 GTS_WEB_TEMPLATE_BASE_DIR='/root' \
 GTS_WEB_ASSET_BASE_DIR='/root' \
+GTS_INSTANCE_EXPOSE_LOOKUP=true \
 GTS_INSTANCE_EXPOSE_PEERS=true \
 GTS_INSTANCE_EXPOSE_SUSPENDED=true \
 GTS_INSTANCE_EXPOSE_SUSPENDED_WEB=true \


### PR DESCRIPTION
# Description

This lets an instance admin configure whether the
/api/v1/accounts/lookup endpoint requires authentication or not. Parts of this information can be gleamed through webfinger so it's conceivable people are OK with this being public.

The endpoint is documented as being public in the Masto API, so this allows an admin to make our implementation behave in the same manner should they want to.

The default remains false, it needs to be explicitly enabled.

Fixes #1939

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
