### PR TITLE
[feature] Set timezone in Docker using TZ env variable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,8 @@ builds:
       - netgo
       - osusergo
       - static_build
+      - kvformat
+      - timetzdata
     env:
       - CGO_ENABLED=0
     goos:

--- a/docs/getting_started/installation/container.md
+++ b/docs/getting_started/installation/container.md
@@ -51,6 +51,17 @@ If desired, update the GoToSocial Docker image tag to the version of GtS you wan
 
 Change the `GTS_HOST` environment variable to the domain you are running GoToSocial on.
 
+### Server Timezone (optional but recommended)
+
+To ensure that your GoToSocial server displays the correct time on posts and in logs, you can set the timezone of the server by editing the `TZ` environment variable.
+
+1. Remove the `#` before `TZ: UTC` in the environment section.
+2. Change the `UTC` part to your timezone identifier. For a list of these identifiers, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+
+For example, if you are running your server in Minsk, you would set `TZ: Europe/Minsk`, Japan would be `TZ: Japan`, Dubai would be `TZ: Asia/Dubai`, etc.
+
+If you don't set this, the default `UTC` will be used.
+
 ### User (optional / probably not necessary)
 
 By default, Dockerized GoToSocial runs with Linux user/group `1000:1000`, which is fine in most cases. If you want to run as a different user/group, you should change the `user` field in the docker-compose.yaml accordingly.

--- a/example/docker-compose/docker-compose.yaml
+++ b/example/docker-compose/docker-compose.yaml
@@ -15,6 +15,8 @@ services:
       GTS_LETSENCRYPT_EMAIL_ADDRESS: ""
       ## For reverse proxy setups:
       # GTS_TRUSTED_PROXIES: "172.x.x.x"
+      ## Set the timezone of your server:
+      #TZ: UTC
     ports:
       - "443:8080"
       ## For letsencrypt:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@ set -e
 log_exec() { echo "$ ${*}"; "$@"; }
 
 # Grab environment variables and set defaults + requirements.
-GO_BUILDTAGS="${GO_BUILDTAGS-} netgo osusergo static_build kvformat"
+GO_BUILDTAGS="${GO_BUILDTAGS-} netgo osusergo static_build kvformat timetzdata"
 GO_LDFLAGS="${GO_LDFLAGS-} -s -w -extldflags '-static' -X 'main.Version=${VERSION:-$(git describe --tags --abbrev=0)}'"
 GO_GCFLAGS=${GO_GCFLAGS-}
 
@@ -16,6 +16,7 @@ GO_GCFLAGS=${GO_GCFLAGS-}
 
 # Available Go build tags, with explanation, followed by benefits of enabling it:
 # - kvformat:    enables prettier output of log fields                       (slightly better performance)
+# - timetzdata:  embed timezone database inside binary                       (allow setting local time inside Docker containers, at cost of 450KB)
 # - notracing:   disables compiling-in otel tracing support                  (reduced binary size, better performance)
 # - noerrcaller: disables caller function prefix in errors                   (slightly better performance, at cost of err readability)
 # - debug:       enables /debug/pprof endpoint                               (adds debug, at performance cost)


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates our build flags to embed the timezone database into the binary, so that timezone can be set using the TZ environment variable inside Docker containers, rather than always falling back to the default UTC.

See:

- https://pkg.go.dev/time#Location
- https://pkg.go.dev/time/tzdata

closes https://github.com/superseriousbusiness/gotosocial/issues/2045

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
