### PR TITLE
[feature/performance] support uncaching remote emoji + scheduled cleanup functions

### DIFF
--- a/cmd/gotosocial/action/admin/media/prune/all.go
+++ b/cmd/gotosocial/action/admin/media/prune/all.go
@@ -50,7 +50,7 @@ var All action.GTSAction = func(ctx context.Context) error {
 
 	// Perform the actual pruning with logging.
 	prune.cleaner.Media().All(ctx, days)
-	prune.cleaner.Emoji().All(ctx)
+	prune.cleaner.Emoji().All(ctx, days)
 
 	// Perform a cleanup of storage (for removed local dirs).
 	if err := prune.storage.Storage.Clean(ctx); err != nil {

--- a/internal/cleaner/cleaner_test.go
+++ b/internal/cleaner/cleaner_test.go
@@ -1,0 +1,82 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cleaner_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/cleaner"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/state"
+	"github.com/superseriousbusiness/gotosocial/testrig"
+)
+
+type CleanerTestSuite struct {
+	state   state.State
+	cleaner *cleaner.Cleaner
+	emojis  map[string]*gtsmodel.Emoji
+	suite.Suite
+}
+
+func TestCleanerTestSuite(t *testing.T) {
+	suite.Run(t, &CleanerTestSuite{})
+}
+
+func (suite *CleanerTestSuite) SetupSuite() {
+	testrig.InitTestConfig()
+	testrig.InitTestLog()
+}
+
+func (suite *CleanerTestSuite) SetupTest() {
+	// Initialize gts caches.
+	suite.state.Caches.Init()
+
+	// Ensure scheduler started (even if unused).
+	suite.state.Workers.Scheduler.Start(nil)
+
+	// Initialize test database.
+	_ = testrig.NewTestDB(&suite.state)
+	testrig.StandardDBSetup(suite.state.DB, nil)
+
+	// Initialize test storage (in-memory).
+	suite.state.Storage = testrig.NewInMemoryStorage()
+
+	// Initialize test cleaner instance.
+	suite.cleaner = cleaner.New(&suite.state)
+
+	// Allocate new test model emojis.
+	suite.emojis = testrig.NewTestEmojis()
+}
+
+func (suite *CleanerTestSuite) TearDownTest() {
+	_ = suite.state.DB.Stop(context.Background())
+	suite.state.DB = nil
+}
+
+// mapvals extracts a slice of values from the values contained within the map.
+func mapvals[Key comparable, Val any](m map[Key]Val) []Val {
+	var i int
+	vals := make([]Val, len(m))
+	for _, val := range m {
+		vals[i] = val
+		i++
+	}
+	return vals
+}

--- a/internal/cleaner/cleaner_test.go
+++ b/internal/cleaner/cleaner_test.go
@@ -18,7 +18,6 @@
 package cleaner_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -66,8 +65,7 @@ func (suite *CleanerTestSuite) SetupTest() {
 }
 
 func (suite *CleanerTestSuite) TearDownTest() {
-	_ = suite.state.DB.Stop(context.Background())
-	suite.state.DB = nil
+	testrig.StandardDBTeardown(suite.state.DB)
 }
 
 // mapvals extracts a slice of values from the values contained within the map.

--- a/internal/cleaner/emoji.go
+++ b/internal/cleaner/emoji.go
@@ -311,12 +311,12 @@ func (e *Emoji) fixCacheState(ctx context.Context, emoji *gtsmodel.Emoji) (bool,
 	switch {
 	case *emoji.Cached && !exist:
 		// Mark as uncached if expected files don't exist.
-		l.Debug("cached=true exists=false => uncaching")
+		l.Debug("cached=true exists=false => marking uncached")
 		return true, e.uncache(ctx, emoji)
 
 	case !*emoji.Cached && exist:
 		// Remove files if we don't expect them to exist.
-		l.Debug("cached=false exists=true => deleting")
+		l.Debug("cached=false exists=true => removing files")
 		_, err := e.removeFiles(ctx,
 			emoji.ImageStaticPath,
 			emoji.ImagePath,

--- a/internal/cleaner/emoji.go
+++ b/internal/cleaner/emoji.go
@@ -37,19 +37,13 @@ type Emoji struct {
 
 // All will execute all cleaner.Emoji utilities synchronously, including output logging.
 // Context will be checked for `gtscontext.DryRun()` in order to actually perform the action.
-func (e *Emoji) All(ctx context.Context) {
-	e.LogPruneMissing(ctx)
+func (e *Emoji) All(ctx context.Context, maxRemoteDays int) {
+	t := time.Now().Add(-24 * time.Hour * time.Duration(maxRemoteDays))
+	e.LogUncacheRemote(ctx, t)
 	e.LogFixBroken(ctx)
-}
-
-// LogPruneMissing performs Emoji.PruneMissing(...), logging the start and outcome.
-func (e *Emoji) LogPruneMissing(ctx context.Context) {
-	log.Info(ctx, "start")
-	if n, err := e.PruneMissing(ctx); err != nil {
-		log.Error(ctx, err)
-	} else {
-		log.Infof(ctx, "pruned: %d", n)
-	}
+	e.LogPruneUnused(ctx)
+	e.LogFixCacheStates(ctx)
+	_ = e.state.Storage.Storage.Clean(ctx)
 }
 
 // LogUncacheRemote performs Emoji.UncacheRemote(...), logging the start and outcome.
@@ -72,46 +66,24 @@ func (e *Emoji) LogFixBroken(ctx context.Context) {
 	}
 }
 
-// PruneMissing will delete emoji with missing files from the database and storage driver.
-// Context will be checked for `gtscontext.DryRun()` to perform the action. NOTE: this function
-// should be updated to match media.FixCacheStat() if we ever support emoji uncaching.
-func (e *Emoji) PruneMissing(ctx context.Context) (int, error) {
-	var (
-		total int
-		maxID string
-	)
-
-	for {
-		// Fetch the next batch of emoji media up to next ID.
-		emojis, err := e.state.DB.GetEmojis(ctx, maxID, selectLimit)
-		if err != nil && !errors.Is(err, db.ErrNoEntries) {
-			return total, gtserror.Newf("error getting emojis: %w", err)
-		}
-
-		if len(emojis) == 0 {
-			// reached end.
-			break
-		}
-
-		// Use last as the next 'maxID' value.
-		maxID = emojis[len(emojis)-1].ID
-
-		for _, emoji := range emojis {
-			// Check / fix missing emoji media.
-			fixed, err := e.pruneMissing(ctx, emoji)
-			if err != nil {
-				return total, err
-			}
-
-			if fixed {
-				// Update
-				// count.
-				total++
-			}
-		}
+// LogPruneUnused performs Emoji.PruneUnused(...), logging the start and outcome.
+func (e *Emoji) LogPruneUnused(ctx context.Context) {
+	log.Info(ctx, "start")
+	if n, err := e.PruneUnused(ctx); err != nil {
+		log.Error(ctx, err)
+	} else {
+		log.Infof(ctx, "pruned: %d", n)
 	}
+}
 
-	return total, nil
+// LogFixCacheStates performs Emoji.FixCacheStates(...), logging the start and outcome.
+func (e *Emoji) LogFixCacheStates(ctx context.Context) {
+	log.Info(ctx, "start")
+	if n, err := e.FixCacheStates(ctx); err != nil {
+		log.Error(ctx, err)
+	} else {
+		log.Infof(ctx, "fixed: %d", n)
+	}
 }
 
 // UncacheRemote will uncache all remote emoji older than given input time. Context
@@ -127,8 +99,8 @@ func (e *Emoji) UncacheRemote(ctx context.Context, olderThan time.Time) (int, er
 	mostRecent := olderThan
 
 	for {
-		// Fetch the next batch of emojis older than last-set time.
-		emojis, err := e.state.DB.GetRemoteEmojisOlderThan(ctx, olderThan, selectLimit)
+		// Fetch the next batch of cached emojis older than last-set time.
+		emojis, err := e.state.DB.GetCachedEmojisOlderThan(ctx, olderThan, selectLimit)
 		if err != nil && !errors.Is(err, db.ErrNoEntries) {
 			return total, gtserror.Newf("error getting remote emoji: %w", err)
 		}
@@ -204,22 +176,156 @@ func (e *Emoji) FixBroken(ctx context.Context) (int, error) {
 	return total, nil
 }
 
-func (e *Emoji) pruneMissing(ctx context.Context, emoji *gtsmodel.Emoji) (bool, error) {
-	return e.checkFiles(ctx, func() error {
-		// Emoji missing files, delete it.
-		// NOTE: if we ever support uncaching
-		// of emojis, change to e.uncache().
-		// In that case we should also rename
-		// this function to match the media
-		// equivalent -> fixCacheState().
-		log.WithContext(ctx).
-			WithField("emoji", emoji.ID).
-			Debug("deleting due to missing emoji")
-		return e.delete(ctx, emoji)
-	},
+// PruneUnused will delete all unused emoji media from the database and storage driver.
+// Context will be checked for `gtscontext.DryRun()` to perform the action. NOTE: this function
+// should be updated to match media.FixCacheStat() if we ever support emoji uncaching.
+func (e *Emoji) PruneUnused(ctx context.Context) (int, error) {
+	var (
+		total int
+		maxID string
+	)
+
+	for {
+		// Fetch the next batch of emoji media up to next ID.
+		emojis, err := e.state.DB.GetRemoteEmojis(ctx, maxID, selectLimit)
+		if err != nil && !errors.Is(err, db.ErrNoEntries) {
+			return total, gtserror.Newf("error getting remote emojis: %w", err)
+		}
+
+		if len(emojis) == 0 {
+			// reached end.
+			break
+		}
+
+		// Use last as the next 'maxID' value.
+		maxID = emojis[len(emojis)-1].ID
+
+		for _, emoji := range emojis {
+			// Check / prune unused emoji media.
+			fixed, err := e.pruneUnused(ctx, emoji)
+			if err != nil {
+				return total, err
+			}
+
+			if fixed {
+				// Update
+				// count.
+				total++
+			}
+		}
+	}
+
+	return total, nil
+}
+
+// FixCacheStatus will check all emoji for up-to-date cache status (i.e. in storage driver).
+// Context will be checked for `gtscontext.DryRun()` to perform the action. NOTE: this function
+// should be updated to match media.FixCacheStat() if we ever support emoji uncaching.
+func (e *Emoji) FixCacheStates(ctx context.Context) (int, error) {
+	var (
+		total int
+		maxID string
+	)
+
+	for {
+		// Fetch the next batch of emoji media up to next ID.
+		emojis, err := e.state.DB.GetRemoteEmojis(ctx, maxID, selectLimit)
+		if err != nil && !errors.Is(err, db.ErrNoEntries) {
+			return total, gtserror.Newf("error getting remote emojis: %w", err)
+		}
+
+		if len(emojis) == 0 {
+			// reached end.
+			break
+		}
+
+		// Use last as the next 'maxID' value.
+		maxID = emojis[len(emojis)-1].ID
+
+		for _, emoji := range emojis {
+			// Check / fix required emoji cache states.
+			fixed, err := e.fixCacheState(ctx, emoji)
+			if err != nil {
+				return total, err
+			}
+
+			if fixed {
+				// Update
+				// count.
+				total++
+			}
+		}
+	}
+
+	return total, nil
+}
+
+func (e *Emoji) pruneUnused(ctx context.Context, emoji *gtsmodel.Emoji) (bool, error) {
+	// Start a log entry for emoji.
+	l := log.WithContext(ctx).
+		WithField("emoji", emoji.ID)
+
+	// Load any related accounts using this emoji.
+	accounts, err := e.getRelatedAccounts(ctx, emoji)
+	if err != nil {
+		return false, err
+	} else if len(accounts) > 0 {
+		l.Debug("skipping as account emoji in use")
+		return false, nil
+	}
+
+	// Load any related statuses using this emoji.
+	statuses, err := e.getRelatedStatuses(ctx, emoji)
+	if err != nil {
+		return false, err
+	} else if len(statuses) > 0 {
+		l.Debug("skipping as status emoji in use")
+		return false, nil
+	}
+
+	// Check not recently created, give it some time to be "used" again.
+	if time.Now().Add(-24 * time.Hour * 7).Before(emoji.CreatedAt) {
+		l.Debug("skipping due to recently created")
+		return false, nil
+	}
+
+	// Emoji totally unused, delete it.
+	l.Debug("deleting unused emoji")
+	return true, e.delete(ctx, emoji)
+}
+
+func (e *Emoji) fixCacheState(ctx context.Context, emoji *gtsmodel.Emoji) (bool, error) {
+	// Start a log entry for emoji.
+	l := log.WithContext(ctx).
+		WithField("emoji", emoji.ID)
+
+	// Check whether files exist.
+	exist, err := e.haveFiles(ctx,
 		emoji.ImageStaticPath,
 		emoji.ImagePath,
 	)
+	if err != nil {
+		return false, err
+	}
+
+	switch {
+	case *emoji.Cached && !exist:
+		// Mark as uncached if expected files don't exist.
+		l.Debug("cached=true exists=false => uncaching")
+		return true, e.uncache(ctx, emoji)
+
+	case !*emoji.Cached && exist:
+		// Remove files if we don't expect them to exist.
+		l.Debug("cached=false exists=true => deleting")
+		_, err := e.removeFiles(ctx,
+			emoji.ImageStaticPath,
+			emoji.ImagePath,
+		)
+		return true, err
+
+	default:
+		return false, nil
+	}
 }
 
 func (e *Emoji) uncacheRemote(ctx context.Context, after time.Time, emoji *gtsmodel.Emoji) (bool, error) {

--- a/internal/cleaner/emoji.go
+++ b/internal/cleaner/emoji.go
@@ -360,6 +360,7 @@ func (e *Emoji) uncacheRemote(ctx context.Context, after time.Time, emoji *gtsmo
 	for _, status := range statuses {
 		if status.FetchedAt.After(after) {
 			l.Debug("skipping due to recently fetched status")
+			return false, nil
 		}
 	}
 

--- a/internal/cleaner/emoji_test.go
+++ b/internal/cleaner/emoji_test.go
@@ -139,6 +139,11 @@ func (suite *CleanerTestSuite) shouldUncacheEmoji(ctx context.Context, emoji *gt
 		return false, nil
 	}
 
+	if emoji.Cached == nil || !*emoji.Cached {
+		// Emoji is already uncached.
+		return false, nil
+	}
+
 	// Get related accounts using this emoji (if any).
 	accounts, err := suite.state.DB.GetAccountsUsingEmoji(ctx, emoji.ID)
 	if err != nil {

--- a/internal/cleaner/emoji_test.go
+++ b/internal/cleaner/emoji_test.go
@@ -1,0 +1,387 @@
+package cleaner_test
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/gtscontext"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+)
+
+func (suite *CleanerTestSuite) TestEmojiUncacheRemote() {
+	suite.testEmojiUncacheRemote(
+		context.Background(),
+		mapvals(suite.emojis),
+	)
+}
+
+func (suite *CleanerTestSuite) TestEmojiUncacheRemoteDryRun() {
+	suite.testEmojiUncacheRemote(
+		gtscontext.SetDryRun(context.Background()),
+		mapvals(suite.emojis),
+	)
+}
+
+func (suite *CleanerTestSuite) TestEmojiFixBroken() {
+	suite.testEmojiFixBroken(
+		context.Background(),
+		mapvals(suite.emojis),
+	)
+}
+
+func (suite *CleanerTestSuite) TestEmojiFixBrokenDryRun() {
+	suite.testEmojiFixBroken(
+		gtscontext.SetDryRun(context.Background()),
+		mapvals(suite.emojis),
+	)
+}
+
+func (suite *CleanerTestSuite) TestEmojiPruneUnused() {
+	suite.testEmojiPruneUnused(
+		context.Background(),
+		mapvals(suite.emojis),
+	)
+}
+
+func (suite *CleanerTestSuite) TestEmojiPruneUnusedDryRun() {
+	suite.testEmojiPruneUnused(
+		gtscontext.SetDryRun(context.Background()),
+		mapvals(suite.emojis),
+	)
+}
+
+func (suite *CleanerTestSuite) TestEmojiFixCacheStates() {
+	suite.testEmojiFixCacheStates(
+		context.Background(),
+		mapvals(suite.emojis),
+	)
+}
+
+func (suite *CleanerTestSuite) TestEmojiFixCacheStatesDryRun() {
+	suite.testEmojiFixCacheStates(
+		gtscontext.SetDryRun(context.Background()),
+		mapvals(suite.emojis),
+	)
+}
+
+func (suite *CleanerTestSuite) testEmojiUncacheRemote(ctx context.Context, emojis []*gtsmodel.Emoji) {
+	var uncacheIDs []string
+
+	// Test state.
+	t := suite.T()
+
+	// Get max remote cache days to keep.
+	days := config.GetMediaRemoteCacheDays()
+	olderThan := time.Now().Add(-24 * time.Hour * time.Duration(days))
+
+	for _, emoji := range emojis {
+		// Check whether this emoji should be uncached.
+		ok, err := suite.shouldUncacheEmoji(ctx, emoji, olderThan)
+		if err != nil {
+			t.Fatalf("error checking whether emoji should be uncached: %v", err)
+		}
+
+		if ok {
+			// Mark this emoji ID as to be uncached.
+			uncacheIDs = append(uncacheIDs, emoji.ID)
+		}
+	}
+
+	// Attempt to uncache remote emojis.
+	found, err := suite.cleaner.Emoji().UncacheRemote(ctx, olderThan)
+	if err != nil {
+		t.Errorf("error uncaching remote emojis: %v", err)
+		return
+	}
+
+	// Check expected were uncached.
+	if found != len(uncacheIDs) {
+		t.Errorf("expected %d emojis to be uncached, %d were", len(uncacheIDs), found)
+		return
+	}
+
+	if gtscontext.DryRun(ctx) {
+		// nothing else to test.
+		return
+	}
+
+	for _, id := range uncacheIDs {
+		// Fetch the emoji by ID that should now be uncached.
+		emoji, err := suite.state.DB.GetEmojiByID(ctx, id)
+		if err != nil {
+			t.Fatalf("error fetching emoji from database: %v", err)
+		}
+
+		// Check cache state.
+		if *emoji.Cached {
+			t.Errorf("emoji %s@%s should have been uncached", emoji.Shortcode, emoji.Domain)
+		}
+
+		// Check that the emoji files in storage have been deleted.
+		if ok, err := suite.state.Storage.Has(ctx, emoji.ImagePath); err != nil {
+			t.Fatalf("error checking storage for emoji: %v", err)
+		} else if ok {
+			t.Errorf("emoji %s@%s image path should not exist", emoji.Shortcode, emoji.Domain)
+		} else if ok, err := suite.state.Storage.Has(ctx, emoji.ImageStaticPath); err != nil {
+			t.Fatalf("error checking storage for emoji: %v", err)
+		} else if ok {
+			t.Errorf("emoji %s@%s image static path should not exist", emoji.Shortcode, emoji.Domain)
+		}
+	}
+}
+
+func (suite *CleanerTestSuite) shouldUncacheEmoji(ctx context.Context, emoji *gtsmodel.Emoji, after time.Time) (bool, error) {
+	// Get related accounts using this emoji (if any).
+	accounts, err := suite.state.DB.GetAccountsUsingEmoji(ctx, emoji.ID)
+	if err != nil {
+		return false, err
+	}
+
+	// Check if accounts are recently updated.
+	for _, account := range accounts {
+		if account.FetchedAt.After(after) {
+			return false, nil
+		}
+	}
+
+	// Get related statuses using this emoji (if any).
+	statuses, err := suite.state.DB.GetStatusesUsingEmoji(ctx, emoji.ID)
+	if err != nil {
+		return false, err
+	}
+
+	// Check if statuses are recently updated.
+	for _, status := range statuses {
+		if status.FetchedAt.After(after) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (suite *CleanerTestSuite) testEmojiFixBroken(ctx context.Context, emojis []*gtsmodel.Emoji) {
+	var fixIDs []string
+
+	// Test state.
+	t := suite.T()
+
+	for _, emoji := range emojis {
+		// Check whether this emoji should be fixed.
+		ok, err := suite.shouldFixBrokenEmoji(ctx, emoji)
+		if err != nil {
+			t.Fatalf("error checking whether emoji should be fixed: %v", err)
+		}
+
+		if ok {
+			// Mark this emoji ID as to be fixed.
+			fixIDs = append(fixIDs, emoji.ID)
+		}
+	}
+
+	// Attempt to fix broken emojis.
+	found, err := suite.cleaner.Emoji().FixBroken(ctx)
+	if err != nil {
+		t.Errorf("error fixing broken emojis: %v", err)
+		return
+	}
+
+	// Check expected were fixed.
+	if found != len(fixIDs) {
+		t.Errorf("expected %d emojis to be fixed, %d were", len(fixIDs), found)
+		return
+	}
+
+	if gtscontext.DryRun(ctx) {
+		// nothing else to test.
+		return
+	}
+
+	for _, id := range fixIDs {
+		// Fetch the emoji by ID that should now be fixed.
+		emoji, err := suite.state.DB.GetEmojiByID(ctx, id)
+		if err != nil {
+			t.Fatalf("error fetching emoji from database: %v", err)
+		}
+
+		// Ensure category was cleared.
+		if emoji.CategoryID != "" {
+			t.Errorf("emoji %s@%s should have empty category", emoji.Shortcode, emoji.Domain)
+		}
+	}
+}
+
+func (suite *CleanerTestSuite) shouldFixBrokenEmoji(ctx context.Context, emoji *gtsmodel.Emoji) (bool, error) {
+	if emoji.CategoryID == "" {
+		// no category issue.
+		return false, nil
+	}
+
+	// Get the related category for this emoji.
+	category, err := suite.state.DB.GetEmojiCategory(ctx, emoji.CategoryID)
+	if err != nil && !errors.Is(err, db.ErrNoEntries) {
+		return false, nil
+	}
+
+	return (category == nil), nil
+}
+
+func (suite *CleanerTestSuite) testEmojiPruneUnused(ctx context.Context, emojis []*gtsmodel.Emoji) {
+	var pruneIDs []string
+
+	// Test state.
+	t := suite.T()
+
+	for _, emoji := range emojis {
+		// Check whether this emoji should be pruned.
+		ok, err := suite.shouldPruneEmoji(ctx, emoji)
+		if err != nil {
+			t.Fatalf("error checking whether emoji should be pruned: %v", err)
+		}
+
+		if ok {
+			// Mark this emoji ID as to be pruned.
+			pruneIDs = append(pruneIDs, emoji.ID)
+		}
+	}
+
+	// Attempt to prune emojis.
+	found, err := suite.cleaner.Emoji().PruneUnused(ctx)
+	if err != nil {
+		t.Errorf("error fixing broken emojis: %v", err)
+		return
+	}
+
+	// Check expected were pruned.
+	if found != len(pruneIDs) {
+		t.Errorf("expected %d emojis to be pruned, %d were", len(pruneIDs), found)
+		return
+	}
+
+	if gtscontext.DryRun(ctx) {
+		// nothing else to test.
+		return
+	}
+
+	for _, id := range pruneIDs {
+		// Fetch the emoji by ID that should now be pruned.
+		emoji, err := suite.state.DB.GetEmojiByID(ctx, id)
+		if err != nil && !errors.Is(err, db.ErrNoEntries) {
+			t.Fatalf("error fetching emoji from database: %v", err)
+		}
+
+		// Ensure gone.
+		if emoji != nil {
+			t.Errorf("emoji %s@%s should have been pruned", emoji.Shortcode, emoji.Domain)
+		}
+	}
+}
+
+func (suite *CleanerTestSuite) shouldPruneEmoji(ctx context.Context, emoji *gtsmodel.Emoji) (bool, error) {
+	// Get related accounts using this emoji (if any).
+	accounts, err := suite.state.DB.GetAccountsUsingEmoji(ctx, emoji.ID)
+	if err != nil {
+		return false, err
+	} else if len(accounts) > 0 {
+		return false, nil
+	}
+
+	// Get related statuses using this emoji (if any).
+	statuses, err := suite.state.DB.GetStatusesUsingEmoji(ctx, emoji.ID)
+	if err != nil {
+		return false, err
+	} else if len(statuses) > 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (suite *CleanerTestSuite) testEmojiFixCacheStates(ctx context.Context, emojis []*gtsmodel.Emoji) {
+	var fixIDs []string
+
+	// Test state.
+	t := suite.T()
+
+	for _, emoji := range emojis {
+		// Check whether this emoji should be fixed.
+		ok, err := suite.shouldFixEmojiCacheState(ctx, emoji)
+		if err != nil {
+			t.Fatalf("error checking whether emoji should be fixed: %v", err)
+		}
+
+		if ok {
+			// Mark this emoji ID as to be fixed.
+			fixIDs = append(fixIDs, emoji.ID)
+		}
+	}
+
+	// Attempt to fix broken emoji cache states.
+	found, err := suite.cleaner.Emoji().FixCacheStates(ctx)
+	if err != nil {
+		t.Errorf("error fixing broken emojis: %v", err)
+		return
+	}
+
+	// Check expected were fixed.
+	if found != len(fixIDs) {
+		t.Errorf("expected %d emojis to be fixed, %d were", len(fixIDs), found)
+		return
+	}
+
+	if gtscontext.DryRun(ctx) {
+		// nothing else to test.
+		return
+	}
+
+	for _, id := range fixIDs {
+		// Fetch the emoji by ID that should now be fixed.
+		emoji, err := suite.state.DB.GetEmojiByID(ctx, id)
+		if err != nil {
+			t.Fatalf("error fetching emoji from database: %v", err)
+		}
+
+		// Ensure emoji cache state has been fixed.
+		ok, err := suite.shouldFixEmojiCacheState(ctx, emoji)
+		if err != nil {
+			t.Fatalf("error checking whether emoji should be fixed: %v", err)
+		} else if ok {
+			t.Errorf("emoji %s@%s cache state should have been fixed", emoji.Shortcode, emoji.Domain)
+		}
+	}
+}
+
+func (suite *CleanerTestSuite) shouldFixEmojiCacheState(ctx context.Context, emoji *gtsmodel.Emoji) (bool, error) {
+	// Check whether emoji image path exists.
+	haveImage, err := suite.state.Storage.Has(ctx, emoji.ImagePath)
+	if err != nil {
+		return false, err
+	}
+
+	// Check whether emoji static path exists.
+	haveStatic, err := suite.state.Storage.Has(ctx, emoji.ImageStaticPath)
+	if err != nil {
+		return false, err
+	}
+
+	switch exists := (haveImage && haveStatic); {
+	case emoji.Cached != nil &&
+		*emoji.Cached && !exists:
+		// (cached can be nil in tests)
+		// Cached but missing files.
+		return true, nil
+
+	case emoji.Cached != nil &&
+		!*emoji.Cached && exists:
+		// (cached can be nil in tests)
+		// Uncached but unexpected files.
+		return true, nil
+
+	default:
+		// No cache state issue.
+		return false, nil
+	}
+}

--- a/internal/cleaner/emoji_test.go
+++ b/internal/cleaner/emoji_test.go
@@ -134,6 +134,11 @@ func (suite *CleanerTestSuite) testEmojiUncacheRemote(ctx context.Context, emoji
 }
 
 func (suite *CleanerTestSuite) shouldUncacheEmoji(ctx context.Context, emoji *gtsmodel.Emoji, after time.Time) (bool, error) {
+	if emoji.ImageRemoteURL == "" {
+		// Local emojis are never uncached.
+		return false, nil
+	}
+
 	// Get related accounts using this emoji (if any).
 	accounts, err := suite.state.DB.GetAccountsUsingEmoji(ctx, emoji.ID)
 	if err != nil {
@@ -281,6 +286,11 @@ func (suite *CleanerTestSuite) testEmojiPruneUnused(ctx context.Context, emojis 
 }
 
 func (suite *CleanerTestSuite) shouldPruneEmoji(ctx context.Context, emoji *gtsmodel.Emoji) (bool, error) {
+	if emoji.ImageRemoteURL == "" {
+		// Local emojis are never pruned.
+		return false, nil
+	}
+
 	// Get related accounts using this emoji (if any).
 	accounts, err := suite.state.DB.GetAccountsUsingEmoji(ctx, emoji.ID)
 	if err != nil {

--- a/internal/cleaner/media.go
+++ b/internal/cleaner/media.go
@@ -96,9 +96,9 @@ func (m *Media) PruneOrphaned(ctx context.Context) (int, error) {
 
 	// All media files in storage will have path fitting: {$account}/{$type}/{$size}/{$id}.{$ext}
 	if err := m.state.Storage.WalkKeys(ctx, func(ctx context.Context, path string) error {
+		// Check for our expected fileserver path format.
 		if !regexes.FilePath.MatchString(path) {
-			// This is not our expected media
-			// path format, skip this one.
+			log.Warn(ctx, "unexpected storage item: %s", path)
 			return nil
 		}
 
@@ -177,10 +177,10 @@ func (m *Media) UncacheRemote(ctx context.Context, olderThan time.Time) (int, er
 	mostRecent := olderThan
 
 	for {
-		// Fetch the next batch of attachments older than last-set time.
-		attachments, err := m.state.DB.GetRemoteMediaOlderThan(ctx, olderThan, selectLimit)
+		// Fetch the next batch of cached attachments older than last-set time.
+		attachments, err := m.state.DB.GetCachedAttachmentsOlderThan(ctx, olderThan, selectLimit)
 		if err != nil && !errors.Is(err, db.ErrNoEntries) {
-			return total, gtserror.Newf("error getting remote media: %w", err)
+			return total, gtserror.Newf("error getting remote attachments: %w", err)
 		}
 
 		if len(attachments) == 0 {
@@ -220,9 +220,9 @@ func (m *Media) FixCacheStates(ctx context.Context) (int, error) {
 
 	for {
 		// Fetch the next batch of media attachments up to next max ID.
-		attachments, err := m.state.DB.GetAttachments(ctx, maxID, selectLimit)
+		attachments, err := m.state.DB.GetRemoteAttachments(ctx, maxID, selectLimit)
 		if err != nil && !errors.Is(err, db.ErrNoEntries) {
-			return total, gtserror.Newf("error getting avatars / headers: %w", err)
+			return total, gtserror.Newf("error getting remote attachments: %w", err)
 		}
 
 		if len(attachments) == 0 {
@@ -323,7 +323,7 @@ func (m *Media) pruneUnused(ctx context.Context, media *gtsmodel.MediaAttachment
 	l := log.WithContext(ctx).
 		WithField("media", media.ID)
 
-		// Check whether we have the required account for media.
+	// Check whether we have the required account for media.
 	account, missing, err := m.getRelatedAccount(ctx, media)
 	if err != nil {
 		return false, err
@@ -367,14 +367,6 @@ func (m *Media) pruneUnused(ctx context.Context, media *gtsmodel.MediaAttachment
 }
 
 func (m *Media) fixCacheState(ctx context.Context, media *gtsmodel.MediaAttachment) (bool, error) {
-	if !*media.Cached {
-		// We ignore uncached media, a
-		// false negative is a much better
-		// situation than a false positive,
-		// re-cache will just overwrite it.
-		return false, nil
-	}
-
 	// Start a log entry for media.
 	l := log.WithContext(ctx).
 		WithField("media", media.ID)
@@ -397,15 +389,33 @@ func (m *Media) fixCacheState(ctx context.Context, media *gtsmodel.MediaAttachme
 		return false, nil
 	}
 
-	// So we know this a valid cached media entry.
-	// Check that we have the files on disk required....
-	return m.checkFiles(ctx, func() error {
-		l.Debug("uncaching due to missing media")
-		return m.uncache(ctx, media)
-	},
+	// Check whether files exist.
+	exist, err := m.haveFiles(ctx,
 		media.Thumbnail.Path,
 		media.File.Path,
 	)
+	if err != nil {
+		return false, err
+	}
+
+	switch {
+	case *media.Cached && !exist:
+		// Mark as uncached if expected files don't exist.
+		l.Debug("cached=true exists=false => uncaching")
+		return true, m.uncache(ctx, media)
+
+	case !*media.Cached && exist:
+		// Remove files if we don't expect them to exist.
+		l.Debug("cached=false exists=true => deleting")
+		_, err := m.removeFiles(ctx,
+			media.Thumbnail.Path,
+			media.File.Path,
+		)
+		return true, err
+
+	default:
+		return false, nil
+	}
 }
 
 func (m *Media) uncacheRemote(ctx context.Context, after time.Time, media *gtsmodel.MediaAttachment) (bool, error) {

--- a/internal/cleaner/media.go
+++ b/internal/cleaner/media.go
@@ -178,7 +178,7 @@ func (m *Media) UncacheRemote(ctx context.Context, olderThan time.Time) (int, er
 
 	for {
 		// Fetch the next batch of attachments older than last-set time.
-		attachments, err := m.state.DB.GetRemoteOlderThan(ctx, olderThan, selectLimit)
+		attachments, err := m.state.DB.GetRemoteMediaOlderThan(ctx, olderThan, selectLimit)
 		if err != nil && !errors.Is(err, db.ErrNoEntries) {
 			return total, gtserror.Newf("error getting remote media: %w", err)
 		}

--- a/internal/db/account.go
+++ b/internal/db/account.go
@@ -73,6 +73,9 @@ type Account interface {
 	// GetAccountFaves fetches faves/likes created by the target accountID.
 	GetAccountFaves(ctx context.Context, accountID string) ([]*gtsmodel.StatusFave, Error)
 
+	// GetAccountsUsingEmoji ...
+	GetAccountsUsingEmoji(ctx context.Context, emojiID string) ([]*gtsmodel.Account, error)
+
 	// GetAccountStatusesCount is a shortcut for the common action of counting statuses produced by accountID.
 	CountAccountStatuses(ctx context.Context, accountID string) (int, Error)
 

--- a/internal/db/account.go
+++ b/internal/db/account.go
@@ -73,7 +73,7 @@ type Account interface {
 	// GetAccountFaves fetches faves/likes created by the target accountID.
 	GetAccountFaves(ctx context.Context, accountID string) ([]*gtsmodel.StatusFave, Error)
 
-	// GetAccountsUsingEmoji ...
+	// GetAccountsUsingEmoji fetches all account models using emoji with given ID stored in their 'emojis' column.
 	GetAccountsUsingEmoji(ctx context.Context, emojiID string) ([]*gtsmodel.Account, error)
 
 	// GetAccountStatusesCount is a shortcut for the common action of counting statuses produced by accountID.

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -467,10 +467,9 @@ func (a *accountDB) GetAccountCustomCSSByUsername(ctx context.Context, username 
 
 func (a *accountDB) GetAccountsUsingEmoji(ctx context.Context, emojiID string) ([]*gtsmodel.Account, error) {
 	var accountIDs []string
-	if _, err := a.conn.NewSelect().
+	if _, err := whereLike(a.conn.NewSelect().
 		Table("accounts").
-		Column("id").
-		Where("? IN (emojis)", emojiID).
+		Column("id"), "emojis", emojiID).
 		Exec(ctx, &accountIDs); err != nil {
 		return nil, a.conn.ProcessError(err)
 	}

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -56,6 +56,27 @@ func (a *accountDB) GetAccountByID(ctx context.Context, id string) (*gtsmodel.Ac
 	)
 }
 
+func (a *accountDB) GetAccountsByIDs(ctx context.Context, ids []string) ([]*gtsmodel.Account, error) {
+	accounts := make([]*gtsmodel.Account, 0, len(ids))
+
+	for _, id := range ids {
+		// Attempt to fetch account from DB.
+		account, err := a.GetAccountByID(
+			gtscontext.SetBarebones(ctx),
+			id,
+		)
+		if err != nil {
+			log.Errorf(ctx, "error getting account %q: %v", id, err)
+			continue
+		}
+
+		// Append account to return slice.
+		accounts = append(accounts, account)
+	}
+
+	return accounts, nil
+}
+
 func (a *accountDB) GetAccountByURI(ctx context.Context, uri string) (*gtsmodel.Account, db.Error) {
 	return a.getAccount(
 		ctx,
@@ -442,6 +463,18 @@ func (a *accountDB) GetAccountCustomCSSByUsername(ctx context.Context, username 
 	}
 
 	return account.CustomCSS, nil
+}
+
+func (a *accountDB) GetAccountsUsingEmoji(ctx context.Context, emojiID string) ([]*gtsmodel.Account, error) {
+	var accountIDs []string
+	if _, err := a.conn.NewSelect().
+		Table("accounts").
+		Column("id").
+		Where("? IN (emojis)", emojiID).
+		Exec(ctx, &accountIDs); err != nil {
+		return nil, a.conn.ProcessError(err)
+	}
+	return a.GetAccountsByIDs(ctx, accountIDs)
 }
 
 func (a *accountDB) GetAccountFaves(ctx context.Context, accountID string) ([]*gtsmodel.StatusFave, db.Error) {

--- a/internal/db/bundb/emoji.go
+++ b/internal/db/bundb/emoji.go
@@ -127,7 +127,7 @@ func (e *emojiDB) DeleteEmojiByID(ctx context.Context, id string) db.Error {
 		}
 
 		// Prepare SELECT accounts query.
-		aq := e.conn.NewSelect().
+		aq := tx.NewSelect().
 			Table("accounts").
 			Column("id")
 
@@ -171,7 +171,7 @@ func (e *emojiDB) DeleteEmojiByID(ctx context.Context, id string) db.Error {
 		}
 
 		// Prepare SELECT statuses query.
-		sq := e.conn.NewSelect().
+		sq := tx.NewSelect().
 			Table("statuses").
 			Column("id")
 

--- a/internal/db/bundb/emoji.go
+++ b/internal/db/bundb/emoji.go
@@ -126,11 +126,20 @@ func (e *emojiDB) DeleteEmojiByID(ctx context.Context, id string) db.Error {
 			return err
 		}
 
-		// Select all accounts using this emoji.
-		if _, err := whereLike(tx.NewSelect().
+		// Prepare SELECT accounts query.
+		aq := e.conn.NewSelect().
 			Table("accounts").
-			Column("id"), "emojis", id).
-			Exec(ctx, &accountIDs); err != nil {
+			Column("id")
+
+		// Append a WHERE LIKE clause to the query
+		// that checks the `emoji` column for any
+		// text containing this specific emoji ID.
+		//
+		// (see GetStatusesUsingEmoji() for details.)
+		aq = whereLike(aq, "emojis", id)
+
+		// Select all accounts using this emoji into accountIDss.
+		if _, err := aq.Exec(ctx, &accountIDs); err != nil {
 			return err
 		}
 
@@ -161,11 +170,20 @@ func (e *emojiDB) DeleteEmojiByID(ctx context.Context, id string) db.Error {
 			}
 		}
 
-		// Select all statuses using this emoji.
-		if _, err := whereLike(tx.NewSelect().
+		// Prepare SELECT statuses query.
+		sq := e.conn.NewSelect().
 			Table("statuses").
-			Column("id"), "emojis", id).
-			Exec(ctx, &statusIDs); err != nil {
+			Column("id")
+
+		// Append a WHERE LIKE clause to the query
+		// that checks the `emoji` column for any
+		// text containing this specific emoji ID.
+		//
+		// (see GetStatusesUsingEmoji() for details.)
+		sq = whereLike(sq, "emojis", id)
+
+		// Select all statuses using this emoji into statusIDs.
+		if _, err := sq.Exec(ctx, &statusIDs); err != nil {
 			return err
 		}
 

--- a/internal/db/bundb/media.go
+++ b/internal/db/bundb/media.go
@@ -232,7 +232,7 @@ func (m *mediaDB) DeleteAttachment(ctx context.Context, id string) error {
 	return m.conn.ProcessError(err)
 }
 
-func (m *mediaDB) GetRemoteOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, db.Error) {
+func (m *mediaDB) GetRemoteMediaOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, db.Error) {
 	attachmentIDs := []string{}
 
 	q := m.conn.

--- a/internal/db/bundb/media.go
+++ b/internal/db/bundb/media.go
@@ -250,7 +250,7 @@ func (m *mediaDB) CountRemoteOlderThan(ctx context.Context, olderThan time.Time)
 }
 
 func (m *mediaDB) GetAttachments(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, error) {
-	var attachmentIDs []string
+	attachmentIDs := make([]string, 0, limit)
 
 	q := m.conn.NewSelect().
 		Table("media_attachments").
@@ -273,7 +273,7 @@ func (m *mediaDB) GetAttachments(ctx context.Context, maxID string, limit int) (
 }
 
 func (m *mediaDB) GetRemoteAttachments(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, error) {
-	var attachmentIDs []string
+	attachmentIDs := make([]string, 0, limit)
 
 	q := m.conn.NewSelect().
 		Table("media_attachments").
@@ -297,7 +297,7 @@ func (m *mediaDB) GetRemoteAttachments(ctx context.Context, maxID string, limit 
 }
 
 func (m *mediaDB) GetCachedAttachmentsOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, db.Error) {
-	var attachmentIDs []string
+	attachmentIDs := make([]string, 0, limit)
 
 	q := m.conn.
 		NewSelect().
@@ -320,7 +320,7 @@ func (m *mediaDB) GetCachedAttachmentsOlderThan(ctx context.Context, olderThan t
 }
 
 func (m *mediaDB) GetAvatarsAndHeaders(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, db.Error) {
-	var attachmentIDs []string
+	attachmentIDs := make([]string, 0, limit)
 
 	q := m.conn.NewSelect().
 		TableExpr("? AS ?", bun.Ident("media_attachments"), bun.Ident("media_attachment")).
@@ -348,7 +348,7 @@ func (m *mediaDB) GetAvatarsAndHeaders(ctx context.Context, maxID string, limit 
 }
 
 func (m *mediaDB) GetLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, db.Error) {
-	attachmentIDs := []string{}
+	attachmentIDs := make([]string, 0, limit)
 
 	q := m.conn.
 		NewSelect().

--- a/internal/db/bundb/media.go
+++ b/internal/db/bundb/media.go
@@ -232,29 +232,6 @@ func (m *mediaDB) DeleteAttachment(ctx context.Context, id string) error {
 	return m.conn.ProcessError(err)
 }
 
-func (m *mediaDB) GetRemoteMediaOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, db.Error) {
-	attachmentIDs := []string{}
-
-	q := m.conn.
-		NewSelect().
-		TableExpr("? AS ?", bun.Ident("media_attachments"), bun.Ident("media_attachment")).
-		Column("media_attachment.id").
-		Where("? = ?", bun.Ident("media_attachment.cached"), true).
-		Where("? < ?", bun.Ident("media_attachment.created_at"), olderThan).
-		Where("? IS NOT NULL", bun.Ident("media_attachment.remote_url")).
-		Order("media_attachment.created_at DESC")
-
-	if limit != 0 {
-		q = q.Limit(limit)
-	}
-
-	if err := q.Scan(ctx, &attachmentIDs); err != nil {
-		return nil, m.conn.ProcessError(err)
-	}
-
-	return m.GetAttachmentsByIDs(ctx, attachmentIDs)
-}
-
 func (m *mediaDB) CountRemoteOlderThan(ctx context.Context, olderThan time.Time) (int, db.Error) {
 	q := m.conn.
 		NewSelect().
@@ -273,7 +250,7 @@ func (m *mediaDB) CountRemoteOlderThan(ctx context.Context, olderThan time.Time)
 }
 
 func (m *mediaDB) GetAttachments(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, error) {
-	attachmentIDs := []string{}
+	var attachmentIDs []string
 
 	q := m.conn.NewSelect().
 		Table("media_attachments").
@@ -281,7 +258,7 @@ func (m *mediaDB) GetAttachments(ctx context.Context, maxID string, limit int) (
 		Order("id DESC")
 
 	if maxID != "" {
-		q = q.Where("? < ?", bun.Ident("id"), maxID)
+		q = q.Where("id < ?", maxID)
 	}
 
 	if limit != 0 {
@@ -295,8 +272,55 @@ func (m *mediaDB) GetAttachments(ctx context.Context, maxID string, limit int) (
 	return m.GetAttachmentsByIDs(ctx, attachmentIDs)
 }
 
+func (m *mediaDB) GetRemoteAttachments(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, error) {
+	var attachmentIDs []string
+
+	q := m.conn.NewSelect().
+		Table("media_attachments").
+		Column("id").
+		Where("remote_url IS NOT NULL").
+		Order("id DESC")
+
+	if maxID != "" {
+		q = q.Where("id < ?", maxID)
+	}
+
+	if limit != 0 {
+		q = q.Limit(limit)
+	}
+
+	if err := q.Scan(ctx, &attachmentIDs); err != nil {
+		return nil, m.conn.ProcessError(err)
+	}
+
+	return m.GetAttachmentsByIDs(ctx, attachmentIDs)
+}
+
+func (m *mediaDB) GetCachedAttachmentsOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, db.Error) {
+	var attachmentIDs []string
+
+	q := m.conn.
+		NewSelect().
+		Table("media_attachments").
+		Column("id").
+		Where("cached = true").
+		Where("remote_url IS NOT NULL").
+		Where("created_at < ?", olderThan).
+		Order("created_at DESC")
+
+	if limit != 0 {
+		q = q.Limit(limit)
+	}
+
+	if err := q.Scan(ctx, &attachmentIDs); err != nil {
+		return nil, m.conn.ProcessError(err)
+	}
+
+	return m.GetAttachmentsByIDs(ctx, attachmentIDs)
+}
+
 func (m *mediaDB) GetAvatarsAndHeaders(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, db.Error) {
-	attachmentIDs := []string{}
+	var attachmentIDs []string
 
 	q := m.conn.NewSelect().
 		TableExpr("? AS ?", bun.Ident("media_attachments"), bun.Ident("media_attachment")).

--- a/internal/db/bundb/media_test.go
+++ b/internal/db/bundb/media_test.go
@@ -38,7 +38,7 @@ func (suite *MediaTestSuite) TestGetAttachmentByID() {
 }
 
 func (suite *MediaTestSuite) TestGetOlder() {
-	attachments, err := suite.db.GetRemoteMediaOlderThan(context.Background(), time.Now(), 20)
+	attachments, err := suite.db.GetCachedAttachmentsOlderThan(context.Background(), time.Now(), 20)
 	suite.NoError(err)
 	suite.Len(attachments, 2)
 }

--- a/internal/db/bundb/media_test.go
+++ b/internal/db/bundb/media_test.go
@@ -38,7 +38,7 @@ func (suite *MediaTestSuite) TestGetAttachmentByID() {
 }
 
 func (suite *MediaTestSuite) TestGetOlder() {
-	attachments, err := suite.db.GetRemoteOlderThan(context.Background(), time.Now(), 20)
+	attachments, err := suite.db.GetRemoteMediaOlderThan(context.Background(), time.Now(), 20)
 	suite.NoError(err)
 	suite.Len(attachments, 2)
 }

--- a/internal/db/bundb/migrations/20230724100000_emoji_cleanup.go
+++ b/internal/db/bundb/migrations/20230724100000_emoji_cleanup.go
@@ -19,6 +19,7 @@ package migrations
 
 import (
 	"context"
+	"strings"
 
 	"github.com/uptrace/bun"
 )
@@ -26,7 +27,9 @@ import (
 func init() {
 	up := func(ctx context.Context, db *bun.DB) error {
 		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-			if _, err := tx.ExecContext(ctx, "ALTER TABLE emojis ADD COLUMN cached BOOLEAN DEFAULT false"); err != nil {
+			_, err := tx.ExecContext(ctx, "ALTER TABLE emojis ADD COLUMN cached BOOLEAN DEFAULT false")
+
+			if err != nil && !(strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "duplicate column name") || strings.Contains(err.Error(), "SQLSTATE 42701")) {
 				return err
 			}
 

--- a/internal/db/bundb/migrations/20230724100000_emoji_cleanup.go
+++ b/internal/db/bundb/migrations/20230724100000_emoji_cleanup.go
@@ -26,23 +26,21 @@ import (
 
 func init() {
 	up := func(ctx context.Context, db *bun.DB) error {
-		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-			_, err := tx.ExecContext(ctx, "ALTER TABLE emojis ADD COLUMN cached BOOLEAN DEFAULT false")
+		_, err := db.ExecContext(ctx, "ALTER TABLE emojis ADD COLUMN cached BOOLEAN DEFAULT false")
 
-			if err != nil && !(strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "duplicate column name") || strings.Contains(err.Error(), "SQLSTATE 42701")) {
-				return err
-			}
+		if err != nil && !(strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "duplicate column name") || strings.Contains(err.Error(), "SQLSTATE 42701")) {
+			return err
+		}
 
-			if _, err := tx.NewUpdate().
-				Table("emojis").
-				Where("disabled = false").
-				Set("cached = true").
-				Exec(ctx); err != nil {
-				return err
-			}
+		if _, err := db.NewUpdate().
+			Table("emojis").
+			Where("disabled = false").
+			Set("cached = true").
+			Exec(ctx); err != nil {
+			return err
+		}
 
-			return nil
-		})
+		return nil
 	}
 
 	down := func(ctx context.Context, db *bun.DB) error {

--- a/internal/db/bundb/migrations/20230724100000_emoji_cleanup.go
+++ b/internal/db/bundb/migrations/20230724100000_emoji_cleanup.go
@@ -1,0 +1,55 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	const batchSize = 100
+	up := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			if _, err := tx.ExecContext(ctx, "ALTER TABLE emojis ADD COLUMN cached BOOLEAN DEFAULT false"); err != nil {
+				return err
+			}
+
+			if _, err := tx.NewUpdate().
+				Table("emojis").
+				Where("disabled NOT NULL AND disabled = false").
+				Set("cached = true").
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}

--- a/internal/db/bundb/migrations/20230724100000_emoji_cleanup.go
+++ b/internal/db/bundb/migrations/20230724100000_emoji_cleanup.go
@@ -35,7 +35,7 @@ func init() {
 
 			if _, err := tx.NewUpdate().
 				Table("emojis").
-				Where("disabled NOT NULL AND disabled = false").
+				Where("disabled = false").
 				Set("cached = true").
 				Exec(ctx); err != nil {
 				return err

--- a/internal/db/bundb/migrations/20230724100000_emoji_cleanup.go
+++ b/internal/db/bundb/migrations/20230724100000_emoji_cleanup.go
@@ -24,7 +24,6 @@ import (
 )
 
 func init() {
-	const batchSize = 100
 	up := func(ctx context.Context, db *bun.DB) error {
 		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 			if _, err := tx.ExecContext(ctx, "ALTER TABLE emojis ADD COLUMN cached BOOLEAN DEFAULT false"); err != nil {

--- a/internal/db/bundb/report.go
+++ b/internal/db/bundb/report.go
@@ -149,7 +149,7 @@ func (r *reportDB) getReport(ctx context.Context, lookup string, dbQuery func(*g
 
 	if len(report.StatusIDs) > 0 {
 		// Fetch reported statuses
-		report.Statuses, err = r.state.DB.GetStatuses(ctx, report.StatusIDs)
+		report.Statuses, err = r.state.DB.GetStatusesByIDs(ctx, report.StatusIDs)
 		if err != nil {
 			return nil, fmt.Errorf("error getting status mentions: %w", err)
 		}

--- a/internal/db/bundb/search.go
+++ b/internal/db/bundb/search.go
@@ -72,26 +72,26 @@ var replacer = strings.NewReplacer(
 )
 
 // whereSubqueryLike appends a WHERE clause to the
-// given SelectQuery q, which searches for matches
-// of searchQuery in the given subQuery using LIKE.
-func whereSubqueryLike(
-	q *bun.SelectQuery,
-	subQuery *bun.SelectQuery,
-	searchQuery string,
+// given SelectQuery, which searches for matches
+// of `search` in the given subQuery using LIKE.
+func whereLike(
+	query *bun.SelectQuery,
+	subject interface{},
+	search string,
 ) *bun.SelectQuery {
 	// Escape existing wildcard + escape
 	// chars in the search query string.
-	searchQuery = replacer.Replace(searchQuery)
+	search = replacer.Replace(search)
 
 	// Add our own wildcards back in; search
 	// zero or more chars around the query.
-	searchQuery = `%` + searchQuery + `%`
+	search = `%` + search + `%`
 
 	// Append resulting WHERE
 	// clause to the main query.
-	return q.Where(
+	return query.Where(
 		"(?) LIKE ? ESCAPE ?",
-		subQuery, searchQuery, `\`,
+		subject, search, `\`,
 	)
 }
 
@@ -167,7 +167,7 @@ func (s *searchDB) SearchForAccounts(
 
 	// Search using LIKE for matches of query
 	// string within accountText subquery.
-	q = whereSubqueryLike(q, accountTextSubq, query)
+	q = whereLike(q, accountTextSubq, query)
 
 	if limit > 0 {
 		// Limit amount of accounts returned.
@@ -345,7 +345,7 @@ func (s *searchDB) SearchForStatuses(
 
 	// Search using LIKE for matches of query
 	// string within statusText subquery.
-	q = whereSubqueryLike(q, statusTextSubq, query)
+	q = whereLike(q, statusTextSubq, query)
 
 	if limit > 0 {
 		// Limit amount of statuses returned.

--- a/internal/db/bundb/search.go
+++ b/internal/db/bundb/search.go
@@ -19,7 +19,6 @@ package bundb
 
 import (
 	"context"
-	"strings"
 
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/id"
@@ -59,40 +58,6 @@ import (
 type searchDB struct {
 	conn  *DBConn
 	state *state.State
-}
-
-// replacer is a thread-safe string replacer which escapes
-// common SQLite + Postgres `LIKE` wildcard chars using the
-// escape character `\`. Initialized as a var in this package
-// so it can be reused.
-var replacer = strings.NewReplacer(
-	`\`, `\\`, // Escape char.
-	`%`, `\%`, // Zero or more char.
-	`_`, `\_`, // Exactly one char.
-)
-
-// whereSubqueryLike appends a WHERE clause to the
-// given SelectQuery, which searches for matches
-// of `search` in the given subQuery using LIKE.
-func whereLike(
-	query *bun.SelectQuery,
-	subject interface{},
-	search string,
-) *bun.SelectQuery {
-	// Escape existing wildcard + escape
-	// chars in the search query string.
-	search = replacer.Replace(search)
-
-	// Add our own wildcards back in; search
-	// zero or more chars around the query.
-	search = `%` + search + `%`
-
-	// Append resulting WHERE
-	// clause to the main query.
-	return query.Where(
-		"(?) LIKE ? ESCAPE ?",
-		subject, search, `\`,
-	)
 }
 
 // Query example (SQLite):

--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -63,10 +63,7 @@ func (s *statusDB) GetStatusesByIDs(ctx context.Context, ids []string) ([]*gtsmo
 
 	for _, id := range ids {
 		// Attempt to fetch status from DB.
-		status, err := s.GetStatusByID(
-			gtscontext.SetBarebones(ctx),
-			id,
-		)
+		status, err := s.GetStatusByID(ctx, id)
 		if err != nil {
 			log.Errorf(ctx, "error getting status %q: %v", id, err)
 			continue

--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -434,10 +434,9 @@ func (s *statusDB) DeleteStatusByID(ctx context.Context, id string) db.Error {
 
 func (s *statusDB) GetStatusesUsingEmoji(ctx context.Context, emojiID string) ([]*gtsmodel.Status, error) {
 	var statusIDs []string
-	if _, err := s.conn.NewSelect().
+	if _, err := whereLike(s.conn.NewSelect().
 		Table("statuses").
-		Column("id").
-		Where("? IN (emojis)", emojiID).
+		Column("id"), "emojis", emojiID).
 		Exec(ctx, &statusIDs); err != nil {
 		return nil, s.conn.ProcessError(err)
 	}

--- a/internal/db/bundb/status_test.go
+++ b/internal/db/bundb/status_test.go
@@ -50,13 +50,13 @@ func (suite *StatusTestSuite) TestGetStatusByID() {
 	suite.True(*status.Likeable)
 }
 
-func (suite *StatusTestSuite) TestGetStatusesByID() {
+func (suite *StatusTestSuite) TestGetStatusesByIDs() {
 	ids := []string{
 		suite.testStatuses["local_account_1_status_1"].ID,
 		suite.testStatuses["local_account_2_status_3"].ID,
 	}
 
-	statuses, err := suite.db.GetStatuses(context.Background(), ids)
+	statuses, err := suite.db.GetStatusesByIDs(context.Background(), ids)
 	if err != nil {
 		suite.FailNow(err.Error())
 	}

--- a/internal/db/emoji.go
+++ b/internal/db/emoji.go
@@ -45,8 +45,11 @@ type Emoji interface {
 	// GetEmojis ...
 	GetEmojis(ctx context.Context, maxID string, limit int) ([]*gtsmodel.Emoji, error)
 
+	// GetRemoteEmojis ...
+	GetRemoteEmojis(ctx context.Context, maxID string, limit int) ([]*gtsmodel.Emoji, error)
+
 	// GetRemoteEmojisOlderThan ...
-	GetRemoteEmojisOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.Emoji, error)
+	GetCachedEmojisOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.Emoji, error)
 
 	// GetEmojisBy gets emojis based on given parameters. Useful for admin actions.
 	GetEmojisBy(ctx context.Context, domain string, includeDisabled bool, includeEnabled bool, shortcode string, maxShortcodeDomain string, minShortcodeDomain string, limit int) ([]*gtsmodel.Emoji, error)

--- a/internal/db/emoji.go
+++ b/internal/db/emoji.go
@@ -42,13 +42,13 @@ type Emoji interface {
 	// GetUseableEmojis gets all emojis which are useable by accounts on this instance.
 	GetUseableEmojis(ctx context.Context) ([]*gtsmodel.Emoji, Error)
 
-	// GetEmojis ...
+	// GetEmojis fetches all emojis with IDs less than 'maxID', up to a maximum of 'limit' emojis.
 	GetEmojis(ctx context.Context, maxID string, limit int) ([]*gtsmodel.Emoji, error)
 
-	// GetRemoteEmojis ...
+	// GetRemoteEmojis fetches all remote emojis with IDs less than 'maxID', up to a maximum of 'limit' emojis.
 	GetRemoteEmojis(ctx context.Context, maxID string, limit int) ([]*gtsmodel.Emoji, error)
 
-	// GetRemoteEmojisOlderThan ...
+	// GetCachedEmojisOlderThan fetches all cached remote emojis with 'updated_at' greater than 'olderThan', up to a maximum of 'limit' emojis.
 	GetCachedEmojisOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.Emoji, error)
 
 	// GetEmojisBy gets emojis based on given parameters. Useful for admin actions.

--- a/internal/db/emoji.go
+++ b/internal/db/emoji.go
@@ -19,6 +19,7 @@ package db
 
 import (
 	"context"
+	"time"
 
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 )
@@ -40,8 +41,13 @@ type Emoji interface {
 	GetEmojisByIDs(ctx context.Context, ids []string) ([]*gtsmodel.Emoji, Error)
 	// GetUseableEmojis gets all emojis which are useable by accounts on this instance.
 	GetUseableEmojis(ctx context.Context) ([]*gtsmodel.Emoji, Error)
+
 	// GetEmojis ...
 	GetEmojis(ctx context.Context, maxID string, limit int) ([]*gtsmodel.Emoji, error)
+
+	// GetRemoteEmojisOlderThan ...
+	GetRemoteEmojisOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.Emoji, error)
+
 	// GetEmojisBy gets emojis based on given parameters. Useful for admin actions.
 	GetEmojisBy(ctx context.Context, domain string, includeDisabled bool, includeEnabled bool, shortcode string, maxShortcodeDomain string, minShortcodeDomain string, limit int) ([]*gtsmodel.Emoji, error)
 	// GetEmojiByID gets a specific emoji by its database ID.

--- a/internal/db/media.go
+++ b/internal/db/media.go
@@ -44,12 +44,12 @@ type Media interface {
 	// GetAttachments ...
 	GetAttachments(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, error)
 
-	// GetRemoteOlderThan gets limit n remote media attachments (including avatars and headers) older than the given
+	// GetRemoteMediaOlderThan gets limit n remote media attachments (including avatars and headers) older than the given
 	// olderThan time. These will be returned in order of attachment.created_at descending (newest to oldest in other words).
 	//
 	// The selected media attachments will be those with both a URL and a RemoteURL filled in.
 	// In other words, media attachments that originated remotely, and that we currently have cached locally.
-	GetRemoteOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, Error)
+	GetRemoteMediaOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, Error)
 
 	// CountRemoteOlderThan is like GetRemoteOlderThan, except instead of getting limit n attachments,
 	// it just counts how many remote attachments in the database (including avatars and headers) meet

--- a/internal/db/media.go
+++ b/internal/db/media.go
@@ -44,12 +44,12 @@ type Media interface {
 	// GetAttachments ...
 	GetAttachments(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, error)
 
-	// GetRemoteMediaOlderThan gets limit n remote media attachments (including avatars and headers) older than the given
-	// olderThan time. These will be returned in order of attachment.created_at descending (newest to oldest in other words).
-	//
-	// The selected media attachments will be those with both a URL and a RemoteURL filled in.
-	// In other words, media attachments that originated remotely, and that we currently have cached locally.
-	GetRemoteMediaOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, Error)
+	// GetRemoteAttachments ...
+	GetRemoteAttachments(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, error)
+
+	// GetCachedAttachmentsOlderThan gets limit n remote attachments (including avatars and headers) older than
+	// the given time. These will be returned in order of attachment.created_at descending (i.e. newest to oldest).
+	GetCachedAttachmentsOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, Error)
 
 	// CountRemoteOlderThan is like GetRemoteOlderThan, except instead of getting limit n attachments,
 	// it just counts how many remote attachments in the database (including avatars and headers) meet

--- a/internal/db/status.go
+++ b/internal/db/status.go
@@ -58,7 +58,7 @@ type Status interface {
 	// GetStatuses gets a slice of statuses corresponding to the given status IDs.
 	GetStatusesByIDs(ctx context.Context, ids []string) ([]*gtsmodel.Status, error)
 
-	// GetStatusesUsingEmoji ...
+	// GetStatusesUsingEmoji fetches all status models using emoji with given ID stored in their 'emojis' column.
 	GetStatusesUsingEmoji(ctx context.Context, emojiID string) ([]*gtsmodel.Status, error)
 
 	// GetStatusParents gets the parent statuses of a given status.

--- a/internal/db/status.go
+++ b/internal/db/status.go
@@ -28,9 +28,6 @@ type Status interface {
 	// GetStatusByID returns one status from the database, with no rel fields populated, only their linking ID / URIs
 	GetStatusByID(ctx context.Context, id string) (*gtsmodel.Status, Error)
 
-	// GetStatuses gets a slice of statuses corresponding to the given status IDs.
-	GetStatuses(ctx context.Context, ids []string) ([]*gtsmodel.Status, Error)
-
 	// GetStatusByURI returns one status from the database, with no rel fields populated, only their linking ID / URIs
 	GetStatusByURI(ctx context.Context, uri string) (*gtsmodel.Status, Error)
 
@@ -57,6 +54,12 @@ type Status interface {
 
 	// CountStatusFaves returns the amount of faves/likes recorded for a status, or an error if something goes wrong
 	CountStatusFaves(ctx context.Context, status *gtsmodel.Status) (int, Error)
+
+	// GetStatuses gets a slice of statuses corresponding to the given status IDs.
+	GetStatusesByIDs(ctx context.Context, ids []string) ([]*gtsmodel.Status, error)
+
+	// GetStatusesUsingEmoji ...
+	GetStatusesUsingEmoji(ctx context.Context, emojiID string) ([]*gtsmodel.Status, error)
 
 	// GetStatusParents gets the parent statuses of a given status.
 	//

--- a/internal/gtsmodel/emoji.go
+++ b/internal/gtsmodel/emoji.go
@@ -42,4 +42,5 @@ type Emoji struct {
 	VisibleInPicker        *bool          `validate:"-" bun:",nullzero,notnull,default:true"`                                                      // Is this emoji visible in the admin emoji picker?
 	Category               *EmojiCategory `validate:"-" bun:"rel:belongs-to"`                                                                      // In which emoji category is this emoji visible?
 	CategoryID             string         `validate:"omitempty,ulid" bun:"type:CHAR(26),nullzero"`                                                 // ID of the category this emoji belongs to.
+	Cached                 *bool          `validate:"-" bun:",nullzero,notnull,default:false"`
 }

--- a/internal/media/manager.go
+++ b/internal/media/manager.go
@@ -159,7 +159,7 @@ func (m *Manager) PreProcessMedia(ctx context.Context, data DataFunc, accountID 
 	return processingMedia, nil
 }
 
-// PreProcessMediaRecache refetches, reprocesses, and recaches an existing attachment that has been uncached via pruneRemote.
+// PreProcessMediaRecache refetches, reprocesses, and recaches an existing attachment that has been uncached via cleaner pruning.
 //
 // Note: unlike ProcessMedia, this will NOT queue the media to be asychronously processed.
 func (m *Manager) PreProcessMediaRecache(ctx context.Context, data DataFunc, attachmentID string) (*ProcessingMedia, error) {
@@ -209,12 +209,8 @@ func (m *Manager) ProcessMedia(ctx context.Context, data DataFunc, accountID str
 //
 // Note: unlike ProcessEmoji, this will NOT queue the emoji to be asynchronously processed.
 func (m *Manager) PreProcessEmoji(ctx context.Context, data DataFunc, shortcode string, emojiID string, uri string, ai *AdditionalEmojiInfo, refresh bool) (*ProcessingEmoji, error) {
-	instanceAccount, err := m.state.DB.GetInstanceAccount(ctx, "")
-	if err != nil {
-		return nil, gtserror.Newf("error fetching this instance account from the db: %s", err)
-	}
-
 	var (
+		err       error
 		newPathID string
 		emoji     *gtsmodel.Emoji
 		now       = time.Now()
@@ -261,8 +257,8 @@ func (m *Manager) PreProcessEmoji(ctx context.Context, data DataFunc, shortcode 
 		}
 
 		// store + serve static image at new path ID
-		emoji.ImageStaticURL = uris.GenerateURIForAttachment(instanceAccount.ID, string(TypeEmoji), string(SizeStatic), newPathID, mimePng)
-		emoji.ImageStaticPath = fmt.Sprintf("%s/%s/%s/%s.%s", instanceAccount.ID, TypeEmoji, SizeStatic, newPathID, mimePng)
+		emoji.ImageStaticURL = uris.GenerateURIForAttachment(m.state.Instance.AccountID, string(TypeEmoji), string(SizeStatic), newPathID, mimePng)
+		emoji.ImageStaticPath = fmt.Sprintf("%s/%s/%s/%s.%s", m.state.Instance.AccountID, TypeEmoji, SizeStatic, newPathID, mimePng)
 
 		emoji.Shortcode = shortcode
 		emoji.URI = uri
@@ -278,12 +274,12 @@ func (m *Manager) PreProcessEmoji(ctx context.Context, data DataFunc, shortcode 
 			Domain:                 "", // assume our own domain unless told otherwise
 			ImageRemoteURL:         "",
 			ImageStaticRemoteURL:   "",
-			ImageURL:               "",                                                                                                         // we don't know yet
-			ImageStaticURL:         uris.GenerateURIForAttachment(instanceAccount.ID, string(TypeEmoji), string(SizeStatic), emojiID, mimePng), // all static emojis are encoded as png
-			ImagePath:              "",                                                                                                         // we don't know yet
-			ImageStaticPath:        fmt.Sprintf("%s/%s/%s/%s.%s", instanceAccount.ID, TypeEmoji, SizeStatic, emojiID, mimePng),                 // all static emojis are encoded as png
-			ImageContentType:       "",                                                                                                         // we don't know yet
-			ImageStaticContentType: mimeImagePng,                                                                                               // all static emojis are encoded as png
+			ImageURL:               "",                                                                                                                 // we don't know yet
+			ImageStaticURL:         uris.GenerateURIForAttachment(m.state.Instance.AccountID, string(TypeEmoji), string(SizeStatic), emojiID, mimePng), // all static emojis are encoded as png
+			ImagePath:              "",                                                                                                                 // we don't know yet
+			ImageStaticPath:        fmt.Sprintf("%s/%s/%s/%s.%s", m.state.Instance.AccountID, TypeEmoji, SizeStatic, emojiID, mimePng),                 // all static emojis are encoded as png
+			ImageContentType:       "",                                                                                                                 // we don't know yet
+			ImageStaticContentType: mimeImagePng,                                                                                                       // all static emojis are encoded as png
 			ImageFileSize:          0,
 			ImageStaticFileSize:    0,
 			Disabled:               &disabled,
@@ -329,12 +325,31 @@ func (m *Manager) PreProcessEmoji(ctx context.Context, data DataFunc, shortcode 
 	}
 
 	processingEmoji := &ProcessingEmoji{
-		instAccID: instanceAccount.ID,
 		emoji:     emoji,
-		refresh:   refresh,
+		existing:  refresh,
 		newPathID: newPathID,
 		dataFn:    data,
 		mgr:       m,
+	}
+
+	return processingEmoji, nil
+}
+
+// PreProcessEmojiRecache refetches, reprocesses, and recaches an existing emoji that has been uncached via cleaner pruning.
+//
+// Note: unlike ProcessEmoji, this will NOT queue the emoji to be asychronously processed.
+func (m *Manager) PreProcessEmojiRecache(ctx context.Context, data DataFunc, emojiID string) (*ProcessingEmoji, error) {
+	// get the existing emoji from the database.
+	emoji, err := m.state.DB.GetEmojiByID(ctx, emojiID)
+	if err != nil {
+		return nil, err
+	}
+
+	processingEmoji := &ProcessingEmoji{
+		emoji:    emoji,
+		dataFn:   data,
+		existing: true, // inidcate recache
+		mgr:      m,
 	}
 
 	return processingEmoji, nil

--- a/internal/processing/admin/media.go
+++ b/internal/processing/admin/media.go
@@ -58,7 +58,7 @@ func (p *Processor) MediaPrune(ctx context.Context, mediaRemoteCacheDays int) gt
 	go func() {
 		ctx := context.Background()
 		p.cleaner.Media().All(ctx, mediaRemoteCacheDays)
-		p.cleaner.Emoji().All(ctx)
+		p.cleaner.Emoji().All(ctx, mediaRemoteCacheDays)
 	}()
 
 	return nil

--- a/internal/processing/fromclientapi.go
+++ b/internal/processing/fromclientapi.go
@@ -982,7 +982,7 @@ func (p *Processor) federateReport(ctx context.Context, report *gtsmodel.Report)
 	}
 
 	if len(report.StatusIDs) > 0 && len(report.Statuses) == 0 {
-		statuses, err := p.state.DB.GetStatuses(ctx, report.StatusIDs)
+		statuses, err := p.state.DB.GetStatusesByIDs(ctx, report.StatusIDs)
 		if err != nil {
 			return fmt.Errorf("federateReport: error getting report statuses from database: %w", err)
 		}

--- a/internal/processing/media/getfile.go
+++ b/internal/processing/media/getfile.go
@@ -205,7 +205,13 @@ func (p *Processor) getEmojiContent(ctx context.Context, fileName string, owning
 	// for using the static URL rather than full size url
 	// is that static emojis are always encoded as png,
 	// so this is more reliable than using full size url
-	imageStaticURL := uris.GenerateURIForAttachment(owningAccountID, string(media.TypeEmoji), string(media.SizeStatic), fileName, "png")
+	imageStaticURL := uris.GenerateURIForAttachment(
+		owningAccountID,
+		string(media.TypeEmoji),
+		string(media.SizeStatic),
+		fileName,
+		"png",
+	)
 
 	e, err := p.state.DB.GetEmojiByStaticURL(ctx, imageStaticURL)
 	if err != nil {

--- a/internal/processing/report/create.go
+++ b/internal/processing/report/create.go
@@ -51,7 +51,7 @@ func (p *Processor) Create(ctx context.Context, account *gtsmodel.Account, form 
 	}
 
 	// fetch statuses by IDs given in the report form (noop if no statuses given)
-	statuses, err := p.state.DB.GetStatuses(ctx, form.StatusIDs)
+	statuses, err := p.state.DB.GetStatusesByIDs(ctx, form.StatusIDs)
 	if err != nil {
 		err = fmt.Errorf("db error fetching report target statuses: %w", err)
 		return nil, gtserror.NewErrorInternalError(err)

--- a/internal/regexes/regexes.go
+++ b/internal/regexes/regexes.go
@@ -70,7 +70,7 @@ const (
 	statusesPath   = userPathPrefix + `/` + statuses + `/(` + ulid + `)$`
 	blockPath      = userPathPrefix + `/` + blocks + `/(` + ulid + `)$`
 	reportPath     = `^/?` + reports + `/(` + ulid + `)$`
-	filePath       = `^/?(` + ulid + `)/([a-z]+)/([a-z]+)/(` + ulid + `)\.([a-z]+)$`
+	filePath       = `^/?(` + ulid + `)/([a-z]+)/([a-z]+)/(` + ulid + `)\.([a-z0-9]+)$`
 )
 
 var (

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -32,6 +32,13 @@ import (
 // subpackage initialization, while the returned subpackage type will later
 // then be set and stored within the State{} itself.
 type State struct {
+	// Instance contains frequently required ID strings
+	// of the current local GoToSocial instance host.
+	Instance struct {
+		ID        string
+		AccountID string
+	}
+
 	// Caches provides access to this state's collection of caches.
 	Caches cache.Caches
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -32,13 +32,6 @@ import (
 // subpackage initialization, while the returned subpackage type will later
 // then be set and stored within the State{} itself.
 type State struct {
-	// Instance contains frequently required ID strings
-	// of the current local GoToSocial instance host.
-	Instance struct {
-		ID        string
-		AccountID string
-	}
-
 	// Caches provides access to this state's collection of caches.
 	Caches cache.Caches
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -97,6 +97,9 @@ func (d *Driver) Has(ctx context.Context, key string) (bool, error) {
 func (d *Driver) WalkKeys(ctx context.Context, walk func(context.Context, string) error) error {
 	return d.Storage.WalkKeys(ctx, storage.WalkKeysOptions{
 		WalkFn: func(ctx context.Context, entry storage.Entry) error {
+			if entry.Key == "store.lock" {
+				return nil // skip this.
+			}
 			return walk(ctx, entry.Key)
 		},
 	})

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -1109,7 +1109,7 @@ func (c *converter) ReportToAdminAPIReport(ctx context.Context, r *gtsmodel.Repo
 
 	statuses := make([]*apimodel.Status, 0, len(r.StatusIDs))
 	if len(r.StatusIDs) != 0 && len(r.Statuses) == 0 {
-		r.Statuses, err = c.db.GetStatuses(ctx, r.StatusIDs)
+		r.Statuses, err = c.db.GetStatusesByIDs(ctx, r.StatusIDs)
 		if err != nil {
 			return nil, fmt.Errorf("ReportToAdminAPIReport: error getting statuses from the db: %w", err)
 		}

--- a/test/run-postgres.sh
+++ b/test/run-postgres.sh
@@ -34,4 +34,4 @@ GTS_DB_PORT=${DB_PORT} \
 GTS_DB_USER=${DB_USER} \
 GTS_DB_PASSWORD=${DB_PASS} \
 GTS_DB_DATABASE=${DB_NAME} \
-go test ./... -p 1
+go test ./... -p 1 ${@}

--- a/test/run-postgres.sh
+++ b/test/run-postgres.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+DB_NAME='postgres'
+DB_USER='postgres'
+DB_PASS='postgres'
+DB_PORT=5432
+
+# Start postgres container
+CID=$(docker run --detach \
+    --env "POSTGRES_DB=${DB_NAME}" \
+    --env "POSTGRES_USER=${DB_USER}" \
+    --env "POSTGRES_PASSWORD=${DB_PASS}" \
+    --env "POSTGRES_HOST_AUTH_METHOD=trust" \
+    --env "PGHOST=0.0.0.0" \
+    --env "PGPORT=${DB_PORT}" \
+    'postgres:latest')
+
+# On exit kill the container
+trap "docker kill ${CID}" exit
+
+sleep 5
+#docker exec "$CID" psql --user "$DB_USER" --password "$DB_PASS" -c "CREATE DATABASE \"${DB_NAME}\" WITH LOCALE \"C.UTF-8\" TEMPLATE \"template0\";"
+docker exec "$CID" psql --user "$DB_USER" --password "$DB_PASS" -c "GRANT ALL PRIVILEGES ON DATABASE \"${DB_NAME}\" TO \"${DB_USER}\";"
+
+# Get running container IP
+IP=$(docker container inspect "${CID}" \
+    --format '{{ .NetworkSettings.IPAddress }}')
+
+GTS_DB_TYPE=postgres \
+GTS_DB_ADDRESS=${IP} \
+GTS_DB_PORT=${DB_PORT} \
+GTS_DB_USER=${DB_USER} \
+GTS_DB_PASSWORD=${DB_PASS} \
+GTS_DB_DATABASE=${DB_NAME} \
+go test ./... -p 1

--- a/test/run-sqlite.sh
+++ b/test/run-sqlite.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 GTS_DB_TYPE=sqlite \
-GTS_DB_ADDRESS=':memory' \
-go test ./...
+GTS_DB_ADDRESS=':memory:' \
+go test ./... ${@}

--- a/test/run-sqlite.sh
+++ b/test/run-sqlite.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+GTS_DB_TYPE=sqlite \
+GTS_DB_ADDRESS=':memory' \
+go test ./...

--- a/testrig/testmodels.go
+++ b/testrig/testmodels.go
@@ -1161,6 +1161,7 @@ func NewTestEmojis() map[string]*gtsmodel.Emoji {
 			URI:                    "http://localhost:8080/emoji/01F8MH9H8E4VG3KDYJR9EGPXCQ",
 			VisibleInPicker:        TrueBool(),
 			CategoryID:             "01GGQ8V4993XK67B2JB396YFB7",
+			Cached:                 FalseBool(),
 		},
 		"yell": {
 			ID:                     "01GD5KP5CQEE1R3X43Y1EHS2CW",
@@ -1183,6 +1184,7 @@ func NewTestEmojis() map[string]*gtsmodel.Emoji {
 			URI:                    "http://fossbros-anonymous.io/emoji/01GD5KP5CQEE1R3X43Y1EHS2CW",
 			VisibleInPicker:        FalseBool(),
 			CategoryID:             "",
+			Cached:                 FalseBool(),
 		},
 	}
 }


### PR DESCRIPTION
# Description
- adds `cached` column to emoji table in similar vein to media attachments
- add emoji cleanup functions to: uncache remote, prune unused, fix cache states
- support recaching emojis not cached on disk
- add emoji cleaner tests. (each designed to take a dataset (emoji slice) to allow easy testing of multiple datasets in the future when we can more easily generate them)
- some small cleanups in the media manager package

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
