### PR TITLE
[bugfix] Use custom bluemonday policy to disallow inline `img` tags

### DIFF
--- a/internal/ap/normalize_test.go
+++ b/internal/ap/normalize_test.go
@@ -146,7 +146,7 @@ func (suite *NormalizeTestSuite) getStatusableWithMultipleAttachments() (vocab.A
 			"type": "Document",
 			"mediaType": "image/jpeg",
 			"url": "https://files.example.org/media_attachments/files/110/258/459/579/509/026/original/b65392ebe0fb04ef.jpeg",
-			"name": "danger: #cute but will claw you :("
+			"name": "image of a cat &amp; there's a note saying: &lt;danger: #cute but will claw you :(&gt;"
 		  }
 		]
 	  }`)
@@ -192,7 +192,7 @@ func (suite *NormalizeTestSuite) TestNormalizeActivityObject() {
 	)
 
 	ap.NormalizeIncomingActivityObject(create, map[string]interface{}{"object": rawNote})
-	suite.Equal(`UPDATE: As of this morning there are now more than 7 million Mastodon users, most from the <a class="hashtag" data-tag="twittermigration" href="https://example.org/tag/twittermigration" rel="tag ugc">#TwitterMigration</a>.<br><br>In fact, 100,000 new accounts have been created since last night.<br><br>Since last night&#39;s spike 8,000-12,000 new accounts are being created every hour.<br><br>Yesterday, I estimated that Mastodon would have 8 million users by the end of the week. That might happen a lot sooner if this trend continues.`, ap.ExtractContent(note))
+	suite.Equal(`UPDATE: As of this morning there are now more than 7 million Mastodon users, most from the <a class="hashtag" href="https://example.org/tag/twittermigration" rel="tag ugc nofollow noreferrer noopener" target="_blank">#TwitterMigration</a>.<br><br>In fact, 100,000 new accounts have been created since last night.<br><br>Since last night's spike 8,000-12,000 new accounts are being created every hour.<br><br>Yesterday, I estimated that Mastodon would have 8 million users by the end of the week. That might happen a lot sooner if this trend continues.`, ap.ExtractContent(note))
 }
 
 func (suite *NormalizeTestSuite) TestNormalizeStatusableAttachmentsOneAttachment() {
@@ -224,7 +224,7 @@ func (suite *NormalizeTestSuite) TestNormalizeStatusableAttachmentsOneAttachment
   "@context": "https://www.w3.org/ns/activitystreams",
   "attachment": {
     "mediaType": "image/jpeg",
-    "name": "DESCRIPTION: here's \u003c\u003ca\u003e\u003e picture of a #cat, it's cute! here's some special characters: \"\" \\ weeee''''",
+    "name": "DESCRIPTION: here's \u003c\u003e picture of a #cat, it's cute! here's some special characters: \"\" \\ weeee''''",
     "type": "Document",
     "url": "https://files.example.org/media_attachments/files/110/258/459/579/509/026/original/b65392ebe0fb04ef.jpeg"
   },
@@ -265,7 +265,7 @@ func (suite *NormalizeTestSuite) TestNormalizeStatusableAttachmentsOneAttachment
   "@context": "https://www.w3.org/ns/activitystreams",
   "attachment": {
     "mediaType": "image/jpeg",
-    "name": "DESCRIPTION: here's \u003c\u003ca\u003e\u003e picture of a #cat, it's cute! here's some special characters: \"\" \\ weeee''''",
+    "name": "DESCRIPTION: here's \u003c\u003e picture of a #cat, it's cute! here's some special characters: \"\" \\ weeee''''",
     "type": "Document",
     "url": "https://files.example.org/media_attachments/files/110/258/459/579/509/026/original/b65392ebe0fb04ef.jpeg"
   },
@@ -304,7 +304,7 @@ func (suite *NormalizeTestSuite) TestNormalizeStatusableAttachmentsMultipleAttac
     },
     {
       "mediaType": "image/jpeg",
-      "name": "danger: #cute%20but%20will%20claw%20you%20:(",
+      "name": "image of a cat \u0026amp; there's a note saying: \u0026lt;danger: #cute but will claw you :(\u0026gt;",
       "type": "Document",
       "url": "https://files.example.org/media_attachments/files/110/258/459/579/509/026/original/b65392ebe0fb04ef.jpeg"
     }
