### PR TITLE
[bugfix] more robust list timeline invalidation

### DIFF
--- a/internal/api/util/parsequery.go
+++ b/internal/api/util/parsequery.go
@@ -73,7 +73,14 @@ func requiredError(key string) gtserror.WithCode {
 */
 
 func ParseLimit(value string, defaultValue int, max, min int) (int, gtserror.WithCode) {
-	return parseInt(value, defaultValue, max, min, LimitKey)
+	i, err := parseInt(value, defaultValue, max, min, LimitKey)
+	if err != nil {
+		return 0, err
+	} else if i == 0 {
+		// treat 0 as an empty query
+		return defaultValue, nil
+	}
+	return i, nil
 }
 
 func ParseLocal(value string, defaultValue bool) (bool, gtserror.WithCode) {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -99,7 +99,7 @@ func (c *Caches) setuphooks() {
 
 	c.GTS.Follow().SetInvalidateCallback(func(follow *gtsmodel.Follow) {
 		// Invalidate any related list entries.
-		c.Visibility.Invalidate("FollowID", follow.ID)
+		c.GTS.ListEntry().Invalidate("FollowID", follow.ID)
 
 		// Invalidate follow origin account ID cached visibility.
 		c.Visibility.Invalidate("ItemID", follow.AccountID)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -93,13 +93,14 @@ func (c *Caches) setuphooks() {
 	})
 
 	c.GTS.EmojiCategory().SetInvalidateCallback(func(category *gtsmodel.EmojiCategory) {
-		// Invalidate entire emoji cache,
-		// as we can't know which emojis
-		// specifically this will effect.
-		c.GTS.Emoji().Clear()
+		// Invalidate any emoji in this category.
+		c.GTS.Emoji().Invalidate("CategoryID", category.ID)
 	})
 
 	c.GTS.Follow().SetInvalidateCallback(func(follow *gtsmodel.Follow) {
+		// Invalidate any related list entries.
+		c.Visibility.Invalidate("FollowID", follow.ID)
+
 		// Invalidate follow origin account ID cached visibility.
 		c.Visibility.Invalidate("ItemID", follow.AccountID)
 		c.Visibility.Invalidate("RequesterID", follow.AccountID)
@@ -120,6 +121,11 @@ func (c *Caches) setuphooks() {
 
 		// Invalidate any cached follow with same ID.
 		c.GTS.Follow().Invalidate("ID", followReq.ID)
+	})
+
+	c.GTS.List().SetInvalidateCallback(func(list *gtsmodel.List) {
+		// Invalidate all cached entries of this list.
+		c.GTS.ListEntry().Invalidate("ListID", list.ID)
 	})
 
 	c.GTS.Status().SetInvalidateCallback(func(status *gtsmodel.Status) {

--- a/internal/cache/gts.go
+++ b/internal/cache/gts.go
@@ -262,6 +262,7 @@ func (c *GTSCaches) initEmoji() {
 		{Name: "URI"},
 		{Name: "Shortcode.Domain"},
 		{Name: "ImageStaticURL"},
+		{Name: "CategoryID", Multi: true},
 	}, func(e1 *gtsmodel.Emoji) *gtsmodel.Emoji {
 		e2 := new(gtsmodel.Emoji)
 		*e2 = *e1
@@ -338,6 +339,8 @@ func (c *GTSCaches) initList() {
 func (c *GTSCaches) initListEntry() {
 	c.listEntry = result.New([]result.Lookup{
 		{Name: "ID"},
+		{Name: "ListID", Multi: true},
+		{Name: "FollowID", Multi: true},
 	}, func(l1 *gtsmodel.ListEntry) *gtsmodel.ListEntry {
 		l2 := new(gtsmodel.ListEntry)
 		*l2 = *l1

--- a/internal/db/bundb/list.go
+++ b/internal/db/bundb/list.go
@@ -211,7 +211,7 @@ func (l *listDB) DeleteListByID(ctx context.Context, id string) error {
 		// Delete all entries attached to list.
 		if _, err := tx.NewDelete().
 			Table("list_entries").
-			Where("list_id = ?", id).
+			Where("? = ?", bun.Ident("list_id"), id).
 			Exec(ctx); err != nil {
 			return err
 		}
@@ -219,7 +219,7 @@ func (l *listDB) DeleteListByID(ctx context.Context, id string) error {
 		// Delete the list itself.
 		_, err := tx.NewDelete().
 			Table("lists").
-			Where("id = ?", id).
+			Where("? = ?", bun.Ident("id"), id).
 			Exec(ctx)
 		return err
 	})
@@ -366,7 +366,7 @@ func (l *listDB) GetListEntriesForFollowID(ctx context.Context, followID string)
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("list_entries"), bun.Ident("entry")).
 		// Select only IDs from table
-		Column("entry.id").
+		ColumnExpr("?", bun.Ident("entry.id")).
 		// Select only entries belonging with given followID.
 		Where("? = ?", bun.Ident("entry.follow_id"), followID).
 		Scan(ctx, &entryIDs); err != nil {
@@ -470,7 +470,7 @@ func (l *listDB) DeleteListEntry(ctx context.Context, id string) error {
 	// Finally delete the list entry.
 	_, err = l.conn.NewDelete().
 		Table("list_entries").
-		Where("id = ?", id).
+		Where("? = ?", bun.Ident("id"), id).
 		Exec(ctx)
 	return err
 }
@@ -482,8 +482,8 @@ func (l *listDB) DeleteListEntriesForFollowID(ctx context.Context, followID stri
 	if err := l.conn.
 		NewSelect().
 		Table("list_entries").
-		Column("id").
-		Where("follow_id = ?", followID).
+		ColumnExpr("?", bun.Ident("id")).
+		Where("? = ?", bun.Ident("follow_id"), followID).
 		Order("id DESC").
 		Scan(ctx, &entryIDs); err != nil {
 		return l.conn.ProcessError(err)

--- a/internal/db/bundb/list.go
+++ b/internal/db/bundb/list.go
@@ -183,7 +183,7 @@ func (l *listDB) UpdateList(ctx context.Context, list *gtsmodel.List, columns ..
 func (l *listDB) DeleteListByID(ctx context.Context, id string) error {
 	// Load list by ID into cache to ensure we can perform
 	// all necessary cache invalidation hooks on removal.
-	_, err := l.GetListEntryByID(
+	_, err := l.GetListByID(
 		// Don't populate the entry;
 		// we only want the list ID.
 		gtscontext.SetBarebones(ctx),

--- a/internal/db/bundb/list.go
+++ b/internal/db/bundb/list.go
@@ -366,7 +366,7 @@ func (l *listDB) GetListEntriesForFollowID(ctx context.Context, followID string)
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("list_entries"), bun.Ident("entry")).
 		// Select only IDs from table
-		ColumnExpr("?", bun.Ident("entry.id")).
+		Column("entry.id").
 		// Select only entries belonging with given followID.
 		Where("? = ?", bun.Ident("entry.follow_id"), followID).
 		Scan(ctx, &entryIDs); err != nil {
@@ -482,7 +482,7 @@ func (l *listDB) DeleteListEntriesForFollowID(ctx context.Context, followID stri
 	if err := l.conn.
 		NewSelect().
 		Table("list_entries").
-		ColumnExpr("?", bun.Ident("id")).
+		Column("id").
 		Where("? = ?", bun.Ident("follow_id"), followID).
 		Order("id DESC").
 		Scan(ctx, &entryIDs); err != nil {

--- a/internal/db/bundb/relationship_follow.go
+++ b/internal/db/bundb/relationship_follow.go
@@ -328,7 +328,8 @@ func (r *relationshipDB) DeleteAccountFollows(ctx context.Context, accountID str
 		}
 
 		// Delete each follow from DB.
-		if err := r.deleteFollow(ctx, follow.ID); err != nil && !errors.Is(err, db.ErrNoEntries) {
+		if err := r.deleteFollow(ctx, follow.ID); err != nil &&
+			!errors.Is(err, db.ErrNoEntries) {
 			return err
 		}
 	}

--- a/internal/processing/account/bookmarks.go
+++ b/internal/processing/account/bookmarks.go
@@ -82,6 +82,7 @@ func (p *Processor) BookmarksGet(ctx context.Context, requestingAccount *gtsmode
 		if bookmark.ID < nextMaxIDValue {
 			nextMaxIDValue = bookmark.ID // Lowest ID (for paging down).
 		}
+
 		if bookmark.ID > prevMinIDValue {
 			prevMinIDValue = bookmark.ID // Highest ID (for paging up).
 		}

--- a/internal/processing/account/statuses.go
+++ b/internal/processing/account/statuses.go
@@ -93,28 +93,21 @@ func (p *Processor) StatusesGet(
 	}
 
 	var (
-		items          = make([]interface{}, 0, count)
-		nextMaxIDValue string
-		prevMinIDValue string
-	)
+		items = make([]interface{}, 0, count)
 
-	for i, s := range filtered {
 		// Set next + prev values before filtering and API
 		// converting, so caller can still page properly.
-		if i == count-1 {
-			nextMaxIDValue = s.ID
-		}
+		nextMaxIDValue = filtered[count-1].ID
+		prevMinIDValue = filtered[0].ID
+	)
 
-		if i == 0 {
-			prevMinIDValue = s.ID
-		}
-
+	for _, s := range filtered {
+		// Convert filtered statuses to API statuses.
 		item, err := p.tc.StatusToAPIStatus(ctx, s, requestingAccount)
 		if err != nil {
-			log.Debugf(ctx, "skipping status %s because it couldn't be converted to its api representation: %s", s.ID, err)
+			log.Errorf(ctx, "error convering to api status: %v", err)
 			continue
 		}
-
 		items = append(items, item)
 	}
 

--- a/internal/processing/account/statuses.go
+++ b/internal/processing/account/statuses.go
@@ -164,23 +164,20 @@ func (p *Processor) WebStatusesGet(ctx context.Context, targetAccountID string, 
 	}
 
 	var (
-		items          = make([]interface{}, 0, count)
-		nextMaxIDValue string
-	)
+		items = make([]interface{}, 0, count)
 
-	for i, s := range statuses {
 		// Set next value before API converting,
 		// so caller can still page properly.
-		if i == count-1 {
-			nextMaxIDValue = s.ID
-		}
+		nextMaxIDValue = statuses[count-1].ID
+	)
 
+	for _, s := range statuses {
+		// Convert fetched statuses to API statuses.
 		item, err := p.tc.StatusToAPIStatus(ctx, s, nil)
 		if err != nil {
-			log.Debugf(ctx, "skipping status %s because it couldn't be converted to its api representation: %s", s.ID, err)
+			log.Errorf(ctx, "error convering to api status: %v", err)
 			continue
 		}
-
 		items = append(items, item)
 	}
 

--- a/internal/processing/admin/report.go
+++ b/internal/processing/admin/report.go
@@ -54,22 +54,14 @@ func (p *Processor) ReportsGet(
 
 	count := len(reports)
 	items := make([]interface{}, 0, count)
-	nextMaxIDValue := ""
-	prevMinIDValue := ""
-	for i, r := range reports {
+	nextMaxIDValue := reports[count-1].ID
+	prevMinIDValue := reports[0].ID
+
+	for _, r := range reports {
 		item, err := p.tc.ReportToAdminAPIReport(ctx, r, account)
 		if err != nil {
 			return nil, gtserror.NewErrorInternalError(fmt.Errorf("error converting report to api: %s", err))
 		}
-
-		if i == count-1 {
-			nextMaxIDValue = item.ID
-		}
-
-		if i == 0 {
-			prevMinIDValue = item.ID
-		}
-
 		items = append(items, item)
 	}
 

--- a/internal/processing/list/delete.go
+++ b/internal/processing/list/delete.go
@@ -27,7 +27,8 @@ import (
 
 // Delete deletes one list for the given account.
 func (p *Processor) Delete(ctx context.Context, account *gtsmodel.Account, id string) gtserror.WithCode {
-	list, errWithCode := p.getList(
+	// Ensure list exists + is owned by requesting account.
+	_, errWithCode := p.getList(
 		// Use barebones ctx; no embedded
 		// structs necessary for this call.
 		gtscontext.SetBarebones(ctx),
@@ -38,7 +39,7 @@ func (p *Processor) Delete(ctx context.Context, account *gtsmodel.Account, id st
 		return errWithCode
 	}
 
-	if err := p.state.DB.DeleteListByID(ctx, list.ID); err != nil {
+	if err := p.state.DB.DeleteListByID(ctx, id); err != nil {
 		return gtserror.NewErrorInternalError(err)
 	}
 

--- a/internal/processing/list/get.go
+++ b/internal/processing/list/get.go
@@ -112,11 +112,7 @@ func (p *Processor) GetListAccounts(
 		return util.EmptyPageableResponse(), nil
 	}
 
-	var (
-		items          = make([]interface{}, count)
-		nextMaxIDValue string
-		prevMinIDValue string
-	)
+	items := make([]interface{}, 0, count)
 
 	// For each list entry, we want the account it points to.
 	// To get this, we need to first get the follow that the
@@ -125,14 +121,6 @@ func (p *Processor) GetListAccounts(
 	//
 	// We do paging not by account ID, but by list entry ID.
 	for i, listEntry := range listEntries {
-		if i == count-1 {
-			nextMaxIDValue = listEntry.ID
-		}
-
-		if i == 0 {
-			prevMinIDValue = listEntry.ID
-		}
-
 		if err := p.state.DB.PopulateListEntry(ctx, listEntry); err != nil {
 			log.Errorf(ctx, "error populating list entry: %v", err)
 			continue
@@ -155,8 +143,8 @@ func (p *Processor) GetListAccounts(
 	return util.PackagePageableResponse(util.PageableResponseParams{
 		Items:          items,
 		Path:           "api/v1/lists/" + listID + "/accounts",
-		NextMaxIDValue: nextMaxIDValue,
-		PrevMinIDValue: prevMinIDValue,
+		NextMaxIDValue: listEntries[count-1].ID, // last in list
+		PrevMinIDValue: listEntries[0].ID,       // first in list
 		Limit:          limit,
 	})
 }

--- a/internal/processing/report/get.go
+++ b/internal/processing/report/get.go
@@ -73,22 +73,14 @@ func (p *Processor) GetMultiple(
 
 	count := len(reports)
 	items := make([]interface{}, 0, count)
-	nextMaxIDValue := ""
-	prevMinIDValue := ""
-	for i, r := range reports {
+	nextMaxIDValue := reports[count-1].ID
+	prevMinIDValue := reports[0].ID
+
+	for _, r := range reports {
 		item, err := p.tc.ReportToAPIReport(ctx, r)
 		if err != nil {
 			return nil, gtserror.NewErrorInternalError(fmt.Errorf("error converting report to api: %s", err))
 		}
-
-		if i == count-1 {
-			nextMaxIDValue = item.ID
-		}
-
-		if i == 0 {
-			prevMinIDValue = item.ID
-		}
-
 		items = append(items, item)
 	}
 

--- a/internal/processing/timeline/faved.go
+++ b/internal/processing/timeline/faved.go
@@ -46,7 +46,7 @@ func (p *Processor) FavedTimelineGet(ctx context.Context, authed *oauth.Auth, ma
 	for _, s := range statuses {
 		visible, err := p.filter.StatusVisible(ctx, authed.Account, s)
 		if err != nil {
-			log.Debugf(ctx, "skipping status %s because of an error checking status visibility: %s", s.ID, err)
+			log.Errorf(ctx, "error checking status visibility: %v", err)
 			continue
 		}
 
@@ -56,7 +56,7 @@ func (p *Processor) FavedTimelineGet(ctx context.Context, authed *oauth.Auth, ma
 
 		apiStatus, err := p.tc.StatusToAPIStatus(ctx, s, authed.Account)
 		if err != nil {
-			log.Debugf(ctx, "skipping status %s because it couldn't be converted to its api representation: %s", s.ID, err)
+			log.Errorf(ctx, "error convering to api status: %v", err)
 			continue
 		}
 
@@ -65,7 +65,7 @@ func (p *Processor) FavedTimelineGet(ctx context.Context, authed *oauth.Auth, ma
 
 	return util.PackagePageableResponse(util.PageableResponseParams{
 		Items:          items,
-		Path:           "api/v1/favourites",
+		Path:           "/api/v1/favourites",
 		NextMaxIDValue: nextMaxID,
 		PrevMinIDValue: prevMinID,
 		Limit:          limit,

--- a/internal/processing/timeline/home.go
+++ b/internal/processing/timeline/home.go
@@ -116,25 +116,17 @@ func (p *Processor) HomeTimelineGet(ctx context.Context, authed *oauth.Auth, max
 
 	var (
 		items          = make([]interface{}, count)
-		nextMaxIDValue string
-		prevMinIDValue string
+		nextMaxIDValue = statuses[count-1].GetID()
+		prevMinIDValue = statuses[0].GetID()
 	)
 
-	for i, item := range statuses {
-		if i == count-1 {
-			nextMaxIDValue = item.GetID()
-		}
-
-		if i == 0 {
-			prevMinIDValue = item.GetID()
-		}
-
-		items[i] = item
+	for i := range statuses {
+		items[i] = statuses[i]
 	}
 
 	return util.PackagePageableResponse(util.PageableResponseParams{
 		Items:          items,
-		Path:           "api/v1/timelines/home",
+		Path:           "/api/v1/timelines/home",
 		NextMaxIDValue: nextMaxIDValue,
 		PrevMinIDValue: prevMinIDValue,
 		Limit:          limit,

--- a/internal/processing/timeline/list.go
+++ b/internal/processing/timeline/list.go
@@ -142,25 +142,17 @@ func (p *Processor) ListTimelineGet(ctx context.Context, authed *oauth.Auth, lis
 
 	var (
 		items          = make([]interface{}, count)
-		nextMaxIDValue string
-		prevMinIDValue string
+		nextMaxIDValue = statuses[count-1].GetID()
+		prevMinIDValue = statuses[0].GetID()
 	)
 
-	for i, item := range statuses {
-		if i == count-1 {
-			nextMaxIDValue = item.GetID()
-		}
-
-		if i == 0 {
-			prevMinIDValue = item.GetID()
-		}
-
-		items[i] = item
+	for i := range statuses {
+		items[i] = statuses[i]
 	}
 
 	return util.PackagePageableResponse(util.PageableResponseParams{
 		Items:          items,
-		Path:           "api/v1/timelines/list/" + listID,
+		Path:           "/api/v1/timelines/list/" + listID,
 		NextMaxIDValue: nextMaxIDValue,
 		PrevMinIDValue: prevMinIDValue,
 		Limit:          limit,


### PR DESCRIPTION
# Description
- make list + list-entry cache invalidation more thorough
- allow list entry invalidation by ListID + FollowID
- allow emoji invalidation by CategoryID
- use `defaultValue` when a limit of `0` is provided
- update errors being logged to DEBUG, to log to ERROR

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
