### PR TITLE
[performance] retry db queries on busy errors

### DIFF
--- a/example/config.yaml
+++ b/example/config.yaml
@@ -194,10 +194,6 @@ db-tls-ca-cert: ""
 #
 # If you set the multiplier to less than 1, only one open connection will be used regardless of cpu count.
 #
-# PLEASE NOTE!!: This setting currently only applies for Postgres. SQLite will always use 1 connection regardless
-# of what is set here. This behavior will change in future when we implement better SQLITE_BUSY handling.
-# See https://github.com/superseriousbusiness/gotosocial/issues/1407 for more details.
-#
 # Examples: [16, 8, 10, 2]
 # Default: 8
 db-max-open-conns-multiplier: 8

--- a/internal/db/account.go
+++ b/internal/db/account.go
@@ -27,67 +27,67 @@ import (
 // Account contains functions related to account getting/setting/creation.
 type Account interface {
 	// GetAccountByID returns one account with the given ID, or an error if something goes wrong.
-	GetAccountByID(ctx context.Context, id string) (*gtsmodel.Account, Error)
+	GetAccountByID(ctx context.Context, id string) (*gtsmodel.Account, error)
 
 	// GetAccountByURI returns one account with the given URI, or an error if something goes wrong.
-	GetAccountByURI(ctx context.Context, uri string) (*gtsmodel.Account, Error)
+	GetAccountByURI(ctx context.Context, uri string) (*gtsmodel.Account, error)
 
 	// GetAccountByURL returns one account with the given URL, or an error if something goes wrong.
-	GetAccountByURL(ctx context.Context, uri string) (*gtsmodel.Account, Error)
+	GetAccountByURL(ctx context.Context, uri string) (*gtsmodel.Account, error)
 
 	// GetAccountByUsernameDomain returns one account with the given username and domain, or an error if something goes wrong.
-	GetAccountByUsernameDomain(ctx context.Context, username string, domain string) (*gtsmodel.Account, Error)
+	GetAccountByUsernameDomain(ctx context.Context, username string, domain string) (*gtsmodel.Account, error)
 
 	// GetAccountByPubkeyID returns one account with the given public key URI (ID), or an error if something goes wrong.
-	GetAccountByPubkeyID(ctx context.Context, id string) (*gtsmodel.Account, Error)
+	GetAccountByPubkeyID(ctx context.Context, id string) (*gtsmodel.Account, error)
 
 	// GetAccountByInboxURI returns one account with the given inbox_uri, or an error if something goes wrong.
-	GetAccountByInboxURI(ctx context.Context, uri string) (*gtsmodel.Account, Error)
+	GetAccountByInboxURI(ctx context.Context, uri string) (*gtsmodel.Account, error)
 
 	// GetAccountByOutboxURI returns one account with the given outbox_uri, or an error if something goes wrong.
-	GetAccountByOutboxURI(ctx context.Context, uri string) (*gtsmodel.Account, Error)
+	GetAccountByOutboxURI(ctx context.Context, uri string) (*gtsmodel.Account, error)
 
 	// GetAccountByFollowingURI returns one account with the given following_uri, or an error if something goes wrong.
-	GetAccountByFollowingURI(ctx context.Context, uri string) (*gtsmodel.Account, Error)
+	GetAccountByFollowingURI(ctx context.Context, uri string) (*gtsmodel.Account, error)
 
 	// GetAccountByFollowersURI returns one account with the given followers_uri, or an error if something goes wrong.
-	GetAccountByFollowersURI(ctx context.Context, uri string) (*gtsmodel.Account, Error)
+	GetAccountByFollowersURI(ctx context.Context, uri string) (*gtsmodel.Account, error)
 
 	// PopulateAccount ensures that all sub-models of an account are populated (e.g. avatar, header etc).
 	PopulateAccount(ctx context.Context, account *gtsmodel.Account) error
 
 	// PutAccount puts one account in the database.
-	PutAccount(ctx context.Context, account *gtsmodel.Account) Error
+	PutAccount(ctx context.Context, account *gtsmodel.Account) error
 
 	// UpdateAccount updates one account by ID.
-	UpdateAccount(ctx context.Context, account *gtsmodel.Account, columns ...string) Error
+	UpdateAccount(ctx context.Context, account *gtsmodel.Account, columns ...string) error
 
 	// DeleteAccount deletes one account from the database by its ID.
 	// DO NOT USE THIS WHEN SUSPENDING ACCOUNTS! In that case you should mark the
 	// account as suspended instead, rather than deleting from the db entirely.
-	DeleteAccount(ctx context.Context, id string) Error
+	DeleteAccount(ctx context.Context, id string) error
 
 	// GetAccountCustomCSSByUsername returns the custom css of an account on this instance with the given username.
-	GetAccountCustomCSSByUsername(ctx context.Context, username string) (string, Error)
+	GetAccountCustomCSSByUsername(ctx context.Context, username string) (string, error)
 
 	// GetAccountFaves fetches faves/likes created by the target accountID.
-	GetAccountFaves(ctx context.Context, accountID string) ([]*gtsmodel.StatusFave, Error)
+	GetAccountFaves(ctx context.Context, accountID string) ([]*gtsmodel.StatusFave, error)
 
 	// GetAccountsUsingEmoji fetches all account models using emoji with given ID stored in their 'emojis' column.
 	GetAccountsUsingEmoji(ctx context.Context, emojiID string) ([]*gtsmodel.Account, error)
 
 	// GetAccountStatusesCount is a shortcut for the common action of counting statuses produced by accountID.
-	CountAccountStatuses(ctx context.Context, accountID string) (int, Error)
+	CountAccountStatuses(ctx context.Context, accountID string) (int, error)
 
 	// CountAccountPinned returns the total number of pinned statuses owned by account with the given id.
-	CountAccountPinned(ctx context.Context, accountID string) (int, Error)
+	CountAccountPinned(ctx context.Context, accountID string) (int, error)
 
 	// GetAccountStatuses is a shortcut for getting the most recent statuses. accountID is optional, if not provided
 	// then all statuses will be returned. If limit is set to 0, the size of the returned slice will not be limited. This can
 	// be very memory intensive so you probably shouldn't do this!
 	//
 	// In the case of no statuses, this function will return db.ErrNoEntries.
-	GetAccountStatuses(ctx context.Context, accountID string, limit int, excludeReplies bool, excludeReblogs bool, maxID string, minID string, mediaOnly bool, publicOnly bool) ([]*gtsmodel.Status, Error)
+	GetAccountStatuses(ctx context.Context, accountID string, limit int, excludeReplies bool, excludeReblogs bool, maxID string, minID string, mediaOnly bool, publicOnly bool) ([]*gtsmodel.Status, error)
 
 	// GetAccountPinnedStatuses returns ONLY statuses owned by the give accountID for which a corresponding StatusPin
 	// exists in the database. Statuses which are not pinned will not be returned by this function.
@@ -95,28 +95,28 @@ type Account interface {
 	// Statuses will be returned in the order in which they were pinned, from latest pinned to oldest pinned (descending).
 	//
 	// In the case of no statuses, this function will return db.ErrNoEntries.
-	GetAccountPinnedStatuses(ctx context.Context, accountID string) ([]*gtsmodel.Status, Error)
+	GetAccountPinnedStatuses(ctx context.Context, accountID string) ([]*gtsmodel.Status, error)
 
 	// GetAccountWebStatuses is similar to GetAccountStatuses, but it's specifically for returning statuses that
 	// should be visible via the web view of an account. So, only public, federated statuses that aren't boosts
 	// or replies.
 	//
 	// In the case of no statuses, this function will return db.ErrNoEntries.
-	GetAccountWebStatuses(ctx context.Context, accountID string, limit int, maxID string) ([]*gtsmodel.Status, Error)
+	GetAccountWebStatuses(ctx context.Context, accountID string, limit int, maxID string) ([]*gtsmodel.Status, error)
 
-	GetAccountBlocks(ctx context.Context, accountID string, maxID string, sinceID string, limit int) ([]*gtsmodel.Account, string, string, Error)
+	GetAccountBlocks(ctx context.Context, accountID string, maxID string, sinceID string, limit int) ([]*gtsmodel.Account, string, string, error)
 
 	// GetAccountLastPosted simply gets the timestamp of the most recent post by the account.
 	//
 	// If webOnly is true, then the time of the last non-reply, non-boost, public status of the account will be returned.
 	//
 	// The returned time will be zero if account has never posted anything.
-	GetAccountLastPosted(ctx context.Context, accountID string, webOnly bool) (time.Time, Error)
+	GetAccountLastPosted(ctx context.Context, accountID string, webOnly bool) (time.Time, error)
 
 	// SetAccountHeaderOrAvatar sets the header or avatar for the given accountID to the given media attachment.
-	SetAccountHeaderOrAvatar(ctx context.Context, mediaAttachment *gtsmodel.MediaAttachment, accountID string) Error
+	SetAccountHeaderOrAvatar(ctx context.Context, mediaAttachment *gtsmodel.MediaAttachment, accountID string) error
 
 	// GetInstanceAccount returns the instance account for the given domain.
 	// If domain is empty, this instance account will be returned.
-	GetInstanceAccount(ctx context.Context, domain string) (*gtsmodel.Account, Error)
+	GetInstanceAccount(ctx context.Context, domain string) (*gtsmodel.Account, error)
 }

--- a/internal/db/admin.go
+++ b/internal/db/admin.go
@@ -27,26 +27,26 @@ import (
 type Admin interface {
 	// IsUsernameAvailable checks whether a given username is available on our domain.
 	// Returns an error if the username is already taken, or something went wrong in the db.
-	IsUsernameAvailable(ctx context.Context, username string) (bool, Error)
+	IsUsernameAvailable(ctx context.Context, username string) (bool, error)
 
 	// IsEmailAvailable checks whether a given email address for a new account is available to be used on our domain.
 	// Return an error if:
 	// A) the email is already associated with an account
 	// B) we block signups from this email domain
 	// C) something went wrong in the db
-	IsEmailAvailable(ctx context.Context, email string) (bool, Error)
+	IsEmailAvailable(ctx context.Context, email string) (bool, error)
 
 	// NewSignup creates a new user in the database with the given parameters.
 	// By the time this function is called, it should be assumed that all the parameters have passed validation!
-	NewSignup(ctx context.Context, newSignup gtsmodel.NewSignup) (*gtsmodel.User, Error)
+	NewSignup(ctx context.Context, newSignup gtsmodel.NewSignup) (*gtsmodel.User, error)
 
 	// CreateInstanceAccount creates an account in the database with the same username as the instance host value.
 	// Ie., if the instance is hosted at 'example.org' the instance user will have a username of 'example.org'.
 	// This is needed for things like serving files that belong to the instance and not an individual user/account.
-	CreateInstanceAccount(ctx context.Context) Error
+	CreateInstanceAccount(ctx context.Context) error
 
 	// CreateInstanceInstance creates an instance in the database with the same domain as the instance host value.
 	// Ie., if the instance is hosted at 'example.org' the instance will have a domain of 'example.org'.
 	// This is needed for things like serving instance information through /api/v1/instance
-	CreateInstanceInstance(ctx context.Context) Error
+	CreateInstanceInstance(ctx context.Context) error
 }

--- a/internal/db/basic.go
+++ b/internal/db/basic.go
@@ -23,58 +23,58 @@ import "context"
 type Basic interface {
 	// CreateTable creates a table for the given interface.
 	// For implementations that don't use tables, this can just return nil.
-	CreateTable(ctx context.Context, i interface{}) Error
+	CreateTable(ctx context.Context, i interface{}) error
 
 	// CreateAllTables creates *all* tables necessary for the running of GoToSocial.
 	// Because it uses the 'if not exists' parameter it is safe to run against a GtS that's already been initialized.
-	CreateAllTables(ctx context.Context) Error
+	CreateAllTables(ctx context.Context) error
 
 	// DropTable drops the table for the given interface.
 	// For implementations that don't use tables, this can just return nil.
-	DropTable(ctx context.Context, i interface{}) Error
+	DropTable(ctx context.Context, i interface{}) error
 
 	// Stop should stop and close the database connection cleanly, returning an error if this is not possible.
 	// If the database implementation doesn't need to be stopped, this can just return nil.
-	Stop(ctx context.Context) Error
+	Stop(ctx context.Context) error
 
 	// IsHealthy should return nil if the database connection is healthy, or an error if not.
-	IsHealthy(ctx context.Context) Error
+	IsHealthy(ctx context.Context) error
 
 	// GetByID gets one entry by its id. In a database like postgres, this might be the 'id' field of the entry,
 	// for other implementations (for example, in-memory) it might just be the key of a map.
 	// The given interface i will be set to the result of the query, whatever it is. Use a pointer or a slice.
 	// In case of no entries, a 'no entries' error will be returned
-	GetByID(ctx context.Context, id string, i interface{}) Error
+	GetByID(ctx context.Context, id string, i interface{}) error
 
 	// GetWhere gets one entry where key = value. This is similar to GetByID but allows the caller to specify the
 	// name of the key to select from.
 	// The given interface i will be set to the result of the query, whatever it is. Use a pointer or a slice.
 	// In case of no entries, a 'no entries' error will be returned
-	GetWhere(ctx context.Context, where []Where, i interface{}) Error
+	GetWhere(ctx context.Context, where []Where, i interface{}) error
 
 	// GetAll will try to get all entries of type i.
 	// The given interface i will be set to the result of the query, whatever it is. Use a pointer or a slice.
 	// In case of no entries, a 'no entries' error will be returned
-	GetAll(ctx context.Context, i interface{}) Error
+	GetAll(ctx context.Context, i interface{}) error
 
 	// Put simply stores i. It is up to the implementation to figure out how to store it, and using what key.
 	// The given interface i will be set to the result of the query, whatever it is. Use a pointer or a slice.
-	Put(ctx context.Context, i interface{}) Error
+	Put(ctx context.Context, i interface{}) error
 
 	// UpdateByID updates values of i based on its id.
 	// If any columns are specified, these will be updated exclusively.
 	// Otherwise, the whole model will be updated.
 	// The given interface i will be set to the result of the query, whatever it is. Use a pointer or a slice.
-	UpdateByID(ctx context.Context, i interface{}, id string, columns ...string) Error
+	UpdateByID(ctx context.Context, i interface{}, id string, columns ...string) error
 
 	// UpdateWhere updates column key of interface i with the given value, where the given parameters apply.
-	UpdateWhere(ctx context.Context, where []Where, key string, value interface{}, i interface{}) Error
+	UpdateWhere(ctx context.Context, where []Where, key string, value interface{}, i interface{}) error
 
 	// DeleteByID removes i with id id.
 	// If i didn't exist anyway, then no error should be returned.
-	DeleteByID(ctx context.Context, id string, i interface{}) Error
+	DeleteByID(ctx context.Context, id string, i interface{}) error
 
 	// DeleteWhere deletes i where key = value
 	// If i didn't exist anyway, then no error should be returned.
-	DeleteWhere(ctx context.Context, where []Where, i interface{}) Error
+	DeleteWhere(ctx context.Context, where []Where, i interface{}) error
 }

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -562,7 +562,7 @@ func (a *accountDB) GetAccountStatuses(ctx context.Context, accountID string, li
 		// implementation differs between SQLite and Postgres,
 		// so we have to be thorough to cover all eventualities
 		q = q.WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
-			switch a.conn.Dialect().Name() {
+			switch a.conn.db.Dialect().Name() {
 			case dialect.PG:
 				return q.
 					Where("? IS NOT NULL", bun.Ident("status.attachments")).

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -42,7 +42,7 @@ type accountDB struct {
 	state *state.State
 }
 
-func (a *accountDB) GetAccountByID(ctx context.Context, id string) (*gtsmodel.Account, db.Error) {
+func (a *accountDB) GetAccountByID(ctx context.Context, id string) (*gtsmodel.Account, error) {
 	return a.getAccount(
 		ctx,
 		"ID",
@@ -77,7 +77,7 @@ func (a *accountDB) GetAccountsByIDs(ctx context.Context, ids []string) ([]*gtsm
 	return accounts, nil
 }
 
-func (a *accountDB) GetAccountByURI(ctx context.Context, uri string) (*gtsmodel.Account, db.Error) {
+func (a *accountDB) GetAccountByURI(ctx context.Context, uri string) (*gtsmodel.Account, error) {
 	return a.getAccount(
 		ctx,
 		"URI",
@@ -91,7 +91,7 @@ func (a *accountDB) GetAccountByURI(ctx context.Context, uri string) (*gtsmodel.
 	)
 }
 
-func (a *accountDB) GetAccountByURL(ctx context.Context, url string) (*gtsmodel.Account, db.Error) {
+func (a *accountDB) GetAccountByURL(ctx context.Context, url string) (*gtsmodel.Account, error) {
 	return a.getAccount(
 		ctx,
 		"URL",
@@ -105,7 +105,7 @@ func (a *accountDB) GetAccountByURL(ctx context.Context, url string) (*gtsmodel.
 	)
 }
 
-func (a *accountDB) GetAccountByUsernameDomain(ctx context.Context, username string, domain string) (*gtsmodel.Account, db.Error) {
+func (a *accountDB) GetAccountByUsernameDomain(ctx context.Context, username string, domain string) (*gtsmodel.Account, error) {
 	if domain != "" {
 		// Normalize the domain as punycode
 		var err error
@@ -139,7 +139,7 @@ func (a *accountDB) GetAccountByUsernameDomain(ctx context.Context, username str
 	)
 }
 
-func (a *accountDB) GetAccountByPubkeyID(ctx context.Context, id string) (*gtsmodel.Account, db.Error) {
+func (a *accountDB) GetAccountByPubkeyID(ctx context.Context, id string) (*gtsmodel.Account, error) {
 	return a.getAccount(
 		ctx,
 		"PublicKeyURI",
@@ -153,7 +153,7 @@ func (a *accountDB) GetAccountByPubkeyID(ctx context.Context, id string) (*gtsmo
 	)
 }
 
-func (a *accountDB) GetAccountByInboxURI(ctx context.Context, uri string) (*gtsmodel.Account, db.Error) {
+func (a *accountDB) GetAccountByInboxURI(ctx context.Context, uri string) (*gtsmodel.Account, error) {
 	return a.getAccount(
 		ctx,
 		"InboxURI",
@@ -167,7 +167,7 @@ func (a *accountDB) GetAccountByInboxURI(ctx context.Context, uri string) (*gtsm
 	)
 }
 
-func (a *accountDB) GetAccountByOutboxURI(ctx context.Context, uri string) (*gtsmodel.Account, db.Error) {
+func (a *accountDB) GetAccountByOutboxURI(ctx context.Context, uri string) (*gtsmodel.Account, error) {
 	return a.getAccount(
 		ctx,
 		"OutboxURI",
@@ -181,7 +181,7 @@ func (a *accountDB) GetAccountByOutboxURI(ctx context.Context, uri string) (*gts
 	)
 }
 
-func (a *accountDB) GetAccountByFollowersURI(ctx context.Context, uri string) (*gtsmodel.Account, db.Error) {
+func (a *accountDB) GetAccountByFollowersURI(ctx context.Context, uri string) (*gtsmodel.Account, error) {
 	return a.getAccount(
 		ctx,
 		"FollowersURI",
@@ -195,7 +195,7 @@ func (a *accountDB) GetAccountByFollowersURI(ctx context.Context, uri string) (*
 	)
 }
 
-func (a *accountDB) GetAccountByFollowingURI(ctx context.Context, uri string) (*gtsmodel.Account, db.Error) {
+func (a *accountDB) GetAccountByFollowingURI(ctx context.Context, uri string) (*gtsmodel.Account, error) {
 	return a.getAccount(
 		ctx,
 		"FollowingURI",
@@ -209,7 +209,7 @@ func (a *accountDB) GetAccountByFollowingURI(ctx context.Context, uri string) (*
 	)
 }
 
-func (a *accountDB) GetInstanceAccount(ctx context.Context, domain string) (*gtsmodel.Account, db.Error) {
+func (a *accountDB) GetInstanceAccount(ctx context.Context, domain string) (*gtsmodel.Account, error) {
 	var username string
 
 	if domain == "" {
@@ -223,7 +223,7 @@ func (a *accountDB) GetInstanceAccount(ctx context.Context, domain string) (*gts
 	return a.GetAccountByUsernameDomain(ctx, username, domain)
 }
 
-func (a *accountDB) getAccount(ctx context.Context, lookup string, dbQuery func(*gtsmodel.Account) error, keyParts ...any) (*gtsmodel.Account, db.Error) {
+func (a *accountDB) getAccount(ctx context.Context, lookup string, dbQuery func(*gtsmodel.Account) error, keyParts ...any) (*gtsmodel.Account, error) {
 	// Fetch account from database cache with loader callback
 	account, err := a.state.Caches.GTS.Account().Load(lookup, func() (*gtsmodel.Account, error) {
 		var account gtsmodel.Account
@@ -294,7 +294,7 @@ func (a *accountDB) PopulateAccount(ctx context.Context, account *gtsmodel.Accou
 	return errs.Combine()
 }
 
-func (a *accountDB) PutAccount(ctx context.Context, account *gtsmodel.Account) db.Error {
+func (a *accountDB) PutAccount(ctx context.Context, account *gtsmodel.Account) error {
 	return a.state.Caches.GTS.Account().Store(account, func() error {
 		// It is safe to run this database transaction within cache.Store
 		// as the cache does not attempt a mutex lock until AFTER hook.
@@ -317,7 +317,7 @@ func (a *accountDB) PutAccount(ctx context.Context, account *gtsmodel.Account) d
 	})
 }
 
-func (a *accountDB) UpdateAccount(ctx context.Context, account *gtsmodel.Account, columns ...string) db.Error {
+func (a *accountDB) UpdateAccount(ctx context.Context, account *gtsmodel.Account, columns ...string) error {
 	account.UpdatedAt = time.Now()
 	if len(columns) > 0 {
 		// If we're updating by column, ensure "updated_at" is included.
@@ -362,7 +362,7 @@ func (a *accountDB) UpdateAccount(ctx context.Context, account *gtsmodel.Account
 	})
 }
 
-func (a *accountDB) DeleteAccount(ctx context.Context, id string) db.Error {
+func (a *accountDB) DeleteAccount(ctx context.Context, id string) error {
 	defer a.state.Caches.GTS.Account().Invalidate("ID", id)
 
 	// Load account into cache before attempting a delete,
@@ -396,7 +396,7 @@ func (a *accountDB) DeleteAccount(ctx context.Context, id string) db.Error {
 	})
 }
 
-func (a *accountDB) GetAccountLastPosted(ctx context.Context, accountID string, webOnly bool) (time.Time, db.Error) {
+func (a *accountDB) GetAccountLastPosted(ctx context.Context, accountID string, webOnly bool) (time.Time, error) {
 	createdAt := time.Time{}
 
 	q := a.conn.
@@ -421,7 +421,7 @@ func (a *accountDB) GetAccountLastPosted(ctx context.Context, accountID string, 
 	return createdAt, nil
 }
 
-func (a *accountDB) SetAccountHeaderOrAvatar(ctx context.Context, mediaAttachment *gtsmodel.MediaAttachment, accountID string) db.Error {
+func (a *accountDB) SetAccountHeaderOrAvatar(ctx context.Context, mediaAttachment *gtsmodel.MediaAttachment, accountID string) error {
 	if *mediaAttachment.Avatar && *mediaAttachment.Header {
 		return errors.New("one media attachment cannot be both header and avatar")
 	}
@@ -456,7 +456,7 @@ func (a *accountDB) SetAccountHeaderOrAvatar(ctx context.Context, mediaAttachmen
 	return nil
 }
 
-func (a *accountDB) GetAccountCustomCSSByUsername(ctx context.Context, username string) (string, db.Error) {
+func (a *accountDB) GetAccountCustomCSSByUsername(ctx context.Context, username string) (string, error) {
 	account, err := a.GetAccountByUsernameDomain(ctx, username, "")
 	if err != nil {
 		return "", err
@@ -493,7 +493,7 @@ func (a *accountDB) GetAccountsUsingEmoji(ctx context.Context, emojiID string) (
 	return a.GetAccountsByIDs(ctx, accountIDs)
 }
 
-func (a *accountDB) GetAccountFaves(ctx context.Context, accountID string) ([]*gtsmodel.StatusFave, db.Error) {
+func (a *accountDB) GetAccountFaves(ctx context.Context, accountID string) ([]*gtsmodel.StatusFave, error) {
 	faves := new([]*gtsmodel.StatusFave)
 
 	if err := a.conn.
@@ -507,7 +507,7 @@ func (a *accountDB) GetAccountFaves(ctx context.Context, accountID string) ([]*g
 	return *faves, nil
 }
 
-func (a *accountDB) CountAccountStatuses(ctx context.Context, accountID string) (int, db.Error) {
+func (a *accountDB) CountAccountStatuses(ctx context.Context, accountID string) (int, error) {
 	return a.conn.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("statuses"), bun.Ident("status")).
@@ -515,7 +515,7 @@ func (a *accountDB) CountAccountStatuses(ctx context.Context, accountID string) 
 		Count(ctx)
 }
 
-func (a *accountDB) CountAccountPinned(ctx context.Context, accountID string) (int, db.Error) {
+func (a *accountDB) CountAccountPinned(ctx context.Context, accountID string) (int, error) {
 	return a.conn.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("statuses"), bun.Ident("status")).
@@ -524,7 +524,7 @@ func (a *accountDB) CountAccountPinned(ctx context.Context, accountID string) (i
 		Count(ctx)
 }
 
-func (a *accountDB) GetAccountStatuses(ctx context.Context, accountID string, limit int, excludeReplies bool, excludeReblogs bool, maxID string, minID string, mediaOnly bool, publicOnly bool) ([]*gtsmodel.Status, db.Error) {
+func (a *accountDB) GetAccountStatuses(ctx context.Context, accountID string, limit int, excludeReplies bool, excludeReblogs bool, maxID string, minID string, mediaOnly bool, publicOnly bool) ([]*gtsmodel.Status, error) {
 	// Ensure reasonable
 	if limit < 0 {
 		limit = 0
@@ -628,7 +628,7 @@ func (a *accountDB) GetAccountStatuses(ctx context.Context, accountID string, li
 	return a.statusesFromIDs(ctx, statusIDs)
 }
 
-func (a *accountDB) GetAccountPinnedStatuses(ctx context.Context, accountID string) ([]*gtsmodel.Status, db.Error) {
+func (a *accountDB) GetAccountPinnedStatuses(ctx context.Context, accountID string) ([]*gtsmodel.Status, error) {
 	statusIDs := []string{}
 
 	q := a.conn.
@@ -646,7 +646,7 @@ func (a *accountDB) GetAccountPinnedStatuses(ctx context.Context, accountID stri
 	return a.statusesFromIDs(ctx, statusIDs)
 }
 
-func (a *accountDB) GetAccountWebStatuses(ctx context.Context, accountID string, limit int, maxID string) ([]*gtsmodel.Status, db.Error) {
+func (a *accountDB) GetAccountWebStatuses(ctx context.Context, accountID string, limit int, maxID string) ([]*gtsmodel.Status, error) {
 	// Ensure reasonable
 	if limit < 0 {
 		limit = 0
@@ -694,7 +694,7 @@ func (a *accountDB) GetAccountWebStatuses(ctx context.Context, accountID string,
 	return a.statusesFromIDs(ctx, statusIDs)
 }
 
-func (a *accountDB) GetAccountBlocks(ctx context.Context, accountID string, maxID string, sinceID string, limit int) ([]*gtsmodel.Account, string, string, db.Error) {
+func (a *accountDB) GetAccountBlocks(ctx context.Context, accountID string, maxID string, sinceID string, limit int) ([]*gtsmodel.Account, string, string, error) {
 	blocks := []*gtsmodel.Block{}
 
 	fq := a.conn.
@@ -734,7 +734,7 @@ func (a *accountDB) GetAccountBlocks(ctx context.Context, accountID string, maxI
 	return accounts, nextMaxID, prevMinID, nil
 }
 
-func (a *accountDB) statusesFromIDs(ctx context.Context, statusIDs []string) ([]*gtsmodel.Status, db.Error) {
+func (a *accountDB) statusesFromIDs(ctx context.Context, statusIDs []string) ([]*gtsmodel.Status, error) {
 	// Catch case of no statuses early
 	if len(statusIDs) == 0 {
 		return nil, db.ErrNoEntries

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -562,7 +562,7 @@ func (a *accountDB) GetAccountStatuses(ctx context.Context, accountID string, li
 		// implementation differs between SQLite and Postgres,
 		// so we have to be thorough to cover all eventualities
 		q = q.WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
-			switch a.conn.db.Dialect().Name() {
+			switch a.conn.Dialect().Name() {
 			case dialect.PG:
 				return q.
 					Where("? IS NOT NULL", bun.Ident("status.attachments")).

--- a/internal/db/bundb/account_test.go
+++ b/internal/db/bundb/account_test.go
@@ -260,7 +260,7 @@ func (suite *AccountTestSuite) TestUpdateAccount() {
 	}
 
 	noCache := &gtsmodel.Account{}
-	err = dbService.GetConn().
+	err = dbService.DB().
 		NewSelect().
 		Model(noCache).
 		Where("? = ?", bun.Ident("account.id"), testAccount.ID).
@@ -288,7 +288,7 @@ func (suite *AccountTestSuite) TestUpdateAccount() {
 	suite.Empty(updated.EmojiIDs)
 	suite.WithinDuration(time.Now(), updated.UpdatedAt, 5*time.Second)
 
-	err = dbService.GetConn().
+	err = dbService.DB().
 		NewSelect().
 		Model(noCache).
 		Where("? = ?", bun.Ident("account.id"), testAccount.ID).

--- a/internal/db/bundb/admin.go
+++ b/internal/db/bundb/admin.go
@@ -48,7 +48,7 @@ type adminDB struct {
 	state *state.State
 }
 
-func (a *adminDB) IsUsernameAvailable(ctx context.Context, username string) (bool, db.Error) {
+func (a *adminDB) IsUsernameAvailable(ctx context.Context, username string) (bool, error) {
 	q := a.conn.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("accounts"), bun.Ident("account")).
@@ -58,7 +58,7 @@ func (a *adminDB) IsUsernameAvailable(ctx context.Context, username string) (boo
 	return a.conn.NotExists(ctx, q)
 }
 
-func (a *adminDB) IsEmailAvailable(ctx context.Context, email string) (bool, db.Error) {
+func (a *adminDB) IsEmailAvailable(ctx context.Context, email string) (bool, error) {
 	// parse the domain from the email
 	m, err := mail.ParseAddress(email)
 	if err != nil {
@@ -90,7 +90,7 @@ func (a *adminDB) IsEmailAvailable(ctx context.Context, email string) (bool, db.
 	return a.conn.NotExists(ctx, q)
 }
 
-func (a *adminDB) NewSignup(ctx context.Context, newSignup gtsmodel.NewSignup) (*gtsmodel.User, db.Error) {
+func (a *adminDB) NewSignup(ctx context.Context, newSignup gtsmodel.NewSignup) (*gtsmodel.User, error) {
 	// If something went wrong previously while doing a new
 	// sign up with this username, we might already have an
 	// account, so check first.
@@ -220,7 +220,7 @@ func (a *adminDB) NewSignup(ctx context.Context, newSignup gtsmodel.NewSignup) (
 	return user, nil
 }
 
-func (a *adminDB) CreateInstanceAccount(ctx context.Context) db.Error {
+func (a *adminDB) CreateInstanceAccount(ctx context.Context) error {
 	username := config.GetHost()
 
 	q := a.conn.
@@ -277,7 +277,7 @@ func (a *adminDB) CreateInstanceAccount(ctx context.Context) db.Error {
 	return nil
 }
 
-func (a *adminDB) CreateInstanceInstance(ctx context.Context) db.Error {
+func (a *adminDB) CreateInstanceInstance(ctx context.Context) error {
 	protocol := config.GetProtocol()
 	host := config.GetHost()
 

--- a/internal/db/bundb/admin.go
+++ b/internal/db/bundb/admin.go
@@ -44,18 +44,18 @@ import (
 const rsaKeyBits = 2048
 
 type adminDB struct {
-	conn  *DBConn
+	db    *WrappedDB
 	state *state.State
 }
 
 func (a *adminDB) IsUsernameAvailable(ctx context.Context, username string) (bool, error) {
-	q := a.conn.
+	q := a.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("accounts"), bun.Ident("account")).
 		Column("account.id").
 		Where("? = ?", bun.Ident("account.username"), username).
 		Where("? IS NULL", bun.Ident("account.domain"))
-	return a.conn.NotExists(ctx, q)
+	return a.db.NotExists(ctx, q)
 }
 
 func (a *adminDB) IsEmailAvailable(ctx context.Context, email string) (bool, error) {
@@ -67,12 +67,12 @@ func (a *adminDB) IsEmailAvailable(ctx context.Context, email string) (bool, err
 	domain := strings.Split(m.Address, "@")[1] // domain will always be the second part after @
 
 	// check if the email domain is blocked
-	emailDomainBlockedQ := a.conn.
+	emailDomainBlockedQ := a.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("email_domain_blocks"), bun.Ident("email_domain_block")).
 		Column("email_domain_block.id").
 		Where("? = ?", bun.Ident("email_domain_block.domain"), domain)
-	emailDomainBlocked, err := a.conn.Exists(ctx, emailDomainBlockedQ)
+	emailDomainBlocked, err := a.db.Exists(ctx, emailDomainBlockedQ)
 	if err != nil {
 		return false, err
 	}
@@ -81,13 +81,13 @@ func (a *adminDB) IsEmailAvailable(ctx context.Context, email string) (bool, err
 	}
 
 	// check if this email is associated with a user already
-	q := a.conn.
+	q := a.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("users"), bun.Ident("user")).
 		Column("user.id").
 		Where("? = ?", bun.Ident("user.email"), email).
 		WhereOr("? = ?", bun.Ident("user.unconfirmed_email"), email)
-	return a.conn.NotExists(ctx, q)
+	return a.db.NotExists(ctx, q)
 }
 
 func (a *adminDB) NewSignup(ctx context.Context, newSignup gtsmodel.NewSignup) (*gtsmodel.User, error) {
@@ -223,14 +223,14 @@ func (a *adminDB) NewSignup(ctx context.Context, newSignup gtsmodel.NewSignup) (
 func (a *adminDB) CreateInstanceAccount(ctx context.Context) error {
 	username := config.GetHost()
 
-	q := a.conn.
+	q := a.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("accounts"), bun.Ident("account")).
 		Column("account.id").
 		Where("? = ?", bun.Ident("account.username"), username).
 		Where("? IS NULL", bun.Ident("account.domain"))
 
-	exists, err := a.conn.Exists(ctx, q)
+	exists, err := a.db.Exists(ctx, q)
 	if err != nil {
 		return err
 	}
@@ -282,13 +282,13 @@ func (a *adminDB) CreateInstanceInstance(ctx context.Context) error {
 	host := config.GetHost()
 
 	// check if instance entry already exists
-	q := a.conn.
+	q := a.db.
 		NewSelect().
 		Column("instance.id").
 		TableExpr("? AS ?", bun.Ident("instances"), bun.Ident("instance")).
 		Where("? = ?", bun.Ident("instance.domain"), host)
 
-	exists, err := a.conn.Exists(ctx, q)
+	exists, err := a.db.Exists(ctx, q)
 	if err != nil {
 		return err
 	}
@@ -309,13 +309,13 @@ func (a *adminDB) CreateInstanceInstance(ctx context.Context) error {
 		URI:    fmt.Sprintf("%s://%s", protocol, host),
 	}
 
-	insertQ := a.conn.
+	insertQ := a.db.
 		NewInsert().
 		Model(i)
 
 	_, err = insertQ.Exec(ctx)
 	if err != nil {
-		return a.conn.ProcessError(err)
+		return a.db.ProcessError(err)
 	}
 
 	log.Infof(ctx, "created instance instance %s with id %s", host, i.ID)

--- a/internal/db/bundb/basic.go
+++ b/internal/db/bundb/basic.go
@@ -28,22 +28,22 @@ import (
 )
 
 type basicDB struct {
-	conn *DBConn
+	db *WrappedDB
 }
 
 func (b *basicDB) Put(ctx context.Context, i interface{}) error {
-	_, err := b.conn.NewInsert().Model(i).Exec(ctx)
-	return b.conn.ProcessError(err)
+	_, err := b.db.NewInsert().Model(i).Exec(ctx)
+	return b.db.ProcessError(err)
 }
 
 func (b *basicDB) GetByID(ctx context.Context, id string, i interface{}) error {
-	q := b.conn.
+	q := b.db.
 		NewSelect().
 		Model(i).
 		Where("id = ?", id)
 
 	err := q.Scan(ctx)
-	return b.conn.ProcessError(err)
+	return b.db.ProcessError(err)
 }
 
 func (b *basicDB) GetWhere(ctx context.Context, where []db.Where, i interface{}) error {
@@ -51,31 +51,31 @@ func (b *basicDB) GetWhere(ctx context.Context, where []db.Where, i interface{})
 		return errors.New("no queries provided")
 	}
 
-	q := b.conn.NewSelect().Model(i)
+	q := b.db.NewSelect().Model(i)
 
 	selectWhere(q, where)
 
 	err := q.Scan(ctx)
-	return b.conn.ProcessError(err)
+	return b.db.ProcessError(err)
 }
 
 func (b *basicDB) GetAll(ctx context.Context, i interface{}) error {
-	q := b.conn.
+	q := b.db.
 		NewSelect().
 		Model(i)
 
 	err := q.Scan(ctx)
-	return b.conn.ProcessError(err)
+	return b.db.ProcessError(err)
 }
 
 func (b *basicDB) DeleteByID(ctx context.Context, id string, i interface{}) error {
-	q := b.conn.
+	q := b.db.
 		NewDelete().
 		Model(i).
 		Where("id = ?", id)
 
 	_, err := q.Exec(ctx)
-	return b.conn.ProcessError(err)
+	return b.db.ProcessError(err)
 }
 
 func (b *basicDB) DeleteWhere(ctx context.Context, where []db.Where, i interface{}) error {
@@ -83,40 +83,40 @@ func (b *basicDB) DeleteWhere(ctx context.Context, where []db.Where, i interface
 		return errors.New("no queries provided")
 	}
 
-	q := b.conn.
+	q := b.db.
 		NewDelete().
 		Model(i)
 
 	deleteWhere(q, where)
 
 	_, err := q.Exec(ctx)
-	return b.conn.ProcessError(err)
+	return b.db.ProcessError(err)
 }
 
 func (b *basicDB) UpdateByID(ctx context.Context, i interface{}, id string, columns ...string) error {
-	q := b.conn.
+	q := b.db.
 		NewUpdate().
 		Model(i).
 		Column(columns...).
 		Where("? = ?", bun.Ident("id"), id)
 
 	_, err := q.Exec(ctx)
-	return b.conn.ProcessError(err)
+	return b.db.ProcessError(err)
 }
 
 func (b *basicDB) UpdateWhere(ctx context.Context, where []db.Where, key string, value interface{}, i interface{}) error {
-	q := b.conn.NewUpdate().Model(i)
+	q := b.db.NewUpdate().Model(i)
 
 	updateWhere(q, where)
 
 	q = q.Set("? = ?", bun.Ident(key), value)
 
 	_, err := q.Exec(ctx)
-	return b.conn.ProcessError(err)
+	return b.db.ProcessError(err)
 }
 
 func (b *basicDB) CreateTable(ctx context.Context, i interface{}) error {
-	_, err := b.conn.NewCreateTable().Model(i).IfNotExists().Exec(ctx)
+	_, err := b.db.NewCreateTable().Model(i).IfNotExists().Exec(ctx)
 	return err
 }
 
@@ -155,15 +155,15 @@ func (b *basicDB) CreateAllTables(ctx context.Context) error {
 }
 
 func (b *basicDB) DropTable(ctx context.Context, i interface{}) error {
-	_, err := b.conn.NewDropTable().Model(i).IfExists().Exec(ctx)
-	return b.conn.ProcessError(err)
+	_, err := b.db.NewDropTable().Model(i).IfExists().Exec(ctx)
+	return b.db.ProcessError(err)
 }
 
 func (b *basicDB) IsHealthy(ctx context.Context) error {
-	return b.conn.DB.PingContext(ctx)
+	return b.db.DB.PingContext(ctx)
 }
 
 func (b *basicDB) Stop(ctx context.Context) error {
 	log.Info(ctx, "closing db connection")
-	return b.conn.DB.Close()
+	return b.db.DB.Close()
 }

--- a/internal/db/bundb/basic.go
+++ b/internal/db/bundb/basic.go
@@ -160,10 +160,10 @@ func (b *basicDB) DropTable(ctx context.Context, i interface{}) error {
 }
 
 func (b *basicDB) IsHealthy(ctx context.Context) error {
-	return b.conn.db.PingContext(ctx)
+	return b.conn.DB.PingContext(ctx)
 }
 
 func (b *basicDB) Stop(ctx context.Context) error {
 	log.Info(ctx, "closing db connection")
-	return b.conn.db.Close()
+	return b.conn.DB.Close()
 }

--- a/internal/db/bundb/basic.go
+++ b/internal/db/bundb/basic.go
@@ -31,12 +31,12 @@ type basicDB struct {
 	conn *DBConn
 }
 
-func (b *basicDB) Put(ctx context.Context, i interface{}) db.Error {
+func (b *basicDB) Put(ctx context.Context, i interface{}) error {
 	_, err := b.conn.NewInsert().Model(i).Exec(ctx)
 	return b.conn.ProcessError(err)
 }
 
-func (b *basicDB) GetByID(ctx context.Context, id string, i interface{}) db.Error {
+func (b *basicDB) GetByID(ctx context.Context, id string, i interface{}) error {
 	q := b.conn.
 		NewSelect().
 		Model(i).
@@ -46,7 +46,7 @@ func (b *basicDB) GetByID(ctx context.Context, id string, i interface{}) db.Erro
 	return b.conn.ProcessError(err)
 }
 
-func (b *basicDB) GetWhere(ctx context.Context, where []db.Where, i interface{}) db.Error {
+func (b *basicDB) GetWhere(ctx context.Context, where []db.Where, i interface{}) error {
 	if len(where) == 0 {
 		return errors.New("no queries provided")
 	}
@@ -59,7 +59,7 @@ func (b *basicDB) GetWhere(ctx context.Context, where []db.Where, i interface{})
 	return b.conn.ProcessError(err)
 }
 
-func (b *basicDB) GetAll(ctx context.Context, i interface{}) db.Error {
+func (b *basicDB) GetAll(ctx context.Context, i interface{}) error {
 	q := b.conn.
 		NewSelect().
 		Model(i)
@@ -68,7 +68,7 @@ func (b *basicDB) GetAll(ctx context.Context, i interface{}) db.Error {
 	return b.conn.ProcessError(err)
 }
 
-func (b *basicDB) DeleteByID(ctx context.Context, id string, i interface{}) db.Error {
+func (b *basicDB) DeleteByID(ctx context.Context, id string, i interface{}) error {
 	q := b.conn.
 		NewDelete().
 		Model(i).
@@ -78,7 +78,7 @@ func (b *basicDB) DeleteByID(ctx context.Context, id string, i interface{}) db.E
 	return b.conn.ProcessError(err)
 }
 
-func (b *basicDB) DeleteWhere(ctx context.Context, where []db.Where, i interface{}) db.Error {
+func (b *basicDB) DeleteWhere(ctx context.Context, where []db.Where, i interface{}) error {
 	if len(where) == 0 {
 		return errors.New("no queries provided")
 	}
@@ -93,7 +93,7 @@ func (b *basicDB) DeleteWhere(ctx context.Context, where []db.Where, i interface
 	return b.conn.ProcessError(err)
 }
 
-func (b *basicDB) UpdateByID(ctx context.Context, i interface{}, id string, columns ...string) db.Error {
+func (b *basicDB) UpdateByID(ctx context.Context, i interface{}, id string, columns ...string) error {
 	q := b.conn.
 		NewUpdate().
 		Model(i).
@@ -104,7 +104,7 @@ func (b *basicDB) UpdateByID(ctx context.Context, i interface{}, id string, colu
 	return b.conn.ProcessError(err)
 }
 
-func (b *basicDB) UpdateWhere(ctx context.Context, where []db.Where, key string, value interface{}, i interface{}) db.Error {
+func (b *basicDB) UpdateWhere(ctx context.Context, where []db.Where, key string, value interface{}, i interface{}) error {
 	q := b.conn.NewUpdate().Model(i)
 
 	updateWhere(q, where)
@@ -115,12 +115,12 @@ func (b *basicDB) UpdateWhere(ctx context.Context, where []db.Where, key string,
 	return b.conn.ProcessError(err)
 }
 
-func (b *basicDB) CreateTable(ctx context.Context, i interface{}) db.Error {
+func (b *basicDB) CreateTable(ctx context.Context, i interface{}) error {
 	_, err := b.conn.NewCreateTable().Model(i).IfNotExists().Exec(ctx)
 	return err
 }
 
-func (b *basicDB) CreateAllTables(ctx context.Context) db.Error {
+func (b *basicDB) CreateAllTables(ctx context.Context) error {
 	models := []interface{}{
 		&gtsmodel.Account{},
 		&gtsmodel.Application{},
@@ -154,16 +154,16 @@ func (b *basicDB) CreateAllTables(ctx context.Context) db.Error {
 	return nil
 }
 
-func (b *basicDB) DropTable(ctx context.Context, i interface{}) db.Error {
+func (b *basicDB) DropTable(ctx context.Context, i interface{}) error {
 	_, err := b.conn.NewDropTable().Model(i).IfExists().Exec(ctx)
 	return b.conn.ProcessError(err)
 }
 
-func (b *basicDB) IsHealthy(ctx context.Context) db.Error {
-	return b.conn.PingContext(ctx)
+func (b *basicDB) IsHealthy(ctx context.Context) error {
+	return b.conn.db.PingContext(ctx)
 }
 
-func (b *basicDB) Stop(ctx context.Context) db.Error {
+func (b *basicDB) Stop(ctx context.Context) error {
 	log.Info(ctx, "closing db connection")
-	return b.conn.Close()
+	return b.conn.db.Close()
 }

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -326,9 +326,9 @@ func sqliteConn(ctx context.Context) (*DBConn, error) {
 	// Tune db connections for sqlite, see:
 	// - https://bun.uptrace.dev/guide/running-bun-in-production.html#database-sql
 	// - https://www.alexedwards.net/blog/configuring-sqldb
-	sqldb.SetMaxOpenConns(1)    // only 1 connection regardless of multiplier, see https://github.com/superseriousbusiness/gotosocial/issues/1407
-	sqldb.SetMaxIdleConns(1)    // only keep max 1 idle connection around
-	sqldb.SetConnMaxLifetime(0) // don't kill connections due to age
+	sqldb.SetMaxOpenConns(maxOpenConns()) // x number of conns per CPU
+	sqldb.SetMaxIdleConns(1)              // only keep max 1 idle connection around
+	sqldb.SetConnMaxLifetime(0)           // don't kill connections due to age
 
 	// Wrap Bun database conn in our own wrapper
 	conn := WrapDBConn(bun.NewDB(sqldb, sqlitedialect.New()))

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -132,9 +132,9 @@ func NewBunDBService(ctx context.Context, state *state.State) (db.DB, error) {
 	}
 
 	// Add database query hooks.
-	conn.db.AddQueryHook(queryHook{})
+	conn.DB.AddQueryHook(queryHook{})
 	if config.GetTracingEnabled() {
-		conn.db.AddQueryHook(tracing.InstrumentBun())
+		conn.DB.AddQueryHook(tracing.InstrumentBun())
 	}
 
 	// execute sqlite pragmas *after* adding database hook;
@@ -148,13 +148,13 @@ func NewBunDBService(ctx context.Context, state *state.State) (db.DB, error) {
 	// table registration is needed for many-to-many, see:
 	// https://bun.uptrace.dev/orm/many-to-many-relation/
 	for _, t := range registerTables {
-		conn.db.RegisterModel(t)
+		conn.DB.RegisterModel(t)
 	}
 
 	// perform any pending database migrations: this includes
 	// the very first 'migration' on startup which just creates
 	// necessary tables
-	if err := doMigration(ctx, conn.db); err != nil {
+	if err := doMigration(ctx, conn.DB); err != nil {
 		return nil, fmt.Errorf("db migration error: %s", err)
 	}
 
@@ -262,7 +262,7 @@ func pgConn(ctx context.Context) (*DBConn, error) {
 	conn := WrapDBConn(bun.NewDB(sqldb, pgdialect.New()))
 
 	// ping to check the db is there and listening
-	if err := conn.db.PingContext(ctx); err != nil {
+	if err := conn.DB.PingContext(ctx); err != nil {
 		return nil, fmt.Errorf("postgres ping: %s", err)
 	}
 
@@ -334,7 +334,7 @@ func sqliteConn(ctx context.Context) (*DBConn, error) {
 	conn := WrapDBConn(bun.NewDB(sqldb, sqlitedialect.New()))
 
 	// ping to check the db is there and listening
-	if err := conn.db.PingContext(ctx); err != nil {
+	if err := conn.DB.PingContext(ctx); err != nil {
 		if errWithCode, ok := err.(*sqlite.Error); ok {
 			err = errors.New(sqlite.ErrorCodeString[errWithCode.Code()])
 		}

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -79,13 +79,13 @@ type DBService struct {
 	db.Timeline
 	db.User
 	db.Tombstone
-	conn *DBConn
+	db *WrappedDB
 }
 
-// GetConn returns the underlying bun connection.
+// GetDB returns the underlying database connection pool.
 // Should only be used in testing + exceptional circumstance.
-func (dbService *DBService) GetConn() *DBConn {
-	return dbService.conn
+func (dbService *DBService) DB() *WrappedDB {
+	return dbService.db
 }
 
 func doMigration(ctx context.Context, db *bun.DB) error {
@@ -112,18 +112,18 @@ func doMigration(ctx context.Context, db *bun.DB) error {
 // NewBunDBService returns a bunDB derived from the provided config, which implements the go-fed DB interface.
 // Under the hood, it uses https://github.com/uptrace/bun to create and maintain a database connection.
 func NewBunDBService(ctx context.Context, state *state.State) (db.DB, error) {
-	var conn *DBConn
+	var db *WrappedDB
 	var err error
 	t := strings.ToLower(config.GetDbType())
 
 	switch t {
 	case "postgres":
-		conn, err = pgConn(ctx)
+		db, err = pgConn(ctx)
 		if err != nil {
 			return nil, err
 		}
 	case "sqlite":
-		conn, err = sqliteConn(ctx)
+		db, err = sqliteConn(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -132,15 +132,15 @@ func NewBunDBService(ctx context.Context, state *state.State) (db.DB, error) {
 	}
 
 	// Add database query hooks.
-	conn.DB.AddQueryHook(queryHook{})
+	db.AddQueryHook(queryHook{})
 	if config.GetTracingEnabled() {
-		conn.DB.AddQueryHook(tracing.InstrumentBun())
+		db.AddQueryHook(tracing.InstrumentBun())
 	}
 
 	// execute sqlite pragmas *after* adding database hook;
 	// this allows the pragma queries to be logged
 	if t == "sqlite" {
-		if err := sqlitePragmas(ctx, conn); err != nil {
+		if err := sqlitePragmas(ctx, db); err != nil {
 			return nil, err
 		}
 	}
@@ -148,103 +148,103 @@ func NewBunDBService(ctx context.Context, state *state.State) (db.DB, error) {
 	// table registration is needed for many-to-many, see:
 	// https://bun.uptrace.dev/orm/many-to-many-relation/
 	for _, t := range registerTables {
-		conn.DB.RegisterModel(t)
+		db.RegisterModel(t)
 	}
 
 	// perform any pending database migrations: this includes
 	// the very first 'migration' on startup which just creates
 	// necessary tables
-	if err := doMigration(ctx, conn.DB); err != nil {
+	if err := doMigration(ctx, db.DB); err != nil {
 		return nil, fmt.Errorf("db migration error: %s", err)
 	}
 
 	ps := &DBService{
 		Account: &accountDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		Admin: &adminDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		Basic: &basicDB{
-			conn: conn,
+			db: db,
 		},
 		Domain: &domainDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		Emoji: &emojiDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		Instance: &instanceDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		List: &listDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		Media: &mediaDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		Mention: &mentionDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		Notification: &notificationDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		Relationship: &relationshipDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		Report: &reportDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		Search: &searchDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		Session: &sessionDB{
-			conn: conn,
+			db: db,
 		},
 		Status: &statusDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		StatusBookmark: &statusBookmarkDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		StatusFave: &statusFaveDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		Timeline: &timelineDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		User: &userDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
 		Tombstone: &tombstoneDB{
-			conn:  conn,
+			db:    db,
 			state: state,
 		},
-		conn: conn,
+		db: db,
 	}
 
 	// we can confidently return this useable service now
 	return ps, nil
 }
 
-func pgConn(ctx context.Context) (*DBConn, error) {
+func pgConn(ctx context.Context) (*WrappedDB, error) {
 	opts, err := deriveBunDBPGOptions() //nolint:contextcheck
 	if err != nil {
 		return nil, fmt.Errorf("could not create bundb postgres options: %s", err)
@@ -259,7 +259,7 @@ func pgConn(ctx context.Context) (*DBConn, error) {
 	sqldb.SetMaxIdleConns(2)                  // assume default 2; if max idle is less than max open, it will be automatically adjusted
 	sqldb.SetConnMaxLifetime(5 * time.Minute) // fine to kill old connections
 
-	conn := WrapDBConn(bun.NewDB(sqldb, pgdialect.New()))
+	conn := WrapDB(bun.NewDB(sqldb, pgdialect.New()))
 
 	// ping to check the db is there and listening
 	if err := conn.DB.PingContext(ctx); err != nil {
@@ -270,7 +270,7 @@ func pgConn(ctx context.Context) (*DBConn, error) {
 	return conn, nil
 }
 
-func sqliteConn(ctx context.Context) (*DBConn, error) {
+func sqliteConn(ctx context.Context) (*WrappedDB, error) {
 	// validate db address has actually been set
 	address := config.GetDbAddress()
 	if address == "" {
@@ -331,7 +331,7 @@ func sqliteConn(ctx context.Context) (*DBConn, error) {
 	sqldb.SetConnMaxLifetime(0)           // don't kill connections due to age
 
 	// Wrap Bun database conn in our own wrapper
-	conn := WrapDBConn(bun.NewDB(sqldb, sqlitedialect.New()))
+	conn := WrapDB(bun.NewDB(sqldb, sqlitedialect.New()))
 
 	// ping to check the db is there and listening
 	if err := conn.DB.PingContext(ctx); err != nil {
@@ -445,7 +445,7 @@ func deriveBunDBPGOptions() (*pgx.ConnConfig, error) {
 
 // sqlitePragmas sets desired sqlite pragmas based on configured values, and
 // logs the results of the pragma queries. Errors if something goes wrong.
-func sqlitePragmas(ctx context.Context, conn *DBConn) error {
+func sqlitePragmas(ctx context.Context, db *WrappedDB) error {
 	var pragmas [][]string
 	if mode := config.GetDbSqliteJournalMode(); mode != "" {
 		// Set the user provided SQLite journal mode
@@ -475,12 +475,12 @@ func sqlitePragmas(ctx context.Context, conn *DBConn) error {
 		pk := p[0]
 		pv := p[1]
 
-		if _, err := conn.ExecContext(ctx, "PRAGMA ?=?", bun.Ident(pk), bun.Safe(pv)); err != nil {
+		if _, err := db.ExecContext(ctx, "PRAGMA ?=?", bun.Ident(pk), bun.Safe(pv)); err != nil {
 			return fmt.Errorf("error executing sqlite pragma %s: %w", pk, err)
 		}
 
 		var res string
-		if err := conn.NewRaw("PRAGMA ?", bun.Ident(pk)).Scan(ctx, &res); err != nil {
+		if err := db.NewRaw("PRAGMA ?", bun.Ident(pk)).Scan(ctx, &res); err != nil {
 			return fmt.Errorf("error scanning sqlite pragma %s: %w", pv, err)
 		}
 
@@ -502,7 +502,7 @@ func (dbService *DBService) TagStringToTag(ctx context.Context, t string, origin
 	tag := &gtsmodel.Tag{}
 	// we can use selectorinsert here to create the new tag if it doesn't exist already
 	// inserted will be true if this is a new tag we just created
-	if err := dbService.conn.NewSelect().Model(tag).Where("LOWER(?) = LOWER(?)", bun.Ident("name"), t).Scan(ctx); err != nil && err != sql.ErrNoRows {
+	if err := dbService.db.NewSelect().Model(tag).Where("LOWER(?) = LOWER(?)", bun.Ident("name"), t).Scan(ctx); err != nil && err != sql.ErrNoRows {
 		return nil, fmt.Errorf("error getting tag with name %s: %s", t, err)
 	}
 

--- a/internal/db/bundb/conn.go
+++ b/internal/db/bundb/conn.go
@@ -20,6 +20,8 @@ package bundb
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"time"
 
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/uptrace/bun"
@@ -28,13 +30,13 @@ import (
 
 // DBConn wrapps a bun.DB conn to provide SQL-type specific additional functionality
 type DBConn struct {
-	errProc func(error) db.Error // errProc is the SQL-type specific error processor
-	*bun.DB                      // DB is the underlying bun.DB connection
+	errProc func(error) error // errProc is the SQL-type specific error processor
+	db      *bun.DB           // DB is the underlying bun.DB connection
 }
 
 // WrapDBConn wraps a bun DB connection to provide our own error processing dependent on DB dialect.
 func WrapDBConn(dbConn *bun.DB) *DBConn {
-	var errProc func(error) db.Error
+	var errProc func(error) error
 	switch dbConn.Dialect().Name() {
 	case dialect.PG:
 		errProc = processPostgresError
@@ -45,61 +47,151 @@ func WrapDBConn(dbConn *bun.DB) *DBConn {
 	}
 	return &DBConn{
 		errProc: errProc,
-		DB:      dbConn,
+		db:      dbConn,
 	}
 }
 
-// RunInTx wraps execution of the supplied transaction function.
-func (conn *DBConn) RunInTx(ctx context.Context, fn func(bun.Tx) error) db.Error {
-	return conn.ProcessError(func() error {
-		// Acquire a new transaction
-		tx, err := conn.BeginTx(ctx, nil)
-		if err != nil {
-			return err
-		}
-
-		var done bool
-
-		defer func() {
-			if !done {
-				_ = tx.Rollback()
-			}
-		}()
-
-		// Perform supplied transaction
-		if err := fn(tx); err != nil {
-			return err
-		}
-
-		// Finally, commit
-		err = tx.Commit() //nolint:contextcheck
-		done = true
+func (conn *DBConn) BeginTx(ctx context.Context, opts *sql.TxOptions) (tx bun.Tx, err error) {
+	err = retryOnBusy(ctx, func() error {
+		tx, err = conn.db.BeginTx(ctx, opts)
+		err = conn.ProcessError(err)
 		return err
-	}())
+	})
+	return
 }
 
-// ProcessError processes an error to replace any known values with our own db.Error types,
-// making it easier to catch specific situations (e.g. no rows, already exists, etc)
-func (conn *DBConn) ProcessError(err error) db.Error {
-	switch {
-	case err == nil:
-		return nil
-	case err == sql.ErrNoRows:
-		return db.ErrNoEntries
-	default:
+func (conn *DBConn) ExecContext(ctx context.Context, query string, args ...any) (result sql.Result, err error) {
+	err = retryOnBusy(ctx, func() error {
+		result, err = conn.db.ExecContext(ctx, query, args...)
+		err = conn.ProcessError(err)
+		return err
+	})
+	return
+}
+
+func (conn *DBConn) QueryContext(ctx context.Context, query string, args ...any) (rows *sql.Rows, err error) {
+	err = retryOnBusy(ctx, func() error {
+		rows, err = conn.db.QueryContext(ctx, query, args...)
+		err = conn.ProcessError(err)
+		return err
+	})
+	return
+}
+
+func (conn *DBConn) QueryRowContext(ctx context.Context, query string, args ...any) (row *sql.Row) {
+	_ = retryOnBusy(ctx, func() error {
+		row = conn.db.QueryRowContext(ctx, query, args...)
+		err := conn.ProcessError(row.Err())
+		return err
+	})
+	return
+}
+
+func (conn *DBConn) RunInTx(ctx context.Context, fn func(bun.Tx) error) error {
+	// Attempt to start new transaction.
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	var done bool
+
+	defer func() {
+		if !done {
+			// Rollback (with retry-backoff).
+			_ = retryOnBusy(ctx, func() error {
+				err := tx.Rollback()
+				return conn.errProc(err)
+			})
+		}
+	}()
+
+	// Perform supplied transaction
+	if err := fn(tx); err != nil {
 		return conn.errProc(err)
 	}
+
+	// Commit (with retry-backoff).
+	err = retryOnBusy(ctx, func() error {
+		err := tx.Commit()
+		return conn.errProc(err)
+	})
+	done = true
+	return err
+}
+
+func (conn *DBConn) NewValues(model interface{}) *bun.ValuesQuery {
+	return bun.NewValuesQuery(conn.db, model).Conn(conn)
+}
+
+func (conn *DBConn) NewMerge() *bun.MergeQuery {
+	return bun.NewMergeQuery(conn.db).Conn(conn)
+}
+
+func (conn *DBConn) NewSelect() *bun.SelectQuery {
+	return bun.NewSelectQuery(conn.db).Conn(conn)
+}
+
+func (conn *DBConn) NewInsert() *bun.InsertQuery {
+	return bun.NewInsertQuery(conn.db).Conn(conn)
+}
+
+func (conn *DBConn) NewUpdate() *bun.UpdateQuery {
+	return bun.NewUpdateQuery(conn.db).Conn(conn)
+}
+
+func (conn *DBConn) NewDelete() *bun.DeleteQuery {
+	return bun.NewDeleteQuery(conn.db).Conn(conn)
+}
+
+func (conn *DBConn) NewRaw(query string, args ...interface{}) *bun.RawQuery {
+	return bun.NewRawQuery(conn.db, query, args...).Conn(conn)
+}
+
+func (conn *DBConn) NewCreateTable() *bun.CreateTableQuery {
+	return bun.NewCreateTableQuery(conn.db).Conn(conn)
+}
+
+func (conn *DBConn) NewDropTable() *bun.DropTableQuery {
+	return bun.NewDropTableQuery(conn.db).Conn(conn)
+}
+
+func (conn *DBConn) NewCreateIndex() *bun.CreateIndexQuery {
+	return bun.NewCreateIndexQuery(conn.db).Conn(conn)
+}
+
+func (conn *DBConn) NewDropIndex() *bun.DropIndexQuery {
+	return bun.NewDropIndexQuery(conn.db).Conn(conn)
+}
+
+func (conn *DBConn) NewTruncateTable() *bun.TruncateTableQuery {
+	return bun.NewTruncateTableQuery(conn.db).Conn(conn)
+}
+
+func (conn *DBConn) NewAddColumn() *bun.AddColumnQuery {
+	return bun.NewAddColumnQuery(conn.db).Conn(conn)
+}
+
+func (conn *DBConn) NewDropColumn() *bun.DropColumnQuery {
+	return bun.NewDropColumnQuery(conn.db).Conn(conn)
+}
+
+// ProcessError processes an error to replace any known values with our own error types,
+// making it easier to catch specific situations (e.g. no rows, already exists, etc)
+func (conn *DBConn) ProcessError(err error) error {
+	if err == nil {
+		return err
+	}
+	return conn.errProc(err)
 }
 
 // Exists checks the results of a SelectQuery for the existence of the data in question, masking ErrNoEntries errors
-func (conn *DBConn) Exists(ctx context.Context, query *bun.SelectQuery) (bool, db.Error) {
+func (conn *DBConn) Exists(ctx context.Context, query *bun.SelectQuery) (bool, error) {
 	exists, err := query.Exists(ctx)
-
-	// Process error as our own and check if it exists
-	switch err := conn.ProcessError(err); err {
+	switch err {
 	case nil:
 		return exists, nil
-	case db.ErrNoEntries:
+	case sql.ErrNoRows:
 		return false, nil
 	default:
 		return false, err
@@ -107,7 +199,84 @@ func (conn *DBConn) Exists(ctx context.Context, query *bun.SelectQuery) (bool, d
 }
 
 // NotExists is the functional opposite of conn.Exists()
-func (conn *DBConn) NotExists(ctx context.Context, query *bun.SelectQuery) (bool, db.Error) {
+func (conn *DBConn) NotExists(ctx context.Context, query *bun.SelectQuery) (bool, error) {
 	exists, err := conn.Exists(ctx, query)
 	return !exists, err
+}
+
+const maxRetries = 5
+
+var backoffs = []time.Duration{
+	1 * time.Millisecond,
+	2 * time.Millisecond,
+	10 * time.Millisecond,
+	50 * time.Millisecond,
+	1 / 64 * time.Second,
+	1 / 32 * time.Second,
+	1 / 16 * time.Second,
+	1 / 8 * time.Second,
+	1 / 4 * time.Second,
+	1 / 2 * time.Second,
+	1 * time.Second,
+	2 * time.Second,
+	4 * time.Second,
+	8 * time.Second,
+}
+
+// retryOnBusy will retry given function on returned db.ErrBusyTimeout.
+func retryOnBusy(ctx context.Context, fn func() error) error {
+	const (
+		// max no. attempts.
+		maxRetries = 10
+
+		// base backoff duration multiplier.
+		baseBackoff = 2 * time.Millisecond
+	)
+
+	for i := 0; i < maxRetries; i += 2 {
+		// Perform func.
+		err := fn()
+
+		if err != db.ErrBusyTimeout {
+			// May be nil, or may be
+			// some other error, either
+			// way return here.
+			return err
+		}
+
+		// backoff according to a multiplier of 2^n.
+		backoff := baseBackoff * (1 << (i + 1))
+
+		select {
+		// Context cancelled.
+		case <-ctx.Done():
+
+		// Backoff for some time.
+		case <-time.After(backoff):
+		}
+	}
+
+	return fmt.Errorf("%w (waited > %s)", baseBackoff*(1<<maxRetries))
+}
+
+func retryBackoff(ctx context.Context, fn func() error, backoff time.Duration) (bool, error) {
+	// Perform func.
+	err := fn()
+
+	if err != db.ErrBusyTimeout {
+		// May be nil, or may be
+		// some other error, either
+		// way return here.
+		return false, err
+	}
+
+	select {
+	// Context cancelled.
+	case <-ctx.Done():
+
+	// Backoff for some time.
+	case <-time.After(backoff):
+	}
+
+	return true, nil
 }

--- a/internal/db/bundb/conn.go
+++ b/internal/db/bundb/conn.go
@@ -51,6 +51,7 @@ func WrapDBConn(dbConn *bun.DB) *DBConn {
 	}
 }
 
+// BeginTx wraps bun.DB.BeginTx() with retry-busy timeout.
 func (conn *DBConn) BeginTx(ctx context.Context, opts *sql.TxOptions) (tx bun.Tx, err error) {
 	err = retryOnBusy(ctx, func() error {
 		tx, err = conn.DB.BeginTx(ctx, opts)
@@ -60,6 +61,7 @@ func (conn *DBConn) BeginTx(ctx context.Context, opts *sql.TxOptions) (tx bun.Tx
 	return
 }
 
+// ExecContext wraps bun.DB.ExecContext() with retry-busy timeout.
 func (conn *DBConn) ExecContext(ctx context.Context, query string, args ...any) (result sql.Result, err error) {
 	err = retryOnBusy(ctx, func() error {
 		result, err = conn.DB.ExecContext(ctx, query, args...)
@@ -69,6 +71,7 @@ func (conn *DBConn) ExecContext(ctx context.Context, query string, args ...any) 
 	return
 }
 
+// QueryContext wraps bun.DB.QueryContext() with retry-busy timeout.
 func (conn *DBConn) QueryContext(ctx context.Context, query string, args ...any) (rows *sql.Rows, err error) {
 	err = retryOnBusy(ctx, func() error {
 		rows, err = conn.DB.QueryContext(ctx, query, args...)
@@ -78,6 +81,7 @@ func (conn *DBConn) QueryContext(ctx context.Context, query string, args ...any)
 	return
 }
 
+// QueryRowContext wraps bun.DB.QueryRowContext() with retry-busy timeout.
 func (conn *DBConn) QueryRowContext(ctx context.Context, query string, args ...any) (row *sql.Row) {
 	_ = retryOnBusy(ctx, func() error {
 		row = conn.DB.QueryRowContext(ctx, query, args...)
@@ -87,6 +91,7 @@ func (conn *DBConn) QueryRowContext(ctx context.Context, query string, args ...a
 	return
 }
 
+// RunInTx is functionally the same as bun.DB.RunInTx() but with retry-busy timeouts.
 func (conn *DBConn) RunInTx(ctx context.Context, fn func(bun.Tx) error) error {
 	// Attempt to start new transaction.
 	tx, err := conn.BeginTx(ctx, nil)
@@ -204,7 +209,7 @@ func (conn *DBConn) NotExists(ctx context.Context, query *bun.SelectQuery) (bool
 	return !exists, err
 }
 
-// retryOnBusy will retry given function on returned db.ErrBusyTimeout.
+// retryOnBusy will retry given function on returned 'errBusy'.
 func retryOnBusy(ctx context.Context, fn func() error) error {
 	const (
 		// max no. attempts.

--- a/internal/db/bundb/conn.go
+++ b/internal/db/bundb/conn.go
@@ -204,25 +204,6 @@ func (conn *DBConn) NotExists(ctx context.Context, query *bun.SelectQuery) (bool
 	return !exists, err
 }
 
-const maxRetries = 5
-
-var backoffs = []time.Duration{
-	1 * time.Millisecond,
-	2 * time.Millisecond,
-	10 * time.Millisecond,
-	50 * time.Millisecond,
-	1 / 64 * time.Second,
-	1 / 32 * time.Second,
-	1 / 16 * time.Second,
-	1 / 8 * time.Second,
-	1 / 4 * time.Second,
-	1 / 2 * time.Second,
-	1 * time.Second,
-	2 * time.Second,
-	4 * time.Second,
-	8 * time.Second,
-}
-
 // retryOnBusy will retry given function on returned db.ErrBusyTimeout.
 func retryOnBusy(ctx context.Context, fn func() error) error {
 	const (

--- a/internal/db/bundb/conn.go
+++ b/internal/db/bundb/conn.go
@@ -218,7 +218,7 @@ func retryOnBusy(ctx context.Context, fn func() error) error {
 		// Perform func.
 		err := fn()
 
-		if err != db.ErrBusyTimeout {
+		if err != errBusy {
 			// May be nil, or may be
 			// some other error, either
 			// way return here.

--- a/internal/db/bundb/conn.go
+++ b/internal/db/bundb/conn.go
@@ -62,7 +62,7 @@ func (conn *DBConn) BeginTx(ctx context.Context, opts *sql.TxOptions) (tx bun.Tx
 
 func (conn *DBConn) ExecContext(ctx context.Context, query string, args ...any) (result sql.Result, err error) {
 	err = retryOnBusy(ctx, func() error {
-		result, err = conn.db.ExecContext(ctx, query, args...)
+		result, err = conn.db.DB.ExecContext(ctx, query, args...)
 		err = conn.ProcessError(err)
 		return err
 	})
@@ -71,7 +71,7 @@ func (conn *DBConn) ExecContext(ctx context.Context, query string, args ...any) 
 
 func (conn *DBConn) QueryContext(ctx context.Context, query string, args ...any) (rows *sql.Rows, err error) {
 	err = retryOnBusy(ctx, func() error {
-		rows, err = conn.db.QueryContext(ctx, query, args...)
+		rows, err = conn.db.DB.QueryContext(ctx, query, args...)
 		err = conn.ProcessError(err)
 		return err
 	})
@@ -80,7 +80,7 @@ func (conn *DBConn) QueryContext(ctx context.Context, query string, args ...any)
 
 func (conn *DBConn) QueryRowContext(ctx context.Context, query string, args ...any) (row *sql.Row) {
 	_ = retryOnBusy(ctx, func() error {
-		row = conn.db.QueryRowContext(ctx, query, args...)
+		row = conn.db.DB.QueryRowContext(ctx, query, args...)
 		err := conn.ProcessError(row.Err())
 		return err
 	})

--- a/internal/db/bundb/conn.go
+++ b/internal/db/bundb/conn.go
@@ -180,7 +180,7 @@ func (conn *DBConn) NewDropColumn() *bun.DropColumnQuery {
 // making it easier to catch specific situations (e.g. no rows, already exists, etc)
 func (conn *DBConn) ProcessError(err error) error {
 	if err == nil {
-		return err
+		return nil
 	}
 	return conn.errProc(err)
 }

--- a/internal/db/bundb/conn.go
+++ b/internal/db/bundb/conn.go
@@ -31,7 +31,7 @@ import (
 // DBConn wrapps a bun.DB conn to provide SQL-type specific additional functionality
 type DBConn struct {
 	errProc func(error) error // errProc is the SQL-type specific error processor
-	db      *bun.DB           // DB is the underlying bun.DB connection
+	*bun.DB                   // DB is the underlying bun.DB connection
 }
 
 // WrapDBConn wraps a bun DB connection to provide our own error processing dependent on DB dialect.
@@ -47,13 +47,13 @@ func WrapDBConn(dbConn *bun.DB) *DBConn {
 	}
 	return &DBConn{
 		errProc: errProc,
-		db:      dbConn,
+		DB:      dbConn,
 	}
 }
 
 func (conn *DBConn) BeginTx(ctx context.Context, opts *sql.TxOptions) (tx bun.Tx, err error) {
 	err = retryOnBusy(ctx, func() error {
-		tx, err = conn.db.BeginTx(ctx, opts)
+		tx, err = conn.DB.BeginTx(ctx, opts)
 		err = conn.ProcessError(err)
 		return err
 	})
@@ -62,7 +62,7 @@ func (conn *DBConn) BeginTx(ctx context.Context, opts *sql.TxOptions) (tx bun.Tx
 
 func (conn *DBConn) ExecContext(ctx context.Context, query string, args ...any) (result sql.Result, err error) {
 	err = retryOnBusy(ctx, func() error {
-		result, err = conn.db.DB.ExecContext(ctx, query, args...)
+		result, err = conn.DB.ExecContext(ctx, query, args...)
 		err = conn.ProcessError(err)
 		return err
 	})
@@ -71,7 +71,7 @@ func (conn *DBConn) ExecContext(ctx context.Context, query string, args ...any) 
 
 func (conn *DBConn) QueryContext(ctx context.Context, query string, args ...any) (rows *sql.Rows, err error) {
 	err = retryOnBusy(ctx, func() error {
-		rows, err = conn.db.DB.QueryContext(ctx, query, args...)
+		rows, err = conn.DB.QueryContext(ctx, query, args...)
 		err = conn.ProcessError(err)
 		return err
 	})
@@ -80,7 +80,7 @@ func (conn *DBConn) QueryContext(ctx context.Context, query string, args ...any)
 
 func (conn *DBConn) QueryRowContext(ctx context.Context, query string, args ...any) (row *sql.Row) {
 	_ = retryOnBusy(ctx, func() error {
-		row = conn.db.DB.QueryRowContext(ctx, query, args...)
+		row = conn.DB.QueryRowContext(ctx, query, args...)
 		err := conn.ProcessError(row.Err())
 		return err
 	})
@@ -121,59 +121,59 @@ func (conn *DBConn) RunInTx(ctx context.Context, fn func(bun.Tx) error) error {
 }
 
 func (conn *DBConn) NewValues(model interface{}) *bun.ValuesQuery {
-	return bun.NewValuesQuery(conn.db, model).Conn(conn)
+	return bun.NewValuesQuery(conn.DB, model).Conn(conn)
 }
 
 func (conn *DBConn) NewMerge() *bun.MergeQuery {
-	return bun.NewMergeQuery(conn.db).Conn(conn)
+	return bun.NewMergeQuery(conn.DB).Conn(conn)
 }
 
 func (conn *DBConn) NewSelect() *bun.SelectQuery {
-	return bun.NewSelectQuery(conn.db).Conn(conn)
+	return bun.NewSelectQuery(conn.DB).Conn(conn)
 }
 
 func (conn *DBConn) NewInsert() *bun.InsertQuery {
-	return bun.NewInsertQuery(conn.db).Conn(conn)
+	return bun.NewInsertQuery(conn.DB).Conn(conn)
 }
 
 func (conn *DBConn) NewUpdate() *bun.UpdateQuery {
-	return bun.NewUpdateQuery(conn.db).Conn(conn)
+	return bun.NewUpdateQuery(conn.DB).Conn(conn)
 }
 
 func (conn *DBConn) NewDelete() *bun.DeleteQuery {
-	return bun.NewDeleteQuery(conn.db).Conn(conn)
+	return bun.NewDeleteQuery(conn.DB).Conn(conn)
 }
 
 func (conn *DBConn) NewRaw(query string, args ...interface{}) *bun.RawQuery {
-	return bun.NewRawQuery(conn.db, query, args...).Conn(conn)
+	return bun.NewRawQuery(conn.DB, query, args...).Conn(conn)
 }
 
 func (conn *DBConn) NewCreateTable() *bun.CreateTableQuery {
-	return bun.NewCreateTableQuery(conn.db).Conn(conn)
+	return bun.NewCreateTableQuery(conn.DB).Conn(conn)
 }
 
 func (conn *DBConn) NewDropTable() *bun.DropTableQuery {
-	return bun.NewDropTableQuery(conn.db).Conn(conn)
+	return bun.NewDropTableQuery(conn.DB).Conn(conn)
 }
 
 func (conn *DBConn) NewCreateIndex() *bun.CreateIndexQuery {
-	return bun.NewCreateIndexQuery(conn.db).Conn(conn)
+	return bun.NewCreateIndexQuery(conn.DB).Conn(conn)
 }
 
 func (conn *DBConn) NewDropIndex() *bun.DropIndexQuery {
-	return bun.NewDropIndexQuery(conn.db).Conn(conn)
+	return bun.NewDropIndexQuery(conn.DB).Conn(conn)
 }
 
 func (conn *DBConn) NewTruncateTable() *bun.TruncateTableQuery {
-	return bun.NewTruncateTableQuery(conn.db).Conn(conn)
+	return bun.NewTruncateTableQuery(conn.DB).Conn(conn)
 }
 
 func (conn *DBConn) NewAddColumn() *bun.AddColumnQuery {
-	return bun.NewAddColumnQuery(conn.db).Conn(conn)
+	return bun.NewAddColumnQuery(conn.DB).Conn(conn)
 }
 
 func (conn *DBConn) NewDropColumn() *bun.DropColumnQuery {
-	return bun.NewDropColumnQuery(conn.db).Conn(conn)
+	return bun.NewDropColumnQuery(conn.DB).Conn(conn)
 }
 
 // ProcessError processes an error to replace any known values with our own error types,

--- a/internal/db/bundb/conn.go
+++ b/internal/db/bundb/conn.go
@@ -208,10 +208,13 @@ func (conn *DBConn) NotExists(ctx context.Context, query *bun.SelectQuery) (bool
 func retryOnBusy(ctx context.Context, fn func() error) error {
 	const (
 		// max no. attempts.
-		maxRetries = 10
+		maxRetries = 16
 
 		// base backoff duration multiplier.
 		baseBackoff = 2 * time.Millisecond
+
+		// maximum backoff duration possible.
+		maxBackoff = baseBackoff * (1 << maxRetries)
 	)
 
 	for i := 0; i < maxRetries; i += 2 {
@@ -237,5 +240,5 @@ func retryOnBusy(ctx context.Context, fn func() error) error {
 		}
 	}
 
-	return gtserror.Newf("%w (waited > %s)", db.ErrBusyTimeout, baseBackoff*(1<<maxRetries))
+	return gtserror.Newf("%w (waited > %s)", db.ErrBusyTimeout, maxBackoff)
 }

--- a/internal/db/bundb/domain.go
+++ b/internal/db/bundb/domain.go
@@ -34,7 +34,7 @@ type domainDB struct {
 	state *state.State
 }
 
-func (d *domainDB) CreateDomainBlock(ctx context.Context, block *gtsmodel.DomainBlock) db.Error {
+func (d *domainDB) CreateDomainBlock(ctx context.Context, block *gtsmodel.DomainBlock) error {
 	// Normalize the domain as punycode
 	var err error
 	block.Domain, err = util.Punify(block.Domain)
@@ -55,7 +55,7 @@ func (d *domainDB) CreateDomainBlock(ctx context.Context, block *gtsmodel.Domain
 	return nil
 }
 
-func (d *domainDB) GetDomainBlock(ctx context.Context, domain string) (*gtsmodel.DomainBlock, db.Error) {
+func (d *domainDB) GetDomainBlock(ctx context.Context, domain string) (*gtsmodel.DomainBlock, error) {
 	// Normalize the domain as punycode
 	domain, err := util.Punify(domain)
 	if err != nil {
@@ -95,7 +95,7 @@ func (d *domainDB) GetDomainBlocks(ctx context.Context) ([]*gtsmodel.DomainBlock
 	return blocks, nil
 }
 
-func (d *domainDB) GetDomainBlockByID(ctx context.Context, id string) (*gtsmodel.DomainBlock, db.Error) {
+func (d *domainDB) GetDomainBlockByID(ctx context.Context, id string) (*gtsmodel.DomainBlock, error) {
 	var block gtsmodel.DomainBlock
 
 	q := d.conn.
@@ -109,7 +109,7 @@ func (d *domainDB) GetDomainBlockByID(ctx context.Context, id string) (*gtsmodel
 	return &block, nil
 }
 
-func (d *domainDB) DeleteDomainBlock(ctx context.Context, domain string) db.Error {
+func (d *domainDB) DeleteDomainBlock(ctx context.Context, domain string) error {
 	// Normalize the domain as punycode
 	domain, err := util.Punify(domain)
 	if err != nil {
@@ -130,7 +130,7 @@ func (d *domainDB) DeleteDomainBlock(ctx context.Context, domain string) db.Erro
 	return nil
 }
 
-func (d *domainDB) IsDomainBlocked(ctx context.Context, domain string) (bool, db.Error) {
+func (d *domainDB) IsDomainBlocked(ctx context.Context, domain string) (bool, error) {
 	// Normalize the domain as punycode
 	domain, err := util.Punify(domain)
 	if err != nil {
@@ -159,7 +159,7 @@ func (d *domainDB) IsDomainBlocked(ctx context.Context, domain string) (bool, db
 	})
 }
 
-func (d *domainDB) AreDomainsBlocked(ctx context.Context, domains []string) (bool, db.Error) {
+func (d *domainDB) AreDomainsBlocked(ctx context.Context, domains []string) (bool, error) {
 	for _, domain := range domains {
 		if blocked, err := d.IsDomainBlocked(ctx, domain); err != nil {
 			return false, err
@@ -170,11 +170,11 @@ func (d *domainDB) AreDomainsBlocked(ctx context.Context, domains []string) (boo
 	return false, nil
 }
 
-func (d *domainDB) IsURIBlocked(ctx context.Context, uri *url.URL) (bool, db.Error) {
+func (d *domainDB) IsURIBlocked(ctx context.Context, uri *url.URL) (bool, error) {
 	return d.IsDomainBlocked(ctx, uri.Hostname())
 }
 
-func (d *domainDB) AreURIsBlocked(ctx context.Context, uris []*url.URL) (bool, db.Error) {
+func (d *domainDB) AreURIsBlocked(ctx context.Context, uris []*url.URL) (bool, error) {
 	for _, uri := range uris {
 		if blocked, err := d.IsDomainBlocked(ctx, uri.Hostname()); err != nil {
 			return false, err

--- a/internal/db/bundb/emoji.go
+++ b/internal/db/bundb/emoji.go
@@ -255,7 +255,7 @@ func (e *emojiDB) GetEmojisBy(ctx context.Context, domain string, includeDisable
 	//		"emojis" AS "emoji"
 	//	ORDER BY
 	//		"shortcode_domain" ASC
-	switch e.conn.db.Dialect().Name() {
+	switch e.conn.Dialect().Name() {
 	case dialect.SQLite:
 		subQuery = subQuery.ColumnExpr("LOWER(? || ? || COALESCE(?, ?)) AS ?", bun.Ident("emoji.shortcode"), "@", bun.Ident("emoji.domain"), "", bun.Ident("shortcode_domain"))
 	case dialect.PG:

--- a/internal/db/bundb/emoji.go
+++ b/internal/db/bundb/emoji.go
@@ -34,14 +34,14 @@ import (
 )
 
 type emojiDB struct {
-	conn  *DBConn
+	db    *WrappedDB
 	state *state.State
 }
 
 func (e *emojiDB) PutEmoji(ctx context.Context, emoji *gtsmodel.Emoji) error {
 	return e.state.Caches.GTS.Emoji().Store(emoji, func() error {
-		_, err := e.conn.NewInsert().Model(emoji).Exec(ctx)
-		return e.conn.ProcessError(err)
+		_, err := e.db.NewInsert().Model(emoji).Exec(ctx)
+		return e.db.ProcessError(err)
 	})
 }
 
@@ -54,13 +54,13 @@ func (e *emojiDB) UpdateEmoji(ctx context.Context, emoji *gtsmodel.Emoji, column
 
 	// Update the emoji model in the database.
 	return e.state.Caches.GTS.Emoji().Store(emoji, func() error {
-		_, err := e.conn.
+		_, err := e.db.
 			NewUpdate().
 			Model(emoji).
 			Where("? = ?", bun.Ident("emoji.id"), emoji.ID).
 			Column(columns...).
 			Exec(ctx)
-		return e.conn.ProcessError(err)
+		return e.db.ProcessError(err)
 	})
 }
 
@@ -105,7 +105,7 @@ func (e *emojiDB) DeleteEmojiByID(ctx context.Context, id string) error {
 		return err
 	}
 
-	return e.conn.RunInTx(ctx, func(tx bun.Tx) error {
+	return e.db.RunInTx(ctx, func(tx bun.Tx) error {
 		// delete links between this emoji and any statuses that use it
 		// TODO: remove when we delete this table
 		if _, err := tx.
@@ -229,7 +229,7 @@ func (e *emojiDB) DeleteEmojiByID(ctx context.Context, id string) error {
 func (e *emojiDB) GetEmojisBy(ctx context.Context, domain string, includeDisabled bool, includeEnabled bool, shortcode string, maxShortcodeDomain string, minShortcodeDomain string, limit int) ([]*gtsmodel.Emoji, error) {
 	emojiIDs := []string{}
 
-	subQuery := e.conn.
+	subQuery := e.db.
 		NewSelect().
 		ColumnExpr("? AS ?", bun.Ident("emoji.id"), bun.Ident("emoji_ids"))
 
@@ -255,7 +255,7 @@ func (e *emojiDB) GetEmojisBy(ctx context.Context, domain string, includeDisable
 	//		"emojis" AS "emoji"
 	//	ORDER BY
 	//		"shortcode_domain" ASC
-	switch e.conn.Dialect().Name() {
+	switch e.db.Dialect().Name() {
 	case dialect.SQLite:
 		subQuery = subQuery.ColumnExpr("LOWER(? || ? || COALESCE(?, ?)) AS ?", bun.Ident("emoji.shortcode"), "@", bun.Ident("emoji.domain"), "", bun.Ident("shortcode_domain"))
 	case dialect.PG:
@@ -321,12 +321,12 @@ func (e *emojiDB) GetEmojisBy(ctx context.Context, domain string, includeDisable
 	//		ORDER BY
 	//			"shortcode_domain" ASC
 	//	) AS "subquery"
-	if err := e.conn.
+	if err := e.db.
 		NewSelect().
 		Column("subquery.emoji_ids").
 		TableExpr("(?) AS ?", subQuery, bun.Ident("subquery")).
 		Scan(ctx, &emojiIDs); err != nil {
-		return nil, e.conn.ProcessError(err)
+		return nil, e.db.ProcessError(err)
 	}
 
 	if order == "DESC" {
@@ -346,7 +346,7 @@ func (e *emojiDB) GetEmojisBy(ctx context.Context, domain string, includeDisable
 func (e *emojiDB) GetEmojis(ctx context.Context, maxID string, limit int) ([]*gtsmodel.Emoji, error) {
 	var emojiIDs []string
 
-	q := e.conn.NewSelect().
+	q := e.db.NewSelect().
 		Table("emojis").
 		Column("id").
 		Order("id DESC")
@@ -360,7 +360,7 @@ func (e *emojiDB) GetEmojis(ctx context.Context, maxID string, limit int) ([]*gt
 	}
 
 	if err := q.Scan(ctx, &emojiIDs); err != nil {
-		return nil, e.conn.ProcessError(err)
+		return nil, e.db.ProcessError(err)
 	}
 
 	return e.GetEmojisByIDs(ctx, emojiIDs)
@@ -369,7 +369,7 @@ func (e *emojiDB) GetEmojis(ctx context.Context, maxID string, limit int) ([]*gt
 func (e *emojiDB) GetRemoteEmojis(ctx context.Context, maxID string, limit int) ([]*gtsmodel.Emoji, error) {
 	var emojiIDs []string
 
-	q := e.conn.NewSelect().
+	q := e.db.NewSelect().
 		Table("emojis").
 		Column("id").
 		Where("domain IS NOT NULL").
@@ -384,7 +384,7 @@ func (e *emojiDB) GetRemoteEmojis(ctx context.Context, maxID string, limit int) 
 	}
 
 	if err := q.Scan(ctx, &emojiIDs); err != nil {
-		return nil, e.conn.ProcessError(err)
+		return nil, e.db.ProcessError(err)
 	}
 
 	return e.GetEmojisByIDs(ctx, emojiIDs)
@@ -393,7 +393,7 @@ func (e *emojiDB) GetRemoteEmojis(ctx context.Context, maxID string, limit int) 
 func (e *emojiDB) GetCachedEmojisOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.Emoji, error) {
 	var emojiIDs []string
 
-	q := e.conn.NewSelect().
+	q := e.db.NewSelect().
 		Table("emojis").
 		Column("id").
 		Where("cached = true").
@@ -406,7 +406,7 @@ func (e *emojiDB) GetCachedEmojisOlderThan(ctx context.Context, olderThan time.T
 	}
 
 	if err := q.Scan(ctx, &emojiIDs); err != nil {
-		return nil, e.conn.ProcessError(err)
+		return nil, e.db.ProcessError(err)
 	}
 
 	return e.GetEmojisByIDs(ctx, emojiIDs)
@@ -415,7 +415,7 @@ func (e *emojiDB) GetCachedEmojisOlderThan(ctx context.Context, olderThan time.T
 func (e *emojiDB) GetUseableEmojis(ctx context.Context) ([]*gtsmodel.Emoji, error) {
 	emojiIDs := []string{}
 
-	q := e.conn.
+	q := e.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("emojis"), bun.Ident("emoji")).
 		Column("emoji.id").
@@ -425,7 +425,7 @@ func (e *emojiDB) GetUseableEmojis(ctx context.Context) ([]*gtsmodel.Emoji, erro
 		Order("emoji.shortcode ASC")
 
 	if err := q.Scan(ctx, &emojiIDs); err != nil {
-		return nil, e.conn.ProcessError(err)
+		return nil, e.db.ProcessError(err)
 	}
 
 	return e.GetEmojisByIDs(ctx, emojiIDs)
@@ -436,7 +436,7 @@ func (e *emojiDB) GetEmojiByID(ctx context.Context, id string) (*gtsmodel.Emoji,
 		ctx,
 		"ID",
 		func(emoji *gtsmodel.Emoji) error {
-			return e.conn.
+			return e.db.
 				NewSelect().
 				Model(emoji).
 				Where("? = ?", bun.Ident("emoji.id"), id).Scan(ctx)
@@ -450,7 +450,7 @@ func (e *emojiDB) GetEmojiByURI(ctx context.Context, uri string) (*gtsmodel.Emoj
 		ctx,
 		"URI",
 		func(emoji *gtsmodel.Emoji) error {
-			return e.conn.
+			return e.db.
 				NewSelect().
 				Model(emoji).
 				Where("? = ?", bun.Ident("emoji.uri"), uri).Scan(ctx)
@@ -464,7 +464,7 @@ func (e *emojiDB) GetEmojiByShortcodeDomain(ctx context.Context, shortcode strin
 		ctx,
 		"Shortcode.Domain",
 		func(emoji *gtsmodel.Emoji) error {
-			q := e.conn.
+			q := e.db.
 				NewSelect().
 				Model(emoji)
 
@@ -488,7 +488,7 @@ func (e *emojiDB) GetEmojiByStaticURL(ctx context.Context, imageStaticURL string
 		ctx,
 		"ImageStaticURL",
 		func(emoji *gtsmodel.Emoji) error {
-			return e.conn.
+			return e.db.
 				NewSelect().
 				Model(emoji).
 				Where("? = ?", bun.Ident("emoji.image_static_url"), imageStaticURL).
@@ -500,22 +500,22 @@ func (e *emojiDB) GetEmojiByStaticURL(ctx context.Context, imageStaticURL string
 
 func (e *emojiDB) PutEmojiCategory(ctx context.Context, emojiCategory *gtsmodel.EmojiCategory) error {
 	return e.state.Caches.GTS.EmojiCategory().Store(emojiCategory, func() error {
-		_, err := e.conn.NewInsert().Model(emojiCategory).Exec(ctx)
-		return e.conn.ProcessError(err)
+		_, err := e.db.NewInsert().Model(emojiCategory).Exec(ctx)
+		return e.db.ProcessError(err)
 	})
 }
 
 func (e *emojiDB) GetEmojiCategories(ctx context.Context) ([]*gtsmodel.EmojiCategory, error) {
 	emojiCategoryIDs := []string{}
 
-	q := e.conn.
+	q := e.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("emoji_categories"), bun.Ident("emoji_category")).
 		Column("emoji_category.id").
 		Order("emoji_category.name ASC")
 
 	if err := q.Scan(ctx, &emojiCategoryIDs); err != nil {
-		return nil, e.conn.ProcessError(err)
+		return nil, e.db.ProcessError(err)
 	}
 
 	return e.GetEmojiCategoriesByIDs(ctx, emojiCategoryIDs)
@@ -526,7 +526,7 @@ func (e *emojiDB) GetEmojiCategory(ctx context.Context, id string) (*gtsmodel.Em
 		ctx,
 		"ID",
 		func(emojiCategory *gtsmodel.EmojiCategory) error {
-			return e.conn.
+			return e.db.
 				NewSelect().
 				Model(emojiCategory).
 				Where("? = ?", bun.Ident("emoji_category.id"), id).Scan(ctx)
@@ -540,7 +540,7 @@ func (e *emojiDB) GetEmojiCategoryByName(ctx context.Context, name string) (*gts
 		ctx,
 		"Name",
 		func(emojiCategory *gtsmodel.EmojiCategory) error {
-			return e.conn.
+			return e.db.
 				NewSelect().
 				Model(emojiCategory).
 				Where("LOWER(?) = ?", bun.Ident("emoji_category.name"), strings.ToLower(name)).Scan(ctx)
@@ -556,7 +556,7 @@ func (e *emojiDB) getEmoji(ctx context.Context, lookup string, dbQuery func(*gts
 
 		// Not cached! Perform database query
 		if err := dbQuery(&emoji); err != nil {
-			return nil, e.conn.ProcessError(err)
+			return nil, e.db.ProcessError(err)
 		}
 
 		return &emoji, nil
@@ -606,7 +606,7 @@ func (e *emojiDB) getEmojiCategory(ctx context.Context, lookup string, dbQuery f
 
 		// Not cached! Perform database query
 		if err := dbQuery(&category); err != nil {
-			return nil, e.conn.ProcessError(err)
+			return nil, e.db.ProcessError(err)
 		}
 
 		return &category, nil

--- a/internal/db/bundb/errors.go
+++ b/internal/db/bundb/errors.go
@@ -18,11 +18,17 @@
 package bundb
 
 import (
+	"errors"
+
 	"github.com/jackc/pgconn"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"modernc.org/sqlite"
 	sqlite3 "modernc.org/sqlite/lib"
 )
+
+// errBusy is a sentinel error indicating
+// busy database (e.g. retry needed).
+var errBusy = errors.New("busy")
 
 // processPostgresError processes an error, replacing any postgres specific errors with our own error type
 func processPostgresError(err error) error {
@@ -55,6 +61,8 @@ func processSQLiteError(err error) error {
 	case sqlite3.SQLITE_CONSTRAINT_UNIQUE,
 		sqlite3.SQLITE_CONSTRAINT_PRIMARYKEY:
 		return db.ErrAlreadyExists
+	case sqlite3.SQLITE_BUSY:
+		return errBusy
 	case sqlite3.SQLITE_BUSY_TIMEOUT:
 		return db.ErrBusyTimeout
 	}

--- a/internal/db/bundb/errors.go
+++ b/internal/db/bundb/errors.go
@@ -40,7 +40,7 @@ func processPostgresError(err error) error {
 
 	// Handle supplied error code:
 	// (https://www.postgresql.org/docs/10/errcodes-appendix.html)
-	switch pgErr.Code {
+	switch pgErr.Code { //nolint
 	case "23505" /* unique_violation */ :
 		return db.ErrAlreadyExists
 	}

--- a/internal/db/bundb/instance.go
+++ b/internal/db/bundb/instance.go
@@ -38,7 +38,7 @@ type instanceDB struct {
 	state *state.State
 }
 
-func (i *instanceDB) CountInstanceUsers(ctx context.Context, domain string) (int, db.Error) {
+func (i *instanceDB) CountInstanceUsers(ctx context.Context, domain string) (int, error) {
 	q := i.conn.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("accounts"), bun.Ident("account")).
@@ -61,7 +61,7 @@ func (i *instanceDB) CountInstanceUsers(ctx context.Context, domain string) (int
 	return count, nil
 }
 
-func (i *instanceDB) CountInstanceStatuses(ctx context.Context, domain string) (int, db.Error) {
+func (i *instanceDB) CountInstanceStatuses(ctx context.Context, domain string) (int, error) {
 	q := i.conn.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("statuses"), bun.Ident("status"))
@@ -83,7 +83,7 @@ func (i *instanceDB) CountInstanceStatuses(ctx context.Context, domain string) (
 	return count, nil
 }
 
-func (i *instanceDB) CountInstanceDomains(ctx context.Context, domain string) (int, db.Error) {
+func (i *instanceDB) CountInstanceDomains(ctx context.Context, domain string) (int, error) {
 	q := i.conn.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("instances"), bun.Ident("instance"))
@@ -106,7 +106,7 @@ func (i *instanceDB) CountInstanceDomains(ctx context.Context, domain string) (i
 	return count, nil
 }
 
-func (i *instanceDB) GetInstance(ctx context.Context, domain string) (*gtsmodel.Instance, db.Error) {
+func (i *instanceDB) GetInstance(ctx context.Context, domain string) (*gtsmodel.Instance, error) {
 	// Normalize the domain as punycode
 	var err error
 	domain, err = util.Punify(domain)
@@ -141,7 +141,7 @@ func (i *instanceDB) GetInstanceByID(ctx context.Context, id string) (*gtsmodel.
 	)
 }
 
-func (i *instanceDB) getInstance(ctx context.Context, lookup string, dbQuery func(*gtsmodel.Instance) error, keyParts ...any) (*gtsmodel.Instance, db.Error) {
+func (i *instanceDB) getInstance(ctx context.Context, lookup string, dbQuery func(*gtsmodel.Instance) error, keyParts ...any) (*gtsmodel.Instance, error) {
 	// Fetch instance from database cache with loader callback
 	instance, err := i.state.Caches.GTS.Instance().Load(lookup, func() (*gtsmodel.Instance, error) {
 		var instance gtsmodel.Instance
@@ -240,7 +240,7 @@ func (i *instanceDB) UpdateInstance(ctx context.Context, instance *gtsmodel.Inst
 	})
 }
 
-func (i *instanceDB) GetInstancePeers(ctx context.Context, includeSuspended bool) ([]*gtsmodel.Instance, db.Error) {
+func (i *instanceDB) GetInstancePeers(ctx context.Context, includeSuspended bool) ([]*gtsmodel.Instance, error) {
 	instanceIDs := []string{}
 
 	q := i.conn.
@@ -280,7 +280,7 @@ func (i *instanceDB) GetInstancePeers(ctx context.Context, includeSuspended bool
 	return instances, nil
 }
 
-func (i *instanceDB) GetInstanceAccounts(ctx context.Context, domain string, maxID string, limit int) ([]*gtsmodel.Account, db.Error) {
+func (i *instanceDB) GetInstanceAccounts(ctx context.Context, domain string, maxID string, limit int) ([]*gtsmodel.Account, error) {
 	// Ensure reasonable
 	if limit < 0 {
 		limit = 0
@@ -340,7 +340,7 @@ func (i *instanceDB) GetInstanceAccounts(ctx context.Context, domain string, max
 	return accounts, nil
 }
 
-func (i *instanceDB) GetInstanceModeratorAddresses(ctx context.Context) ([]string, db.Error) {
+func (i *instanceDB) GetInstanceModeratorAddresses(ctx context.Context) ([]string, error) {
 	addresses := []string{}
 
 	// Select email addresses of approved, confirmed,

--- a/internal/db/bundb/media.go
+++ b/internal/db/bundb/media.go
@@ -36,7 +36,7 @@ type mediaDB struct {
 	state *state.State
 }
 
-func (m *mediaDB) GetAttachmentByID(ctx context.Context, id string) (*gtsmodel.MediaAttachment, db.Error) {
+func (m *mediaDB) GetAttachmentByID(ctx context.Context, id string) (*gtsmodel.MediaAttachment, error) {
 	return m.getAttachment(
 		ctx,
 		"ID",
@@ -68,7 +68,7 @@ func (m *mediaDB) GetAttachmentsByIDs(ctx context.Context, ids []string) ([]*gts
 	return attachments, nil
 }
 
-func (m *mediaDB) getAttachment(ctx context.Context, lookup string, dbQuery func(*gtsmodel.MediaAttachment) error, keyParts ...any) (*gtsmodel.MediaAttachment, db.Error) {
+func (m *mediaDB) getAttachment(ctx context.Context, lookup string, dbQuery func(*gtsmodel.MediaAttachment) error, keyParts ...any) (*gtsmodel.MediaAttachment, error) {
 	return m.state.Caches.GTS.Media().Load(lookup, func() (*gtsmodel.MediaAttachment, error) {
 		var attachment gtsmodel.MediaAttachment
 
@@ -232,7 +232,7 @@ func (m *mediaDB) DeleteAttachment(ctx context.Context, id string) error {
 	return m.conn.ProcessError(err)
 }
 
-func (m *mediaDB) CountRemoteOlderThan(ctx context.Context, olderThan time.Time) (int, db.Error) {
+func (m *mediaDB) CountRemoteOlderThan(ctx context.Context, olderThan time.Time) (int, error) {
 	q := m.conn.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("media_attachments"), bun.Ident("media_attachment")).
@@ -296,7 +296,7 @@ func (m *mediaDB) GetRemoteAttachments(ctx context.Context, maxID string, limit 
 	return m.GetAttachmentsByIDs(ctx, attachmentIDs)
 }
 
-func (m *mediaDB) GetCachedAttachmentsOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, db.Error) {
+func (m *mediaDB) GetCachedAttachmentsOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, error) {
 	attachmentIDs := make([]string, 0, limit)
 
 	q := m.conn.
@@ -319,7 +319,7 @@ func (m *mediaDB) GetCachedAttachmentsOlderThan(ctx context.Context, olderThan t
 	return m.GetAttachmentsByIDs(ctx, attachmentIDs)
 }
 
-func (m *mediaDB) GetAvatarsAndHeaders(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, db.Error) {
+func (m *mediaDB) GetAvatarsAndHeaders(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, error) {
 	attachmentIDs := make([]string, 0, limit)
 
 	q := m.conn.NewSelect().
@@ -347,7 +347,7 @@ func (m *mediaDB) GetAvatarsAndHeaders(ctx context.Context, maxID string, limit 
 	return m.GetAttachmentsByIDs(ctx, attachmentIDs)
 }
 
-func (m *mediaDB) GetLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, db.Error) {
+func (m *mediaDB) GetLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, error) {
 	attachmentIDs := make([]string, 0, limit)
 
 	q := m.conn.
@@ -373,7 +373,7 @@ func (m *mediaDB) GetLocalUnattachedOlderThan(ctx context.Context, olderThan tim
 	return m.GetAttachmentsByIDs(ctx, attachmentIDs)
 }
 
-func (m *mediaDB) CountLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time) (int, db.Error) {
+func (m *mediaDB) CountLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time) (int, error) {
 	q := m.conn.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("media_attachments"), bun.Ident("media_attachment")).

--- a/internal/db/bundb/media.go
+++ b/internal/db/bundb/media.go
@@ -32,7 +32,7 @@ import (
 )
 
 type mediaDB struct {
-	conn  *DBConn
+	db    *WrappedDB
 	state *state.State
 }
 
@@ -41,7 +41,7 @@ func (m *mediaDB) GetAttachmentByID(ctx context.Context, id string) (*gtsmodel.M
 		ctx,
 		"ID",
 		func(attachment *gtsmodel.MediaAttachment) error {
-			return m.conn.NewSelect().
+			return m.db.NewSelect().
 				Model(attachment).
 				Where("? = ?", bun.Ident("media_attachment.id"), id).
 				Scan(ctx)
@@ -74,7 +74,7 @@ func (m *mediaDB) getAttachment(ctx context.Context, lookup string, dbQuery func
 
 		// Not cached! Perform database query
 		if err := dbQuery(&attachment); err != nil {
-			return nil, m.conn.ProcessError(err)
+			return nil, m.db.ProcessError(err)
 		}
 
 		return &attachment, nil
@@ -83,8 +83,8 @@ func (m *mediaDB) getAttachment(ctx context.Context, lookup string, dbQuery func
 
 func (m *mediaDB) PutAttachment(ctx context.Context, media *gtsmodel.MediaAttachment) error {
 	return m.state.Caches.GTS.Media().Store(media, func() error {
-		_, err := m.conn.NewInsert().Model(media).Exec(ctx)
-		return m.conn.ProcessError(err)
+		_, err := m.db.NewInsert().Model(media).Exec(ctx)
+		return m.db.ProcessError(err)
 	})
 }
 
@@ -96,12 +96,12 @@ func (m *mediaDB) UpdateAttachment(ctx context.Context, media *gtsmodel.MediaAtt
 	}
 
 	return m.state.Caches.GTS.Media().Store(media, func() error {
-		_, err := m.conn.NewUpdate().
+		_, err := m.db.NewUpdate().
 			Model(media).
 			Where("? = ?", bun.Ident("media_attachment.id"), media.ID).
 			Column(columns...).
 			Exec(ctx)
-		return m.conn.ProcessError(err)
+		return m.db.ProcessError(err)
 	})
 }
 
@@ -126,7 +126,7 @@ func (m *mediaDB) DeleteAttachment(ctx context.Context, id string) error {
 	)
 
 	// Delete media attachment in new transaction.
-	err = m.conn.RunInTx(ctx, func(tx bun.Tx) error {
+	err = m.db.RunInTx(ctx, func(tx bun.Tx) error {
 		if media.AccountID != "" {
 			var account gtsmodel.Account
 
@@ -229,11 +229,11 @@ func (m *mediaDB) DeleteAttachment(ctx context.Context, id string) error {
 		m.state.Caches.GTS.Status().Invalidate("ID", media.StatusID)
 	}
 
-	return m.conn.ProcessError(err)
+	return m.db.ProcessError(err)
 }
 
 func (m *mediaDB) CountRemoteOlderThan(ctx context.Context, olderThan time.Time) (int, error) {
-	q := m.conn.
+	q := m.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("media_attachments"), bun.Ident("media_attachment")).
 		Column("media_attachment.id").
@@ -243,7 +243,7 @@ func (m *mediaDB) CountRemoteOlderThan(ctx context.Context, olderThan time.Time)
 
 	count, err := q.Count(ctx)
 	if err != nil {
-		return 0, m.conn.ProcessError(err)
+		return 0, m.db.ProcessError(err)
 	}
 
 	return count, nil
@@ -252,7 +252,7 @@ func (m *mediaDB) CountRemoteOlderThan(ctx context.Context, olderThan time.Time)
 func (m *mediaDB) GetAttachments(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, error) {
 	attachmentIDs := make([]string, 0, limit)
 
-	q := m.conn.NewSelect().
+	q := m.db.NewSelect().
 		Table("media_attachments").
 		Column("id").
 		Order("id DESC")
@@ -266,7 +266,7 @@ func (m *mediaDB) GetAttachments(ctx context.Context, maxID string, limit int) (
 	}
 
 	if err := q.Scan(ctx, &attachmentIDs); err != nil {
-		return nil, m.conn.ProcessError(err)
+		return nil, m.db.ProcessError(err)
 	}
 
 	return m.GetAttachmentsByIDs(ctx, attachmentIDs)
@@ -275,7 +275,7 @@ func (m *mediaDB) GetAttachments(ctx context.Context, maxID string, limit int) (
 func (m *mediaDB) GetRemoteAttachments(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, error) {
 	attachmentIDs := make([]string, 0, limit)
 
-	q := m.conn.NewSelect().
+	q := m.db.NewSelect().
 		Table("media_attachments").
 		Column("id").
 		Where("remote_url IS NOT NULL").
@@ -290,7 +290,7 @@ func (m *mediaDB) GetRemoteAttachments(ctx context.Context, maxID string, limit 
 	}
 
 	if err := q.Scan(ctx, &attachmentIDs); err != nil {
-		return nil, m.conn.ProcessError(err)
+		return nil, m.db.ProcessError(err)
 	}
 
 	return m.GetAttachmentsByIDs(ctx, attachmentIDs)
@@ -299,7 +299,7 @@ func (m *mediaDB) GetRemoteAttachments(ctx context.Context, maxID string, limit 
 func (m *mediaDB) GetCachedAttachmentsOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, error) {
 	attachmentIDs := make([]string, 0, limit)
 
-	q := m.conn.
+	q := m.db.
 		NewSelect().
 		Table("media_attachments").
 		Column("id").
@@ -313,7 +313,7 @@ func (m *mediaDB) GetCachedAttachmentsOlderThan(ctx context.Context, olderThan t
 	}
 
 	if err := q.Scan(ctx, &attachmentIDs); err != nil {
-		return nil, m.conn.ProcessError(err)
+		return nil, m.db.ProcessError(err)
 	}
 
 	return m.GetAttachmentsByIDs(ctx, attachmentIDs)
@@ -322,7 +322,7 @@ func (m *mediaDB) GetCachedAttachmentsOlderThan(ctx context.Context, olderThan t
 func (m *mediaDB) GetAvatarsAndHeaders(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, error) {
 	attachmentIDs := make([]string, 0, limit)
 
-	q := m.conn.NewSelect().
+	q := m.db.NewSelect().
 		TableExpr("? AS ?", bun.Ident("media_attachments"), bun.Ident("media_attachment")).
 		Column("media_attachment.id").
 		WhereGroup(" AND ", func(innerQ *bun.SelectQuery) *bun.SelectQuery {
@@ -341,7 +341,7 @@ func (m *mediaDB) GetAvatarsAndHeaders(ctx context.Context, maxID string, limit 
 	}
 
 	if err := q.Scan(ctx, &attachmentIDs); err != nil {
-		return nil, m.conn.ProcessError(err)
+		return nil, m.db.ProcessError(err)
 	}
 
 	return m.GetAttachmentsByIDs(ctx, attachmentIDs)
@@ -350,7 +350,7 @@ func (m *mediaDB) GetAvatarsAndHeaders(ctx context.Context, maxID string, limit 
 func (m *mediaDB) GetLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, error) {
 	attachmentIDs := make([]string, 0, limit)
 
-	q := m.conn.
+	q := m.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("media_attachments"), bun.Ident("media_attachment")).
 		Column("media_attachment.id").
@@ -367,14 +367,14 @@ func (m *mediaDB) GetLocalUnattachedOlderThan(ctx context.Context, olderThan tim
 	}
 
 	if err := q.Scan(ctx, &attachmentIDs); err != nil {
-		return nil, m.conn.ProcessError(err)
+		return nil, m.db.ProcessError(err)
 	}
 
 	return m.GetAttachmentsByIDs(ctx, attachmentIDs)
 }
 
 func (m *mediaDB) CountLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time) (int, error) {
-	q := m.conn.
+	q := m.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("media_attachments"), bun.Ident("media_attachment")).
 		Column("media_attachment.id").
@@ -387,7 +387,7 @@ func (m *mediaDB) CountLocalUnattachedOlderThan(ctx context.Context, olderThan t
 
 	count, err := q.Count(ctx)
 	if err != nil {
-		return 0, m.conn.ProcessError(err)
+		return 0, m.db.ProcessError(err)
 	}
 
 	return count, nil

--- a/internal/db/bundb/mention.go
+++ b/internal/db/bundb/mention.go
@@ -35,7 +35,7 @@ type mentionDB struct {
 	state *state.State
 }
 
-func (m *mentionDB) GetMention(ctx context.Context, id string) (*gtsmodel.Mention, db.Error) {
+func (m *mentionDB) GetMention(ctx context.Context, id string) (*gtsmodel.Mention, error) {
 	mention, err := m.state.Caches.GTS.Mention().Load("ID", func() (*gtsmodel.Mention, error) {
 		var mention gtsmodel.Mention
 
@@ -84,7 +84,7 @@ func (m *mentionDB) GetMention(ctx context.Context, id string) (*gtsmodel.Mentio
 	return mention, nil
 }
 
-func (m *mentionDB) GetMentions(ctx context.Context, ids []string) ([]*gtsmodel.Mention, db.Error) {
+func (m *mentionDB) GetMentions(ctx context.Context, ids []string) ([]*gtsmodel.Mention, error) {
 	mentions := make([]*gtsmodel.Mention, 0, len(ids))
 
 	for _, id := range ids {

--- a/internal/db/bundb/mention.go
+++ b/internal/db/bundb/mention.go
@@ -31,7 +31,7 @@ import (
 )
 
 type mentionDB struct {
-	conn  *DBConn
+	db    *WrappedDB
 	state *state.State
 }
 
@@ -39,13 +39,13 @@ func (m *mentionDB) GetMention(ctx context.Context, id string) (*gtsmodel.Mentio
 	mention, err := m.state.Caches.GTS.Mention().Load("ID", func() (*gtsmodel.Mention, error) {
 		var mention gtsmodel.Mention
 
-		q := m.conn.
+		q := m.db.
 			NewSelect().
 			Model(&mention).
 			Where("? = ?", bun.Ident("mention.id"), id)
 
 		if err := q.Scan(ctx); err != nil {
-			return nil, m.conn.ProcessError(err)
+			return nil, m.db.ProcessError(err)
 		}
 
 		return &mention, nil
@@ -104,8 +104,8 @@ func (m *mentionDB) GetMentions(ctx context.Context, ids []string) ([]*gtsmodel.
 
 func (m *mentionDB) PutMention(ctx context.Context, mention *gtsmodel.Mention) error {
 	return m.state.Caches.GTS.Mention().Store(mention, func() error {
-		_, err := m.conn.NewInsert().Model(mention).Exec(ctx)
-		return m.conn.ProcessError(err)
+		_, err := m.db.NewInsert().Model(mention).Exec(ctx)
+		return m.db.ProcessError(err)
 	})
 }
 
@@ -125,9 +125,9 @@ func (m *mentionDB) DeleteMentionByID(ctx context.Context, id string) error {
 	}
 
 	// Finally delete mention from DB.
-	_, err = m.conn.NewDelete().
+	_, err = m.db.NewDelete().
 		Table("mentions").
 		Where("? = ?", bun.Ident("id"), id).
 		Exec(ctx)
-	return m.conn.ProcessError(err)
+	return m.db.ProcessError(err)
 }

--- a/internal/db/bundb/notification.go
+++ b/internal/db/bundb/notification.go
@@ -35,7 +35,7 @@ type notificationDB struct {
 	state *state.State
 }
 
-func (n *notificationDB) GetNotificationByID(ctx context.Context, id string) (*gtsmodel.Notification, db.Error) {
+func (n *notificationDB) GetNotificationByID(ctx context.Context, id string) (*gtsmodel.Notification, error) {
 	return n.state.Caches.GTS.Notification().Load("ID", func() (*gtsmodel.Notification, error) {
 		var notif gtsmodel.Notification
 
@@ -56,7 +56,7 @@ func (n *notificationDB) GetNotification(
 	targetAccountID string,
 	originAccountID string,
 	statusID string,
-) (*gtsmodel.Notification, db.Error) {
+) (*gtsmodel.Notification, error) {
 	return n.state.Caches.GTS.Notification().Load("NotificationType.TargetAccountID.OriginAccountID.StatusID", func() (*gtsmodel.Notification, error) {
 		var notif gtsmodel.Notification
 
@@ -83,7 +83,7 @@ func (n *notificationDB) GetAccountNotifications(
 	minID string,
 	limit int,
 	excludeTypes []string,
-) ([]*gtsmodel.Notification, db.Error) {
+) ([]*gtsmodel.Notification, error) {
 	// Ensure reasonable
 	if limit < 0 {
 		limit = 0
@@ -179,7 +179,7 @@ func (n *notificationDB) PutNotification(ctx context.Context, notif *gtsmodel.No
 	})
 }
 
-func (n *notificationDB) DeleteNotificationByID(ctx context.Context, id string) db.Error {
+func (n *notificationDB) DeleteNotificationByID(ctx context.Context, id string) error {
 	defer n.state.Caches.GTS.Notification().Invalidate("ID", id)
 
 	// Load notif into cache before attempting a delete,
@@ -202,7 +202,7 @@ func (n *notificationDB) DeleteNotificationByID(ctx context.Context, id string) 
 	return n.conn.ProcessError(err)
 }
 
-func (n *notificationDB) DeleteNotifications(ctx context.Context, types []string, targetAccountID string, originAccountID string) db.Error {
+func (n *notificationDB) DeleteNotifications(ctx context.Context, types []string, targetAccountID string, originAccountID string) error {
 	if targetAccountID == "" && originAccountID == "" {
 		return errors.New("DeleteNotifications: one of targetAccountID or originAccountID must be set")
 	}
@@ -255,7 +255,7 @@ func (n *notificationDB) DeleteNotifications(ctx context.Context, types []string
 	return n.conn.ProcessError(err)
 }
 
-func (n *notificationDB) DeleteNotificationsForStatus(ctx context.Context, statusID string) db.Error {
+func (n *notificationDB) DeleteNotificationsForStatus(ctx context.Context, statusID string) error {
 	var notifIDs []string
 
 	q := n.conn.

--- a/internal/db/bundb/notification.go
+++ b/internal/db/bundb/notification.go
@@ -31,7 +31,7 @@ import (
 )
 
 type notificationDB struct {
-	conn  *DBConn
+	db    *WrappedDB
 	state *state.State
 }
 
@@ -39,11 +39,11 @@ func (n *notificationDB) GetNotificationByID(ctx context.Context, id string) (*g
 	return n.state.Caches.GTS.Notification().Load("ID", func() (*gtsmodel.Notification, error) {
 		var notif gtsmodel.Notification
 
-		q := n.conn.NewSelect().
+		q := n.db.NewSelect().
 			Model(&notif).
 			Where("? = ?", bun.Ident("notification.id"), id)
 		if err := q.Scan(ctx); err != nil {
-			return nil, n.conn.ProcessError(err)
+			return nil, n.db.ProcessError(err)
 		}
 
 		return &notif, nil
@@ -60,7 +60,7 @@ func (n *notificationDB) GetNotification(
 	return n.state.Caches.GTS.Notification().Load("NotificationType.TargetAccountID.OriginAccountID.StatusID", func() (*gtsmodel.Notification, error) {
 		var notif gtsmodel.Notification
 
-		q := n.conn.NewSelect().
+		q := n.db.NewSelect().
 			Model(&notif).
 			Where("? = ?", bun.Ident("notification_type"), notificationType).
 			Where("? = ?", bun.Ident("target_account_id"), targetAccountID).
@@ -68,7 +68,7 @@ func (n *notificationDB) GetNotification(
 			Where("? = ?", bun.Ident("status_id"), statusID)
 
 		if err := q.Scan(ctx); err != nil {
-			return nil, n.conn.ProcessError(err)
+			return nil, n.db.ProcessError(err)
 		}
 
 		return &notif, nil
@@ -95,7 +95,7 @@ func (n *notificationDB) GetAccountNotifications(
 		frontToBack = true
 	)
 
-	q := n.conn.
+	q := n.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("notifications"), bun.Ident("notification")).
 		Column("notification.id")
@@ -140,7 +140,7 @@ func (n *notificationDB) GetAccountNotifications(
 	}
 
 	if err := q.Scan(ctx, &notifIDs); err != nil {
-		return nil, n.conn.ProcessError(err)
+		return nil, n.db.ProcessError(err)
 	}
 
 	if len(notifIDs) == 0 {
@@ -174,8 +174,8 @@ func (n *notificationDB) GetAccountNotifications(
 
 func (n *notificationDB) PutNotification(ctx context.Context, notif *gtsmodel.Notification) error {
 	return n.state.Caches.GTS.Notification().Store(notif, func() error {
-		_, err := n.conn.NewInsert().Model(notif).Exec(ctx)
-		return n.conn.ProcessError(err)
+		_, err := n.db.NewInsert().Model(notif).Exec(ctx)
+		return n.db.ProcessError(err)
 	})
 }
 
@@ -195,11 +195,11 @@ func (n *notificationDB) DeleteNotificationByID(ctx context.Context, id string) 
 	}
 
 	// Finally delete notif from DB.
-	_, err = n.conn.NewDelete().
+	_, err = n.db.NewDelete().
 		TableExpr("? AS ?", bun.Ident("notifications"), bun.Ident("notification")).
 		Where("? = ?", bun.Ident("notification.id"), id).
 		Exec(ctx)
-	return n.conn.ProcessError(err)
+	return n.db.ProcessError(err)
 }
 
 func (n *notificationDB) DeleteNotifications(ctx context.Context, types []string, targetAccountID string, originAccountID string) error {
@@ -209,7 +209,7 @@ func (n *notificationDB) DeleteNotifications(ctx context.Context, types []string
 
 	var notifIDs []string
 
-	q := n.conn.
+	q := n.db.
 		NewSelect().
 		Column("id").
 		Table("notifications")
@@ -227,7 +227,7 @@ func (n *notificationDB) DeleteNotifications(ctx context.Context, types []string
 	}
 
 	if _, err := q.Exec(ctx, &notifIDs); err != nil {
-		return n.conn.ProcessError(err)
+		return n.db.ProcessError(err)
 	}
 
 	defer func() {
@@ -248,24 +248,24 @@ func (n *notificationDB) DeleteNotifications(ctx context.Context, types []string
 	}
 
 	// Finally delete all from DB.
-	_, err := n.conn.NewDelete().
+	_, err := n.db.NewDelete().
 		Table("notifications").
 		Where("? IN (?)", bun.Ident("id"), bun.In(notifIDs)).
 		Exec(ctx)
-	return n.conn.ProcessError(err)
+	return n.db.ProcessError(err)
 }
 
 func (n *notificationDB) DeleteNotificationsForStatus(ctx context.Context, statusID string) error {
 	var notifIDs []string
 
-	q := n.conn.
+	q := n.db.
 		NewSelect().
 		Column("id").
 		Table("notifications").
 		Where("? = ?", bun.Ident("status_id"), statusID)
 
 	if _, err := q.Exec(ctx, &notifIDs); err != nil {
-		return n.conn.ProcessError(err)
+		return n.db.ProcessError(err)
 	}
 
 	defer func() {
@@ -286,9 +286,9 @@ func (n *notificationDB) DeleteNotificationsForStatus(ctx context.Context, statu
 	}
 
 	// Finally delete all from DB.
-	_, err := n.conn.NewDelete().
+	_, err := n.db.NewDelete().
 		Table("notifications").
 		Where("? IN (?)", bun.Ident("id"), bun.In(notifIDs)).
 		Exec(ctx)
-	return n.conn.ProcessError(err)
+	return n.db.ProcessError(err)
 }

--- a/internal/db/bundb/relationship.go
+++ b/internal/db/bundb/relationship.go
@@ -30,7 +30,7 @@ import (
 )
 
 type relationshipDB struct {
-	conn  *DBConn
+	db    *WrappedDB
 	state *state.State
 }
 
@@ -90,91 +90,91 @@ func (r *relationshipDB) GetRelationship(ctx context.Context, requestingAccount 
 
 func (r *relationshipDB) GetAccountFollows(ctx context.Context, accountID string) ([]*gtsmodel.Follow, error) {
 	var followIDs []string
-	if err := newSelectFollows(r.conn, accountID).
+	if err := newSelectFollows(r.db, accountID).
 		Scan(ctx, &followIDs); err != nil {
-		return nil, r.conn.ProcessError(err)
+		return nil, r.db.ProcessError(err)
 	}
 	return r.GetFollowsByIDs(ctx, followIDs)
 }
 
 func (r *relationshipDB) GetAccountLocalFollows(ctx context.Context, accountID string) ([]*gtsmodel.Follow, error) {
 	var followIDs []string
-	if err := newSelectLocalFollows(r.conn, accountID).
+	if err := newSelectLocalFollows(r.db, accountID).
 		Scan(ctx, &followIDs); err != nil {
-		return nil, r.conn.ProcessError(err)
+		return nil, r.db.ProcessError(err)
 	}
 	return r.GetFollowsByIDs(ctx, followIDs)
 }
 
 func (r *relationshipDB) GetAccountFollowers(ctx context.Context, accountID string) ([]*gtsmodel.Follow, error) {
 	var followIDs []string
-	if err := newSelectFollowers(r.conn, accountID).
+	if err := newSelectFollowers(r.db, accountID).
 		Scan(ctx, &followIDs); err != nil {
-		return nil, r.conn.ProcessError(err)
+		return nil, r.db.ProcessError(err)
 	}
 	return r.GetFollowsByIDs(ctx, followIDs)
 }
 
 func (r *relationshipDB) GetAccountLocalFollowers(ctx context.Context, accountID string) ([]*gtsmodel.Follow, error) {
 	var followIDs []string
-	if err := newSelectLocalFollowers(r.conn, accountID).
+	if err := newSelectLocalFollowers(r.db, accountID).
 		Scan(ctx, &followIDs); err != nil {
-		return nil, r.conn.ProcessError(err)
+		return nil, r.db.ProcessError(err)
 	}
 	return r.GetFollowsByIDs(ctx, followIDs)
 }
 
 func (r *relationshipDB) CountAccountFollows(ctx context.Context, accountID string) (int, error) {
-	n, err := newSelectFollows(r.conn, accountID).Count(ctx)
-	return n, r.conn.ProcessError(err)
+	n, err := newSelectFollows(r.db, accountID).Count(ctx)
+	return n, r.db.ProcessError(err)
 }
 
 func (r *relationshipDB) CountAccountLocalFollows(ctx context.Context, accountID string) (int, error) {
-	n, err := newSelectLocalFollows(r.conn, accountID).Count(ctx)
-	return n, r.conn.ProcessError(err)
+	n, err := newSelectLocalFollows(r.db, accountID).Count(ctx)
+	return n, r.db.ProcessError(err)
 }
 
 func (r *relationshipDB) CountAccountFollowers(ctx context.Context, accountID string) (int, error) {
-	n, err := newSelectFollowers(r.conn, accountID).Count(ctx)
-	return n, r.conn.ProcessError(err)
+	n, err := newSelectFollowers(r.db, accountID).Count(ctx)
+	return n, r.db.ProcessError(err)
 }
 
 func (r *relationshipDB) CountAccountLocalFollowers(ctx context.Context, accountID string) (int, error) {
-	n, err := newSelectLocalFollowers(r.conn, accountID).Count(ctx)
-	return n, r.conn.ProcessError(err)
+	n, err := newSelectLocalFollowers(r.db, accountID).Count(ctx)
+	return n, r.db.ProcessError(err)
 }
 
 func (r *relationshipDB) GetAccountFollowRequests(ctx context.Context, accountID string) ([]*gtsmodel.FollowRequest, error) {
 	var followReqIDs []string
-	if err := newSelectFollowRequests(r.conn, accountID).
+	if err := newSelectFollowRequests(r.db, accountID).
 		Scan(ctx, &followReqIDs); err != nil {
-		return nil, r.conn.ProcessError(err)
+		return nil, r.db.ProcessError(err)
 	}
 	return r.GetFollowRequestsByIDs(ctx, followReqIDs)
 }
 
 func (r *relationshipDB) GetAccountFollowRequesting(ctx context.Context, accountID string) ([]*gtsmodel.FollowRequest, error) {
 	var followReqIDs []string
-	if err := newSelectFollowRequesting(r.conn, accountID).
+	if err := newSelectFollowRequesting(r.db, accountID).
 		Scan(ctx, &followReqIDs); err != nil {
-		return nil, r.conn.ProcessError(err)
+		return nil, r.db.ProcessError(err)
 	}
 	return r.GetFollowRequestsByIDs(ctx, followReqIDs)
 }
 
 func (r *relationshipDB) CountAccountFollowRequests(ctx context.Context, accountID string) (int, error) {
-	n, err := newSelectFollowRequests(r.conn, accountID).Count(ctx)
-	return n, r.conn.ProcessError(err)
+	n, err := newSelectFollowRequests(r.db, accountID).Count(ctx)
+	return n, r.db.ProcessError(err)
 }
 
 func (r *relationshipDB) CountAccountFollowRequesting(ctx context.Context, accountID string) (int, error) {
-	n, err := newSelectFollowRequesting(r.conn, accountID).Count(ctx)
-	return n, r.conn.ProcessError(err)
+	n, err := newSelectFollowRequesting(r.db, accountID).Count(ctx)
+	return n, r.db.ProcessError(err)
 }
 
 // newSelectFollowRequests returns a new select query for all rows in the follow_requests table with target_account_id = accountID.
-func newSelectFollowRequests(conn *DBConn, accountID string) *bun.SelectQuery {
-	return conn.NewSelect().
+func newSelectFollowRequests(db *WrappedDB, accountID string) *bun.SelectQuery {
+	return db.NewSelect().
 		TableExpr("?", bun.Ident("follow_requests")).
 		ColumnExpr("?", bun.Ident("id")).
 		Where("? = ?", bun.Ident("target_account_id"), accountID).
@@ -182,8 +182,8 @@ func newSelectFollowRequests(conn *DBConn, accountID string) *bun.SelectQuery {
 }
 
 // newSelectFollowRequesting returns a new select query for all rows in the follow_requests table with account_id = accountID.
-func newSelectFollowRequesting(conn *DBConn, accountID string) *bun.SelectQuery {
-	return conn.NewSelect().
+func newSelectFollowRequesting(db *WrappedDB, accountID string) *bun.SelectQuery {
+	return db.NewSelect().
 		TableExpr("?", bun.Ident("follow_requests")).
 		ColumnExpr("?", bun.Ident("id")).
 		Where("? = ?", bun.Ident("target_account_id"), accountID).
@@ -191,8 +191,8 @@ func newSelectFollowRequesting(conn *DBConn, accountID string) *bun.SelectQuery 
 }
 
 // newSelectFollows returns a new select query for all rows in the follows table with account_id = accountID.
-func newSelectFollows(conn *DBConn, accountID string) *bun.SelectQuery {
-	return conn.NewSelect().
+func newSelectFollows(db *WrappedDB, accountID string) *bun.SelectQuery {
+	return db.NewSelect().
 		Table("follows").
 		Column("id").
 		Where("? = ?", bun.Ident("account_id"), accountID).
@@ -201,15 +201,15 @@ func newSelectFollows(conn *DBConn, accountID string) *bun.SelectQuery {
 
 // newSelectLocalFollows returns a new select query for all rows in the follows table with
 // account_id = accountID where the corresponding account ID has a NULL domain (i.e. is local).
-func newSelectLocalFollows(conn *DBConn, accountID string) *bun.SelectQuery {
-	return conn.NewSelect().
+func newSelectLocalFollows(db *WrappedDB, accountID string) *bun.SelectQuery {
+	return db.NewSelect().
 		Table("follows").
 		Column("id").
 		Where("? = ? AND ? IN (?)",
 			bun.Ident("account_id"),
 			accountID,
 			bun.Ident("target_account_id"),
-			conn.NewSelect().
+			db.NewSelect().
 				Table("accounts").
 				Column("id").
 				Where("? IS NULL", bun.Ident("domain")),
@@ -218,8 +218,8 @@ func newSelectLocalFollows(conn *DBConn, accountID string) *bun.SelectQuery {
 }
 
 // newSelectFollowers returns a new select query for all rows in the follows table with target_account_id = accountID.
-func newSelectFollowers(conn *DBConn, accountID string) *bun.SelectQuery {
-	return conn.NewSelect().
+func newSelectFollowers(db *WrappedDB, accountID string) *bun.SelectQuery {
+	return db.NewSelect().
 		Table("follows").
 		Column("id").
 		Where("? = ?", bun.Ident("target_account_id"), accountID).
@@ -228,15 +228,15 @@ func newSelectFollowers(conn *DBConn, accountID string) *bun.SelectQuery {
 
 // newSelectLocalFollowers returns a new select query for all rows in the follows table with
 // target_account_id = accountID where the corresponding account ID has a NULL domain (i.e. is local).
-func newSelectLocalFollowers(conn *DBConn, accountID string) *bun.SelectQuery {
-	return conn.NewSelect().
+func newSelectLocalFollowers(db *WrappedDB, accountID string) *bun.SelectQuery {
+	return db.NewSelect().
 		Table("follows").
 		Column("id").
 		Where("? = ? AND ? IN (?)",
 			bun.Ident("target_account_id"),
 			accountID,
 			bun.Ident("account_id"),
-			conn.NewSelect().
+			db.NewSelect().
 				Table("accounts").
 				Column("id").
 				Where("? IS NULL", bun.Ident("domain")),

--- a/internal/db/bundb/relationship.go
+++ b/internal/db/bundb/relationship.go
@@ -34,7 +34,7 @@ type relationshipDB struct {
 	state *state.State
 }
 
-func (r *relationshipDB) GetRelationship(ctx context.Context, requestingAccount string, targetAccount string) (*gtsmodel.Relationship, db.Error) {
+func (r *relationshipDB) GetRelationship(ctx context.Context, requestingAccount string, targetAccount string) (*gtsmodel.Relationship, error) {
 	var rel gtsmodel.Relationship
 	rel.ID = targetAccount
 

--- a/internal/db/bundb/relationship_block.go
+++ b/internal/db/bundb/relationship_block.go
@@ -28,7 +28,7 @@ import (
 	"github.com/uptrace/bun"
 )
 
-func (r *relationshipDB) IsBlocked(ctx context.Context, sourceAccountID string, targetAccountID string) (bool, db.Error) {
+func (r *relationshipDB) IsBlocked(ctx context.Context, sourceAccountID string, targetAccountID string) (bool, error) {
 	block, err := r.GetBlock(
 		gtscontext.SetBarebones(ctx),
 		sourceAccountID,

--- a/internal/db/bundb/relationship_follow.go
+++ b/internal/db/bundb/relationship_follow.go
@@ -94,7 +94,7 @@ func (r *relationshipDB) GetFollowsByIDs(ctx context.Context, ids []string) ([]*
 	return follows, nil
 }
 
-func (r *relationshipDB) IsFollowing(ctx context.Context, sourceAccountID string, targetAccountID string) (bool, db.Error) {
+func (r *relationshipDB) IsFollowing(ctx context.Context, sourceAccountID string, targetAccountID string) (bool, error) {
 	follow, err := r.GetFollow(
 		gtscontext.SetBarebones(ctx),
 		sourceAccountID,
@@ -106,7 +106,7 @@ func (r *relationshipDB) IsFollowing(ctx context.Context, sourceAccountID string
 	return (follow != nil), nil
 }
 
-func (r *relationshipDB) IsMutualFollowing(ctx context.Context, accountID1 string, accountID2 string) (bool, db.Error) {
+func (r *relationshipDB) IsMutualFollowing(ctx context.Context, accountID1 string, accountID2 string) (bool, error) {
 	// make sure account 1 follows account 2
 	f1, err := r.IsFollowing(ctx,
 		accountID1,

--- a/internal/db/bundb/relationship_follow_req.go
+++ b/internal/db/bundb/relationship_follow_req.go
@@ -93,7 +93,7 @@ func (r *relationshipDB) GetFollowRequestsByIDs(ctx context.Context, ids []strin
 	return followReqs, nil
 }
 
-func (r *relationshipDB) IsFollowRequested(ctx context.Context, sourceAccountID string, targetAccountID string) (bool, db.Error) {
+func (r *relationshipDB) IsFollowRequested(ctx context.Context, sourceAccountID string, targetAccountID string) (bool, error) {
 	followReq, err := r.GetFollowRequest(
 		gtscontext.SetBarebones(ctx),
 		sourceAccountID,
@@ -175,7 +175,7 @@ func (r *relationshipDB) UpdateFollowRequest(ctx context.Context, followRequest 
 	})
 }
 
-func (r *relationshipDB) AcceptFollowRequest(ctx context.Context, sourceAccountID string, targetAccountID string) (*gtsmodel.Follow, db.Error) {
+func (r *relationshipDB) AcceptFollowRequest(ctx context.Context, sourceAccountID string, targetAccountID string) (*gtsmodel.Follow, error) {
 	// Get original follow request.
 	followReq, err := r.GetFollowRequest(ctx, sourceAccountID, targetAccountID)
 	if err != nil {
@@ -230,7 +230,7 @@ func (r *relationshipDB) AcceptFollowRequest(ctx context.Context, sourceAccountI
 	return follow, nil
 }
 
-func (r *relationshipDB) RejectFollowRequest(ctx context.Context, sourceAccountID string, targetAccountID string) db.Error {
+func (r *relationshipDB) RejectFollowRequest(ctx context.Context, sourceAccountID string, targetAccountID string) error {
 	// Delete follow request first.
 	if err := r.DeleteFollowRequest(ctx, sourceAccountID, targetAccountID); err != nil {
 		return err

--- a/internal/db/bundb/report.go
+++ b/internal/db/bundb/report.go
@@ -32,12 +32,12 @@ import (
 )
 
 type reportDB struct {
-	conn  *DBConn
+	db    *WrappedDB
 	state *state.State
 }
 
 func (r *reportDB) newReportQ(report interface{}) *bun.SelectQuery {
-	return r.conn.NewSelect().Model(report)
+	return r.db.NewSelect().Model(report)
 }
 
 func (r *reportDB) GetReportByID(ctx context.Context, id string) (*gtsmodel.Report, error) {
@@ -54,7 +54,7 @@ func (r *reportDB) GetReportByID(ctx context.Context, id string) (*gtsmodel.Repo
 func (r *reportDB) GetReports(ctx context.Context, resolved *bool, accountID string, targetAccountID string, maxID string, sinceID string, minID string, limit int) ([]*gtsmodel.Report, error) {
 	reportIDs := []string{}
 
-	q := r.conn.
+	q := r.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("reports"), bun.Ident("report")).
 		Column("report.id").
@@ -94,7 +94,7 @@ func (r *reportDB) GetReports(ctx context.Context, resolved *bool, accountID str
 	}
 
 	if err := q.Scan(ctx, &reportIDs); err != nil {
-		return nil, r.conn.ProcessError(err)
+		return nil, r.db.ProcessError(err)
 	}
 
 	// Catch case of no reports early
@@ -125,7 +125,7 @@ func (r *reportDB) getReport(ctx context.Context, lookup string, dbQuery func(*g
 
 		// Not cached! Perform database query
 		if err := dbQuery(&report); err != nil {
-			return nil, r.conn.ProcessError(err)
+			return nil, r.db.ProcessError(err)
 		}
 
 		return &report, nil
@@ -168,8 +168,8 @@ func (r *reportDB) getReport(ctx context.Context, lookup string, dbQuery func(*g
 
 func (r *reportDB) PutReport(ctx context.Context, report *gtsmodel.Report) error {
 	return r.state.Caches.GTS.Report().Store(report, func() error {
-		_, err := r.conn.NewInsert().Model(report).Exec(ctx)
-		return r.conn.ProcessError(err)
+		_, err := r.db.NewInsert().Model(report).Exec(ctx)
+		return r.db.ProcessError(err)
 	})
 }
 
@@ -180,13 +180,13 @@ func (r *reportDB) UpdateReport(ctx context.Context, report *gtsmodel.Report, co
 		columns = append(columns, "updated_at")
 	}
 
-	if _, err := r.conn.
+	if _, err := r.db.
 		NewUpdate().
 		Model(report).
 		Where("? = ?", bun.Ident("report.id"), report.ID).
 		Column(columns...).
 		Exec(ctx); err != nil {
-		return nil, r.conn.ProcessError(err)
+		return nil, r.db.ProcessError(err)
 	}
 
 	r.state.Caches.GTS.Report().Invalidate("ID", report.ID)
@@ -209,9 +209,9 @@ func (r *reportDB) DeleteReportByID(ctx context.Context, id string) error {
 	}
 
 	// Finally delete report from DB.
-	_, err = r.conn.NewDelete().
+	_, err = r.db.NewDelete().
 		TableExpr("? AS ?", bun.Ident("reports"), bun.Ident("report")).
 		Where("? = ?", bun.Ident("report.id"), id).
 		Exec(ctx)
-	return r.conn.ProcessError(err)
+	return r.db.ProcessError(err)
 }

--- a/internal/db/bundb/search.go
+++ b/internal/db/bundb/search.go
@@ -225,7 +225,7 @@ func (s *searchDB) accountText(following bool) *bun.SelectQuery {
 	// different number of placeholders depending on
 	// following/not following. COALESCE calls ensure
 	// that we're not trying to concatenate null values.
-	d := s.conn.Dialect().Name()
+	d := s.conn.db.Dialect().Name()
 	switch {
 
 	case d == dialect.SQLite && following:
@@ -365,7 +365,7 @@ func (s *searchDB) statusText() *bun.SelectQuery {
 
 	// SQLite and Postgres use different
 	// syntaxes for concatenation.
-	switch s.conn.Dialect().Name() {
+	switch s.conn.db.Dialect().Name() {
 
 	case dialect.SQLite:
 		statusText = statusText.ColumnExpr(

--- a/internal/db/bundb/search.go
+++ b/internal/db/bundb/search.go
@@ -225,7 +225,7 @@ func (s *searchDB) accountText(following bool) *bun.SelectQuery {
 	// different number of placeholders depending on
 	// following/not following. COALESCE calls ensure
 	// that we're not trying to concatenate null values.
-	d := s.conn.db.Dialect().Name()
+	d := s.conn.Dialect().Name()
 	switch {
 
 	case d == dialect.SQLite && following:
@@ -365,7 +365,7 @@ func (s *searchDB) statusText() *bun.SelectQuery {
 
 	// SQLite and Postgres use different
 	// syntaxes for concatenation.
-	switch s.conn.db.Dialect().Name() {
+	switch s.conn.Dialect().Name() {
 
 	case dialect.SQLite:
 		statusText = statusText.ColumnExpr(

--- a/internal/db/bundb/session.go
+++ b/internal/db/bundb/session.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rand"
 	"io"
 
-	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/id"
 )
@@ -31,7 +30,7 @@ type sessionDB struct {
 	conn *DBConn
 }
 
-func (s *sessionDB) GetSession(ctx context.Context) (*gtsmodel.RouterSession, db.Error) {
+func (s *sessionDB) GetSession(ctx context.Context) (*gtsmodel.RouterSession, error) {
 	rss := make([]*gtsmodel.RouterSession, 0, 1)
 
 	// get the first router session in the db or...
@@ -52,7 +51,7 @@ func (s *sessionDB) GetSession(ctx context.Context) (*gtsmodel.RouterSession, db
 	return rss[0], nil
 }
 
-func (s *sessionDB) createSession(ctx context.Context) (*gtsmodel.RouterSession, db.Error) {
+func (s *sessionDB) createSession(ctx context.Context) (*gtsmodel.RouterSession, error) {
 	buf := make([]byte, 64)
 	auth := buf[:32]
 	crypt := buf[32:64]

--- a/internal/db/bundb/session.go
+++ b/internal/db/bundb/session.go
@@ -27,20 +27,20 @@ import (
 )
 
 type sessionDB struct {
-	conn *DBConn
+	db *WrappedDB
 }
 
 func (s *sessionDB) GetSession(ctx context.Context) (*gtsmodel.RouterSession, error) {
 	rss := make([]*gtsmodel.RouterSession, 0, 1)
 
 	// get the first router session in the db or...
-	if err := s.conn.
+	if err := s.db.
 		NewSelect().
 		Model(&rss).
 		Limit(1).
 		Order("router_session.id DESC").
 		Scan(ctx); err != nil {
-		return nil, s.conn.ProcessError(err)
+		return nil, s.db.ProcessError(err)
 	}
 
 	// ... create a new one
@@ -66,11 +66,11 @@ func (s *sessionDB) createSession(ctx context.Context) (*gtsmodel.RouterSession,
 		Crypt: crypt,
 	}
 
-	if _, err := s.conn.
+	if _, err := s.db.
 		NewInsert().
 		Model(rs).
 		Exec(ctx); err != nil {
-		return nil, s.conn.ProcessError(err)
+		return nil, s.db.ProcessError(err)
 	}
 
 	return rs, nil

--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -35,12 +35,12 @@ import (
 )
 
 type statusDB struct {
-	conn  *DBConn
+	db    *WrappedDB
 	state *state.State
 }
 
 func (s *statusDB) newStatusQ(status interface{}) *bun.SelectQuery {
-	return s.conn.
+	return s.db.
 		NewSelect().
 		Model(status).
 		Relation("Tags").
@@ -105,7 +105,7 @@ func (s *statusDB) getStatus(ctx context.Context, lookup string, dbQuery func(*g
 
 		// Not cached! Perform database query.
 		if err := dbQuery(&status); err != nil {
-			return nil, s.conn.ProcessError(err)
+			return nil, s.db.ProcessError(err)
 		}
 
 		return &status, nil
@@ -248,7 +248,7 @@ func (s *statusDB) PutStatus(ctx context.Context, status *gtsmodel.Status) error
 		// It is safe to run this database transaction within cache.Store
 		// as the cache does not attempt a mutex lock until AFTER hook.
 		//
-		return s.conn.RunInTx(ctx, func(tx bun.Tx) error {
+		return s.db.RunInTx(ctx, func(tx bun.Tx) error {
 			// create links between this status and any emojis it uses
 			for _, i := range status.EmojiIDs {
 				if _, err := tx.
@@ -259,7 +259,7 @@ func (s *statusDB) PutStatus(ctx context.Context, status *gtsmodel.Status) error
 					}).
 					On("CONFLICT (?, ?) DO NOTHING", bun.Ident("status_id"), bun.Ident("emoji_id")).
 					Exec(ctx); err != nil {
-					err = s.conn.ProcessError(err)
+					err = s.db.ProcessError(err)
 					if !errors.Is(err, db.ErrAlreadyExists) {
 						return err
 					}
@@ -276,7 +276,7 @@ func (s *statusDB) PutStatus(ctx context.Context, status *gtsmodel.Status) error
 					}).
 					On("CONFLICT (?, ?) DO NOTHING", bun.Ident("status_id"), bun.Ident("tag_id")).
 					Exec(ctx); err != nil {
-					err = s.conn.ProcessError(err)
+					err = s.db.ProcessError(err)
 					if !errors.Is(err, db.ErrAlreadyExists) {
 						return err
 					}
@@ -292,7 +292,7 @@ func (s *statusDB) PutStatus(ctx context.Context, status *gtsmodel.Status) error
 					Model(a).
 					Where("? = ?", bun.Ident("media_attachment.id"), a.ID).
 					Exec(ctx); err != nil {
-					err = s.conn.ProcessError(err)
+					err = s.db.ProcessError(err)
 					if !errors.Is(err, db.ErrAlreadyExists) {
 						return err
 					}
@@ -317,7 +317,7 @@ func (s *statusDB) UpdateStatus(ctx context.Context, status *gtsmodel.Status, co
 		// It is safe to run this database transaction within cache.Store
 		// as the cache does not attempt a mutex lock until AFTER hook.
 		//
-		return s.conn.RunInTx(ctx, func(tx bun.Tx) error {
+		return s.db.RunInTx(ctx, func(tx bun.Tx) error {
 			// create links between this status and any emojis it uses
 			for _, i := range status.EmojiIDs {
 				if _, err := tx.
@@ -328,7 +328,7 @@ func (s *statusDB) UpdateStatus(ctx context.Context, status *gtsmodel.Status, co
 					}).
 					On("CONFLICT (?, ?) DO NOTHING", bun.Ident("status_id"), bun.Ident("emoji_id")).
 					Exec(ctx); err != nil {
-					err = s.conn.ProcessError(err)
+					err = s.db.ProcessError(err)
 					if !errors.Is(err, db.ErrAlreadyExists) {
 						return err
 					}
@@ -345,7 +345,7 @@ func (s *statusDB) UpdateStatus(ctx context.Context, status *gtsmodel.Status, co
 					}).
 					On("CONFLICT (?, ?) DO NOTHING", bun.Ident("status_id"), bun.Ident("tag_id")).
 					Exec(ctx); err != nil {
-					err = s.conn.ProcessError(err)
+					err = s.db.ProcessError(err)
 					if !errors.Is(err, db.ErrAlreadyExists) {
 						return err
 					}
@@ -361,7 +361,7 @@ func (s *statusDB) UpdateStatus(ctx context.Context, status *gtsmodel.Status, co
 					Model(a).
 					Where("? = ?", bun.Ident("media_attachment.id"), a.ID).
 					Exec(ctx); err != nil {
-					err = s.conn.ProcessError(err)
+					err = s.db.ProcessError(err)
 					if !errors.Is(err, db.ErrAlreadyExists) {
 						return err
 					}
@@ -397,7 +397,7 @@ func (s *statusDB) DeleteStatusByID(ctx context.Context, id string) error {
 		return err
 	}
 
-	return s.conn.RunInTx(ctx, func(tx bun.Tx) error {
+	return s.db.RunInTx(ctx, func(tx bun.Tx) error {
 		// delete links between this status and any emojis it uses
 		if _, err := tx.
 			NewDelete().
@@ -433,7 +433,7 @@ func (s *statusDB) GetStatusesUsingEmoji(ctx context.Context, emojiID string) ([
 	var statusIDs []string
 
 	// Create SELECT status query.
-	q := s.conn.NewSelect().
+	q := s.db.NewSelect().
 		Table("statuses").
 		Column("id")
 
@@ -450,7 +450,7 @@ func (s *statusDB) GetStatusesUsingEmoji(ctx context.Context, emojiID string) ([
 
 	// Execute the query, scanning destination into statusIDs.
 	if _, err := q.Exec(ctx, &statusIDs); err != nil {
-		return nil, s.conn.ProcessError(err)
+		return nil, s.db.ProcessError(err)
 	}
 
 	// Convert status IDs into status objects.
@@ -509,7 +509,7 @@ func (s *statusDB) GetStatusChildren(ctx context.Context, status *gtsmodel.Statu
 func (s *statusDB) statusChildren(ctx context.Context, status *gtsmodel.Status, foundStatuses *list.List, onlyDirect bool, minID string) {
 	var childIDs []string
 
-	q := s.conn.
+	q := s.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("statuses"), bun.Ident("status")).
 		Column("status.id").
@@ -555,7 +555,7 @@ func (s *statusDB) statusChildren(ctx context.Context, status *gtsmodel.Status, 
 }
 
 func (s *statusDB) CountStatusReplies(ctx context.Context, status *gtsmodel.Status) (int, error) {
-	return s.conn.
+	return s.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("statuses"), bun.Ident("status")).
 		Where("? = ?", bun.Ident("status.in_reply_to_id"), status.ID).
@@ -563,7 +563,7 @@ func (s *statusDB) CountStatusReplies(ctx context.Context, status *gtsmodel.Stat
 }
 
 func (s *statusDB) CountStatusReblogs(ctx context.Context, status *gtsmodel.Status) (int, error) {
-	return s.conn.
+	return s.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("statuses"), bun.Ident("status")).
 		Where("? = ?", bun.Ident("status.boost_of_id"), status.ID).
@@ -571,7 +571,7 @@ func (s *statusDB) CountStatusReblogs(ctx context.Context, status *gtsmodel.Stat
 }
 
 func (s *statusDB) CountStatusFaves(ctx context.Context, status *gtsmodel.Status) (int, error) {
-	return s.conn.
+	return s.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("status_faves"), bun.Ident("status_fave")).
 		Where("? = ?", bun.Ident("status_fave.status_id"), status.ID).
@@ -579,43 +579,43 @@ func (s *statusDB) CountStatusFaves(ctx context.Context, status *gtsmodel.Status
 }
 
 func (s *statusDB) IsStatusFavedBy(ctx context.Context, status *gtsmodel.Status, accountID string) (bool, error) {
-	q := s.conn.
+	q := s.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("status_faves"), bun.Ident("status_fave")).
 		Where("? = ?", bun.Ident("status_fave.status_id"), status.ID).
 		Where("? = ?", bun.Ident("status_fave.account_id"), accountID)
 
-	return s.conn.Exists(ctx, q)
+	return s.db.Exists(ctx, q)
 }
 
 func (s *statusDB) IsStatusRebloggedBy(ctx context.Context, status *gtsmodel.Status, accountID string) (bool, error) {
-	q := s.conn.
+	q := s.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("statuses"), bun.Ident("status")).
 		Where("? = ?", bun.Ident("status.boost_of_id"), status.ID).
 		Where("? = ?", bun.Ident("status.account_id"), accountID)
 
-	return s.conn.Exists(ctx, q)
+	return s.db.Exists(ctx, q)
 }
 
 func (s *statusDB) IsStatusMutedBy(ctx context.Context, status *gtsmodel.Status, accountID string) (bool, error) {
-	q := s.conn.
+	q := s.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("status_mutes"), bun.Ident("status_mute")).
 		Where("? = ?", bun.Ident("status_mute.status_id"), status.ID).
 		Where("? = ?", bun.Ident("status_mute.account_id"), accountID)
 
-	return s.conn.Exists(ctx, q)
+	return s.db.Exists(ctx, q)
 }
 
 func (s *statusDB) IsStatusBookmarkedBy(ctx context.Context, status *gtsmodel.Status, accountID string) (bool, error) {
-	q := s.conn.
+	q := s.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("status_bookmarks"), bun.Ident("status_bookmark")).
 		Where("? = ?", bun.Ident("status_bookmark.status_id"), status.ID).
 		Where("? = ?", bun.Ident("status_bookmark.account_id"), accountID)
 
-	return s.conn.Exists(ctx, q)
+	return s.db.Exists(ctx, q)
 }
 
 func (s *statusDB) GetStatusReblogs(ctx context.Context, status *gtsmodel.Status) ([]*gtsmodel.Status, error) {
@@ -626,7 +626,7 @@ func (s *statusDB) GetStatusReblogs(ctx context.Context, status *gtsmodel.Status
 		Where("? = ?", bun.Ident("status.boost_of_id"), status.ID)
 
 	if err := q.Scan(ctx); err != nil {
-		return nil, s.conn.ProcessError(err)
+		return nil, s.db.ProcessError(err)
 	}
 	return reblogs, nil
 }

--- a/internal/db/bundb/statusbookmark.go
+++ b/internal/db/bundb/statusbookmark.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
@@ -34,7 +33,7 @@ type statusBookmarkDB struct {
 	state *state.State
 }
 
-func (s *statusBookmarkDB) GetStatusBookmark(ctx context.Context, id string) (*gtsmodel.StatusBookmark, db.Error) {
+func (s *statusBookmarkDB) GetStatusBookmark(ctx context.Context, id string) (*gtsmodel.StatusBookmark, error) {
 	bookmark := new(gtsmodel.StatusBookmark)
 
 	err := s.conn.
@@ -64,7 +63,7 @@ func (s *statusBookmarkDB) GetStatusBookmark(ctx context.Context, id string) (*g
 	return bookmark, nil
 }
 
-func (s *statusBookmarkDB) GetStatusBookmarkID(ctx context.Context, accountID string, statusID string) (string, db.Error) {
+func (s *statusBookmarkDB) GetStatusBookmarkID(ctx context.Context, accountID string, statusID string) (string, error) {
 	var id string
 
 	q := s.conn.
@@ -82,7 +81,7 @@ func (s *statusBookmarkDB) GetStatusBookmarkID(ctx context.Context, accountID st
 	return id, nil
 }
 
-func (s *statusBookmarkDB) GetStatusBookmarks(ctx context.Context, accountID string, limit int, maxID string, minID string) ([]*gtsmodel.StatusBookmark, db.Error) {
+func (s *statusBookmarkDB) GetStatusBookmarks(ctx context.Context, accountID string, limit int, maxID string, minID string) ([]*gtsmodel.StatusBookmark, error) {
 	// Ensure reasonable
 	if limit < 0 {
 		limit = 0
@@ -133,7 +132,7 @@ func (s *statusBookmarkDB) GetStatusBookmarks(ctx context.Context, accountID str
 	return bookmarks, nil
 }
 
-func (s *statusBookmarkDB) PutStatusBookmark(ctx context.Context, statusBookmark *gtsmodel.StatusBookmark) db.Error {
+func (s *statusBookmarkDB) PutStatusBookmark(ctx context.Context, statusBookmark *gtsmodel.StatusBookmark) error {
 	_, err := s.conn.
 		NewInsert().
 		Model(statusBookmark).
@@ -142,7 +141,7 @@ func (s *statusBookmarkDB) PutStatusBookmark(ctx context.Context, statusBookmark
 	return s.conn.ProcessError(err)
 }
 
-func (s *statusBookmarkDB) DeleteStatusBookmark(ctx context.Context, id string) db.Error {
+func (s *statusBookmarkDB) DeleteStatusBookmark(ctx context.Context, id string) error {
 	_, err := s.conn.
 		NewDelete().
 		TableExpr("? AS ?", bun.Ident("status_bookmarks"), bun.Ident("status_bookmark")).
@@ -152,7 +151,7 @@ func (s *statusBookmarkDB) DeleteStatusBookmark(ctx context.Context, id string) 
 	return s.conn.ProcessError(err)
 }
 
-func (s *statusBookmarkDB) DeleteStatusBookmarks(ctx context.Context, targetAccountID string, originAccountID string) db.Error {
+func (s *statusBookmarkDB) DeleteStatusBookmarks(ctx context.Context, targetAccountID string, originAccountID string) error {
 	if targetAccountID == "" && originAccountID == "" {
 		return errors.New("DeleteBookmarks: one of targetAccountID or originAccountID must be set")
 	}
@@ -180,7 +179,7 @@ func (s *statusBookmarkDB) DeleteStatusBookmarks(ctx context.Context, targetAcco
 	return nil
 }
 
-func (s *statusBookmarkDB) DeleteStatusBookmarksForStatus(ctx context.Context, statusID string) db.Error {
+func (s *statusBookmarkDB) DeleteStatusBookmarksForStatus(ctx context.Context, statusID string) error {
 	// TODO: Capture bookmark IDs in a RETURNING
 	// statement (when bookmarks have a cache),
 	// + use the IDs to invalidate cache entries.

--- a/internal/db/bundb/statusfave.go
+++ b/internal/db/bundb/statusfave.go
@@ -36,7 +36,7 @@ type statusFaveDB struct {
 	state *state.State
 }
 
-func (s *statusFaveDB) GetStatusFave(ctx context.Context, accountID string, statusID string) (*gtsmodel.StatusFave, db.Error) {
+func (s *statusFaveDB) GetStatusFave(ctx context.Context, accountID string, statusID string) (*gtsmodel.StatusFave, error) {
 	return s.getStatusFave(
 		ctx,
 		"AccountID.StatusID",
@@ -53,7 +53,7 @@ func (s *statusFaveDB) GetStatusFave(ctx context.Context, accountID string, stat
 	)
 }
 
-func (s *statusFaveDB) GetStatusFaveByID(ctx context.Context, id string) (*gtsmodel.StatusFave, db.Error) {
+func (s *statusFaveDB) GetStatusFaveByID(ctx context.Context, id string) (*gtsmodel.StatusFave, error) {
 	return s.getStatusFave(
 		ctx,
 		"ID",
@@ -119,7 +119,7 @@ func (s *statusFaveDB) getStatusFave(ctx context.Context, lookup string, dbQuery
 	return fave, nil
 }
 
-func (s *statusFaveDB) GetStatusFavesForStatus(ctx context.Context, statusID string) ([]*gtsmodel.StatusFave, db.Error) {
+func (s *statusFaveDB) GetStatusFavesForStatus(ctx context.Context, statusID string) ([]*gtsmodel.StatusFave, error) {
 	ids := []string{}
 
 	if err := s.conn.
@@ -188,7 +188,7 @@ func (s *statusFaveDB) PopulateStatusFave(ctx context.Context, statusFave *gtsmo
 	return errs.Combine()
 }
 
-func (s *statusFaveDB) PutStatusFave(ctx context.Context, fave *gtsmodel.StatusFave) db.Error {
+func (s *statusFaveDB) PutStatusFave(ctx context.Context, fave *gtsmodel.StatusFave) error {
 	return s.state.Caches.GTS.StatusFave().Store(fave, func() error {
 		_, err := s.conn.
 			NewInsert().
@@ -198,7 +198,7 @@ func (s *statusFaveDB) PutStatusFave(ctx context.Context, fave *gtsmodel.StatusF
 	})
 }
 
-func (s *statusFaveDB) DeleteStatusFaveByID(ctx context.Context, id string) db.Error {
+func (s *statusFaveDB) DeleteStatusFaveByID(ctx context.Context, id string) error {
 	defer s.state.Caches.GTS.StatusFave().Invalidate("ID", id)
 
 	// Load fave into cache before attempting a delete,
@@ -221,7 +221,7 @@ func (s *statusFaveDB) DeleteStatusFaveByID(ctx context.Context, id string) db.E
 	return s.conn.ProcessError(err)
 }
 
-func (s *statusFaveDB) DeleteStatusFaves(ctx context.Context, targetAccountID string, originAccountID string) db.Error {
+func (s *statusFaveDB) DeleteStatusFaves(ctx context.Context, targetAccountID string, originAccountID string) error {
 	if targetAccountID == "" && originAccountID == "" {
 		return errors.New("DeleteStatusFaves: one of targetAccountID or originAccountID must be set")
 	}
@@ -270,7 +270,7 @@ func (s *statusFaveDB) DeleteStatusFaves(ctx context.Context, targetAccountID st
 	return s.conn.ProcessError(err)
 }
 
-func (s *statusFaveDB) DeleteStatusFavesForStatus(ctx context.Context, statusID string) db.Error {
+func (s *statusFaveDB) DeleteStatusFavesForStatus(ctx context.Context, statusID string) error {
 	// Capture fave IDs in a RETURNING statement.
 	var faveIDs []string
 

--- a/internal/db/bundb/timeline.go
+++ b/internal/db/bundb/timeline.go
@@ -37,7 +37,7 @@ type timelineDB struct {
 	state *state.State
 }
 
-func (t *timelineDB) GetHomeTimeline(ctx context.Context, accountID string, maxID string, sinceID string, minID string, limit int, local bool) ([]*gtsmodel.Status, db.Error) {
+func (t *timelineDB) GetHomeTimeline(ctx context.Context, accountID string, maxID string, sinceID string, minID string, limit int, local bool) ([]*gtsmodel.Status, error) {
 	// Ensure reasonable
 	if limit < 0 {
 		limit = 0
@@ -151,7 +151,7 @@ func (t *timelineDB) GetHomeTimeline(ctx context.Context, accountID string, maxI
 	return statuses, nil
 }
 
-func (t *timelineDB) GetPublicTimeline(ctx context.Context, maxID string, sinceID string, minID string, limit int, local bool) ([]*gtsmodel.Status, db.Error) {
+func (t *timelineDB) GetPublicTimeline(ctx context.Context, maxID string, sinceID string, minID string, limit int, local bool) ([]*gtsmodel.Status, error) {
 	// Ensure reasonable
 	if limit < 0 {
 		limit = 0
@@ -224,7 +224,7 @@ func (t *timelineDB) GetPublicTimeline(ctx context.Context, maxID string, sinceI
 
 // TODO optimize this query and the logic here, because it's slow as balls -- it takes like a literal second to return with a limit of 20!
 // It might be worth serving it through a timeline instead of raw DB queries, like we do for Home feeds.
-func (t *timelineDB) GetFavedTimeline(ctx context.Context, accountID string, maxID string, minID string, limit int) ([]*gtsmodel.Status, string, string, db.Error) {
+func (t *timelineDB) GetFavedTimeline(ctx context.Context, accountID string, maxID string, minID string, limit int) ([]*gtsmodel.Status, string, string, error) {
 	// Ensure reasonable
 	if limit < 0 {
 		limit = 0

--- a/internal/db/bundb/timeline.go
+++ b/internal/db/bundb/timeline.go
@@ -33,7 +33,7 @@ import (
 )
 
 type timelineDB struct {
-	conn  *DBConn
+	db    *WrappedDB
 	state *state.State
 }
 
@@ -49,7 +49,7 @@ func (t *timelineDB) GetHomeTimeline(ctx context.Context, accountID string, maxI
 		frontToBack = true
 	)
 
-	q := t.conn.
+	q := t.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("statuses"), bun.Ident("status")).
 		// Select only IDs from table
@@ -103,7 +103,7 @@ func (t *timelineDB) GetHomeTimeline(ctx context.Context, accountID string, maxI
 
 	// Subquery to select target (followed) account
 	// IDs from follows owned by given accountID.
-	subQ := t.conn.
+	subQ := t.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("follows"), bun.Ident("follow")).
 		Column("follow.target_account_id").
@@ -119,7 +119,7 @@ func (t *timelineDB) GetHomeTimeline(ctx context.Context, accountID string, maxI
 	})
 
 	if err := q.Scan(ctx, &statusIDs); err != nil {
-		return nil, t.conn.ProcessError(err)
+		return nil, t.db.ProcessError(err)
 	}
 
 	if len(statusIDs) == 0 {
@@ -160,7 +160,7 @@ func (t *timelineDB) GetPublicTimeline(ctx context.Context, maxID string, sinceI
 	// Make educated guess for slice size
 	statusIDs := make([]string, 0, limit)
 
-	q := t.conn.
+	q := t.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("statuses"), bun.Ident("status")).
 		Column("status.id").
@@ -202,7 +202,7 @@ func (t *timelineDB) GetPublicTimeline(ctx context.Context, maxID string, sinceI
 	}
 
 	if err := q.Scan(ctx, &statusIDs); err != nil {
-		return nil, t.conn.ProcessError(err)
+		return nil, t.db.ProcessError(err)
 	}
 
 	statuses := make([]*gtsmodel.Status, 0, len(statusIDs))
@@ -233,7 +233,7 @@ func (t *timelineDB) GetFavedTimeline(ctx context.Context, accountID string, max
 	// Make educated guess for slice size
 	faves := make([]*gtsmodel.StatusFave, 0, limit)
 
-	fq := t.conn.
+	fq := t.db.
 		NewSelect().
 		Model(&faves).
 		Where("? = ?", bun.Ident("status_fave.account_id"), accountID).
@@ -253,7 +253,7 @@ func (t *timelineDB) GetFavedTimeline(ctx context.Context, accountID string, max
 
 	err := fq.Scan(ctx)
 	if err != nil {
-		return nil, "", "", t.conn.ProcessError(err)
+		return nil, "", "", t.db.ProcessError(err)
 	}
 
 	if len(faves) == 0 {
@@ -322,7 +322,7 @@ func (t *timelineDB) GetListTimeline(
 	}
 
 	// Select target account IDs from follows.
-	subQ := t.conn.
+	subQ := t.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("follows"), bun.Ident("follow")).
 		Column("follow.target_account_id").
@@ -330,7 +330,7 @@ func (t *timelineDB) GetListTimeline(
 
 	// Select only status IDs created
 	// by one of the followed accounts.
-	q := t.conn.
+	q := t.db.
 		NewSelect().
 		TableExpr("? AS ?", bun.Ident("statuses"), bun.Ident("status")).
 		// Select only IDs from table
@@ -379,7 +379,7 @@ func (t *timelineDB) GetListTimeline(
 	}
 
 	if err := q.Scan(ctx, &statusIDs); err != nil {
-		return nil, t.conn.ProcessError(err)
+		return nil, t.db.ProcessError(err)
 	}
 
 	if len(statusIDs) == 0 {

--- a/internal/db/bundb/tombstone.go
+++ b/internal/db/bundb/tombstone.go
@@ -31,7 +31,7 @@ type tombstoneDB struct {
 	state *state.State
 }
 
-func (t *tombstoneDB) GetTombstoneByURI(ctx context.Context, uri string) (*gtsmodel.Tombstone, db.Error) {
+func (t *tombstoneDB) GetTombstoneByURI(ctx context.Context, uri string) (*gtsmodel.Tombstone, error) {
 	return t.state.Caches.GTS.Tombstone().Load("URI", func() (*gtsmodel.Tombstone, error) {
 		var tomb gtsmodel.Tombstone
 
@@ -48,7 +48,7 @@ func (t *tombstoneDB) GetTombstoneByURI(ctx context.Context, uri string) (*gtsmo
 	}, uri)
 }
 
-func (t *tombstoneDB) TombstoneExistsWithURI(ctx context.Context, uri string) (bool, db.Error) {
+func (t *tombstoneDB) TombstoneExistsWithURI(ctx context.Context, uri string) (bool, error) {
 	tomb, err := t.GetTombstoneByURI(ctx, uri)
 	if err == db.ErrNoEntries {
 		err = nil
@@ -56,7 +56,7 @@ func (t *tombstoneDB) TombstoneExistsWithURI(ctx context.Context, uri string) (b
 	return (tomb != nil), err
 }
 
-func (t *tombstoneDB) PutTombstone(ctx context.Context, tombstone *gtsmodel.Tombstone) db.Error {
+func (t *tombstoneDB) PutTombstone(ctx context.Context, tombstone *gtsmodel.Tombstone) error {
 	return t.state.Caches.GTS.Tombstone().Store(tombstone, func() error {
 		_, err := t.conn.
 			NewInsert().
@@ -66,7 +66,7 @@ func (t *tombstoneDB) PutTombstone(ctx context.Context, tombstone *gtsmodel.Tomb
 	})
 }
 
-func (t *tombstoneDB) DeleteTombstone(ctx context.Context, id string) db.Error {
+func (t *tombstoneDB) DeleteTombstone(ctx context.Context, id string) error {
 	defer t.state.Caches.GTS.Tombstone().Invalidate("ID", id)
 
 	// Delete tombstone from DB.

--- a/internal/db/bundb/user.go
+++ b/internal/db/bundb/user.go
@@ -34,7 +34,7 @@ type userDB struct {
 	state *state.State
 }
 
-func (u *userDB) GetUserByID(ctx context.Context, id string) (*gtsmodel.User, db.Error) {
+func (u *userDB) GetUserByID(ctx context.Context, id string) (*gtsmodel.User, error) {
 	return u.state.Caches.GTS.User().Load("ID", func() (*gtsmodel.User, error) {
 		var user gtsmodel.User
 
@@ -52,7 +52,7 @@ func (u *userDB) GetUserByID(ctx context.Context, id string) (*gtsmodel.User, db
 	}, id)
 }
 
-func (u *userDB) GetUserByAccountID(ctx context.Context, accountID string) (*gtsmodel.User, db.Error) {
+func (u *userDB) GetUserByAccountID(ctx context.Context, accountID string) (*gtsmodel.User, error) {
 	return u.state.Caches.GTS.User().Load("AccountID", func() (*gtsmodel.User, error) {
 		var user gtsmodel.User
 
@@ -70,7 +70,7 @@ func (u *userDB) GetUserByAccountID(ctx context.Context, accountID string) (*gts
 	}, accountID)
 }
 
-func (u *userDB) GetUserByEmailAddress(ctx context.Context, emailAddress string) (*gtsmodel.User, db.Error) {
+func (u *userDB) GetUserByEmailAddress(ctx context.Context, emailAddress string) (*gtsmodel.User, error) {
 	return u.state.Caches.GTS.User().Load("Email", func() (*gtsmodel.User, error) {
 		var user gtsmodel.User
 
@@ -88,7 +88,7 @@ func (u *userDB) GetUserByEmailAddress(ctx context.Context, emailAddress string)
 	}, emailAddress)
 }
 
-func (u *userDB) GetUserByExternalID(ctx context.Context, id string) (*gtsmodel.User, db.Error) {
+func (u *userDB) GetUserByExternalID(ctx context.Context, id string) (*gtsmodel.User, error) {
 	return u.state.Caches.GTS.User().Load("ExternalID", func() (*gtsmodel.User, error) {
 		var user gtsmodel.User
 
@@ -106,7 +106,7 @@ func (u *userDB) GetUserByExternalID(ctx context.Context, id string) (*gtsmodel.
 	}, id)
 }
 
-func (u *userDB) GetUserByConfirmationToken(ctx context.Context, confirmationToken string) (*gtsmodel.User, db.Error) {
+func (u *userDB) GetUserByConfirmationToken(ctx context.Context, confirmationToken string) (*gtsmodel.User, error) {
 	return u.state.Caches.GTS.User().Load("ConfirmationToken", func() (*gtsmodel.User, error) {
 		var user gtsmodel.User
 
@@ -124,7 +124,7 @@ func (u *userDB) GetUserByConfirmationToken(ctx context.Context, confirmationTok
 	}, confirmationToken)
 }
 
-func (u *userDB) GetAllUsers(ctx context.Context) ([]*gtsmodel.User, db.Error) {
+func (u *userDB) GetAllUsers(ctx context.Context) ([]*gtsmodel.User, error) {
 	var users []*gtsmodel.User
 	q := u.conn.
 		NewSelect().
@@ -138,7 +138,7 @@ func (u *userDB) GetAllUsers(ctx context.Context) ([]*gtsmodel.User, db.Error) {
 	return users, nil
 }
 
-func (u *userDB) PutUser(ctx context.Context, user *gtsmodel.User) db.Error {
+func (u *userDB) PutUser(ctx context.Context, user *gtsmodel.User) error {
 	return u.state.Caches.GTS.User().Store(user, func() error {
 		_, err := u.conn.
 			NewInsert().
@@ -148,7 +148,7 @@ func (u *userDB) PutUser(ctx context.Context, user *gtsmodel.User) db.Error {
 	})
 }
 
-func (u *userDB) UpdateUser(ctx context.Context, user *gtsmodel.User, columns ...string) db.Error {
+func (u *userDB) UpdateUser(ctx context.Context, user *gtsmodel.User, columns ...string) error {
 	// Update the user's last-updated
 	user.UpdatedAt = time.Now()
 
@@ -168,7 +168,7 @@ func (u *userDB) UpdateUser(ctx context.Context, user *gtsmodel.User, columns ..
 	})
 }
 
-func (u *userDB) DeleteUserByID(ctx context.Context, userID string) db.Error {
+func (u *userDB) DeleteUserByID(ctx context.Context, userID string) error {
 	defer u.state.Caches.GTS.User().Invalidate("ID", userID)
 
 	// Load user into cache before attempting a delete,

--- a/internal/db/bundb/user.go
+++ b/internal/db/bundb/user.go
@@ -30,7 +30,7 @@ import (
 )
 
 type userDB struct {
-	conn  *DBConn
+	db    *WrappedDB
 	state *state.State
 }
 
@@ -38,14 +38,14 @@ func (u *userDB) GetUserByID(ctx context.Context, id string) (*gtsmodel.User, er
 	return u.state.Caches.GTS.User().Load("ID", func() (*gtsmodel.User, error) {
 		var user gtsmodel.User
 
-		q := u.conn.
+		q := u.db.
 			NewSelect().
 			Model(&user).
 			Relation("Account").
 			Where("? = ?", bun.Ident("user.id"), id)
 
 		if err := q.Scan(ctx); err != nil {
-			return nil, u.conn.ProcessError(err)
+			return nil, u.db.ProcessError(err)
 		}
 
 		return &user, nil
@@ -56,14 +56,14 @@ func (u *userDB) GetUserByAccountID(ctx context.Context, accountID string) (*gts
 	return u.state.Caches.GTS.User().Load("AccountID", func() (*gtsmodel.User, error) {
 		var user gtsmodel.User
 
-		q := u.conn.
+		q := u.db.
 			NewSelect().
 			Model(&user).
 			Relation("Account").
 			Where("? = ?", bun.Ident("user.account_id"), accountID)
 
 		if err := q.Scan(ctx); err != nil {
-			return nil, u.conn.ProcessError(err)
+			return nil, u.db.ProcessError(err)
 		}
 
 		return &user, nil
@@ -74,14 +74,14 @@ func (u *userDB) GetUserByEmailAddress(ctx context.Context, emailAddress string)
 	return u.state.Caches.GTS.User().Load("Email", func() (*gtsmodel.User, error) {
 		var user gtsmodel.User
 
-		q := u.conn.
+		q := u.db.
 			NewSelect().
 			Model(&user).
 			Relation("Account").
 			Where("? = ?", bun.Ident("user.email"), emailAddress)
 
 		if err := q.Scan(ctx); err != nil {
-			return nil, u.conn.ProcessError(err)
+			return nil, u.db.ProcessError(err)
 		}
 
 		return &user, nil
@@ -92,14 +92,14 @@ func (u *userDB) GetUserByExternalID(ctx context.Context, id string) (*gtsmodel.
 	return u.state.Caches.GTS.User().Load("ExternalID", func() (*gtsmodel.User, error) {
 		var user gtsmodel.User
 
-		q := u.conn.
+		q := u.db.
 			NewSelect().
 			Model(&user).
 			Relation("Account").
 			Where("? = ?", bun.Ident("user.external_id"), id)
 
 		if err := q.Scan(ctx); err != nil {
-			return nil, u.conn.ProcessError(err)
+			return nil, u.db.ProcessError(err)
 		}
 
 		return &user, nil
@@ -110,14 +110,14 @@ func (u *userDB) GetUserByConfirmationToken(ctx context.Context, confirmationTok
 	return u.state.Caches.GTS.User().Load("ConfirmationToken", func() (*gtsmodel.User, error) {
 		var user gtsmodel.User
 
-		q := u.conn.
+		q := u.db.
 			NewSelect().
 			Model(&user).
 			Relation("Account").
 			Where("? = ?", bun.Ident("user.confirmation_token"), confirmationToken)
 
 		if err := q.Scan(ctx); err != nil {
-			return nil, u.conn.ProcessError(err)
+			return nil, u.db.ProcessError(err)
 		}
 
 		return &user, nil
@@ -126,13 +126,13 @@ func (u *userDB) GetUserByConfirmationToken(ctx context.Context, confirmationTok
 
 func (u *userDB) GetAllUsers(ctx context.Context) ([]*gtsmodel.User, error) {
 	var users []*gtsmodel.User
-	q := u.conn.
+	q := u.db.
 		NewSelect().
 		Model(&users).
 		Relation("Account")
 
 	if err := q.Scan(ctx); err != nil {
-		return nil, u.conn.ProcessError(err)
+		return nil, u.db.ProcessError(err)
 	}
 
 	return users, nil
@@ -140,11 +140,11 @@ func (u *userDB) GetAllUsers(ctx context.Context) ([]*gtsmodel.User, error) {
 
 func (u *userDB) PutUser(ctx context.Context, user *gtsmodel.User) error {
 	return u.state.Caches.GTS.User().Store(user, func() error {
-		_, err := u.conn.
+		_, err := u.db.
 			NewInsert().
 			Model(user).
 			Exec(ctx)
-		return u.conn.ProcessError(err)
+		return u.db.ProcessError(err)
 	})
 }
 
@@ -158,13 +158,13 @@ func (u *userDB) UpdateUser(ctx context.Context, user *gtsmodel.User, columns ..
 	}
 
 	return u.state.Caches.GTS.User().Store(user, func() error {
-		_, err := u.conn.
+		_, err := u.db.
 			NewUpdate().
 			Model(user).
 			Where("? = ?", bun.Ident("user.id"), user.ID).
 			Column(columns...).
 			Exec(ctx)
-		return u.conn.ProcessError(err)
+		return u.db.ProcessError(err)
 	})
 }
 
@@ -184,9 +184,9 @@ func (u *userDB) DeleteUserByID(ctx context.Context, userID string) error {
 	}
 
 	// Finally delete user from DB.
-	_, err = u.conn.NewDelete().
+	_, err = u.db.NewDelete().
 		TableExpr("? AS ?", bun.Ident("users"), bun.Ident("user")).
 		Where("? = ?", bun.Ident("user.id"), userID).
 		Exec(ctx)
-	return u.conn.ProcessError(err)
+	return u.db.ProcessError(err)
 }

--- a/internal/db/domain.go
+++ b/internal/db/domain.go
@@ -27,29 +27,29 @@ import (
 // Domain contains DB functions related to domains and domain blocks.
 type Domain interface {
 	// CreateDomainBlock puts the given instance-level domain block into the database.
-	CreateDomainBlock(ctx context.Context, block *gtsmodel.DomainBlock) Error
+	CreateDomainBlock(ctx context.Context, block *gtsmodel.DomainBlock) error
 
 	// GetDomainBlock returns one instance-level domain block with the given domain, if it exists.
-	GetDomainBlock(ctx context.Context, domain string) (*gtsmodel.DomainBlock, Error)
+	GetDomainBlock(ctx context.Context, domain string) (*gtsmodel.DomainBlock, error)
 
 	// GetDomainBlockByID returns one instance-level domain block with the given id, if it exists.
-	GetDomainBlockByID(ctx context.Context, id string) (*gtsmodel.DomainBlock, Error)
+	GetDomainBlockByID(ctx context.Context, id string) (*gtsmodel.DomainBlock, error)
 
 	// GetDomainBlocks returns all instance-level domain blocks currently enforced by this instance.
 	GetDomainBlocks(ctx context.Context) ([]*gtsmodel.DomainBlock, error)
 
 	// DeleteDomainBlock deletes an instance-level domain block with the given domain, if it exists.
-	DeleteDomainBlock(ctx context.Context, domain string) Error
+	DeleteDomainBlock(ctx context.Context, domain string) error
 
 	// IsDomainBlocked checks if an instance-level domain block exists for the given domain string (eg., `example.org`).
-	IsDomainBlocked(ctx context.Context, domain string) (bool, Error)
+	IsDomainBlocked(ctx context.Context, domain string) (bool, error)
 
 	// AreDomainsBlocked checks if an instance-level domain block exists for any of the given domains strings, and returns true if even one is found.
-	AreDomainsBlocked(ctx context.Context, domains []string) (bool, Error)
+	AreDomainsBlocked(ctx context.Context, domains []string) (bool, error)
 
 	// IsURIBlocked checks if an instance-level domain block exists for the `host` in the given URI (eg., `https://example.org/users/whatever`).
-	IsURIBlocked(ctx context.Context, uri *url.URL) (bool, Error)
+	IsURIBlocked(ctx context.Context, uri *url.URL) (bool, error)
 
 	// AreURIsBlocked checks if an instance-level domain block exists for any `host` in the given URI slice, and returns true if even one is found.
-	AreURIsBlocked(ctx context.Context, uris []*url.URL) (bool, Error)
+	AreURIsBlocked(ctx context.Context, uris []*url.URL) (bool, error)
 }

--- a/internal/db/emoji.go
+++ b/internal/db/emoji.go
@@ -31,16 +31,16 @@ const EmojiAllDomains string = "all"
 // Emoji contains functions for getting emoji in the database.
 type Emoji interface {
 	// PutEmoji puts one emoji in the database.
-	PutEmoji(ctx context.Context, emoji *gtsmodel.Emoji) Error
+	PutEmoji(ctx context.Context, emoji *gtsmodel.Emoji) error
 	// UpdateEmoji updates the given columns of one emoji.
 	// If no columns are specified, every column is updated.
 	UpdateEmoji(ctx context.Context, emoji *gtsmodel.Emoji, columns ...string) error
 	// DeleteEmojiByID deletes one emoji by its database ID.
-	DeleteEmojiByID(ctx context.Context, id string) Error
+	DeleteEmojiByID(ctx context.Context, id string) error
 	// GetEmojisByIDs gets emojis for the given IDs.
-	GetEmojisByIDs(ctx context.Context, ids []string) ([]*gtsmodel.Emoji, Error)
+	GetEmojisByIDs(ctx context.Context, ids []string) ([]*gtsmodel.Emoji, error)
 	// GetUseableEmojis gets all emojis which are useable by accounts on this instance.
-	GetUseableEmojis(ctx context.Context) ([]*gtsmodel.Emoji, Error)
+	GetUseableEmojis(ctx context.Context) ([]*gtsmodel.Emoji, error)
 
 	// GetEmojis fetches all emojis with IDs less than 'maxID', up to a maximum of 'limit' emojis.
 	GetEmojis(ctx context.Context, maxID string, limit int) ([]*gtsmodel.Emoji, error)
@@ -54,22 +54,22 @@ type Emoji interface {
 	// GetEmojisBy gets emojis based on given parameters. Useful for admin actions.
 	GetEmojisBy(ctx context.Context, domain string, includeDisabled bool, includeEnabled bool, shortcode string, maxShortcodeDomain string, minShortcodeDomain string, limit int) ([]*gtsmodel.Emoji, error)
 	// GetEmojiByID gets a specific emoji by its database ID.
-	GetEmojiByID(ctx context.Context, id string) (*gtsmodel.Emoji, Error)
+	GetEmojiByID(ctx context.Context, id string) (*gtsmodel.Emoji, error)
 	// GetEmojiByShortcodeDomain gets an emoji based on its shortcode and domain.
 	// For local emoji, domain should be an empty string.
-	GetEmojiByShortcodeDomain(ctx context.Context, shortcode string, domain string) (*gtsmodel.Emoji, Error)
+	GetEmojiByShortcodeDomain(ctx context.Context, shortcode string, domain string) (*gtsmodel.Emoji, error)
 	// GetEmojiByURI returns one emoji based on its ActivityPub URI.
-	GetEmojiByURI(ctx context.Context, uri string) (*gtsmodel.Emoji, Error)
+	GetEmojiByURI(ctx context.Context, uri string) (*gtsmodel.Emoji, error)
 	// GetEmojiByStaticURL gets an emoji using the URL of the static version of the emoji image.
-	GetEmojiByStaticURL(ctx context.Context, imageStaticURL string) (*gtsmodel.Emoji, Error)
+	GetEmojiByStaticURL(ctx context.Context, imageStaticURL string) (*gtsmodel.Emoji, error)
 	// PutEmojiCategory puts one new emoji category in the database.
-	PutEmojiCategory(ctx context.Context, emojiCategory *gtsmodel.EmojiCategory) Error
+	PutEmojiCategory(ctx context.Context, emojiCategory *gtsmodel.EmojiCategory) error
 	// GetEmojiCategoriesByIDs gets emoji categories for given IDs.
-	GetEmojiCategoriesByIDs(ctx context.Context, ids []string) ([]*gtsmodel.EmojiCategory, Error)
+	GetEmojiCategoriesByIDs(ctx context.Context, ids []string) ([]*gtsmodel.EmojiCategory, error)
 	// GetEmojiCategories gets a slice of the names of all existing emoji categories.
-	GetEmojiCategories(ctx context.Context) ([]*gtsmodel.EmojiCategory, Error)
+	GetEmojiCategories(ctx context.Context) ([]*gtsmodel.EmojiCategory, error)
 	// GetEmojiCategory gets one emoji category by its id.
-	GetEmojiCategory(ctx context.Context, id string) (*gtsmodel.EmojiCategory, Error)
+	GetEmojiCategory(ctx context.Context, id string) (*gtsmodel.EmojiCategory, error)
 	// GetEmojiCategoryByName gets one emoji category by its name.
-	GetEmojiCategoryByName(ctx context.Context, name string) (*gtsmodel.EmojiCategory, Error)
+	GetEmojiCategoryByName(ctx context.Context, name string) (*gtsmodel.EmojiCategory, error)
 }

--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -31,6 +31,6 @@ var (
 	ErrAlreadyExists = errors.New("already exists")
 
 	// ErrBusyTimeout is returned if the database connection indicates the connection is too busy
-	// to copmlete the supplied query. This is generally intended to be handled internally by the DB.
+	// to complete the supplied query. This is generally intended to be handled internally by the DB.
 	ErrBusyTimeout = errors.New("busy timeout")
 )

--- a/internal/db/error.go
+++ b/internal/db/error.go
@@ -17,18 +17,20 @@
 
 package db
 
-import "fmt"
-
-// Error denotes a database error.
-type Error error
+import (
+	"database/sql"
+	"errors"
+)
 
 var (
-	// ErrNoEntries is returned when a caller expected an entry for a query, but none was found.
-	ErrNoEntries Error = fmt.Errorf("no entries")
-	// ErrMultipleEntries is returned when a caller expected ONE entry for a query, but multiples were found.
-	ErrMultipleEntries Error = fmt.Errorf("multiple entries")
+	// ErrNoEntries is a direct ptr to sql.ErrNoRows since that is returned regardless
+	// of DB dialect. It is returned when no rows (entries) can be found for a query.
+	ErrNoEntries = sql.ErrNoRows
+
 	// ErrAlreadyExists is returned when a conflict was encountered in the db when doing an insert.
-	ErrAlreadyExists Error = fmt.Errorf("already exists")
-	// ErrUnknown denotes an unknown database error.
-	ErrUnknown Error = fmt.Errorf("unknown error")
+	ErrAlreadyExists = errors.New("already exists")
+
+	// ErrBusyTimeout is returned if the database connection indicates the connection is too busy
+	// to copmlete the supplied query. This is generally intended to be handled internally by the DB.
+	ErrBusyTimeout = errors.New("busy timeout")
 )

--- a/internal/db/instance.go
+++ b/internal/db/instance.go
@@ -26,16 +26,16 @@ import (
 // Instance contains functions for instance-level actions (counting instance users etc.).
 type Instance interface {
 	// CountInstanceUsers returns the number of known accounts registered with the given domain.
-	CountInstanceUsers(ctx context.Context, domain string) (int, Error)
+	CountInstanceUsers(ctx context.Context, domain string) (int, error)
 
 	// CountInstanceStatuses returns the number of known statuses posted from the given domain.
-	CountInstanceStatuses(ctx context.Context, domain string) (int, Error)
+	CountInstanceStatuses(ctx context.Context, domain string) (int, error)
 
 	// CountInstanceDomains returns the number of known instances known that the given domain federates with.
-	CountInstanceDomains(ctx context.Context, domain string) (int, Error)
+	CountInstanceDomains(ctx context.Context, domain string) (int, error)
 
 	// GetInstance returns the instance entry for the given domain, if it exists.
-	GetInstance(ctx context.Context, domain string) (*gtsmodel.Instance, Error)
+	GetInstance(ctx context.Context, domain string) (*gtsmodel.Instance, error)
 
 	// GetInstanceByID returns the instance entry corresponding to the given id, if it exists.
 	GetInstanceByID(ctx context.Context, id string) (*gtsmodel.Instance, error)
@@ -47,12 +47,12 @@ type Instance interface {
 	UpdateInstance(ctx context.Context, instance *gtsmodel.Instance, columns ...string) error
 
 	// GetInstanceAccounts returns a slice of accounts from the given instance, arranged by ID.
-	GetInstanceAccounts(ctx context.Context, domain string, maxID string, limit int) ([]*gtsmodel.Account, Error)
+	GetInstanceAccounts(ctx context.Context, domain string, maxID string, limit int) ([]*gtsmodel.Account, error)
 
 	// GetInstancePeers returns a slice of instances that the host instance knows about.
-	GetInstancePeers(ctx context.Context, includeSuspended bool) ([]*gtsmodel.Instance, Error)
+	GetInstancePeers(ctx context.Context, includeSuspended bool) ([]*gtsmodel.Instance, error)
 
 	// GetInstanceModeratorAddresses returns a slice of email addresses belonging to active
 	// (as in, not suspended) moderators + admins on this instance.
-	GetInstanceModeratorAddresses(ctx context.Context) ([]string, Error)
+	GetInstanceModeratorAddresses(ctx context.Context) ([]string, error)
 }

--- a/internal/db/media.go
+++ b/internal/db/media.go
@@ -27,7 +27,7 @@ import (
 // Media contains functions related to creating/getting/removing media attachments.
 type Media interface {
 	// GetAttachmentByID gets a single attachment by its ID.
-	GetAttachmentByID(ctx context.Context, id string) (*gtsmodel.MediaAttachment, Error)
+	GetAttachmentByID(ctx context.Context, id string) (*gtsmodel.MediaAttachment, error)
 
 	// GetAttachmentsByIDs fetches a list of media attachments for given IDs.
 	GetAttachmentsByIDs(ctx context.Context, ids []string) ([]*gtsmodel.MediaAttachment, error)
@@ -49,25 +49,25 @@ type Media interface {
 
 	// GetCachedAttachmentsOlderThan gets limit n remote attachments (including avatars and headers) older than
 	// the given time. These will be returned in order of attachment.created_at descending (i.e. newest to oldest).
-	GetCachedAttachmentsOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, Error)
+	GetCachedAttachmentsOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, error)
 
 	// CountRemoteOlderThan is like GetRemoteOlderThan, except instead of getting limit n attachments,
 	// it just counts how many remote attachments in the database (including avatars and headers) meet
 	// the olderThan criteria.
-	CountRemoteOlderThan(ctx context.Context, olderThan time.Time) (int, Error)
+	CountRemoteOlderThan(ctx context.Context, olderThan time.Time) (int, error)
 
 	// GetAvatarsAndHeaders fetches limit n avatars and headers with an id < maxID. These headers
 	// and avis may be in use or not; the caller should check this if it's important.
-	GetAvatarsAndHeaders(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, Error)
+	GetAvatarsAndHeaders(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, error)
 
 	// GetLocalUnattachedOlderThan fetches limit n local media attachments (including avatars and headers), older than
 	// the given time, which aren't header or avatars, and aren't attached to a status. In other words, attachments which were
 	// uploaded but never used for whatever reason, or attachments that were attached to a status which was subsequently deleted.
 	//
 	// These will be returned in order of attachment.created_at descending (newest to oldest in other words).
-	GetLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, Error)
+	GetLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, error)
 
 	// CountLocalUnattachedOlderThan is like GetLocalUnattachedOlderThan, except instead of getting limit n attachments,
 	// it just counts how many local attachments in the database meet the olderThan criteria.
-	CountLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time) (int, Error)
+	CountLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time) (int, error)
 }

--- a/internal/db/mention.go
+++ b/internal/db/mention.go
@@ -26,10 +26,10 @@ import (
 // Mention contains functions for getting/creating mentions in the database.
 type Mention interface {
 	// GetMention gets a single mention by ID
-	GetMention(ctx context.Context, id string) (*gtsmodel.Mention, Error)
+	GetMention(ctx context.Context, id string) (*gtsmodel.Mention, error)
 
 	// GetMentions gets multiple mentions.
-	GetMentions(ctx context.Context, ids []string) ([]*gtsmodel.Mention, Error)
+	GetMentions(ctx context.Context, ids []string) ([]*gtsmodel.Mention, error)
 
 	// PutMention will insert the given mention into the database.
 	PutMention(ctx context.Context, mention *gtsmodel.Mention) error

--- a/internal/db/notification.go
+++ b/internal/db/notification.go
@@ -28,21 +28,21 @@ type Notification interface {
 	// GetNotifications returns a slice of notifications that pertain to the given accountID.
 	//
 	// Returned notifications will be ordered ID descending (ie., highest/newest to lowest/oldest).
-	GetAccountNotifications(ctx context.Context, accountID string, maxID string, sinceID string, minID string, limit int, excludeTypes []string) ([]*gtsmodel.Notification, Error)
+	GetAccountNotifications(ctx context.Context, accountID string, maxID string, sinceID string, minID string, limit int, excludeTypes []string) ([]*gtsmodel.Notification, error)
 
 	// GetNotification returns one notification according to its id.
-	GetNotificationByID(ctx context.Context, id string) (*gtsmodel.Notification, Error)
+	GetNotificationByID(ctx context.Context, id string) (*gtsmodel.Notification, error)
 
 	// GetNotification gets one notification according to the provided parameters, if it exists.
 	// Since not all notifications are about a status, statusID can be an empty string.
-	GetNotification(ctx context.Context, notificationType gtsmodel.NotificationType, targetAccountID string, originAccountID string, statusID string) (*gtsmodel.Notification, Error)
+	GetNotification(ctx context.Context, notificationType gtsmodel.NotificationType, targetAccountID string, originAccountID string, statusID string) (*gtsmodel.Notification, error)
 
 	// PutNotification will insert the given notification into the database.
 	PutNotification(ctx context.Context, notif *gtsmodel.Notification) error
 
 	// DeleteNotificationByID deletes one notification according to its id,
 	// and removes that notification from the in-memory cache.
-	DeleteNotificationByID(ctx context.Context, id string) Error
+	DeleteNotificationByID(ctx context.Context, id string) error
 
 	// DeleteNotifications mass deletes notifications targeting targetAccountID
 	// and/or originating from originAccountID.
@@ -57,10 +57,10 @@ type Notification interface {
 	// originate from originAccountID will be deleted.
 	//
 	// At least one parameter must not be an empty string.
-	DeleteNotifications(ctx context.Context, types []string, targetAccountID string, originAccountID string) Error
+	DeleteNotifications(ctx context.Context, types []string, targetAccountID string, originAccountID string) error
 
 	// DeleteNotificationsForStatus deletes all notifications that relate to
 	// the given statusID. This function is useful when a status has been deleted,
 	// and so notifications relating to that status must also be deleted.
-	DeleteNotificationsForStatus(ctx context.Context, statusID string) Error
+	DeleteNotificationsForStatus(ctx context.Context, statusID string) error
 }

--- a/internal/db/relationship.go
+++ b/internal/db/relationship.go
@@ -26,7 +26,7 @@ import (
 // Relationship contains functions for getting or modifying the relationship between two accounts.
 type Relationship interface {
 	// IsBlocked checks whether source account has a block in place against target.
-	IsBlocked(ctx context.Context, sourceAccountID string, targetAccountID string) (bool, Error)
+	IsBlocked(ctx context.Context, sourceAccountID string, targetAccountID string) (bool, error)
 
 	// IsEitherBlocked checks whether there is a block in place between either of account1 and account2.
 	IsEitherBlocked(ctx context.Context, accountID1 string, accountID2 string) (bool, error)
@@ -53,7 +53,7 @@ type Relationship interface {
 	DeleteAccountBlocks(ctx context.Context, accountID string) error
 
 	// GetRelationship retrieves the relationship of the targetAccount to the requestingAccount.
-	GetRelationship(ctx context.Context, requestingAccount string, targetAccount string) (*gtsmodel.Relationship, Error)
+	GetRelationship(ctx context.Context, requestingAccount string, targetAccount string) (*gtsmodel.Relationship, error)
 
 	// GetFollowByID fetches follow with given ID from the database.
 	GetFollowByID(ctx context.Context, id string) (*gtsmodel.Follow, error)
@@ -77,13 +77,13 @@ type Relationship interface {
 	GetFollowRequest(ctx context.Context, sourceAccountID string, targetAccountID string) (*gtsmodel.FollowRequest, error)
 
 	// IsFollowing returns true if sourceAccount follows target account, or an error if something goes wrong while finding out.
-	IsFollowing(ctx context.Context, sourceAccountID string, targetAccountID string) (bool, Error)
+	IsFollowing(ctx context.Context, sourceAccountID string, targetAccountID string) (bool, error)
 
 	// IsMutualFollowing returns true if account1 and account2 both follow each other, or an error if something goes wrong while finding out.
-	IsMutualFollowing(ctx context.Context, sourceAccountID string, targetAccountID string) (bool, Error)
+	IsMutualFollowing(ctx context.Context, sourceAccountID string, targetAccountID string) (bool, error)
 
 	// IsFollowRequested returns true if sourceAccount has requested to follow target account, or an error if something goes wrong while finding out.
-	IsFollowRequested(ctx context.Context, sourceAccountID string, targetAccountID string) (bool, Error)
+	IsFollowRequested(ctx context.Context, sourceAccountID string, targetAccountID string) (bool, error)
 
 	// PutFollow attempts to place the given account follow in the database.
 	PutFollow(ctx context.Context, follow *gtsmodel.Follow) error
@@ -125,10 +125,10 @@ type Relationship interface {
 	// In other words, it should create the follow, and delete the existing follow request.
 	//
 	// It will return the newly created follow for further processing.
-	AcceptFollowRequest(ctx context.Context, originAccountID string, targetAccountID string) (*gtsmodel.Follow, Error)
+	AcceptFollowRequest(ctx context.Context, originAccountID string, targetAccountID string) (*gtsmodel.Follow, error)
 
 	// RejectFollowRequest fetches a follow request from the database, and then deletes it.
-	RejectFollowRequest(ctx context.Context, originAccountID string, targetAccountID string) Error
+	RejectFollowRequest(ctx context.Context, originAccountID string, targetAccountID string) error
 
 	// GetAccountFollows returns a slice of follows owned by the given accountID.
 	GetAccountFollows(ctx context.Context, accountID string) ([]*gtsmodel.Follow, error)

--- a/internal/db/report.go
+++ b/internal/db/report.go
@@ -26,18 +26,18 @@ import (
 // Report handles getting/creation/deletion/updating of user reports/flags.
 type Report interface {
 	// GetReportByID gets one report by its db id
-	GetReportByID(ctx context.Context, id string) (*gtsmodel.Report, Error)
+	GetReportByID(ctx context.Context, id string) (*gtsmodel.Report, error)
 	// GetReports gets limit n reports using the given parameters.
 	// Parameters that are empty / zero are ignored.
-	GetReports(ctx context.Context, resolved *bool, accountID string, targetAccountID string, maxID string, sinceID string, minID string, limit int) ([]*gtsmodel.Report, Error)
+	GetReports(ctx context.Context, resolved *bool, accountID string, targetAccountID string, maxID string, sinceID string, minID string, limit int) ([]*gtsmodel.Report, error)
 	// PutReport puts the given report in the database.
-	PutReport(ctx context.Context, report *gtsmodel.Report) Error
+	PutReport(ctx context.Context, report *gtsmodel.Report) error
 	// UpdateReport updates one report by its db id.
 	// The given columns will be updated; if no columns are
 	// provided, then all columns will be updated.
 	// updated_at will also be updated, no need to pass this
 	// as a specific column.
-	UpdateReport(ctx context.Context, report *gtsmodel.Report, columns ...string) (*gtsmodel.Report, Error)
+	UpdateReport(ctx context.Context, report *gtsmodel.Report, columns ...string) (*gtsmodel.Report, error)
 	// DeleteReportByID deletes report with the given id.
-	DeleteReportByID(ctx context.Context, id string) Error
+	DeleteReportByID(ctx context.Context, id string) error
 }

--- a/internal/db/session.go
+++ b/internal/db/session.go
@@ -25,5 +25,5 @@ import (
 
 // Session handles getting/creation of router sessions.
 type Session interface {
-	GetSession(ctx context.Context) (*gtsmodel.RouterSession, Error)
+	GetSession(ctx context.Context) (*gtsmodel.RouterSession, error)
 }

--- a/internal/db/status.go
+++ b/internal/db/status.go
@@ -26,34 +26,34 @@ import (
 // Status contains functions for getting statuses, creating statuses, and checking various other fields on statuses.
 type Status interface {
 	// GetStatusByID returns one status from the database, with no rel fields populated, only their linking ID / URIs
-	GetStatusByID(ctx context.Context, id string) (*gtsmodel.Status, Error)
+	GetStatusByID(ctx context.Context, id string) (*gtsmodel.Status, error)
 
 	// GetStatusByURI returns one status from the database, with no rel fields populated, only their linking ID / URIs
-	GetStatusByURI(ctx context.Context, uri string) (*gtsmodel.Status, Error)
+	GetStatusByURI(ctx context.Context, uri string) (*gtsmodel.Status, error)
 
 	// GetStatusByURL returns one status from the database, with no rel fields populated, only their linking ID / URIs
-	GetStatusByURL(ctx context.Context, uri string) (*gtsmodel.Status, Error)
+	GetStatusByURL(ctx context.Context, uri string) (*gtsmodel.Status, error)
 
 	// PopulateStatus ensures that all sub-models of a status are populated (e.g. mentions, attachments, etc).
 	PopulateStatus(ctx context.Context, status *gtsmodel.Status) error
 
 	// PutStatus stores one status in the database.
-	PutStatus(ctx context.Context, status *gtsmodel.Status) Error
+	PutStatus(ctx context.Context, status *gtsmodel.Status) error
 
 	// UpdateStatus updates one status in the database.
-	UpdateStatus(ctx context.Context, status *gtsmodel.Status, columns ...string) Error
+	UpdateStatus(ctx context.Context, status *gtsmodel.Status, columns ...string) error
 
 	// DeleteStatusByID deletes one status from the database.
-	DeleteStatusByID(ctx context.Context, id string) Error
+	DeleteStatusByID(ctx context.Context, id string) error
 
 	// CountStatusReplies returns the amount of replies recorded for a status, or an error if something goes wrong
-	CountStatusReplies(ctx context.Context, status *gtsmodel.Status) (int, Error)
+	CountStatusReplies(ctx context.Context, status *gtsmodel.Status) (int, error)
 
 	// CountStatusReblogs returns the amount of reblogs/boosts recorded for a status, or an error if something goes wrong
-	CountStatusReblogs(ctx context.Context, status *gtsmodel.Status) (int, Error)
+	CountStatusReblogs(ctx context.Context, status *gtsmodel.Status) (int, error)
 
 	// CountStatusFaves returns the amount of faves/likes recorded for a status, or an error if something goes wrong
-	CountStatusFaves(ctx context.Context, status *gtsmodel.Status) (int, Error)
+	CountStatusFaves(ctx context.Context, status *gtsmodel.Status) (int, error)
 
 	// GetStatuses gets a slice of statuses corresponding to the given status IDs.
 	GetStatusesByIDs(ctx context.Context, ids []string) ([]*gtsmodel.Status, error)
@@ -64,26 +64,26 @@ type Status interface {
 	// GetStatusParents gets the parent statuses of a given status.
 	//
 	// If onlyDirect is true, only the immediate parent will be returned.
-	GetStatusParents(ctx context.Context, status *gtsmodel.Status, onlyDirect bool) ([]*gtsmodel.Status, Error)
+	GetStatusParents(ctx context.Context, status *gtsmodel.Status, onlyDirect bool) ([]*gtsmodel.Status, error)
 
 	// GetStatusChildren gets the child statuses of a given status.
 	//
 	// If onlyDirect is true, only the immediate children will be returned.
-	GetStatusChildren(ctx context.Context, status *gtsmodel.Status, onlyDirect bool, minID string) ([]*gtsmodel.Status, Error)
+	GetStatusChildren(ctx context.Context, status *gtsmodel.Status, onlyDirect bool, minID string) ([]*gtsmodel.Status, error)
 
 	// IsStatusFavedBy checks if a given status has been faved by a given account ID
-	IsStatusFavedBy(ctx context.Context, status *gtsmodel.Status, accountID string) (bool, Error)
+	IsStatusFavedBy(ctx context.Context, status *gtsmodel.Status, accountID string) (bool, error)
 
 	// IsStatusRebloggedBy checks if a given status has been reblogged/boosted by a given account ID
-	IsStatusRebloggedBy(ctx context.Context, status *gtsmodel.Status, accountID string) (bool, Error)
+	IsStatusRebloggedBy(ctx context.Context, status *gtsmodel.Status, accountID string) (bool, error)
 
 	// IsStatusMutedBy checks if a given status has been muted by a given account ID
-	IsStatusMutedBy(ctx context.Context, status *gtsmodel.Status, accountID string) (bool, Error)
+	IsStatusMutedBy(ctx context.Context, status *gtsmodel.Status, accountID string) (bool, error)
 
 	// IsStatusBookmarkedBy checks if a given status has been bookmarked by a given account ID
-	IsStatusBookmarkedBy(ctx context.Context, status *gtsmodel.Status, accountID string) (bool, Error)
+	IsStatusBookmarkedBy(ctx context.Context, status *gtsmodel.Status, accountID string) (bool, error)
 
 	// GetStatusReblogs returns a slice of statuses that are a boost/reblog of the given status.
 	// This slice will be unfiltered, not taking account of blocks and whatnot, so filter it before serving it back to a user.
-	GetStatusReblogs(ctx context.Context, status *gtsmodel.Status) ([]*gtsmodel.Status, Error)
+	GetStatusReblogs(ctx context.Context, status *gtsmodel.Status) ([]*gtsmodel.Status, error)
 }

--- a/internal/db/statusbookmark.go
+++ b/internal/db/statusbookmark.go
@@ -25,24 +25,24 @@ import (
 
 type StatusBookmark interface {
 	// GetStatusBookmark gets one status bookmark with the given ID.
-	GetStatusBookmark(ctx context.Context, id string) (*gtsmodel.StatusBookmark, Error)
+	GetStatusBookmark(ctx context.Context, id string) (*gtsmodel.StatusBookmark, error)
 
 	// GetStatusBookmarkID is a shortcut function for returning just the database ID
 	// of a status bookmark created by the given accountID, targeting the given statusID.
-	GetStatusBookmarkID(ctx context.Context, accountID string, statusID string) (string, Error)
+	GetStatusBookmarkID(ctx context.Context, accountID string, statusID string) (string, error)
 
 	// GetStatusBookmarks retrieves status bookmarks created by the given accountID,
 	// and using the provided parameters. If limit is < 0 then no limit will be set.
 	//
 	// This function is primarily useful for paging through bookmarks in a sort of
 	// timeline view.
-	GetStatusBookmarks(ctx context.Context, accountID string, limit int, maxID string, minID string) ([]*gtsmodel.StatusBookmark, Error)
+	GetStatusBookmarks(ctx context.Context, accountID string, limit int, maxID string, minID string) ([]*gtsmodel.StatusBookmark, error)
 
 	// PutStatusBookmark inserts the given statusBookmark into the database.
-	PutStatusBookmark(ctx context.Context, statusBookmark *gtsmodel.StatusBookmark) Error
+	PutStatusBookmark(ctx context.Context, statusBookmark *gtsmodel.StatusBookmark) error
 
 	// DeleteStatusBookmark deletes one status bookmark with the given ID.
-	DeleteStatusBookmark(ctx context.Context, id string) Error
+	DeleteStatusBookmark(ctx context.Context, id string) error
 
 	// DeleteStatusBookmarks mass deletes status bookmarks targeting targetAccountID
 	// and/or originating from originAccountID and/or bookmarking statusID.
@@ -57,10 +57,10 @@ type StatusBookmark interface {
 	// originate from originAccountID will be deleted.
 	//
 	// At least one parameter must not be an empty string.
-	DeleteStatusBookmarks(ctx context.Context, targetAccountID string, originAccountID string) Error
+	DeleteStatusBookmarks(ctx context.Context, targetAccountID string, originAccountID string) error
 
 	// DeleteStatusBookmarksForStatus deletes all status bookmarks that target the
 	// given status ID. This is useful when a status has been deleted, and you need
 	// to clean up after it.
-	DeleteStatusBookmarksForStatus(ctx context.Context, statusID string) Error
+	DeleteStatusBookmarksForStatus(ctx context.Context, statusID string) error
 }

--- a/internal/db/statusfave.go
+++ b/internal/db/statusfave.go
@@ -26,23 +26,23 @@ import (
 type StatusFave interface {
 	// GetStatusFaveByAccountID gets one status fave created by the given
 	// accountID, targeting the given statusID.
-	GetStatusFave(ctx context.Context, accountID string, statusID string) (*gtsmodel.StatusFave, Error)
+	GetStatusFave(ctx context.Context, accountID string, statusID string) (*gtsmodel.StatusFave, error)
 
 	// GetStatusFave returns one status fave with the given id.
-	GetStatusFaveByID(ctx context.Context, id string) (*gtsmodel.StatusFave, Error)
+	GetStatusFaveByID(ctx context.Context, id string) (*gtsmodel.StatusFave, error)
 
 	// GetStatusFaves returns a slice of faves/likes of the given status.
 	// This slice will be unfiltered, not taking account of blocks and whatnot, so filter it before serving it back to a user.
-	GetStatusFavesForStatus(ctx context.Context, statusID string) ([]*gtsmodel.StatusFave, Error)
+	GetStatusFavesForStatus(ctx context.Context, statusID string) ([]*gtsmodel.StatusFave, error)
 
 	// PopulateStatusFave ensures that all sub-models of a fave are populated (account, status, etc).
 	PopulateStatusFave(ctx context.Context, statusFave *gtsmodel.StatusFave) error
 
 	// PutStatusFave inserts the given statusFave into the database.
-	PutStatusFave(ctx context.Context, statusFave *gtsmodel.StatusFave) Error
+	PutStatusFave(ctx context.Context, statusFave *gtsmodel.StatusFave) error
 
 	// DeleteStatusFave deletes one status fave with the given id.
-	DeleteStatusFaveByID(ctx context.Context, id string) Error
+	DeleteStatusFaveByID(ctx context.Context, id string) error
 
 	// DeleteStatusFaves mass deletes status faves targeting targetAccountID
 	// and/or originating from originAccountID and/or faving statusID.
@@ -57,10 +57,10 @@ type StatusFave interface {
 	// originate from originAccountID will be deleted.
 	//
 	// At least one parameter must not be an empty string.
-	DeleteStatusFaves(ctx context.Context, targetAccountID string, originAccountID string) Error
+	DeleteStatusFaves(ctx context.Context, targetAccountID string, originAccountID string) error
 
 	// DeleteStatusFavesForStatus deletes all status faves that target the
 	// given status ID. This is useful when a status has been deleted, and you need
 	// to clean up after it.
-	DeleteStatusFavesForStatus(ctx context.Context, statusID string) Error
+	DeleteStatusFavesForStatus(ctx context.Context, statusID string) error
 }

--- a/internal/db/timeline.go
+++ b/internal/db/timeline.go
@@ -28,13 +28,13 @@ type Timeline interface {
 	// GetHomeTimeline returns a slice of statuses from accounts that are followed by the given account id.
 	//
 	// Statuses should be returned in descending order of when they were created (newest first).
-	GetHomeTimeline(ctx context.Context, accountID string, maxID string, sinceID string, minID string, limit int, local bool) ([]*gtsmodel.Status, Error)
+	GetHomeTimeline(ctx context.Context, accountID string, maxID string, sinceID string, minID string, limit int, local bool) ([]*gtsmodel.Status, error)
 
 	// GetPublicTimeline fetches the account's PUBLIC timeline -- ie., posts and replies that are public.
 	// It will use the given filters and try to return as many statuses as possible up to the limit.
 	//
 	// Statuses should be returned in descending order of when they were created (newest first).
-	GetPublicTimeline(ctx context.Context, maxID string, sinceID string, minID string, limit int, local bool) ([]*gtsmodel.Status, Error)
+	GetPublicTimeline(ctx context.Context, maxID string, sinceID string, minID string, limit int, local bool) ([]*gtsmodel.Status, error)
 
 	// GetFavedTimeline fetches the account's FAVED timeline -- ie., posts and replies that the requesting account has faved.
 	// It will use the given filters and try to return as many statuses as possible up to the limit.
@@ -43,7 +43,7 @@ type Timeline interface {
 	// In other words, they'll be returned in descending order of when they were faved by the requesting user, not when they were created.
 	//
 	// Also note the extra return values, which correspond to the nextMaxID and prevMinID for building Link headers.
-	GetFavedTimeline(ctx context.Context, accountID string, maxID string, minID string, limit int) ([]*gtsmodel.Status, string, string, Error)
+	GetFavedTimeline(ctx context.Context, accountID string, maxID string, minID string, limit int) ([]*gtsmodel.Status, string, string, error)
 
 	// GetListTimeline returns a slice of statuses from followed accounts collected within the list with the given listID.
 	// Statuses should be returned in descending order of when they were created (newest first).

--- a/internal/db/tombstone.go
+++ b/internal/db/tombstone.go
@@ -26,14 +26,14 @@ import (
 // Tombstone contains functionality for storing + retrieving tombstones for remote AP Activities + Objects.
 type Tombstone interface {
 	// GetTombstoneByURI attempts to fetch a tombstone by the given URI.
-	GetTombstoneByURI(ctx context.Context, uri string) (*gtsmodel.Tombstone, Error)
+	GetTombstoneByURI(ctx context.Context, uri string) (*gtsmodel.Tombstone, error)
 
 	// TombstoneExistsWithURI returns true if a tombstone with the given URI exists.
-	TombstoneExistsWithURI(ctx context.Context, uri string) (bool, Error)
+	TombstoneExistsWithURI(ctx context.Context, uri string) (bool, error)
 
 	// PutTombstone creates a new tombstone in the database.
-	PutTombstone(ctx context.Context, tombstone *gtsmodel.Tombstone) Error
+	PutTombstone(ctx context.Context, tombstone *gtsmodel.Tombstone) error
 
 	// DeleteTombstone deletes a tombstone with the given ID.
-	DeleteTombstone(ctx context.Context, id string) Error
+	DeleteTombstone(ctx context.Context, id string) error
 }

--- a/internal/db/user.go
+++ b/internal/db/user.go
@@ -26,21 +26,21 @@ import (
 // User contains functions related to user getting/setting/creation.
 type User interface {
 	// GetAllUsers returns all local user accounts, or an error if something goes wrong.
-	GetAllUsers(ctx context.Context) ([]*gtsmodel.User, Error)
+	GetAllUsers(ctx context.Context) ([]*gtsmodel.User, error)
 	// GetUserByID returns one user with the given ID, or an error if something goes wrong.
-	GetUserByID(ctx context.Context, id string) (*gtsmodel.User, Error)
+	GetUserByID(ctx context.Context, id string) (*gtsmodel.User, error)
 	// GetUserByAccountID returns one user by its account ID, or an error if something goes wrong.
-	GetUserByAccountID(ctx context.Context, accountID string) (*gtsmodel.User, Error)
+	GetUserByAccountID(ctx context.Context, accountID string) (*gtsmodel.User, error)
 	// GetUserByID returns one user with the given email address, or an error if something goes wrong.
-	GetUserByEmailAddress(ctx context.Context, emailAddress string) (*gtsmodel.User, Error)
+	GetUserByEmailAddress(ctx context.Context, emailAddress string) (*gtsmodel.User, error)
 	// GetUserByExternalID returns one user with the given external id, or an error if something goes wrong.
-	GetUserByExternalID(ctx context.Context, id string) (*gtsmodel.User, Error)
+	GetUserByExternalID(ctx context.Context, id string) (*gtsmodel.User, error)
 	// GetUserByConfirmationToken returns one user by its confirmation token, or an error if something goes wrong.
-	GetUserByConfirmationToken(ctx context.Context, confirmationToken string) (*gtsmodel.User, Error)
+	GetUserByConfirmationToken(ctx context.Context, confirmationToken string) (*gtsmodel.User, error)
 	// PutUser will attempt to place user in the database
-	PutUser(ctx context.Context, user *gtsmodel.User) Error
+	PutUser(ctx context.Context, user *gtsmodel.User) error
 	// UpdateUser updates one user by its primary key, updating either only the specified columns, or all of them.
-	UpdateUser(ctx context.Context, user *gtsmodel.User, columns ...string) Error
+	UpdateUser(ctx context.Context, user *gtsmodel.User, columns ...string) error
 	// DeleteUserByID deletes one user by its ID.
-	DeleteUserByID(ctx context.Context, userID string) Error
+	DeleteUserByID(ctx context.Context, userID string) error
 }

--- a/internal/federation/dereferencing/account_test.go
+++ b/internal/federation/dereferencing/account_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/testrig"
 )
@@ -175,7 +176,7 @@ func (suite *AccountTestSuite) TestDereferenceLocalAccountWithUnknownUsername() 
 		config.GetHost(),
 	)
 	suite.True(gtserror.Unretrievable(err))
-	suite.EqualError(err, "no entries")
+	suite.EqualError(err, db.ErrNoEntries.Error())
 	suite.Nil(fetchedAccount)
 }
 
@@ -189,7 +190,7 @@ func (suite *AccountTestSuite) TestDereferenceLocalAccountWithUnknownUsernameDom
 		"localhost:8080",
 	)
 	suite.True(gtserror.Unretrievable(err))
-	suite.EqualError(err, "no entries")
+	suite.EqualError(err, db.ErrNoEntries.Error())
 	suite.Nil(fetchedAccount)
 }
 
@@ -202,7 +203,7 @@ func (suite *AccountTestSuite) TestDereferenceLocalAccountWithUnknownUserURI() {
 		testrig.URLMustParse("http://localhost:8080/users/thisaccountdoesnotexist"),
 	)
 	suite.True(gtserror.Unretrievable(err))
-	suite.EqualError(err, "no entries")
+	suite.EqualError(err, db.ErrNoEntries.Error())
 	suite.Nil(fetchedAccount)
 }
 

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -232,7 +232,7 @@ func (c *Client) DoSigned(r *http.Request, sign SignFunc) (rsp *http.Response, e
 			return nil, err
 		}
 
-		l.Infof("performing request")
+		l.Info("performing request")
 
 		// Perform the request.
 		rsp, err = c.do(r)

--- a/internal/middleware/signaturecheck.go
+++ b/internal/middleware/signaturecheck.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtscontext"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 
@@ -48,7 +47,7 @@ const (
 // context for use down the line.
 //
 // In case of an error, the request will be aborted with http code 500.
-func SignatureCheck(uriBlocked func(context.Context, *url.URL) (bool, db.Error)) func(*gin.Context) {
+func SignatureCheck(uriBlocked func(context.Context, *url.URL) (bool, error)) func(*gin.Context) {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 

--- a/internal/processing/stream/authorize_test.go
+++ b/internal/processing/stream/authorize_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
 )
 
 type AuthorizeTestSuite struct {
@@ -38,7 +39,7 @@ func (suite *AuthorizeTestSuite) TestAuthorize() {
 	suite.Equal(suite.testAccounts["local_account_2"].ID, account2.ID)
 
 	noAccount, err := suite.streamProcessor.Authorize(context.Background(), "aaaaaaaaaaaaaaaaaaaaa!!")
-	suite.EqualError(err, "could not load access token: no entries")
+	suite.EqualError(err, "could not load access token: "+db.ErrNoEntries.Error())
 	suite.Nil(noAccount)
 }
 

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -62,7 +62,7 @@ const (
 type Module struct {
 	processor    *processing.Processor
 	eTagCache    cache.Cache[string, eTagCacheEntry]
-	isURIBlocked func(context.Context, *url.URL) (bool, db.Error)
+	isURIBlocked func(context.Context, *url.URL) (bool, error)
 }
 
 func New(db db.DB, processor *processing.Processor) *Module {


### PR DESCRIPTION
## Description
- rename DBConn to WrappedDB to better follow "sql" package name conventions
- wrap `bun.DB` to perform retry on returned busy-like-errors (SQLite only, for now(?))
- removes unnecessary `db.Error` type
- makes `db.ErrNoEntries` simply a ptr to `sqlite.ErrNoRows` since that is dialect agnostic

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
