### PR TITLE
chore: update go-mp4 to latest commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	codeberg.org/gruf/go-sched v1.2.3
 	codeberg.org/gruf/go-store/v2 v2.2.2
 	github.com/KimMachineGun/automemlimit v0.2.6
-	github.com/abema/go-mp4 v0.10.1
+	github.com/abema/go-mp4 v0.10.2-0.20230727031202-a1a707db6ecd
 	github.com/buckket/go-blurhash v1.1.0
 	github.com/coreos/go-oidc/v3 v3.6.0
 	github.com/disintegration/imaging v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/KimMachineGun/automemlimit v0.2.6 h1:tQFriVTcIteUkV5EgU9iz03eDY36T8JU5RAjP2r6Kt0=
 github.com/KimMachineGun/automemlimit v0.2.6/go.mod h1:pJhTW/nWJMj6SnWSU2TEKSlCaM+1N5Mej+IfS/5/Ol0=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/abema/go-mp4 v0.10.1 h1:wOhZgNxjduc8r4FJdwPa5x/gdBSSX+8MTnfNj/xkJaE=
-github.com/abema/go-mp4 v0.10.1/go.mod h1:vPl9t5ZK7K0x68jh12/+ECWBCXoWuIDtNgPtU2f04ws=
+github.com/abema/go-mp4 v0.10.2-0.20230727031202-a1a707db6ecd h1:4CFVGpJSO3/TgCd41a9vZy+6IJfqwl8D6uRN7nYLRCg=
+github.com/abema/go-mp4 v0.10.2-0.20230727031202-a1a707db6ecd/go.mod h1:vPl9t5ZK7K0x68jh12/+ECWBCXoWuIDtNgPtU2f04ws=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=

--- a/vendor/github.com/abema/go-mp4/probe.go
+++ b/vendor/github.com/abema/go-mp4/probe.go
@@ -66,7 +66,7 @@ type Sample struct {
 type Chunks []*Chunk
 
 type Chunk struct {
-	DataOffset      uint32
+	DataOffset      uint64
 	SamplesPerChunk uint32
 }
 
@@ -195,6 +195,7 @@ func probeTrak(r io.ReadSeeker, bi *BoxInfo) (*Track, error) {
 		{BoxTypeMdia(), BoxTypeMinf(), BoxTypeStbl(), BoxTypeStsd(), BoxTypeEnca()},
 		{BoxTypeMdia(), BoxTypeMinf(), BoxTypeStbl(), BoxTypeStsd(), BoxTypeEnca(), BoxTypeEsds()},
 		{BoxTypeMdia(), BoxTypeMinf(), BoxTypeStbl(), BoxTypeStco()},
+		{BoxTypeMdia(), BoxTypeMinf(), BoxTypeStbl(), BoxTypeCo64()},
 		{BoxTypeMdia(), BoxTypeMinf(), BoxTypeStbl(), BoxTypeStts()},
 		{BoxTypeMdia(), BoxTypeMinf(), BoxTypeStbl(), BoxTypeCtts()},
 		{BoxTypeMdia(), BoxTypeMinf(), BoxTypeStbl(), BoxTypeStsc()},
@@ -215,6 +216,7 @@ func probeTrak(r io.ReadSeeker, bi *BoxInfo) (*Track, error) {
 	var stsc *Stsc
 	var ctts *Ctts
 	var stsz *Stsz
+	var co64 *Co64
 	for _, bip := range bips {
 		switch bip.Info.Type {
 		case BoxTypeTkhd():
@@ -250,6 +252,8 @@ func probeTrak(r io.ReadSeeker, bi *BoxInfo) (*Track, error) {
 			ctts = bip.Payload.(*Ctts)
 		case BoxTypeStsz():
 			stsz = bip.Payload.(*Stsz)
+		case BoxTypeCo64():
+			co64 = bip.Payload.(*Co64)
 		}
 	}
 
@@ -299,14 +303,21 @@ func probeTrak(r io.ReadSeeker, bi *BoxInfo) (*Track, error) {
 		}
 	}
 
-	if stco == nil {
-		return nil, errors.New("stco box not found")
-	}
 	track.Chunks = make([]*Chunk, 0)
-	for _, offset := range stco.ChunkOffset {
-		track.Chunks = append(track.Chunks, &Chunk{
-			DataOffset: offset,
-		})
+	if stco != nil {
+		for _, offset := range stco.ChunkOffset {
+			track.Chunks = append(track.Chunks, &Chunk{
+				DataOffset: uint64(offset),
+			})
+		}
+	} else if co64 != nil {
+		for _, offset := range co64.ChunkOffset {
+			track.Chunks = append(track.Chunks, &Chunk{
+				DataOffset: offset,
+			})
+		}
+	} else {
+		return nil, errors.New("stco/co64 box not found")
 	}
 
 	if stts == nil {
@@ -572,7 +583,7 @@ func FindIDRFrames(r io.ReadSeeker, trackInfo *TrackInfo) ([]int, error) {
 				continue
 			}
 			for nalOffset := uint32(0); nalOffset+lengthSize+1 <= sample.Size; {
-				if _, err := r.Seek(int64(dataOffset+nalOffset), io.SeekStart); err != nil {
+				if _, err := r.Seek(int64(dataOffset+uint64(nalOffset)), io.SeekStart); err != nil {
 					return nil, err
 				}
 				data := make([]byte, lengthSize+1)
@@ -591,7 +602,7 @@ func FindIDRFrames(r io.ReadSeeker, trackInfo *TrackInfo) ([]int, error) {
 				}
 				nalOffset += lengthSize + length
 			}
-			dataOffset += sample.Size
+			dataOffset += uint64(sample.Size)
 		}
 	}
 	return idxs, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -73,7 +73,7 @@ codeberg.org/gruf/go-store/v2/util
 ## explicit; go 1.19
 github.com/KimMachineGun/automemlimit
 github.com/KimMachineGun/automemlimit/memlimit
-# github.com/abema/go-mp4 v0.10.1
+# github.com/abema/go-mp4 v0.10.2-0.20230727031202-a1a707db6ecd
 ## explicit; go 1.14
 github.com/abema/go-mp4
 github.com/abema/go-mp4/bitio


### PR DESCRIPTION
# Description
This updates the go mp4 lib to include https://github.com/abema/go-mp4/pull/135 which enables support for probing mp4 files with a co64 box instead of a stco box. This is the case for videos recorded on newer android devices.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
