### PR TITLE
[bugfix] handle HEAD requests more elegantly

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -181,6 +181,7 @@ func New(ctx context.Context) (Router, error) {
 	// create the actual engine here -- this is the core request routing handler for gts
 	engine := gin.New()
 	engine.MaxMultipartMemory = maxMultipartMemory
+	engine.HandleMethodNotAllowed = true
 
 	// set up IP forwarding via x-forward-* headers.
 	trustedProxies := config.GetTrustedProxies()


### PR DESCRIPTION
# Description

Updates our HTTP router handle requests with unsupported methods for that route, which means unless it's a HEAD request on a fileserver endpoint it returns a 405 Method Not Allowed.

closes #2016

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
