### PR TITLE
[bugfix] Rework MultiError to wrap + unwrap errors properly

### DIFF
--- a/cmd/gotosocial/action/admin/media/prune/common.go
+++ b/cmd/gotosocial/action/admin/media/prune/common.go
@@ -75,14 +75,14 @@ func setupPrune(ctx context.Context) (*prune, error) {
 }
 
 func (p *prune) shutdown(ctx context.Context) error {
-	var errs gtserror.MultiError
+	errs := gtserror.NewMultiError(2)
 
 	if err := p.storage.Close(); err != nil {
-		errs.Appendf("error closing storage backend: %v", err)
+		errs.Appendf("error closing storage backend: %w", err)
 	}
 
 	if err := p.dbService.Stop(ctx); err != nil {
-		errs.Appendf("error stopping database: %v", err)
+		errs.Appendf("error stopping database: %w", err)
 	}
 
 	p.state.Workers.Stop()

--- a/internal/api/activitypub/users/inboxpost_test.go
+++ b/internal/api/activitypub/users/inboxpost_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -105,16 +104,16 @@ func (suite *InboxPostTestSuite) inboxPost(
 		suite.FailNow(err.Error())
 	}
 
-	errs := gtserror.MultiError{}
+	errs := gtserror.NewMultiError(2)
 
 	// Check expected code + body.
 	if resultCode := recorder.Code; expectedHTTPStatus != resultCode {
-		errs = append(errs, fmt.Sprintf("expected %d got %d", expectedHTTPStatus, resultCode))
+		errs.Appendf("expected %d got %d", expectedHTTPStatus, resultCode)
 	}
 
 	// If we got an expected body, return early.
 	if expectedBody != "" && string(b) != expectedBody {
-		errs = append(errs, fmt.Sprintf("expected %s got %s", expectedBody, string(b)))
+		errs.Appendf("expected %s got %s", expectedBody, string(b))
 	}
 
 	if err := errs.Combine(); err != nil {

--- a/internal/api/client/accounts/accountupdate_test.go
+++ b/internal/api/client/accounts/accountupdate_test.go
@@ -90,16 +90,16 @@ func (suite *AccountUpdateTestSuite) updateAccount(
 		return nil, err
 	}
 
-	errs := gtserror.MultiError{}
+	errs := gtserror.NewMultiError(2)
 
 	// Check expected code + body.
 	if resultCode := recorder.Code; expectedHTTPStatus != resultCode {
-		errs = append(errs, fmt.Sprintf("expected %d got %d", expectedHTTPStatus, resultCode))
+		errs.Appendf("expected %d got %d", expectedHTTPStatus, resultCode)
 	}
 
 	// If we got an expected body, return early.
 	if expectedBody != "" && string(b) != expectedBody {
-		errs = append(errs, fmt.Sprintf("expected %s got %s", expectedBody, string(b)))
+		errs.Appendf("expected %s got %s", expectedBody, string(b))
 	}
 
 	if err := errs.Combine(); err != nil {

--- a/internal/api/client/accounts/lists_test.go
+++ b/internal/api/client/accounts/lists_test.go
@@ -19,7 +19,6 @@ package accounts_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -63,16 +62,16 @@ func (suite *ListsTestSuite) getLists(targetAccountID string, expectedHTTPStatus
 		suite.FailNow(err.Error())
 	}
 
-	errs := gtserror.MultiError{}
+	errs := gtserror.NewMultiError(2)
 
 	// Check expected code + body.
 	if resultCode := recorder.Code; expectedHTTPStatus != resultCode {
-		errs = append(errs, fmt.Sprintf("expected %d got %d", expectedHTTPStatus, resultCode))
+		errs.Appendf("expected %d got %d", expectedHTTPStatus, resultCode)
 	}
 
 	// If we got an expected body, return early.
 	if expectedBody != "" && string(b) != expectedBody {
-		errs = append(errs, fmt.Sprintf("expected %s got %s", expectedBody, string(b)))
+		errs.Appendf("expected %s got %s", expectedBody, string(b))
 	}
 
 	if err := errs.Combine(); err != nil {

--- a/internal/api/client/accounts/search_test.go
+++ b/internal/api/client/accounts/search_test.go
@@ -19,7 +19,6 @@ package accounts_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -99,16 +98,16 @@ func (suite *AccountSearchTestSuite) getSearch(
 		suite.FailNow(err.Error())
 	}
 
-	errs := gtserror.MultiError{}
+	errs := gtserror.NewMultiError(2)
 
 	// Check expected code + body.
 	if resultCode := recorder.Code; expectedHTTPStatus != resultCode {
-		errs = append(errs, fmt.Sprintf("expected %d got %d", expectedHTTPStatus, resultCode))
+		errs.Appendf("expected %d got %d", expectedHTTPStatus, resultCode)
 	}
 
 	// If we got an expected body, return early.
 	if expectedBody != "" && string(b) != expectedBody {
-		errs = append(errs, fmt.Sprintf("expected %s got %s", expectedBody, string(b)))
+		errs.Appendf("expected %s got %s", expectedBody, string(b))
 	}
 
 	if err := errs.Combine(); err != nil {

--- a/internal/api/client/admin/reportresolve_test.go
+++ b/internal/api/client/admin/reportresolve_test.go
@@ -19,7 +19,6 @@ package admin_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -84,16 +83,16 @@ func (suite *ReportResolveTestSuite) resolveReport(
 		return nil, err
 	}
 
-	errs := gtserror.MultiError{}
+	errs := gtserror.NewMultiError(2)
 
 	if resultCode := recorder.Code; expectedHTTPStatus != resultCode {
-		errs = append(errs, fmt.Sprintf("expected %d got %d", expectedHTTPStatus, resultCode))
+		errs.Appendf("expected %d got %d", expectedHTTPStatus, resultCode)
 	}
 
 	// if we got an expected body, return early
 	if expectedBody != "" {
 		if string(b) != expectedBody {
-			errs = append(errs, fmt.Sprintf("expected %s got %s", expectedBody, string(b)))
+			errs.Appendf("expected %s got %s", expectedBody, string(b))
 		}
 		return nil, errs.Combine()
 	}

--- a/internal/api/client/admin/reportsget_test.go
+++ b/internal/api/client/admin/reportsget_test.go
@@ -19,7 +19,6 @@ package admin_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -101,16 +100,16 @@ func (suite *ReportsGetTestSuite) getReports(
 		return nil, "", err
 	}
 
-	errs := gtserror.MultiError{}
+	errs := gtserror.NewMultiError(2)
 
 	if resultCode := recorder.Code; expectedHTTPStatus != resultCode {
-		errs = append(errs, fmt.Sprintf("expected %d got %d", expectedHTTPStatus, resultCode))
+		errs.Appendf("expected %d got %d", expectedHTTPStatus, resultCode)
 	}
 
 	// if we got an expected body, return early
 	if expectedBody != "" {
 		if string(b) != expectedBody {
-			errs = append(errs, fmt.Sprintf("expected %s got %s", expectedBody, string(b)))
+			errs.Appendf("expected %s got %s", expectedBody, string(b))
 		}
 		return nil, "", errs.Combine()
 	}

--- a/internal/api/client/lists/listaccounts_test.go
+++ b/internal/api/client/lists/listaccounts_test.go
@@ -19,7 +19,6 @@ package lists_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -103,17 +102,17 @@ func (suite *ListAccountsTestSuite) getListAccounts(
 		return nil, "", err
 	}
 
-	errs := gtserror.MultiError{}
+	errs := gtserror.NewMultiError(2)
 
 	// check code + body
 	if resultCode := recorder.Code; expectedHTTPStatus != resultCode {
-		errs = append(errs, fmt.Sprintf("expected %d got %d", expectedHTTPStatus, resultCode))
+		errs.Appendf("expected %d got %d", expectedHTTPStatus, resultCode)
 	}
 
 	// if we got an expected body, return early
 	if expectedBody != "" {
 		if string(b) != expectedBody {
-			errs = append(errs, fmt.Sprintf("expected %s got %s", expectedBody, string(b)))
+			errs.Appendf("expected %s got %s", expectedBody, string(b))
 		}
 		return nil, "", errs.Combine()
 	}

--- a/internal/api/client/reports/reportcreate_test.go
+++ b/internal/api/client/reports/reportcreate_test.go
@@ -19,7 +19,6 @@ package reports_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -77,17 +76,17 @@ func (suite *ReportCreateTestSuite) createReport(expectedHTTPStatus int, expecte
 		return nil, err
 	}
 
-	errs := gtserror.MultiError{}
+	errs := gtserror.NewMultiError(2)
 
 	// check code + body
 	if resultCode := recorder.Code; expectedHTTPStatus != resultCode {
-		errs = append(errs, fmt.Sprintf("expected %d got %d", expectedHTTPStatus, resultCode))
+		errs.Appendf("expected %d got %d", expectedHTTPStatus, resultCode)
 	}
 
 	// if we got an expected body, return early
 	if expectedBody != "" {
 		if string(b) != expectedBody {
-			errs = append(errs, fmt.Sprintf("expected %s got %s", expectedBody, string(b)))
+			errs.Appendf("expected %s got %s", expectedBody, string(b))
 		}
 		return nil, errs.Combine()
 	}

--- a/internal/api/client/reports/reportget_test.go
+++ b/internal/api/client/reports/reportget_test.go
@@ -19,7 +19,6 @@ package reports_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -64,17 +63,17 @@ func (suite *ReportGetTestSuite) getReport(expectedHTTPStatus int, expectedBody 
 		return nil, err
 	}
 
-	errs := gtserror.MultiError{}
+	errs := gtserror.NewMultiError(2)
 
 	// check code + body
 	if resultCode := recorder.Code; expectedHTTPStatus != resultCode {
-		errs = append(errs, fmt.Sprintf("expected %d got %d", expectedHTTPStatus, resultCode))
+		errs.Appendf("expected %d got %d", expectedHTTPStatus, resultCode)
 	}
 
 	// if we got an expected body, return early
 	if expectedBody != "" {
 		if string(b) != expectedBody {
-			errs = append(errs, fmt.Sprintf("expected %s got %s", expectedBody, string(b)))
+			errs.Appendf("expected %s got %s", expectedBody, string(b))
 		}
 		return nil, errs.Combine()
 	}

--- a/internal/api/client/search/searchget_test.go
+++ b/internal/api/client/search/searchget_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -122,16 +121,16 @@ func (suite *SearchGetTestSuite) getSearch(
 		suite.FailNow(err.Error())
 	}
 
-	errs := gtserror.MultiError{}
+	errs := gtserror.NewMultiError(2)
 
 	// Check expected code + body.
 	if resultCode := recorder.Code; expectedHTTPStatus != resultCode {
-		errs = append(errs, fmt.Sprintf("expected %d got %d: %v", expectedHTTPStatus, resultCode, ctx.Errors.JSON()))
+		errs.Appendf("expected %d got %d", expectedHTTPStatus, resultCode)
 	}
 
 	// If we got an expected body, return early.
 	if expectedBody != "" && string(b) != expectedBody {
-		errs = append(errs, fmt.Sprintf("expected %s got %s", expectedBody, string(b)))
+		errs.Appendf("expected %s got %s", expectedBody, string(b))
 	}
 
 	if err := errs.Combine(); err != nil {

--- a/internal/api/client/statuses/statuspin_test.go
+++ b/internal/api/client/statuses/statuspin_test.go
@@ -20,7 +20,6 @@ package statuses_test
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -74,20 +73,20 @@ func (suite *StatusPinTestSuite) createPin(
 		return nil, err
 	}
 
-	errs := gtserror.MultiError{}
+	errs := gtserror.NewMultiError(2)
 
-	// check code + body
+	// Check expected code + body.
 	if resultCode := recorder.Code; expectedHTTPStatus != resultCode {
-		errs = append(errs, fmt.Sprintf("expected %d got %d", expectedHTTPStatus, resultCode))
+		errs.Appendf("expected %d got %d", expectedHTTPStatus, resultCode)
 	}
 
-	// if we got an expected body, return early
+	// If we got an expected body, return early.
 	if expectedBody != "" && string(b) != expectedBody {
-		errs = append(errs, fmt.Sprintf("expected %s got %s", expectedBody, string(b)))
+		errs.Appendf("expected %s got %s", expectedBody, string(b))
 	}
 
-	if len(errs) > 0 {
-		return nil, errs.Combine()
+	if err := errs.Combine(); err != nil {
+		suite.FailNow("", "%v (body %s)", err, string(b))
 	}
 
 	resp := &apimodel.Status{}

--- a/internal/api/client/statuses/statusunpin_test.go
+++ b/internal/api/client/statuses/statusunpin_test.go
@@ -19,7 +19,6 @@ package statuses_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -68,20 +67,20 @@ func (suite *StatusUnpinTestSuite) createUnpin(
 		return nil, err
 	}
 
-	errs := gtserror.MultiError{}
+	errs := gtserror.NewMultiError(2)
 
-	// check code + body
+	// Check expected code + body.
 	if resultCode := recorder.Code; expectedHTTPStatus != resultCode {
-		errs = append(errs, fmt.Sprintf("expected %d got %d", expectedHTTPStatus, resultCode))
+		errs.Appendf("expected %d got %d", expectedHTTPStatus, resultCode)
 	}
 
-	// if we got an expected body, return early
+	// If we got an expected body, return early.
 	if expectedBody != "" && string(b) != expectedBody {
-		errs = append(errs, fmt.Sprintf("expected %s got %s", expectedBody, string(b)))
+		errs.Appendf("expected %s got %s", expectedBody, string(b))
 	}
 
-	if len(errs) > 0 {
-		return nil, errs.Combine()
+	if err := errs.Combine(); err != nil {
+		suite.FailNow("", "%v (body %s)", err, string(b))
 	}
 
 	resp := &apimodel.Status{}

--- a/internal/cleaner/cleaner.go
+++ b/internal/cleaner/cleaner.go
@@ -83,19 +83,23 @@ func (c *Cleaner) removeFiles(ctx context.Context, files ...string) (int, error)
 		return len(files), nil
 	}
 
-	var errs gtserror.MultiError
+	var (
+		errs     gtserror.MultiError
+		errCount int
+	)
 
 	for _, path := range files {
 		// Remove each provided storage path.
 		log.Debugf(ctx, "removing file: %s", path)
 		err := c.state.Storage.Delete(ctx, path)
 		if err != nil && !errors.Is(err, storage.ErrNotFound) {
-			errs.Appendf("error removing %s: %v", path, err)
+			errs.Appendf("error removing %s: %w", path, err)
+			errCount++
 		}
 	}
 
 	// Calculate no. files removed.
-	diff := len(files) - len(errs)
+	diff := len(files) - errCount
 
 	// Wrap the combined error slice.
 	if err := errs.Combine(); err != nil {

--- a/internal/db/bundb/instance.go
+++ b/internal/db/bundb/instance.go
@@ -173,7 +173,7 @@ func (i *instanceDB) getInstance(ctx context.Context, lookup string, dbQuery fun
 func (i *instanceDB) populateInstance(ctx context.Context, instance *gtsmodel.Instance) error {
 	var (
 		err  error
-		errs = make(gtserror.MultiError, 0, 2)
+		errs = gtserror.NewMultiError(2)
 	)
 
 	if instance.DomainBlockID != "" && instance.DomainBlock == nil {
@@ -183,7 +183,7 @@ func (i *instanceDB) populateInstance(ctx context.Context, instance *gtsmodel.In
 			instance.Domain,
 		)
 		if err != nil {
-			errs.Append(gtserror.Newf("error populating instance domain block: %w", err))
+			errs.Appendf("error populating instance domain block: %w", err)
 		}
 	}
 
@@ -194,11 +194,15 @@ func (i *instanceDB) populateInstance(ctx context.Context, instance *gtsmodel.In
 			instance.ContactAccountID,
 		)
 		if err != nil {
-			errs.Append(gtserror.Newf("error populating instance contact account: %w", err))
+			errs.Appendf("error populating instance contact account: %w", err)
 		}
 	}
 
-	return errs.Combine()
+	if err := errs.Combine(); err != nil {
+		return gtserror.Newf("%w", err)
+	}
+
+	return nil
 }
 
 func (i *instanceDB) PutInstance(ctx context.Context, instance *gtsmodel.Instance) error {

--- a/internal/db/bundb/list.go
+++ b/internal/db/bundb/list.go
@@ -117,7 +117,7 @@ func (l *listDB) GetListsForAccountID(ctx context.Context, accountID string) ([]
 func (l *listDB) PopulateList(ctx context.Context, list *gtsmodel.List) error {
 	var (
 		err  error
-		errs = make(gtserror.MultiError, 0, 2)
+		errs = gtserror.NewMultiError(2)
 	)
 
 	if list.Account == nil {
@@ -127,7 +127,7 @@ func (l *listDB) PopulateList(ctx context.Context, list *gtsmodel.List) error {
 			list.AccountID,
 		)
 		if err != nil {
-			errs.Append(fmt.Errorf("error populating list account: %w", err))
+			errs.Appendf("error populating list account: %w", err)
 		}
 	}
 
@@ -139,11 +139,15 @@ func (l *listDB) PopulateList(ctx context.Context, list *gtsmodel.List) error {
 			"", "", "", 0,
 		)
 		if err != nil {
-			errs.Append(fmt.Errorf("error populating list entries: %w", err))
+			errs.Appendf("error populating list entries: %w", err)
 		}
 	}
 
-	return errs.Combine()
+	if err := errs.Combine(); err != nil {
+		return gtserror.Newf("%w", err)
+	}
+
+	return nil
 }
 
 func (l *listDB) PutList(ctx context.Context, list *gtsmodel.List) error {

--- a/internal/db/bundb/relationship_follow.go
+++ b/internal/db/bundb/relationship_follow.go
@@ -160,7 +160,7 @@ func (r *relationshipDB) getFollow(ctx context.Context, lookup string, dbQuery f
 func (r *relationshipDB) PopulateFollow(ctx context.Context, follow *gtsmodel.Follow) error {
 	var (
 		err  error
-		errs = make(gtserror.MultiError, 0, 2)
+		errs = gtserror.NewMultiError(2)
 	)
 
 	if follow.Account == nil {
@@ -170,7 +170,7 @@ func (r *relationshipDB) PopulateFollow(ctx context.Context, follow *gtsmodel.Fo
 			follow.AccountID,
 		)
 		if err != nil {
-			errs.Append(fmt.Errorf("error populating follow account: %w", err))
+			errs.Appendf("error populating follow account: %w", err)
 		}
 	}
 
@@ -181,11 +181,15 @@ func (r *relationshipDB) PopulateFollow(ctx context.Context, follow *gtsmodel.Fo
 			follow.TargetAccountID,
 		)
 		if err != nil {
-			errs.Append(fmt.Errorf("error populating follow target account: %w", err))
+			errs.Appendf("error populating follow target account: %w", err)
 		}
 	}
 
-	return errs.Combine()
+	if err := errs.Combine(); err != nil {
+		return gtserror.Newf("%w", err)
+	}
+
+	return nil
 }
 
 func (r *relationshipDB) PutFollow(ctx context.Context, follow *gtsmodel.Follow) error {

--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/superseriousbusiness/gotosocial/internal/db"
@@ -130,7 +129,7 @@ func (s *statusDB) getStatus(ctx context.Context, lookup string, dbQuery func(*g
 func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) error {
 	var (
 		err  error
-		errs = make(gtserror.MultiError, 0, 9)
+		errs = gtserror.NewMultiError(9)
 	)
 
 	if status.Account == nil {
@@ -140,7 +139,7 @@ func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) 
 			status.AccountID,
 		)
 		if err != nil {
-			errs.Append(fmt.Errorf("error populating status author: %w", err))
+			errs.Appendf("error populating status author: %w", err)
 		}
 	}
 
@@ -151,7 +150,7 @@ func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) 
 			status.InReplyToID,
 		)
 		if err != nil {
-			errs.Append(fmt.Errorf("error populating status parent: %w", err))
+			errs.Appendf("error populating status parent: %w", err)
 		}
 	}
 
@@ -163,7 +162,7 @@ func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) 
 				status.InReplyToID,
 			)
 			if err != nil {
-				errs.Append(fmt.Errorf("error populating status parent: %w", err))
+				errs.Appendf("error populating status parent: %w", err)
 			}
 		}
 
@@ -174,7 +173,7 @@ func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) 
 				status.InReplyToAccountID,
 			)
 			if err != nil {
-				errs.Append(fmt.Errorf("error populating status parent author: %w", err))
+				errs.Appendf("error populating status parent author: %w", err)
 			}
 		}
 	}
@@ -187,7 +186,7 @@ func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) 
 				status.BoostOfID,
 			)
 			if err != nil {
-				errs.Append(fmt.Errorf("error populating status boost: %w", err))
+				errs.Appendf("error populating status boost: %w", err)
 			}
 		}
 
