### PR TITLE
[bugfix] only set content-length AFTER rewinding body bytes

### DIFF
--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -247,8 +247,8 @@ func (c *Client) DoSigned(r *http.Request, sign SignFunc) (rsp *http.Response, e
 
 		// Rewind body reader and content-length if set.
 		if rc, ok := r.Body.(*byteutil.ReadNopCloser); ok {
+			rc.Rewind() // set len AFTER rewind
 			r.ContentLength = int64(rc.Len())
-			rc.Rewind()
 		}
 
 		// Sign the outgoing request.


### PR DESCRIPTION
# Description
closes #2079 

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