@@ -326,7 +326,7 @@ func (suite *NormalizeTestSuite) TestNormalizeStatusableAttachmentsMultipleAttac
   "attachment": [
     {
       "mediaType": "image/jpeg",
-      "name": "DESCRIPTION: here's \u003c\u003ca\u003e\u003e picture of a #cat, it's cute! here's some special characters: \"\" \\ weeee''''",
+      "name": "DESCRIPTION: here's \u003c\u003e picture of a #cat, it's cute! here's some special characters: \"\" \\ weeee''''",
       "type": "Document",
       "url": "https://files.example.org/media_attachments/files/110/258/459/579/509/026/original/b65392ebe0fb04ef.jpeg"
     },
@@ -343,7 +343,7 @@ func (suite *NormalizeTestSuite) TestNormalizeStatusableAttachmentsMultipleAttac
     },
     {
       "mediaType": "image/jpeg",
-      "name": "danger: #cute but will claw you :(",
+      "name": "image of a cat \u0026 there's a note saying:",
       "type": "Document",
       "url": "https://files.example.org/media_attachments/files/110/258/459/579/509/026/original/b65392ebe0fb04ef.jpeg"
     }
@@ -380,7 +380,7 @@ func (suite *NormalizeTestSuite) TestNormalizeStatusableSummary() {
 	suite.Equal(`warning: #WEIRD%20%23SUMMARY%20;;;;a;;a;asv%20%20%20%20khop8273987(*%5E&%5E)`, ap.ExtractSummary(statusable))
 
 	ap.NormalizeIncomingSummary(statusable, rawAccount)
-	suite.Equal(`warning: #WEIRD #SUMMARY ;;;;a;;a;asv    khop8273987(*^&^)`, ap.ExtractSummary(statusable))
+	suite.Equal(`warning: #WEIRD #SUMMARY ;;;;a;;a;asv khop8273987(*^&^)`, ap.ExtractSummary(statusable))
 }
 
 func (suite *NormalizeTestSuite) TestNormalizeStatusableName() {

--- a/internal/api/client/statuses/statuscreate_test.go
+++ b/internal/api/client/statuses/statuscreate_test.go
@@ -43,7 +43,7 @@ type StatusCreateTestSuite struct {
 const (
 	statusWithLinksAndTags = "#test alright, should be able to post #links with fragments in them now, let's see........\n\nhttps://docs.gotosocial.org/en/latest/user_guide/posts/#links\n\n#gotosocial\n\n(tobi remember to pull the docker image challenge)"
 	statusMarkdown         = "# Title\n\n## Smaller title\n\nThis is a post written in [markdown](https://www.markdownguide.org/)\n\n<img src=\"https://d33wubrfki0l68.cloudfront.net/f1f475a6fda1c2c4be4cac04033db5c3293032b4/513a4/assets/images/markdown-mark-white.svg\"/>"
-	statusMarkdownExpected = "<h1>Title</h1><h2>Smaller title</h2><p>This is a post written in <a href=\"https://www.markdownguide.org/\" rel=\"nofollow noreferrer noopener\" target=\"_blank\">markdown</a></p><img src=\"https://d33wubrfki0l68.cloudfront.net/f1f475a6fda1c2c4be4cac04033db5c3293032b4/513a4/assets/images/markdown-mark-white.svg\" crossorigin=\"anonymous\">"
+	statusMarkdownExpected = "<h1>Title</h1><h2>Smaller title</h2><p>This is a post written in <a href=\"https://www.markdownguide.org/\" rel=\"nofollow noreferrer noopener\" target=\"_blank\">markdown</a></p>"
 )
 
 // Post a new status with some custom visibility settings

--- a/internal/processing/account/create.go
+++ b/internal/processing/account/create.go
@@ -71,7 +71,7 @@ func (p *Processor) Create(
 		Username:    form.Username,
 		Email:       form.Email,
 		Password:    form.Password,
-		Reason:      text.SanitizePlaintext(reason),
+		Reason:      text.SanitizeToPlaintext(reason),
 		PreApproved: !config.GetAccountsApprovalRequired(), // Mark as approved if no approval required.
 		SignUpIP:    form.IP,
 		Locale:      form.Locale,

--- a/internal/processing/account/update.go
+++ b/internal/processing/account/update.go
@@ -67,7 +67,7 @@ func (p *Processor) Update(ctx context.Context, account *gtsmodel.Account, form 
 		}
 
 		// Parse new display name (always from plaintext).
-		account.DisplayName = text.SanitizePlaintext(displayName)
+		account.DisplayName = text.SanitizeToPlaintext(displayName)
 
 		// If display name has changed, account emojis may have also changed.
 		emojisChanged = true
@@ -110,8 +110,8 @@ func (p *Processor) Update(ctx context.Context, account *gtsmodel.Account, form 
 
 			// Sanitize raw field values.
 			fieldRaw := &gtsmodel.Field{
-				Name:  text.SanitizePlaintext(name),
-				Value: text.SanitizePlaintext(value),
+				Name:  text.SanitizeToPlaintext(name),
+				Value: text.SanitizeToPlaintext(value),
 			}
 			fieldsRaw = append(fieldsRaw, fieldRaw)
 		}
@@ -255,7 +255,7 @@ func (p *Processor) Update(ctx context.Context, account *gtsmodel.Account, form 
 		if err := validate.CustomCSS(customCSS); err != nil {
 			return nil, gtserror.NewErrorBadRequest(err, err.Error())
 		}
-		account.CustomCSS = text.SanitizePlaintext(customCSS)
+		account.CustomCSS = text.SanitizeToPlaintext(customCSS)
 	}
 
 	if form.EnableRSS != nil {

--- a/internal/processing/admin/domainblock.go
+++ b/internal/processing/admin/domainblock.go
@@ -67,8 +67,8 @@ func (p *Processor) DomainBlockCreate(
 			ID:                 id.NewULID(),
 			Domain:             domain,
 			CreatedByAccountID: account.ID,
-			PrivateComment:     text.SanitizePlaintext(privateComment),
-			PublicComment:      text.SanitizePlaintext(publicComment),
+			PrivateComment:     text.SanitizeToPlaintext(privateComment),
+			PublicComment:      text.SanitizeToPlaintext(publicComment),
 			Obfuscate:          &obfuscate,
 			SubscriptionID:     subscriptionID,
 		}

--- a/internal/processing/instance.go
+++ b/internal/processing/instance.go
@@ -159,7 +159,7 @@ func (p *Processor) InstancePatch(ctx context.Context, form *apimodel.InstanceSe
 			return nil, gtserror.NewErrorBadRequest(err, fmt.Sprintf("site title invalid: %s", err))
 		}
 		updatingColumns = append(updatingColumns, "title")
-		instance.Title = text.SanitizePlaintext(*form.Title) // don't allow html in site title
+		instance.Title = text.SanitizeToPlaintext(*form.Title) // don't allow html in site title
 	}
 
 	// validate & update site contact account if it's set on the form
@@ -215,7 +215,7 @@ func (p *Processor) InstancePatch(ctx context.Context, form *apimodel.InstanceSe
 			return nil, gtserror.NewErrorBadRequest(err, err.Error())
 		}
 		updatingColumns = append(updatingColumns, "short_description")
-		instance.ShortDescription = text.SanitizeHTML(*form.ShortDescription) // html is OK in site description, but we should sanitize it
+		instance.ShortDescription = text.SanitizeToHTML(*form.ShortDescription) // html is OK in site description, but we should sanitize it
 	}
 
 	// validate & update site description if it's set on the form
@@ -224,7 +224,7 @@ func (p *Processor) InstancePatch(ctx context.Context, form *apimodel.InstanceSe
 			return nil, gtserror.NewErrorBadRequest(err, err.Error())
 		}
 		updatingColumns = append(updatingColumns, "description")
-		instance.Description = text.SanitizeHTML(*form.Description) // html is OK in site description, but we should sanitize it
+		instance.Description = text.SanitizeToHTML(*form.Description) // html is OK in site description, but we should sanitize it
 	}
 
 	// validate & update site terms if it's set on the form
@@ -233,7 +233,7 @@ func (p *Processor) InstancePatch(ctx context.Context, form *apimodel.InstanceSe
 			return nil, gtserror.NewErrorBadRequest(err, err.Error())
 		}
 		updatingColumns = append(updatingColumns, "terms")
-		instance.Terms = text.SanitizeHTML(*form.Terms) // html is OK in site terms, but we should sanitize it
+		instance.Terms = text.SanitizeToHTML(*form.Terms) // html is OK in site terms, but we should sanitize it
 	}
 
 	var updateInstanceAccount bool

