### PR TITLE
[docs] fix postgres create database command

### DIFF
--- a/docs/configuration/database.md
+++ b/docs/configuration/database.md
@@ -37,7 +37,7 @@ Then you should have already created database `gotosocial` in Postgres, and give
 The psql commands to do this will look something like:
 
 ```psql
-create database gotosocial with locale C.UTF-8 template template0;
+create database gotosocial with locale 'C.UTF-8' template template0;
 create user gotosocial with password 'some_really_good_password';
 grant all privileges on database gotosocial to gotosocial;
 ```


### PR DESCRIPTION
# Description

The current command `create database gotosocial with locale C.UTF-8 template template0;` fails because the locale has to be quoted:
```
postgres=# create database gotosocial with locale C.UTF-8 template template0;
ERROR:  syntax error at or near "."
LINE 1: create database gotosocial with locale C.UTF-8 template temp...
```

Tested manually that it works with the quotes and the official postgres examples also use quotes around the locales: https://www.postgresql.org/docs/current/sql-createdatabase.html

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).