### PR TITLE
[bugfix] Add missing `continue` statement in `prepareXBetweenIDs`

### DIFF
--- a/internal/timeline/prepare.go
+++ b/internal/timeline/prepare.go
@@ -127,6 +127,7 @@ func (t *timeline) prepareXBetweenIDs(ctx context.Context, amount int, behindID 
 				// This means we can remove it and skip past it.
 				l.Debugf("db.ErrNoEntries while trying to prepare %s; will remove from timeline", entry.itemID)
 				t.items.data.Remove(e)
+				continue
 			}
 			// We've got a proper db error.
 			return gtserror.Newf("db error while trying to prepare %s: %w", entry.itemID, err)


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request adds a missing continue statement in timeline preparation that was causing an error to be returned when it oughtn't have been.

Relates to https://github.com/superseriousbusiness/gotosocial/issues/1901

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