--- a/internal/processing/media/update.go
+++ b/internal/processing/media/update.go
@@ -47,7 +47,7 @@ func (p *Processor) Update(ctx context.Context, account *gtsmodel.Account, media
 	var updatingColumns []string
 
 	if form.Description != nil {
-		attachment.Description = text.SanitizePlaintext(*form.Description)
+		attachment.Description = text.SanitizeToPlaintext(*form.Description)
 		updatingColumns = append(updatingColumns, "description")
 	}
 

--- a/internal/processing/status/create.go
+++ b/internal/processing/status/create.go
@@ -54,7 +54,7 @@ func (p *Processor) Create(ctx context.Context, account *gtsmodel.Account, appli
 		Local:                    &local,
 		AccountID:                account.ID,
 		AccountURI:               account.URI,
-		ContentWarning:           text.SanitizePlaintext(form.SpoilerText),
+		ContentWarning:           text.SanitizeToPlaintext(form.SpoilerText),
 		ActivityStreamsType:      ap.ObjectNote,
 		Sensitive:                &sensitive,
 		CreatedWithApplicationID: application.ID,

--- a/internal/text/emojionly.go
+++ b/internal/text/emojionly.go
@@ -61,13 +61,10 @@ func (f *formatter) FromPlainEmojiOnly(ctx context.Context, pmf gtsmodel.ParseMe
 	result.HTML = htmlContentBytes.String()
 
 	// clean anything dangerous out of the HTML
-	result.HTML = SanitizeHTML(result.HTML)
+	result.HTML = SanitizeToHTML(result.HTML)
 
 	// shrink ray
-	result.HTML, err = m.String("text/html", result.HTML)
-	if err != nil {
-		log.Errorf(ctx, "error minifying HTML: %s", err)
-	}
+	result.HTML = MinifyHTML(result.HTML)
 
 	return result
 }

--- a/internal/text/markdown.go
+++ b/internal/text/markdown.go
@@ -57,13 +57,10 @@ func (f *formatter) FromMarkdown(ctx context.Context, pmf gtsmodel.ParseMentionF
 	result.HTML = htmlContentBytes.String()
 
 	// clean anything dangerous out of the HTML
-	result.HTML = SanitizeHTML(result.HTML)
+	result.HTML = SanitizeToHTML(result.HTML)
 
 	// shrink ray
-	result.HTML, err = m.String("text/html", result.HTML)
-	if err != nil {
-		log.Errorf(ctx, "error minifying HTML: %s", err)
-	}
+	result.HTML = MinifyHTML(result.HTML)
 
 	return result
 }

--- a/internal/text/markdown_test.go
+++ b/internal/text/markdown_test.go
@@ -51,7 +51,7 @@ const (
 	withHashtag                     = "# Title\n\nhere's a simple status that uses hashtag #Hashtag!"
 	withHashtagExpected             = "<h1>Title</h1><p>here's a simple status that uses hashtag <a href=\"http://localhost:8080/tags/hashtag\" class=\"mention hashtag\" rel=\"tag nofollow noreferrer noopener\" target=\"_blank\">#<span>Hashtag</span></a>!</p>"
 	mdWithHTML                      = "# Title\n\nHere's a simple text in markdown.\n\nHere's a <a href=\"https://example.org\">link</a>.\n\nHere's an image: <img src=\"https://gts.superseriousbusiness.org/assets/logo.png\" alt=\"The GoToSocial sloth logo.\" width=\"500\" height=\"600\">"
-	mdWithHTMLExpected              = "<h1>Title</h1><p>Here's a simple text in markdown.</p><p>Here's a <a href=\"https://example.org\" rel=\"nofollow noreferrer noopener\" target=\"_blank\">link</a>.</p><p>Here's an image: <img src=\"https://gts.superseriousbusiness.org/assets/logo.png\" alt=\"The GoToSocial sloth logo.\" width=\"500\" height=\"600\" crossorigin=\"anonymous\"></p>"
+	mdWithHTMLExpected              = "<h1>Title</h1><p>Here's a simple text in markdown.</p><p>Here's a <a href=\"https://example.org\" rel=\"nofollow noreferrer noopener\" target=\"_blank\">link</a>.</p><p>Here's an image:</p>"
 	mdWithCheekyHTML                = "# Title\n\nHere's a simple text in markdown.\n\nHere's a cheeky little script: <script>alert(ahhhh)</script>"
 	mdWithCheekyHTMLExpected        = "<h1>Title</h1><p>Here's a simple text in markdown.</p><p>Here's a cheeky little script:</p>"
 	mdWithHashtagInitial            = "#welcome #Hashtag"

--- a/internal/text/minify.go
+++ b/internal/text/minify.go
@@ -18,6 +18,7 @@
 package text
 
 import (
+	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/tdewolff/minify/v2"
 	"github.com/tdewolff/minify/v2/html"
 )
@@ -31,3 +32,23 @@ var m = func() *minify.M {
 	})
 	return m
 }()
+
+// MinifyHTML minifies the given string
+// under the assumption that it's HTML.
+//
+// If input is not HTML encoded, this
+// function will try to do minimization
+// anyway, but this may produce unexpected
+// results.
+//
+// If an error occurs during minimization,
+// it will be logged and the original string
+// returned unmodified.
+func MinifyHTML(in string) string {
+	out, err := m.String("text/html", in)
+	if err != nil {
+		log.Error(nil, err)
+	}
+
+	return out
+}

--- a/internal/text/plain.go
+++ b/internal/text/plain.go
@@ -65,13 +65,10 @@ func (f *formatter) fromPlain(
 	result.HTML = htmlContentBytes.String()
 
 	// Clean anything dangerous out of resulting HTML.
-	result.HTML = SanitizeHTML(result.HTML)
+	result.HTML = SanitizeToHTML(result.HTML)
 
 	// Shrink ray!
-	var err error
-	if result.HTML, err = m.String("text/html", result.HTML); err != nil {
-		log.Errorf(ctx, "error minifying HTML: %s", err)
-	}
+	result.HTML = MinifyHTML(result.HTML)
 
 	return result
 }

--- a/internal/text/sanitize_test.go
+++ b/internal/text/sanitize_test.go
@@ -36,30 +36,30 @@ type SanitizeTestSuite struct {
 }
 
 func (suite *SanitizeTestSuite) TestSanitizeOutgoing() {
-	s := text.SanitizeHTML(sanitizeOutgoing)
+	s := text.SanitizeToHTML(sanitizeOutgoing)
 	suite.Equal(sanitizedOutgoing, s)
 }
 
 func (suite *SanitizeTestSuite) TestSanitizeHTML() {
-	s := text.SanitizeHTML(sanitizeHTML)
+	s := text.SanitizeToHTML(sanitizeHTML)
 	suite.Equal(sanitizedHTML, s)
 }
 
 func (suite *SanitizeTestSuite) TestSanitizeCaption1() {
 	dodgyCaption := "<script>console.log('haha!')</script>this is just a normal caption ;)"
-	sanitized := text.SanitizePlaintext(dodgyCaption)
+	sanitized := text.SanitizeToPlaintext(dodgyCaption)
 	suite.Equal("this is just a normal caption ;)", sanitized)
 }
 
 func (suite *SanitizeTestSuite) TestSanitizeCaption2() {
 	dodgyCaption := "<em>here's a LOUD caption</em>"
-	sanitized := text.SanitizePlaintext(dodgyCaption)
+	sanitized := text.SanitizeToPlaintext(dodgyCaption)
 	suite.Equal("here's a LOUD caption", sanitized)
 }
 
 func (suite *SanitizeTestSuite) TestSanitizeCaption3() {
 	dodgyCaption := ""
-	sanitized := text.SanitizePlaintext(dodgyCaption)
+	sanitized := text.SanitizeToPlaintext(dodgyCaption)
 	suite.Equal("", sanitized)
 }
 
@@ -75,21 +75,21 @@ with some newlines
 
 
 `
-	sanitized := text.SanitizePlaintext(dodgyCaption)
+	sanitized := text.SanitizeToPlaintext(dodgyCaption)
 	suite.Equal("here is\na multi line\ncaption\nwith some newlines", sanitized)
 }
 
 func (suite *SanitizeTestSuite) TestSanitizeCaption5() {
 	// html-escaped: "<script>console.log('aha!')</script> hello world"
 	dodgyCaption := `&lt;script&gt;console.log(&apos;aha!&apos;)&lt;/script&gt; hello world`
-	sanitized := text.SanitizePlaintext(dodgyCaption)
+	sanitized := text.SanitizeToPlaintext(dodgyCaption)
 	suite.Equal("hello world", sanitized)
 }
 
 func (suite *SanitizeTestSuite) TestSanitizeCaption6() {
 	// html-encoded: "<script>console.log('aha!')</script> hello world"
 	dodgyCaption := `&lt;&#115;&#99;&#114;&#105;&#112;&#116;&gt;&#99;&#111;&#110;&#115;&#111;&#108;&#101;&period;&#108;&#111;&#103;&lpar;&apos;&#97;&#104;&#97;&excl;&apos;&rpar;&lt;&sol;&#115;&#99;&#114;&#105;&#112;&#116;&gt;&#32;&#104;&#101;&#108;&#108;&#111;&#32;&#119;&#111;&#114;&#108;&#100;`
-	sanitized := text.SanitizePlaintext(dodgyCaption)
+	sanitized := text.SanitizeToPlaintext(dodgyCaption)
 	suite.Equal("hello world", sanitized)
 }
 