@@ -198,7 +197,7 @@ func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) 
 				status.BoostOfAccountID,
 			)
 			if err != nil {
-				errs.Append(fmt.Errorf("error populating status boost author: %w", err))
+				errs.Appendf("error populating status boost author: %w", err)
 			}
 		}
 	}
@@ -210,7 +209,7 @@ func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) 
 			status.AttachmentIDs,
 		)
 		if err != nil {
-			errs.Append(fmt.Errorf("error populating status attachments: %w", err))
+			errs.Appendf("error populating status attachments: %w", err)
 		}
 	}
 
@@ -221,7 +220,7 @@ func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) 
 			status.TagIDs,
 		)
 		if err != nil {
-			errs.Append(fmt.Errorf("error populating status tags: %w", err))
+			errs.Appendf("error populating status tags: %w", err)
 		}
 	}
 
@@ -232,7 +231,7 @@ func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) 
 			status.MentionIDs,
 		)
 		if err != nil {
-			errs.Append(fmt.Errorf("error populating status mentions: %w", err))
+			errs.Appendf("error populating status mentions: %w", err)
 		}
 	}
 
@@ -243,11 +242,15 @@ func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) 
 			status.EmojiIDs,
 		)
 		if err != nil {
-			errs.Append(fmt.Errorf("error populating status emojis: %w", err))
+			errs.Appendf("error populating status emojis: %w", err)
 		}
 	}
 
