### PR TITLE
[chore] Revert "[feature] Configurable timezone in containers (#2046)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ RUN yarn install --cwd web/source && \
 
 # stage 3: build the executor container
 FROM --platform=${TARGETPLATFORM} alpine:3.17.2 as executor
-RUN apk add --no-cache tzdata
-ENV TZ="UTC"
 
 # switch to non-root user:group for GtS
 USER 1000:1000

--- a/example/docker-compose/docker-compose.yaml
+++ b/example/docker-compose/docker-compose.yaml
@@ -13,7 +13,6 @@ services:
       GTS_DB_ADDRESS: /gotosocial/storage/sqlite.db
       GTS_LETSENCRYPT_ENABLED: "false"
       GTS_LETSENCRYPT_EMAIL_ADDRESS: ""
-      #TZ: "UTC"
       ## For reverse proxy setups:
       # GTS_TRUSTED_PROXIES: "172.x.x.x"
     ports:
@@ -24,8 +23,6 @@ services:
       #- "127.0.0.1:8080:8080"
     volumes:
       - ~/gotosocial/data:/gotosocial/storage
-      #- /etc/localtime:/etc/localtime:ro
-      #- /etc/timezone:/etc/timezone:ro
     restart: "always"
 
 networks:


### PR DESCRIPTION
This reverts commit 96dd0e75f20a1f1f8203f3438ae7a82d260a0ef8 for the reasons given here: https://github.com/superseriousbusiness/gotosocial/pull/2046#issuecomment-1660016251

Essentially, the commit causes our builds to fail because we can't call `apk` or other commands inside build containers with our current setup. We need to find a better way of doing this.