### PR TITLE
[bugfix] Fix incorrect per-loop variable capture

### DIFF
--- a/internal/db/bundb/list.go
+++ b/internal/db/bundb/list.go
@@ -429,6 +429,7 @@ func (l *listDB) PutListEntries(ctx context.Context, entries []*gtsmodel.ListEnt
 	// Finally, insert each list entry into the database.
 	return l.db.RunInTx(ctx, func(tx bun.Tx) error {
 		for _, entry := range entries {
+			entry := entry // rescope
 			if err := l.state.Caches.GTS.ListEntry().Store(entry, func() error {
 				_, err := tx.
 					NewInsert().

--- a/internal/timeline/manager.go
+++ b/internal/timeline/manager.go
@@ -119,6 +119,7 @@ func (m *manager) Start() error {
 	// hasn't been accessed in the last hour.
 	go func() {
 		for now := range time.NewTicker(1 * time.Hour).C {
+			now := now // rescope
 			// Define the range function inside here,
 			// so that we can use the 'now' returned
 			// by the ticker, instead of having to call


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

These should be per iteration, not per loop. This was caught by running a build with the loopvar experiment: go build -gcflags=-d=loopvar=2.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