-	return errs.Combine()
+	if err := errs.Combine(); err != nil {
+		return gtserror.Newf("%w", err)
+	}
+
+	return nil
 }
 
 func (s *statusDB) PutStatus(ctx context.Context, status *gtsmodel.Status) error {

--- a/internal/db/bundb/statusfave.go
+++ b/internal/db/bundb/statusfave.go
@@ -149,7 +149,7 @@ func (s *statusFaveDB) GetStatusFavesForStatus(ctx context.Context, statusID str
 func (s *statusFaveDB) PopulateStatusFave(ctx context.Context, statusFave *gtsmodel.StatusFave) error {
 	var (
 		err  error
-		errs = make(gtserror.MultiError, 0, 3)
+		errs = gtserror.NewMultiError(3)
 	)
 
 	if statusFave.Account == nil {
@@ -159,7 +159,7 @@ func (s *statusFaveDB) PopulateStatusFave(ctx context.Context, statusFave *gtsmo
 			statusFave.AccountID,
 		)
 		if err != nil {
-			errs.Append(fmt.Errorf("error populating status fave author: %w", err))
+			errs.Appendf("error populating status fave author: %w", err)
 		}
 	}
 
@@ -170,7 +170,7 @@ func (s *statusFaveDB) PopulateStatusFave(ctx context.Context, statusFave *gtsmo
 			statusFave.TargetAccountID,
 		)
 		if err != nil {
-			errs.Append(fmt.Errorf("error populating status fave target account: %w", err))
+			errs.Appendf("error populating status fave target account: %w", err)
 		}
 	}
 
@@ -181,11 +181,15 @@ func (s *statusFaveDB) PopulateStatusFave(ctx context.Context, statusFave *gtsmo
 			statusFave.StatusID,
 		)
 		if err != nil {
-			errs.Append(fmt.Errorf("error populating status fave status: %w", err))
+			errs.Appendf("error populating status fave status: %w", err)
 		}
 	}
 
-	return errs.Combine()
+	if err := errs.Combine(); err != nil {
+		return gtserror.Newf("%w", err)
+	}
+
+	return nil
 }
 
 func (s *statusFaveDB) PutStatusFave(ctx context.Context, fave *gtsmodel.StatusFave) error {

--- a/internal/gtserror/multi_test.go
+++ b/internal/gtserror/multi_test.go
@@ -1,0 +1,40 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package gtserror
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+)
+
+func TestMultiError(t *testing.T) {
+	errs := MultiError{
+		
+	}
+
+	for _, err := range []error{
+		db.ErrNoEntries,
+		errors.New("oopsie woopsie we did a fucky wucky etc"),
+		fmt.Errorf("wrapped error: %w", db.ErrAlreadyExists),
+	} {
+		errs.Append(err)
+	}
+}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates our MultiError type to allow it to properly wrap + unwrap errors.

This should fix issues like https://github.com/superseriousbusiness/gotosocial/issues/1925 where we were checking the returned multierror, but it wasn't being recognized properly as a db.ErrNoEntries type, so it ended up being surfaced as an internal server error when it shouldn't have been.

With proper wrapping + unwrapping, calling `errors.Is` on a combined MultiError will now yield the expected result!

closes https://github.com/superseriousbusiness/gotosocial/issues/1925

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
