### PR TITLE
[feature] Lower remote media cache config duration

### DIFF
--- a/docs/configuration/media.md
+++ b/docs/configuration/media.md
@@ -37,8 +37,8 @@ media-description-max-chars: 500
 #
 # If this is set to 0, then media from remote instances will be cached indefinitely.
 # Examples: [30, 60, 7, 0]
-# Default: 30
-media-remote-cache-days: 30
+# Default: 7
+media-remote-cache-days: 7
 
 # Int. Max size in bytes of emojis uploaded to this instance via the admin API.
 # The default is the same as the Mastodon size limit for emojis (50kb), which allows

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -478,8 +478,8 @@ media-description-max-chars: 500
 #
 # If this is set to 0, then media from remote instances will be cached indefinitely.
 # Examples: [30, 60, 7, 0]
-# Default: 30
-media-remote-cache-days: 30
+# Default: 7
+media-remote-cache-days: 7
 
 # Int. Max size in bytes of emojis uploaded to this instance via the admin API.
 # The default is the same as the Mastodon size limit for emojis (50kb), which allows

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -71,7 +71,7 @@ var Defaults = Configuration{
 	MediaVideoMaxSize:        40 * bytesize.MiB,
 	MediaDescriptionMinChars: 0,
 	MediaDescriptionMaxChars: 500,
-	MediaRemoteCacheDays:     30,
+	MediaRemoteCacheDays:     7,
 	MediaEmojiLocalMaxSize:   50 * bytesize.KiB,
 	MediaEmojiRemoteMaxSize:  100 * bytesize.KiB,
 

--- a/testrig/config.go
+++ b/testrig/config.go
@@ -77,7 +77,7 @@ var testDefaults = config.Configuration{
 	MediaVideoMaxSize:        41943040, // 40mb
 	MediaDescriptionMinChars: 0,
 	MediaDescriptionMaxChars: 500,
-	MediaRemoteCacheDays:     30,
+	MediaRemoteCacheDays:     7,
 	MediaEmojiLocalMaxSize:   51200,  // 50kb
 	MediaEmojiRemoteMaxSize:  102400, // 100kb
 


### PR DESCRIPTION
# Description

The old default of 30d can lead to a lot of media getting cached and significant disk usage, even on small or single person instances. A lot of deployments decrease this value, to 15 or even less. This is less of an issue when using object storage, but for local storage which is the more popular deployment option running out of disk space is unpleasant.

With GoToSocial's aim to fit in small places, this changes the default to a much more conservative 7 days. In all likelihood people aren't scrolling that far back in their timeline so this change shouldn't result in any excessive refetching of remote media. Existing deployments will only be affected by this change if the admin hasn't already configured this value, or didn't bootstrap from the example configuration.

closes #(issue)
closes #(another issue)

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
