### PR TITLE
[feature] Report Masto version in /api/v1/instance

### DIFF
--- a/example/config.yaml
+++ b/example/config.yaml
@@ -400,6 +400,15 @@ instance-expose-public-timeline: false
 # Default: true
 instance-deliver-to-shared-inboxes: true
 
+# Bool. This flag will inject a Mastodon version into the version field that
+# is included in /api/v1/instance. This version is often used by Mastodon clients
+# to do API feature detection. By injecting a Mastodon compatible version, it is
+# possible to cajole those clients to behave correctly with GoToSocial.
+#
+# Options: [true, false]
+# Default: false
+instance-inject-mastodon-version: false
+
 ###########################
 ##### ACCOUNTS CONFIG #####
 ###########################

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,7 @@ type Configuration struct {
 	InstanceExposeSuspendedWeb     bool `name:"instance-expose-suspended-web" usage:"Expose list of suspended instances as webpage on /about/suspended"`
 	InstanceExposePublicTimeline   bool `name:"instance-expose-public-timeline" usage:"Allow unauthenticated users to query /api/v1/timelines/public"`
 	InstanceDeliverToSharedInboxes bool `name:"instance-deliver-to-shared-inboxes" usage:"Deliver federated messages to shared inboxes, if they're available."`
+	InstanceInjectMastodonVersion  bool `name:"instance-inject-mastodon-version" usage:"This injects a Mastodon compatible version in /api/v1/instance to help Mastodon clients that use that version for feature detection"`
 
 	AccountsRegistrationOpen bool `name:"accounts-registration-open" usage:"Allow anyone to submit an account signup request. If false, server will be invite-only."`
 	AccountsApprovalRequired bool `name:"accounts-approval-required" usage:"Do account signups require approval by an admin or moderator before user can log in? If false, new registrations will be automatically approved."`

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -849,6 +849,31 @@ func GetInstanceDeliverToSharedInboxes() bool { return global.GetInstanceDeliver
 // SetInstanceDeliverToSharedInboxes safely sets the value for global configuration 'InstanceDeliverToSharedInboxes' field
 func SetInstanceDeliverToSharedInboxes(v bool) { global.SetInstanceDeliverToSharedInboxes(v) }
 
+// GetInstanceInjectMastodonVersion safely fetches the Configuration value for state's 'InstanceInjectMastodonVersion' field
+func (st *ConfigState) GetInstanceInjectMastodonVersion() (v bool) {
+	st.mutex.RLock()
+	v = st.config.InstanceInjectMastodonVersion
+	st.mutex.RUnlock()
+	return
+}
+
+// SetInstanceInjectMastodonVersion safely sets the Configuration value for state's 'InstanceInjectMastodonVersion' field
+func (st *ConfigState) SetInstanceInjectMastodonVersion(v bool) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.InstanceInjectMastodonVersion = v
+	st.reloadToViper()
+}
+
+// InstanceInjectMastodonVersionFlag returns the flag name for the 'InstanceInjectMastodonVersion' field
+func InstanceInjectMastodonVersionFlag() string { return "instance-inject-mastodon-version" }
+
+// GetInstanceInjectMastodonVersion safely fetches the value for global configuration 'InstanceInjectMastodonVersion' field
+func GetInstanceInjectMastodonVersion() bool { return global.GetInstanceInjectMastodonVersion() }
+
+// SetInstanceInjectMastodonVersion safely sets the value for global configuration 'InstanceInjectMastodonVersion' field
+func SetInstanceInjectMastodonVersion(v bool) { global.SetInstanceInjectMastodonVersion(v) }
+
 // GetAccountsRegistrationOpen safely fetches the Configuration value for state's 'AccountsRegistrationOpen' field
 func (st *ConfigState) GetAccountsRegistrationOpen() (v bool) {
 	st.mutex.RLock()

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -45,11 +45,16 @@ const (
 	instanceAccountsMaxFeaturedTags             = 10
 	instanceAccountsMaxProfileFields            = 6 // FIXME: https://github.com/superseriousbusiness/gotosocial/issues/1876
 	instanceSourceURL                           = "https://github.com/superseriousbusiness/gotosocial"
+	instanceMastodonVersion                     = "3.5.3"
 )
 
 var instanceStatusesSupportedMimeTypes = []string{
 	string(apimodel.StatusContentTypePlain),
 	string(apimodel.StatusContentTypeMarkdown),
+}
+
+func toMastodonVersion(in string) string {
+	return instanceMastodonVersion + "+" + strings.ReplaceAll(in, " ", "-")
 }
 
 func (c *converter) AccountToAPIAccountSensitive(ctx context.Context, a *gtsmodel.Account) (*apimodel.Account, error) {
@@ -740,6 +745,10 @@ func (c *converter) InstanceToAPIV1Instance(ctx context.Context, i *gtsmodel.Ins
 		MaxTootChars:     uint(config.GetStatusesMaxChars()),
 	}
 
+	if config.GetInstanceInjectMastodonVersion() {
+		instance.Version = toMastodonVersion(instance.Version)
+	}
+
 	// configuration
 	instance.Configuration.Statuses.MaxCharacters = config.GetStatusesMaxChars()
 	instance.Configuration.Statuses.MaxMediaAttachments = config.GetStatusesMediaMaxFiles()
@@ -837,6 +846,10 @@ func (c *converter) InstanceToAPIV2Instance(ctx context.Context, i *gtsmodel.Ins
 		Usage:         apimodel.InstanceV2Usage{}, // todo: not implemented
 		Languages:     []string{},                 // todo: not implemented
 		Rules:         []interface{}{},            // todo: not implemented
+	}
+
+	if config.GetInstanceInjectMastodonVersion() {
+		instance.Version = toMastodonVersion(instance.Version)
 	}
 
 	// thumbnail

--- a/test/envparsing.sh
+++ b/test/envparsing.sh
@@ -108,6 +108,7 @@ EXPECT=$(cat <<"EOF"
     "instance-expose-public-timeline": true,
     "instance-expose-suspended": true,
     "instance-expose-suspended-web": true,
+    "instance-inject-mastodon-version": true,
     "landing-page-user": "admin",
     "letsencrypt-cert-dir": "/gotosocial/storage/certs",
     "letsencrypt-email-address": "",
@@ -215,6 +216,7 @@ GTS_INSTANCE_EXPOSE_SUSPENDED=true \
 GTS_INSTANCE_EXPOSE_SUSPENDED_WEB=true \
 GTS_INSTANCE_EXPOSE_PUBLIC_TIMELINE=true \
 GTS_INSTANCE_DELIVER_TO_SHARED_INBOXES=false \
+GTS_INSTANCE_INJECT_MASTODON_VERSION=true \
 GTS_ACCOUNTS_ALLOW_CUSTOM_CSS=true \
 GTS_ACCOUNTS_CUSTOM_CSS_LENGTH=5000 \
 GTS_ACCOUNTS_REGISTRATION_OPEN=true \


### PR DESCRIPTION
# Description

A number of applications use the version reported by /api/v1/instance as a way to do feature detection for the Mastodon client API. Due to the current GtS versions in 0.x, this often means GtS gets determined to be non-compatible by clients and libraries that only ever test against Mastodon proper.

This adds a configuration value that allows the admin to decide to inject a Mastodon version in that response instead, in order to cajole clients into working correctly with GtS. This is only done for /api/v1/instance as that's the Masto client API, nodeinfo is left as it is as that should not be used by Masto clients for feature detection.

Since the clients we recommend don't need to be tricked this way, this feature defaults to being off. Admins can enable it if so desired, which may be useful for small communities where admins might have less say over which clients people use.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
