### PR TITLE
[bugfix] don't accept unrelated statuses 

### DIFF
--- a/internal/federation/federatingdb/create.go
+++ b/internal/federation/federatingdb/create.go
@@ -135,7 +135,7 @@ func (f *federatingDB) activityCreate(
 	// Create must have an Object.
 	objectProp := create.GetActivityStreamsObject()
 	if objectProp == nil {
-		return gtserror.New("Create had no Object")
+		return gtserror.New("create had no Object")
 	}
 
 	// Iterate through the Object property and process

--- a/internal/federation/federatingdb/create_test.go
+++ b/internal/federation/federatingdb/create_test.go
@@ -54,7 +54,7 @@ func (suite *CreateTestSuite) TestCreateNote() {
 
 	// status should have some expected values
 	suite.Equal(requestingAccount.ID, status.AccountID)
-	suite.Equal("hey zork here's a new private note for you", status.Content)
+	suite.Equal("@the_mighty_zork@localhost:8080 hey zork here's a new private note for you", status.Content)
 
 	// status should be in the database
 	_, err = suite.db.GetStatusByID(context.Background(), status.ID)

--- a/internal/processing/fromfederator.go
+++ b/internal/processing/fromfederator.go
@@ -25,7 +25,6 @@ import (
 	"codeberg.org/gruf/go-kv"
 	"codeberg.org/gruf/go-logger/v2/level"
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
-	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/id"
@@ -109,13 +108,14 @@ func (p *Processor) ProcessFromFederator(ctx context.Context, federatorMsg messa
 
 // processCreateStatusFromFederator handles Activity Create and Object Note.
 func (p *Processor) processCreateStatusFromFederator(ctx context.Context, federatorMsg messages.FromFederator) error {
-	// Check the federatorMsg for either an already dereferenced
-	// and converted status pinned to the message, or a forwarded
-	// AP IRI that we still need to deref.
 	var (
-		status    *gtsmodel.Status
-		err       error
-		forwarded = federatorMsg.GTSModel == nil
+		status *gtsmodel.Status
+		err    error
+
+		// Check the federatorMsg for either an already dereferenced
+		// and converted status pinned to the message, or a forwarded
+		// AP IRI that we still need to deref.
+		forwarded = (federatorMsg.GTSModel == nil)
 	)
 
 	if forwarded {
@@ -123,25 +123,12 @@ func (p *Processor) processCreateStatusFromFederator(ctx context.Context, federa
 		// This will also cause the status to be inserted into the db.
 		status, err = p.statusFromAPIRI(ctx, federatorMsg)
 	} else {
-		// Model is set, use that.
+		// Model is set, ensure we have the most up-to-date model.
 		status, err = p.statusFromGTSModel(ctx, federatorMsg)
 	}
 
 	if err != nil {
 		return gtserror.Newf("error extracting status from federatorMsg: %w", err)
-	}
-
-	if err := p.state.DB.PutStatus(ctx, status); err != nil {
-		if errors.Is(err, db.ErrAlreadyExists) {
-			// The status already exists in the database, which
-			// means we've already processed it and some race
-			// condition means we didn't catch it yet. We can
-			// just return nil here and be done with it.
-			return nil
-		}
-
-		// Real error.
-		return gtserror.Newf("db error inserting status: %w", err)
 	}
 
 	if status.Account == nil || status.Account.IsRemote() {

--- a/internal/processing/fromfederator.go
+++ b/internal/processing/fromfederator.go
@@ -131,11 +131,6 @@ func (p *Processor) processCreateStatusFromFederator(ctx context.Context, federa
 		return gtserror.Newf("error extracting status from federatorMsg: %w", err)
 	}
 
-	// Before we go whacking this status in our db, ensure
-	// it's actually relevant to the account who received it
-	// in their Inbox, and it's not just a status randomly
-	// blasted at us from somewhere we don't care about.
-
 	if err := p.state.DB.PutStatus(ctx, status); err != nil {
 		if errors.Is(err, db.ErrAlreadyExists) {
 			// The status already exists in the database, which

--- a/internal/typeutils/astointernal.go
+++ b/internal/typeutils/astointernal.go
@@ -283,7 +283,7 @@ func (c *converter) ASStatusToStatus(ctx context.Context, statusable ap.Statusab
 	//
 	// Hashtags for later dereferencing.
 	if hashtags, err := ap.ExtractHashtags(statusable); err != nil {
-		l.Infof("error extracting hashtags: %q", err)
+		l.Warnf("error extracting hashtags: %v", err)
 	} else {
 		status.Tags = hashtags
 	}
@@ -292,7 +292,7 @@ func (c *converter) ASStatusToStatus(ctx context.Context, statusable ap.Statusab
 	//
 	// Custom emojis for later dereferencing.
 	if emojis, err := ap.ExtractEmojis(statusable); err != nil {
-		l.Infof("error extracting emojis: %q", err)
+		l.Warnf("error extracting emojis: %v", err)
 	} else {
 		status.Emojis = emojis
 	}
@@ -301,7 +301,7 @@ func (c *converter) ASStatusToStatus(ctx context.Context, statusable ap.Statusab
 	//
 	// Mentions of other accounts for later dereferencing.
 	if mentions, err := ap.ExtractMentions(statusable); err != nil {
-		l.Infof("error extracting mentions: %q", err)
+		l.Warnf("error extracting mentions: %v", err)
 	} else {
 		status.Mentions = mentions
 	}
@@ -322,7 +322,7 @@ func (c *converter) ASStatusToStatus(ctx context.Context, statusable ap.Statusab
 	// db defaults, will fall back to now if not set.
 	published, err := ap.ExtractPublished(statusable)
 	if err != nil {
-		l.Infof("error extracting published: %q", err)
+		l.Warnf("error extracting published: %v", err)
 	} else {
 		status.CreatedAt = published
 		status.UpdatedAt = published

--- a/test/run-postgres.sh
+++ b/test/run-postgres.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+# Ensure test args are set.
+ARGS=${@}; [ -z "$ARGS" ] && \
+ARGS='./...'
+
+# Database config.
 DB_NAME='postgres'
 DB_USER='postgres'
 DB_PASS='postgres'
@@ -34,4 +39,4 @@ GTS_DB_PORT=${DB_PORT} \
 GTS_DB_USER=${DB_USER} \
 GTS_DB_PASSWORD=${DB_PASS} \
 GTS_DB_DATABASE=${DB_NAME} \
-go test ./... -p 1 ${@}
+go test ./... -p 1 ${ARGS}

--- a/test/run-sqlite.sh
+++ b/test/run-sqlite.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+# Ensure test args are set.
+ARGS=${@}; [ -z "$ARGS" ] && \
+ARGS='./...'
+
+# Run the SQLite tests.
 GTS_DB_TYPE=sqlite \
 GTS_DB_ADDRESS=':memory:' \
-go test ./... ${@}
+go test ${ARGS}

--- a/testrig/testmodels.go
+++ b/testrig/testmodels.go
@@ -2055,13 +2055,16 @@ func NewTestActivities(accounts map[string]*gtsmodel.Account) map[string]Activit
 		URLMustParse("http://fossbros-anonymous.io/users/foss_satan/statuses/5424b153-4553-4f30-9358-7b92f7cd42f6"),
 		URLMustParse("http://fossbros-anonymous.io/@foss_satan/5424b153-4553-4f30-9358-7b92f7cd42f6"),
 		TimeMustParse("2022-07-13T12:13:12+02:00"),
-		"hey zork here's a new private note for you",
+		"@the_mighty_zork@localhost:8080 hey zork here's a new private note for you",
 		"new note for zork",
 		URLMustParse("http://fossbros-anonymous.io/users/foss_satan"),
 		[]*url.URL{URLMustParse("http://localhost:8080/users/the_mighty_zork")},
 		nil,
 		true,
-		[]vocab.ActivityStreamsMention{},
+		[]vocab.ActivityStreamsMention{newAPMention(
+			URLMustParse("http://localhost:8080/users/the_mighty_zork"),
+			"@the_mighty_zork@localhost:8080",
+		)},
 		[]vocab.TootHashtag{},
 		nil,
 	)


### PR DESCRIPTION
# Description
Updates federatingdb logic to only accept status creation activities if the receiving account is either mentioned, or follows the requesting account.  Also reshuffles the `createStatusable()` logic a little so we check for an existing status with URI in the database before bothering with the deref of forwarded status.

closes #1965

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
