### PR TITLE
[bugfix] Properly handle range > content-length

### DIFF
--- a/internal/api/fileserver/servefile.go
+++ b/internal/api/fileserver/servefile.go
@@ -208,10 +208,9 @@ func serveFileRange(rw http.ResponseWriter, r *http.Request, src io.Reader, rng 
 		}
 
 		if end > size {
-			// This range exceeds length of the file, therefore unsatisfiable
-			rw.Header().Set("Content-Range", "bytes *"+strconv.FormatInt(size, 10))
-			http.Error(rw, "Unsatisfiable Range", http.StatusRequestedRangeNotSatisfiable)
-			return
+			// According to the http spec if end >= size the server should return the rest of the file
+			// https://www.rfc-editor.org/rfc/rfc9110#section-14.1.2-6
+			end = size - 1
 		}
 	} else {
 		// No end supplied, implying file end


### PR DESCRIPTION
# Description

This makes the serveFileRange function return the entire file if suffix-range is larger than content-length in compliance with RFC9110

closes #1978 

## Checklist

- [ x ] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ x ] I/we have performed a self-review of added code.
- [ x ] I/we have written code that is legible and maintainable by others.
- [ x ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ x ] I/we have made any necessary changes to documentation.
- [ x ] I/we have added tests that cover new code.
- [ x ] I/we have run tests and they pass locally with the changes.
- [ x ] I/we have run `go fmt ./...` and `golangci-lint run`.
