### PR TITLE
[bugfix] Allow instance accounts to be shown in search results in certain circumstances

### DIFF
--- a/internal/processing/search/accounts.go
+++ b/internal/processing/search/accounts.go
@@ -49,6 +49,13 @@ func (p *Processor) Accounts(
 	resolve bool,
 	following bool,
 ) ([]*apimodel.Account, gtserror.WithCode) {
+	// Don't include instance accounts in this search.
+	//
+	// We don't want someone to start typing '@mastodon'
+	// and then get a million instance service accounts
+	// in their search results.
+	const includeInstanceAccounts = false
+
 	var (
 		foundAccounts = make([]*gtsmodel.Account, 0, limit)
 		appendAccount = func(foundAccount *gtsmodel.Account) { foundAccounts = append(foundAccounts, foundAccount) }
@@ -83,7 +90,12 @@ func (p *Processor) Accounts(
 	// if caller supplied an offset greater than 0, return
 	// nothing as though there were no additional results.
 	if offset > 0 {
-		return p.packageAccounts(ctx, requestingAccount, foundAccounts)
+		return p.packageAccounts(
+			ctx,
+			requestingAccount,
+			foundAccounts,
+			includeInstanceAccounts,
+		)
 	}
 
 	// Return all accounts we can find that match the
@@ -106,5 +118,10 @@ func (p *Processor) Accounts(
 	}
 
 	// Return whatever we got (if anything).
-	return p.packageAccounts(ctx, requestingAccount, foundAccounts)
+	return p.packageAccounts(
+		ctx,
+		requestingAccount,
+		foundAccounts,
+		includeInstanceAccounts,
+	)
 }

--- a/internal/processing/search/lookup.go
+++ b/internal/processing/search/lookup.go
@@ -44,6 +44,13 @@ func (p *Processor) Lookup(
 	requestingAccount *gtsmodel.Account,
 	query string,
 ) (*apimodel.Account, gtserror.WithCode) {
+	// Include instance accounts in this search.
+	//
+	// Lookup is for one specific account so we
+	// can't return loads of instance accounts by
+	// accident.
+	const includeInstanceAccounts = true
+
 	// Validate query.
 	query = strings.TrimSpace(query)
 	if query == "" {
@@ -96,7 +103,12 @@ func (p *Processor) Lookup(
 	// using the packageAccounts function to return it. This
 	// may cause the account to be filtered out if it's not
 	// visible to the caller, so anticipate this.
-	accounts, errWithCode := p.packageAccounts(ctx, requestingAccount, []*gtsmodel.Account{account})
+	accounts, errWithCode := p.packageAccounts(
+		ctx,
+		requestingAccount,
+		[]*gtsmodel.Account{account},
+		includeInstanceAccounts,
+	)
 	if errWithCode != nil {
 		return nil, errWithCode
 	}

--- a/internal/processing/search/util.go
+++ b/internal/processing/search/util.go
@@ -48,11 +48,12 @@ func (p *Processor) packageAccounts(
 	ctx context.Context,
 	requestingAccount *gtsmodel.Account,
 	accounts []*gtsmodel.Account,
+	includeInstanceAccounts bool,
 ) ([]*apimodel.Account, gtserror.WithCode) {
 	apiAccounts := make([]*apimodel.Account, 0, len(accounts))
 
 	for _, account := range accounts {
-		if account.IsInstance() {
+		if !includeInstanceAccounts && account.IsInstance() {
 			// No need to show instance accounts.
 			continue
 		}
@@ -169,8 +170,9 @@ func (p *Processor) packageSearchResult(
 	statuses []*gtsmodel.Status,
 	tags []*gtsmodel.Tag,
 	v1 bool,
+	includeInstanceAccounts bool,
 ) (*apimodel.SearchResult, gtserror.WithCode) {
-	apiAccounts, errWithCode := p.packageAccounts(ctx, requestingAccount, accounts)
+	apiAccounts, errWithCode := p.packageAccounts(ctx, requestingAccount, accounts, includeInstanceAccounts)
 	if errWithCode != nil {
 		return nil, errWithCode
 	}

--- a/internal/visibility/account.go
+++ b/internal/visibility/account.go
@@ -19,10 +19,10 @@ package visibility
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/superseriousbusiness/gotosocial/internal/cache"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 )
@@ -66,7 +66,7 @@ func (f *Filter) isAccountVisibleTo(ctx context.Context, requester *gtsmodel.Acc
 	// Check whether target account is visible to anyone.
 	visible, err := f.isAccountVisible(ctx, account)
 	if err != nil {
-		return false, fmt.Errorf("isAccountVisibleTo: error checking account %s visibility: %w", account.ID, err)
+		return false, gtserror.Newf("error checking account %s visibility: %w", account.ID, err)
 	}
 
 	if !visible {
@@ -83,7 +83,7 @@ func (f *Filter) isAccountVisibleTo(ctx context.Context, requester *gtsmodel.Acc
 	// If requester is not visible, they cannot *see* either.
 	visible, err = f.isAccountVisible(ctx, requester)
 	if err != nil {
-		return false, fmt.Errorf("isAccountVisibleTo: error checking account %s visibility: %w", account.ID, err)
+		return false, gtserror.Newf("error checking account %s visibility: %w", account.ID, err)
 	}
 
 	if !visible {
@@ -97,7 +97,7 @@ func (f *Filter) isAccountVisibleTo(ctx context.Context, requester *gtsmodel.Acc
 		account.ID,
 	)
 	if err != nil {
-		return false, fmt.Errorf("isAccountVisibleTo: error checking account blocks: %w", err)
+		return false, gtserror.Newf("error checking account blocks: %w", err)
 	}
 
 	if blocked {
@@ -121,6 +121,7 @@ func (f *Filter) isAccountVisible(ctx context.Context, account *gtsmodel.Account
 		// Fetch the local user model for this account.
 		user, err := f.state.DB.GetUserByAccountID(ctx, account.ID)
 		if err != nil {
+			err := gtserror.Newf("db error getting user for account %s: %w", account.ID, err)
 			return false, err
 		}
 


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request makes instance account filtering a bit more granular in search results, to account for cases like https://github.com/superseriousbusiness/gotosocial/issues/2044 where there's a genuine need to search for something that our imprecise heuristics identify as an instance account.

As such, you can now search for an instance account by namestring, or by URL/URI, but they'll still be excluded in text search results.

closes https://github.com/superseriousbusiness/gotosocial/issues/2044

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
