### PR TITLE
[bugfix] Set Vary header correctly on cache-control

### DIFF
--- a/internal/api/activitypub/emoji/emojiget.go
+++ b/internal/api/activitypub/emoji/emojiget.go
@@ -36,7 +36,7 @@ func (m *Module) EmojiGetHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := apiutil.NegotiateAccept(c, apiutil.ActivityPubAcceptHeaders...)
+	format, err := apiutil.NegotiateAccept(c, apiutil.ActivityPubHeaders...)
 	if err != nil {
 		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return

--- a/internal/api/activitypub/publickey/publickeyget.go
+++ b/internal/api/activitypub/publickey/publickeyget.go
@@ -42,7 +42,7 @@ func (m *Module) PublicKeyGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
+	format, err := apiutil.NegotiateAccept(c, apiutil.ActivityPubOrHTMLHeaders...)
 	if err != nil {
 		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return

--- a/internal/api/activitypub/users/featured.go
+++ b/internal/api/activitypub/users/featured.go
@@ -67,7 +67,7 @@ func (m *Module) FeaturedCollectionGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
+	format, err := apiutil.NegotiateAccept(c, apiutil.ActivityPubOrHTMLHeaders...)
 	if err != nil {
 		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return

--- a/internal/api/activitypub/users/followers.go
+++ b/internal/api/activitypub/users/followers.go
@@ -38,7 +38,7 @@ func (m *Module) FollowersGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
+	format, err := apiutil.NegotiateAccept(c, apiutil.ActivityPubOrHTMLHeaders...)
 	if err != nil {
 		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return

--- a/internal/api/activitypub/users/following.go
+++ b/internal/api/activitypub/users/following.go
@@ -38,7 +38,7 @@ func (m *Module) FollowingGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
+	format, err := apiutil.NegotiateAccept(c, apiutil.ActivityPubOrHTMLHeaders...)
 	if err != nil {
 		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return

--- a/internal/api/activitypub/users/outboxget.go
+++ b/internal/api/activitypub/users/outboxget.go
@@ -93,7 +93,7 @@ func (m *Module) OutboxGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
+	format, err := apiutil.NegotiateAccept(c, apiutil.ActivityPubOrHTMLHeaders...)
 	if err != nil {
 		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return

--- a/internal/api/activitypub/users/repliesget.go
+++ b/internal/api/activitypub/users/repliesget.go
@@ -108,7 +108,7 @@ func (m *Module) StatusRepliesGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
+	format, err := apiutil.NegotiateAccept(c, apiutil.ActivityPubOrHTMLHeaders...)
 	if err != nil {
 		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return

--- a/internal/api/activitypub/users/statusget.go
+++ b/internal/api/activitypub/users/statusget.go
@@ -46,7 +46,7 @@ func (m *Module) StatusGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
+	format, err := apiutil.NegotiateAccept(c, apiutil.ActivityPubOrHTMLHeaders...)
 	if err != nil {
 		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return

--- a/internal/api/activitypub/users/userget.go
+++ b/internal/api/activitypub/users/userget.go
@@ -46,7 +46,7 @@ func (m *Module) UsersGETHandler(c *gin.Context) {
 		return
 	}
 
-	format, err := apiutil.NegotiateAccept(c, apiutil.HTMLOrActivityPubHeaders...)
+	format, err := apiutil.NegotiateAccept(c, apiutil.ActivityPubOrHTMLHeaders...)
 	if err != nil {
 		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
 		return

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -43,13 +43,16 @@ func (a *Auth) Route(r router.Router, m ...gin.HandlerFunc) {
 
 	// instantiate + attach shared, non-global middlewares to both of these groups
 	var (
-		cacheControlMiddleware = middleware.CacheControl("private", "max-age=120")
-		sessionMiddleware      = middleware.Session(a.sessionName, a.routerSession.Auth, a.routerSession.Crypt)
+		ccMiddleware = middleware.CacheControl(middleware.CacheControlConfig{
+			Directives: []string{"private", "max-age=120"},
+			Vary:       []string{"Accept-Encoding"},
+		})
+		sessionMiddleware = middleware.Session(a.sessionName, a.routerSession.Auth, a.routerSession.Crypt)
 	)
 	authGroup.Use(m...)
 	oauthGroup.Use(m...)
-	authGroup.Use(cacheControlMiddleware, sessionMiddleware)
-	oauthGroup.Use(cacheControlMiddleware, sessionMiddleware)
+	authGroup.Use(ccMiddleware, sessionMiddleware)
+	oauthGroup.Use(ccMiddleware, sessionMiddleware)
 
 	a.auth.RouteAuth(authGroup.Handle)
 	a.auth.RouteOauth(oauthGroup.Handle)

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -45,7 +45,7 @@ func (a *Auth) Route(r router.Router, m ...gin.HandlerFunc) {
 	var (
 		ccMiddleware = middleware.CacheControl(middleware.CacheControlConfig{
 			Directives: []string{"private", "max-age=120"},
-			Vary:       []string{"Accept-Encoding"},
+			Vary:       []string{"Accept", "Accept-Encoding"},
 		})
 		sessionMiddleware = middleware.Session(a.sessionName, a.routerSession.Auth, a.routerSession.Crypt)
 	)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -83,7 +83,10 @@ func (c *Client) Route(r router.Router, m ...gin.HandlerFunc) {
 	apiGroup.Use(m...)
 	apiGroup.Use(
 		middleware.TokenCheck(c.db, c.processor.OAuthValidateBearerToken),
-		middleware.CacheControl("no-store"), // never cache api responses
+		middleware.CacheControl(middleware.CacheControlConfig{
+			// Never cache client api responses.
+			Directives: []string{"no-store"},
+		}),
 	)
 
 	// for each client api module, pass it the Handle function

--- a/internal/api/fileserver.go
+++ b/internal/api/fileserver.go
@@ -47,7 +47,9 @@ func (f *Fileserver) Route(r router.Router, m ...gin.HandlerFunc) {
 	// it expires. This ensures that clients won't cache expired
 	// links. This is done within fileserver/servefile.go.
 	if config.GetStorageBackend() == "local" || config.GetStorageS3Proxy() {
-		fileserverGroup.Use(middleware.CacheControl("private", "max-age=604800")) // 7d
+		fileserverGroup.Use(middleware.CacheControl(middleware.CacheControlConfig{
+			Directives: []string{"private", "max-age=604800"},
+		}))
 	}
 
 	f.fileserver.Route(fileserverGroup.Handle)

--- a/internal/api/fileserver.go
+++ b/internal/api/fileserver.go
@@ -36,8 +36,8 @@ func (f *Fileserver) Route(r router.Router, m ...gin.HandlerFunc) {
 	// Attach middlewares appropriate for this group.
 	fileserverGroup.Use(m...)
 	// If we're using local storage or proxying s3, we can set a
-	// long max-age on all file requests to reflect that we
-	// never host different files at the same URL (since
+	// long max-age + immutable on all file requests to reflect
+	// that we never host different files at the same URL (since
 	// ULIDs are generated per piece of media), so we can
 	// easily prevent clients having to fetch files repeatedly.
 	//
@@ -45,10 +45,17 @@ func (f *Fileserver) Route(r router.Router, m ...gin.HandlerFunc) {
 	// must be set dynamically within the request handler,
 	// based on how long the signed URL has left to live before
 	// it expires. This ensures that clients won't cache expired
-	// links. This is done within fileserver/servefile.go.
+	// links. This is done within fileserver/servefile.go, so we
+	// should not set the middleware here in that case.
+	//
+	// See:
+	//
+	// - https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#avoiding_revalidation
+	// - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#immutable
 	if config.GetStorageBackend() == "local" || config.GetStorageS3Proxy() {
 		fileserverGroup.Use(middleware.CacheControl(middleware.CacheControlConfig{
-			Directives: []string{"private", "max-age=604800"},
+			Directives: []string{"private", "max-age=604800", "immutable"},
+			Vary:       []string{"Range"}, // Cache partial ranges separately.
 		}))
 	}
 

--- a/internal/api/fileserver/servefile.go
+++ b/internal/api/fileserver/servefile.go
@@ -95,7 +95,7 @@ func (m *Module) ServeFile(c *gin.Context) {
 		// Derive the max-age value from how long the link has left until
 		// it expires.
 		maxAge := int(time.Until(content.URL.Expiry).Seconds())
-		c.Header("Cache-Control", "private,max-age="+strconv.Itoa(maxAge))
+		c.Header("Cache-Control", "private, max-age="+strconv.Itoa(maxAge)+", immutable")
 		c.Redirect(http.StatusFound, content.URL.String())
 		return
 	}

--- a/internal/api/nodeinfo.go
+++ b/internal/api/nodeinfo.go
@@ -36,8 +36,11 @@ func (w *NodeInfo) Route(r router.Router, m ...gin.HandlerFunc) {
 	// attach middlewares appropriate for this group
 	nodeInfoGroup.Use(m...)
 	nodeInfoGroup.Use(
-		// allow cache for 2 minutes
-		middleware.CacheControl("public", "max-age=120"),
+		// Allow public cache for 2 minutes.
+		middleware.CacheControl(middleware.CacheControlConfig{
+			Directives: []string{"public", "max-age=120"},
+			Vary:       []string{"Accept-Encoding"},
+		}),
 	)
 
 	w.nodeInfo.Route(nodeInfoGroup.Handle)

--- a/internal/api/util/negotiate.go
+++ b/internal/api/util/negotiate.go
@@ -25,12 +25,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// ActivityPubAcceptHeaders represents the Accept headers mentioned here:
-var ActivityPubAcceptHeaders = []MIME{
-	AppActivityJSON,
-	AppActivityLDJSON,
-}
-
 // JSONAcceptHeaders is a slice of offers that just contains application/json types.
 var JSONAcceptHeaders = []MIME{
 	AppJSON,
@@ -59,12 +53,34 @@ var HTMLAcceptHeaders = []MIME{
 }
 
 // HTMLOrActivityPubHeaders matches text/html first, then activitypub types.
-// This is useful for user URLs that a user might go to in their browser.
+// This is useful for user URLs that a user might go to in their browser,
+// but which should also be able to serve ActivityPub as a fallback.
+//
 // https://www.w3.org/TR/activitypub/#retrieving-objects
 var HTMLOrActivityPubHeaders = []MIME{
 	TextHTML,
-	AppActivityJSON,
 	AppActivityLDJSON,
+	AppActivityJSON,
+}
+
+// ActivityPubOrHTMLHeaders matches activitypub types first, then text/html.
+// This is useful for URLs that should serve ActivityPub by default, but
+// which a user might also go to in their browser sometimes.
+//
+// https://www.w3.org/TR/activitypub/#retrieving-objects
+var ActivityPubOrHTMLHeaders = []MIME{
+	AppActivityLDJSON,
+	AppActivityJSON,
+	TextHTML,
+}
+
+// ActivityPubHeaders matches only activitypub Accept headers.
+// This is useful for URLs should only serve ActivityPub.
+//
+// https://www.w3.org/TR/activitypub/#retrieving-objects
+var ActivityPubHeaders = []MIME{
+	AppActivityLDJSON,
+	AppActivityJSON,
 }
 
 var HostMetaHeaders = []MIME{

--- a/internal/api/wellknown.go
+++ b/internal/api/wellknown.go
@@ -40,8 +40,11 @@ func (w *WellKnown) Route(r router.Router, m ...gin.HandlerFunc) {
 	// attach middlewares appropriate for this group
 	wellKnownGroup.Use(m...)
 	wellKnownGroup.Use(
-		// allow .well-known responses to be cached for 2 minutes
-		middleware.CacheControl("public", "max-age=120"),
+		// Allow public cache for 2 minutes.
+		middleware.CacheControl(middleware.CacheControlConfig{
+			Directives: []string{"public", "max-age=120"},
+			Vary:       []string{"Accept-Encoding"},
+		}),
 	)
 
 	w.nodeInfo.Route(wellKnownGroup.Handle)

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -91,7 +91,9 @@ func (m *Module) Route(r router.Router, mi ...gin.HandlerFunc) {
 	// can still be served
 	profileGroup := r.AttachGroup(profileGroupPath)
 	profileGroup.Use(mi...)
-	profileGroup.Use(middleware.SignatureCheck(m.isURIBlocked), middleware.CacheControl("no-store"))
+	profileGroup.Use(middleware.SignatureCheck(m.isURIBlocked), middleware.CacheControl(middleware.CacheControlConfig{
+		Directives: []string{"no-store"},
+	}))
 	profileGroup.Handle(http.MethodGet, "", m.profileGETHandler) // use empty path here since it's the base of the group
 	profileGroup.Handle(http.MethodGet, statusPath, m.threadGETHandler)
 


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This PR updates the cache-control middleware to allow callers to the middleware to set the Vary header appropriately. This fixes an issue where it was possible to get nginx to cache a 303 response for the main-key endpoint of a GtS user, because it was cacheing the redirect regardless of the Accept header value.

Also updates AP endpoints to prefer serving ActivityPub.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