@@ -104,22 +104,28 @@ func (suite *SanitizeTestSuite) TestSanitizeCustomCSS() {
 	overflow: hidden;
 	text-overflow: ellipsis;
 }`
-	sanitized := text.SanitizePlaintext(customCSS)
+	sanitized := text.SanitizeToPlaintext(customCSS)
 	suite.Equal(customCSS, sanitized) // should be the same as it was before
 }
 
 func (suite *SanitizeTestSuite) TestSanitizeNaughtyCustomCSS1() {
 	// try to break out of <style> into <head> and change the document title
 	customCSS := "</style><title>pee pee poo poo</title><style>"
-	sanitized := text.SanitizePlaintext(customCSS)
+	sanitized := text.SanitizeToPlaintext(customCSS)
 	suite.Empty(sanitized)
 }
 
 func (suite *SanitizeTestSuite) TestSanitizeNaughtyCustomCSS2() {
 	// try to break out of <style> into <head> and change the document title
 	customCSS := "pee pee poo poo</style><title></title><style>"
-	sanitized := text.SanitizePlaintext(customCSS)
+	sanitized := text.SanitizeToPlaintext(customCSS)
 	suite.Equal("pee pee poo poo", sanitized)
+}
+
+func (suite *SanitizeTestSuite) TestSanitizeInlineImg() {
+	withInlineImg := "<p>Here's an inline image: <img class=\"fixed-size-img svelte-uci8eb\" aria-hidden=\"false\" alt=\"A black-and-white photo of an Oblique Strategy card. The card reads: 'Define an area as 'safe' and use it as an anchor'.\" title=\"A black-and-white photo of an Oblique Strategy card. The card reads: 'Define an area as 'safe' and use it as an anchor'.\" width=\"0\" height=\"0\" src=\"https://example.org/fileserver/01H7J83147QMCE17C0RS9P10Y9/attachment/small/01H7J8365XXRTCP6CAMGEM49ZE.jpg\" style=\"object-position: 50% 50%;\"></p>"
+	sanitized := text.SanitizeToHTML(withInlineImg)
+	suite.Equal(`<p>Here&#39;s an inline image: </p>`, sanitized)
 }
 
 func TestSanitizeTestSuite(t *testing.T) {

--- a/internal/web/opengraph.go
+++ b/internal/web/opengraph.go
@@ -67,7 +67,7 @@ func ogBase(instance *apimodel.InstanceV1) *ogMeta {
 	}
 
 	og := &ogMeta{
-		Title:       text.SanitizePlaintext(instance.Title) + " - GoToSocial",
+		Title:       text.SanitizeToPlaintext(instance.Title) + " - GoToSocial",
 		Type:        "website",
 		Locale:      locale,
 		URL:         instance.URI,
@@ -156,7 +156,7 @@ func parseTitle(account *apimodel.Account, accountDomain string) string {
 // parseDescription returns a string description which is
 // safe to use as a template.HTMLAttr inside templates.
 func parseDescription(in string) string {
-	i := text.SanitizePlaintext(in)
+	i := text.SanitizeToPlaintext(in)
 	i = strings.ReplaceAll(i, "\n", " ")
 	i = strings.Join(strings.Fields(i), " ")
 	i = html.EscapeString(i)


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates our sanitization process to remove inline img tags, at least until we can find a nicer way of including them.

Also renames a couple functions that were not well named, and adds comments on the sanitizer linking to MDN docs about the various attributes and elements :)

closes https://github.com/superseriousbusiness/gotosocial/issues/2097

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
