### PR TITLE
[chore] Skip webfinger test on CI

### DIFF
--- a/internal/transport/finger_test.go
+++ b/internal/transport/finger_test.go
@@ -19,6 +19,7 @@ package transport_test
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -42,6 +43,10 @@ func (suite *FingerTestSuite) TestFinger() {
 }
 
 func (suite *FingerTestSuite) TestFingerWithHostMeta() {
+	if os.Getenv("CI") == "true" {
+		suite.T().Skip("this test is flaky on CI for as of yet unknown reasons")
+	}
+
 	wc := suite.state.Caches.GTS.Webfinger()
 	suite.Equal(0, wc.Len(), "expect webfinger cache to be empty")
 


### PR DESCRIPTION
# Description

This keeps being flaky on CI but we so far have no way to reproduce it locally. To that end, disable this test on CI, but leave it running locally in case we might catch the issue there.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
