### PR TITLE
[performance] remove last of relational queries to instead rely on caches

### DIFF
--- a/internal/api/auth/authorize.go
+++ b/internal/api/auth/authorize.go
@@ -75,8 +75,8 @@ func (m *Module) AuthorizeGETHandler(c *gin.Context) {
 		return
 	}
 
-	app := &gtsmodel.Application{}
-	if err := m.db.GetWhere(c.Request.Context(), []db.Where{{Key: sessionClientID, Value: clientID}}, app); err != nil {
+	app, err := m.db.GetApplicationByClientID(c.Request.Context(), clientID)
+	if err != nil {
 		m.clearSession(s)
 		safe := fmt.Sprintf("application for %s %s could not be retrieved", sessionClientID, clientID)
 		var errWithCode gtserror.WithCode

--- a/internal/api/auth/callback.go
+++ b/internal/api/auth/callback.go
@@ -107,8 +107,8 @@ func (m *Module) CallbackGETHandler(c *gin.Context) {
 		return
 	}
 
-	app := &gtsmodel.Application{}
-	if err := m.db.GetWhere(c.Request.Context(), []db.Where{{Key: sessionClientID, Value: clientID}}, app); err != nil {
+	app, err := m.db.GetApplicationByClientID(c.Request.Context(), sessionClientID)
+	if err != nil {
 		m.clearSession(s)
 		safe := fmt.Sprintf("application for %s %s could not be retrieved", sessionClientID, clientID)
 		var errWithCode gtserror.WithCode

--- a/internal/cache/gts.go
+++ b/internal/cache/gts.go
@@ -32,6 +32,7 @@ import (
 type GTSCaches struct {
 	account          *result.Cache[*gtsmodel.Account]
 	accountNote      *result.Cache[*gtsmodel.AccountNote]
+	application      *result.Cache[*gtsmodel.Application]
 	block            *result.Cache[*gtsmodel.Block]
 	blockIDs         *SliceCache[string]
 	boostOfIDs       *SliceCache[string]
@@ -67,6 +68,7 @@ type GTSCaches struct {
 func (c *GTSCaches) Init() {
 	c.initAccount()
 	c.initAccountNote()
+	c.initApplication()
 	c.initBlock()
 	c.initBlockIDs()
 	c.initBoostOfIDs()
@@ -115,6 +117,11 @@ func (c *GTSCaches) Account() *result.Cache[*gtsmodel.Account] {
 // AccountNote provides access to the gtsmodel Note database cache.
 func (c *GTSCaches) AccountNote() *result.Cache[*gtsmodel.AccountNote] {
 	return c.accountNote
+}
+
+// Application provides access to the gtsmodel Application database cache.
+func (c *GTSCaches) Application() *result.Cache[*gtsmodel.Application] {
+	return c.application
 }
 
 // Block provides access to the gtsmodel Block (account) database cache.
@@ -301,6 +308,26 @@ func (c *GTSCaches) initAccountNote() {
 	}, cap)
 
 	c.accountNote.IgnoreErrors(ignoreErrors)
+}
+
+func (c *GTSCaches) initApplication() {
+	// Calculate maximum cache size.
+	cap := calculateResultCacheMax(
+		sizeofApplication(), // model in-mem size.
+		config.GetCacheApplicationMemRatio(),
+	)
+	log.Info(nil, "Application cache size = %d", cap)
+
+	c.application = result.New([]result.Lookup{
+		{Name: "ID"},
+		{Name: "ClientID"},
+	}, func(a1 *gtsmodel.Application) *gtsmodel.Application {
+		a2 := new(gtsmodel.Application)
+		*a2 = *a1
+		return a2
+	}, cap)
+
+	c.application.IgnoreErrors(ignoreErrors)
 }
 
 func (c *GTSCaches) initBlock() {

--- a/internal/cache/gts.go
+++ b/internal/cache/gts.go
@@ -316,7 +316,7 @@ func (c *GTSCaches) initApplication() {
 		sizeofApplication(), // model in-mem size.
 		config.GetCacheApplicationMemRatio(),
 	)
-	log.Info(nil, "Application cache size = %d", cap)
+	log.Infof(nil, "Application cache size = %d", cap)
 
 	c.application = result.New([]result.Lookup{
 		{Name: "ID"},

--- a/internal/cache/size.go
+++ b/internal/cache/size.go
@@ -155,6 +155,7 @@ func totalOfRatios() float64 {
 	return 0 +
 		config.GetCacheAccountMemRatio() +
 		config.GetCacheAccountNoteMemRatio() +
+		config.GetCacheApplicationMemRatio() +
 		config.GetCacheBlockMemRatio() +
 		config.GetCacheBlockIDsMemRatio() +
 		config.GetCacheBoostOfIDsMemRatio() +
@@ -217,7 +218,7 @@ func sizeofAccount() uintptr {
 		SilencedAt:              time.Now(),
 		SuspendedAt:             time.Now(),
 		HideCollections:         func() *bool { ok := true; return &ok }(),
-		SuspensionOrigin:        "",
+		SuspensionOrigin:        exampleID,
 		EnableRSS:               func() *bool { ok := true; return &ok }(),
 	}))
 }
@@ -228,6 +229,20 @@ func sizeofAccountNote() uintptr {
 		AccountID:       exampleID,
 		TargetAccountID: exampleID,
 		Comment:         exampleTextSmall,
+	}))
+}
+
+func sizeofApplication() uintptr {
+	return uintptr(size.Of(&gtsmodel.Application{
+		ID:           exampleID,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+		Name:         exampleUsername,
+		Website:      exampleURI,
+		RedirectURI:  exampleURI,
+		ClientID:     exampleID,
+		ClientSecret: exampleID,
+		Scopes:       exampleTextSmall,
 	}))
 }
 
@@ -500,5 +515,31 @@ func sizeofVisibility() uintptr {
 }
 
 func sizeofUser() uintptr {
-	return uintptr(size.Of(&gtsmodel.User{}))
+	return uintptr(size.Of(&gtsmodel.User{
+		ID:                     exampleID,
+		CreatedAt:              time.Now(),
+		UpdatedAt:              time.Now(),
+		Email:                  exampleURI,
+		AccountID:              exampleID,
+		EncryptedPassword:      exampleTextSmall,
+		CurrentSignInAt:        time.Now(),
+		LastSignInAt:           time.Now(),
+		InviteID:               exampleID,
+		ChosenLanguages:        []string{"en", "fr", "jp"},
+		FilteredLanguages:      []string{"en", "fr", "jp"},
+		Locale:                 "en",
+		CreatedByApplicationID: exampleID,
+		LastEmailedAt:          time.Now(),
+		ConfirmationToken:      exampleTextSmall,
+		ConfirmationSentAt:     time.Now(),
+		ConfirmedAt:            time.Now(),
+		UnconfirmedEmail:       exampleURI,
+		Moderator:              func() *bool { ok := true; return &ok }(),
+		Admin:                  func() *bool { ok := true; return &ok }(),
+		Disabled:               func() *bool { ok := true; return &ok }(),
+		Approved:               func() *bool { ok := true; return &ok }(),
+		ResetPasswordToken:     exampleTextSmall,
+		ResetPasswordSentAt:    time.Now(),
+		ExternalID:             exampleID,
+	}))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,6 +178,7 @@ type CacheConfiguration struct {
 	MemoryTarget             bytesize.Size `name:"memory-target"`
 	AccountMemRatio          float64       `name:"account-mem-ratio"`
 	AccountNoteMemRatio      float64       `name:"account-note-mem-ratio"`
+	ApplicationMemRatio      float64       `name:"application-mem-ratio"`
 	BlockMemRatio            float64       `name:"block-mem-ratio"`
 	BlockIDsMemRatio         float64       `name:"block-mem-ratio"`
 	BoostOfIDsMemRatio       float64       `name:"boost-of-ids-mem-ratio"`

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -147,6 +147,7 @@ var Defaults = Configuration{
 		// be able to make some more sense :D
 		AccountMemRatio:          18,
 		AccountNoteMemRatio:      0.1,
+		ApplicationMemRatio:      0.1,
 		BlockMemRatio:            3,
 		BlockIDsMemRatio:         3,
 		BoostOfIDsMemRatio:       3,
@@ -170,7 +171,7 @@ var Defaults = Configuration{
 		StatusFaveIDsMemRatio:    3,
 		TagMemRatio:              3,
 		TombstoneMemRatio:        2,
-		UserMemRatio:             0.1,
+		UserMemRatio:             0.25,
 		WebfingerMemRatio:        0.1,
 		VisibilityMemRatio:       2,
 	},

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -2499,6 +2499,31 @@ func GetCacheAccountNoteMemRatio() float64 { return global.GetCacheAccountNoteMe
 // SetCacheAccountNoteMemRatio safely sets the value for global configuration 'Cache.AccountNoteMemRatio' field
 func SetCacheAccountNoteMemRatio(v float64) { global.SetCacheAccountNoteMemRatio(v) }
 
+// GetCacheApplicationMemRatio safely fetches the Configuration value for state's 'Cache.ApplicationMemRatio' field
+func (st *ConfigState) GetCacheApplicationMemRatio() (v float64) {
+	st.mutex.RLock()
+	v = st.config.Cache.ApplicationMemRatio
+	st.mutex.RUnlock()
+	return
+}
+
+// SetCacheApplicationMemRatio safely sets the Configuration value for state's 'Cache.ApplicationMemRatio' field
+func (st *ConfigState) SetCacheApplicationMemRatio(v float64) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.Cache.ApplicationMemRatio = v
+	st.reloadToViper()
+}
+
+// CacheApplicationMemRatioFlag returns the flag name for the 'Cache.ApplicationMemRatio' field
+func CacheApplicationMemRatioFlag() string { return "cache-application-mem-ratio" }
+
+// GetCacheApplicationMemRatio safely fetches the value for global configuration 'Cache.ApplicationMemRatio' field
+func GetCacheApplicationMemRatio() float64 { return global.GetCacheApplicationMemRatio() }
+
+// SetCacheApplicationMemRatio safely sets the value for global configuration 'Cache.ApplicationMemRatio' field
+func SetCacheApplicationMemRatio(v float64) { global.SetCacheApplicationMemRatio(v) }
+
 // GetCacheBlockMemRatio safely fetches the Configuration value for state's 'Cache.BlockMemRatio' field
 func (st *ConfigState) GetCacheBlockMemRatio() (v float64) {
 	st.mutex.RLock()

--- a/internal/db/application.go
+++ b/internal/db/application.go
@@ -24,15 +24,15 @@ import (
 )
 
 type Application interface {
-	// GetApplicationByID ...
+	// GetApplicationByID fetches the application from the database with corresponding ID value.
 	GetApplicationByID(ctx context.Context, id string) (*gtsmodel.Application, error)
 
-	// GetApplicationByClientID ...
+	// GetApplicationByClientID fetches the application from the database with corresponding client_id value.
 	GetApplicationByClientID(ctx context.Context, clientID string) (*gtsmodel.Application, error)
 
-	// PutApplication ...
+	// PutApplication places the new application in the database, erroring on non-unique ID or client_id.
 	PutApplication(ctx context.Context, app *gtsmodel.Application) error
 
-	// DeleteApplicationByClientID ...
+	// DeleteApplicationByClientID deletes the application with corresponding client_id value from the database.
 	DeleteApplicationByClientID(ctx context.Context, clientID string) error
 }

--- a/internal/db/application.go
+++ b/internal/db/application.go
@@ -17,34 +17,22 @@
 
 package db
 
-const (
-	// DBTypePostgres represents an underlying POSTGRES database type.
-	DBTypePostgres string = "POSTGRES"
+import (
+	"context"
+
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 )
 
-// DB provides methods for interacting with an underlying database or other storage mechanism.
-type DB interface {
-	Account
-	Admin
-	Application
-	Basic
-	Domain
-	Emoji
-	Instance
-	List
-	Marker
-	Media
-	Mention
-	Notification
-	Relationship
-	Report
-	Search
-	Session
-	Status
-	StatusBookmark
-	StatusFave
-	Tag
-	Timeline
-	User
-	Tombstone
+type Application interface {
+	// GetApplicationByID ...
+	GetApplicationByID(ctx context.Context, id string) (*gtsmodel.Application, error)
+
+	// GetApplicationByClientID ...
+	GetApplicationByClientID(ctx context.Context, clientID string) (*gtsmodel.Application, error)
+
+	// PutApplication ...
+	PutApplication(ctx context.Context, app *gtsmodel.Application) error
+
+	// DeleteApplicationByClientID ...
+	DeleteApplicationByClientID(ctx context.Context, clientID string) error
 }

--- a/internal/db/bundb/application.go
+++ b/internal/db/bundb/application.go
@@ -1,0 +1,97 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package bundb
+
+import (
+	"context"
+
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/state"
+	"github.com/uptrace/bun"
+)
+
+type applicationDB struct {
+	db    *WrappedDB
+	state *state.State
+}
+
+func (a *applicationDB) GetApplicationByID(ctx context.Context, id string) (*gtsmodel.Application, error) {
+	return a.getApplication(
+		ctx,
+		"ID",
+		func(app *gtsmodel.Application) error {
+			return a.db.NewSelect().Model(app).Where("? = ?", bun.Ident("id"), id).Scan(ctx)
+		},
+		id,
+	)
+}
+
+func (a *applicationDB) GetApplicationByClientID(ctx context.Context, clientID string) (*gtsmodel.Application, error) {
+	return a.getApplication(
+		ctx,
+		"ClientID",
+		func(app *gtsmodel.Application) error {
+			return a.db.NewSelect().Model(app).Where("? = ?", bun.Ident("client_id"), clientID).Scan(ctx)
+		},
+		clientID,
+	)
+}
+
+func (a *applicationDB) getApplication(ctx context.Context, lookup string, dbQuery func(*gtsmodel.Application) error, keyParts ...any) (*gtsmodel.Application, error) {
+	return a.state.Caches.GTS.Application().Load(lookup, func() (*gtsmodel.Application, error) {
+		var app gtsmodel.Application
+
+		// Not cached! Perform database query.
+		if err := dbQuery(&app); err != nil {
+			return nil, a.db.ProcessError(err)
+		}
+
+		return &app, nil
+	}, keyParts...)
+}
+
+func (a *applicationDB) PutApplication(ctx context.Context, app *gtsmodel.Application) error {
+	return a.state.Caches.GTS.Application().Store(app, func() error {
+		_, err := a.db.NewInsert().Model(app).Exec(ctx)
+		return a.db.ProcessError(err)
+	})
+}
+
+func (a *applicationDB) DeleteApplicationByClientID(ctx context.Context, clientID string) error {
+	// Attempt to delete application.
+	if _, err := a.db.NewDelete().
+		Table("applications").
+		Where("? = ?", bun.Ident("client_id"), clientID).
+		Exec(ctx); err != nil {
+		return a.db.ProcessError(err)
+	}
+
+	// NOTE about further side effects:
+	//
+	// We don't need to handle updating any statuses or users
+	// (both of which may contain refs to applications), as
+	// DeleteApplication__() is only ever called during an
+	// account deletion, which handles deletion of the user
+	// and all their statuses already.
+	//
+
+	// Clear application from the cache.
+	a.state.Caches.GTS.Application().Invalidate("ClientID", clientID)
+
+	return nil
+}

--- a/internal/db/bundb/application_test.go
+++ b/internal/db/bundb/application_test.go
@@ -1,0 +1,93 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package bundb_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+)
+
+type ApplicationTestSuite struct {
+	BunDBStandardTestSuite
+}
+
+func (suite *ApplicationTestSuite) TestGetApplicationBy() {
+	t := suite.T()
+
+	// Create a new context for this test.
+	ctx, cncl := context.WithCancel(context.Background())
+	defer cncl()
+
+	// Sentinel error to mark avoiding a test case.
+	sentinelErr := errors.New("sentinel")
+
+	// isEqual checks if 2 application models are equal.
+	isEqual := func(a1, a2 gtsmodel.Application) bool {
+		// Clear database-set fields.
+		a1.CreatedAt = time.Time{}
+		a2.CreatedAt = time.Time{}
+		a1.UpdatedAt = time.Time{}
+		a2.UpdatedAt = time.Time{}
+
+		return reflect.DeepEqual(a1, a2)
+	}
+
+	for _, app := range suite.testApplications {
+		for lookup, dbfunc := range map[string]func() (*gtsmodel.Application, error){
+			"id": func() (*gtsmodel.Application, error) {
+				return suite.db.GetApplicationByID(ctx, app.ID)
+			},
+
+			"client_id": func() (*gtsmodel.Application, error) {
+				return suite.db.GetApplicationByClientID(ctx, app.ClientID)
+			},
+		} {
+			// Clear database caches.
+			suite.state.Caches.Init()
+
+			t.Logf("checking database lookup %q", lookup)
+
+			// Perform database function.
+			checkApp, err := dbfunc()
+			if err != nil {
+				if err == sentinelErr {
+					continue
+				}
+
+				t.Errorf("error encountered for database lookup %q: %v", lookup, err)
+				continue
+			}
+
+			// Check received application data.
+			if !isEqual(*checkApp, *app) {
+				t.Errorf("application does not contain expected data: %+v", checkApp)
+				continue
+			}
+		}
+	}
+}
+
+func TestApplicationTestSuite(t *testing.T) {
+	suite.Run(t, new(ApplicationTestSuite))
+}

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -60,6 +60,7 @@ var registerTables = []interface{}{
 type DBService struct {
 	db.Account
 	db.Admin
+	db.Application
 	db.Basic
 	db.Domain
 	db.Emoji
@@ -165,6 +166,10 @@ func NewBunDBService(ctx context.Context, state *state.State) (db.DB, error) {
 			state: state,
 		},
 		Admin: &adminDB{
+			db:    db,
+			state: state,
+		},
+		Application: &applicationDB{
 			db:    db,
 			state: state,
 		},

--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -257,8 +257,8 @@ func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) 
 		}
 	}
 
-	if status.CreatedWithApplication == nil {
-		// Populate the status' CreatedWithApplication.
+	if status.CreatedWithApplication == nil && status.CreatedWithApplicationID != "" {
+		// Populate the status' expected CreatedWithApplication
 		status.CreatedWithApplication, err = s.state.DB.GetApplicationByID(
 			ctx, // these are already barebones
 			status.CreatedWithApplicationID,

--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -37,19 +37,12 @@ type statusDB struct {
 	state *state.State
 }
 
-func (s *statusDB) newStatusQ(status interface{}) *bun.SelectQuery {
-	return s.db.
-		NewSelect().
-		Model(status).
-		Relation("CreatedWithApplication")
-}
-
 func (s *statusDB) GetStatusByID(ctx context.Context, id string) (*gtsmodel.Status, error) {
 	return s.getStatus(
 		ctx,
 		"ID",
 		func(status *gtsmodel.Status) error {
-			return s.newStatusQ(status).Where("? = ?", bun.Ident("status.id"), id).Scan(ctx)
+			return s.db.NewSelect().Model(status).Where("? = ?", bun.Ident("status.id"), id).Scan(ctx)
 		},
 		id,
 	)
@@ -78,7 +71,7 @@ func (s *statusDB) GetStatusByURI(ctx context.Context, uri string) (*gtsmodel.St
 		ctx,
 		"URI",
 		func(status *gtsmodel.Status) error {
-			return s.newStatusQ(status).Where("? = ?", bun.Ident("status.uri"), uri).Scan(ctx)
+			return s.db.NewSelect().Model(status).Where("? = ?", bun.Ident("status.uri"), uri).Scan(ctx)
 		},
 		uri,
 	)
@@ -89,7 +82,7 @@ func (s *statusDB) GetStatusByURL(ctx context.Context, url string) (*gtsmodel.St
 		ctx,
 		"URL",
 		func(status *gtsmodel.Status) error {
-			return s.newStatusQ(status).Where("? = ?", bun.Ident("status.url"), url).Scan(ctx)
+			return s.db.NewSelect().Model(status).Where("? = ?", bun.Ident("status.url"), url).Scan(ctx)
 		},
 		url,
 	)
@@ -100,7 +93,7 @@ func (s *statusDB) GetStatusBoost(ctx context.Context, boostOfID string, byAccou
 		ctx,
 		"BoostOfID.AccountID",
 		func(status *gtsmodel.Status) error {
-			return s.newStatusQ(status).
+			return s.db.NewSelect().Model(status).
 				Where("status.boost_of_id = ?", boostOfID).
 				Where("status.account_id = ?", byAccountID).
 
@@ -261,6 +254,17 @@ func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) 
 		)
 		if err != nil {
 			errs.Appendf("error populating status emojis: %w", err)
+		}
+	}
+
+	if status.CreatedWithApplicationID != "" {
+		// Populate the status' CreatedWithApplication.
+		status.CreatedWithApplication, err = s.state.DB.GetApplicationByID(
+			ctx, // these are already barebones
+			status.CreatedWithApplicationID,
+		)
+		if err != nil {
+			errs.Appendf("error populating status application: %w", err)
 		}
 	}
 

--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -257,8 +257,8 @@ func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) 
 		}
 	}
 
-	if status.CreatedWithApplication == nil && status.CreatedWithApplicationID != "" {
-		// Populate the status' expected CreatedWithApplication
+	if status.CreatedWithApplicationID != "" && status.CreatedWithApplication == nil {
+		// Populate the status' expected CreatedWithApplication (not always set).
 		status.CreatedWithApplication, err = s.state.DB.GetApplicationByID(
 			ctx, // these are already barebones
 			status.CreatedWithApplicationID,

--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -257,7 +257,7 @@ func (s *statusDB) PopulateStatus(ctx context.Context, status *gtsmodel.Status) 
 		}
 	}
 
-	if status.CreatedWithApplicationID != "" {
+	if status.CreatedWithApplication == nil {
 		// Populate the status' CreatedWithApplication.
 		status.CreatedWithApplication, err = s.state.DB.GetApplicationByID(
 			ctx, // these are already barebones

--- a/internal/middleware/tokencheck.go
+++ b/internal/middleware/tokencheck.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
-	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 	"github.com/superseriousbusiness/oauth2/v4"
@@ -125,8 +124,8 @@ func TokenCheck(dbConn db.DB, validateBearerToken func(r *http.Request) (oauth2.
 			log.Tracef(ctx, "authenticated client %s with bearer token, scope is %s", clientID, ti.GetScope())
 
 			// fetch app for this token
-			app := &gtsmodel.Application{}
-			if err := dbConn.GetWhere(ctx, []db.Where{{Key: "client_id", Value: clientID}}, app); err != nil {
+			app, err := dbConn.GetApplicationByClientID(ctx, clientID)
+			if err != nil {
 				if err != db.ErrNoEntries {
 					log.Errorf(ctx, "database error looking for application with clientID %s: %s", clientID, err)
 					return
@@ -134,6 +133,7 @@ func TokenCheck(dbConn db.DB, validateBearerToken func(r *http.Request) (oauth2.
 				log.Warnf(ctx, "no app found for client %s", clientID)
 				return
 			}
+
 			c.Set(oauth.SessionAuthorizedApplication, app)
 		}
 	}

--- a/internal/processing/account/delete.go
+++ b/internal/processing/account/delete.go
@@ -46,12 +46,6 @@ func (p *Processor) Delete(ctx context.Context, account *gtsmodel.Account, origi
 	}...)
 	l.Trace("beginning account delete process")
 
-	if account.IsLocal() {
-		if err := p.deleteUserAndTokensForAccount(ctx, account); err != nil {
-			return gtserror.NewErrorInternalError(err)
-		}
-	}
-
 	if err := p.deleteAccountFollows(ctx, account); err != nil {
 		return gtserror.NewErrorInternalError(err)
 	}
@@ -70,6 +64,14 @@ func (p *Processor) Delete(ctx context.Context, account *gtsmodel.Account, origi
 
 	if err := p.deleteAccountPeripheral(ctx, account); err != nil {
 		return gtserror.NewErrorInternalError(err)
+	}
+
+	if account.IsLocal() {
+		// we tokens, applications and clients for account as one of the last
+		// stages during deletion, as other database models rely on these.
+		if err := p.deleteUserAndTokensForAccount(ctx, account); err != nil {
+			return gtserror.NewErrorInternalError(err)
+		}
 	}
 
 	// To prevent the account being created again,
@@ -305,7 +307,17 @@ func (p *Processor) deleteAccountStatuses(ctx context.Context, account *gtsmodel
 statusLoop:
 	for {
 		// Page through account's statuses.
-		statuses, err = p.state.DB.GetAccountStatuses(ctx, account.ID, deleteSelectLimit, false, false, maxID, "", false, false)
+		statuses, err = p.state.DB.GetAccountStatuses(
+			ctx,
+			account.ID,
+			deleteSelectLimit,
+			false,
+			false,
+			maxID,
+			"",
+			false,
+			false,
+		)
 		if err != nil && !errors.Is(err, db.ErrNoEntries) {
 			// Make sure we don't have a real error.
 			return err

--- a/internal/processing/account/delete.go
+++ b/internal/processing/account/delete.go
@@ -129,7 +129,7 @@ func (p *Processor) deleteUserAndTokensForAccount(ctx context.Context, account *
 		}
 
 		// Delete any OAuth applications associated with this token.
-		if err := p.state.DB.DeleteWhere(ctx, []db.Where{{Key: "client_id", Value: t.ClientID}}, &[]*gtsmodel.Application{}); err != nil {
+		if err := p.state.DB.DeleteApplicationByClientID(ctx, t.ClientID); err != nil {
 			return gtserror.Newf("db error deleting application: %w", err)
 		}
 

--- a/internal/processing/app.go
+++ b/internal/processing/app.go
@@ -61,7 +61,7 @@ func (p *Processor) AppCreate(ctx context.Context, authed *oauth.Auth, form *api
 	}
 
 	// chuck it in the db
-	if err := p.state.DB.Put(ctx, app); err != nil {
+	if err := p.state.DB.PutApplication(ctx, app); err != nil {
 		return nil, gtserror.NewErrorInternalError(err)
 	}
 

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -699,8 +699,8 @@ func (c *converter) StatusToAPIStatus(ctx context.Context, s *gtsmodel.Status, r
 	}
 
 	if appID := s.CreatedWithApplicationID; appID != "" {
-		app := &gtsmodel.Application{}
-		if err := c.db.GetByID(ctx, appID, app); err != nil {
+		app, err := c.db.GetApplicationByID(ctx, appID)
+		if err != nil {
 			return nil, fmt.Errorf("error getting application %s: %w", appID, err)
 		}
 

--- a/test/envparsing.sh
+++ b/test/envparsing.sh
@@ -20,6 +20,7 @@ EXPECT=$(cat << "EOF"
     "cache": {
         "account-mem-ratio": 18,
         "account-note-mem-ratio": 0.1,
+        "application-mem-ratio": 0.1,
         "block-mem-ratio": 3,
         "boost-of-ids-mem-ratio": 3,
         "emoji-category-mem-ratio": 0.1,
@@ -43,7 +44,7 @@ EXPECT=$(cat << "EOF"
         "status-mem-ratio": 18,
         "tag-mem-ratio": 3,
         "tombstone-mem-ratio": 2,
-        "user-mem-ratio": 0.1,
+        "user-mem-ratio": 0.25,
         "visibility-mem-ratio": 2,
         "webfinger-mem-ratio": 0.1
     },


### PR DESCRIPTION
# Description

- Removes relational part of queries for status selects and user selects
- Adds new separate `applicationDB{}` with its own caching

closes https://github.com/superseriousbusiness/gotosocial/issues/1094

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
