### PR TITLE
[bugfix] Fix using wrong key for clientID during oauth callback

### DIFF
--- a/internal/api/auth/callback.go
+++ b/internal/api/auth/callback.go
@@ -107,7 +107,7 @@ func (m *Module) CallbackGETHandler(c *gin.Context) {
 		return
 	}
 
-	app, err := m.db.GetApplicationByClientID(c.Request.Context(), sessionClientID)
+	app, err := m.db.GetApplicationByClientID(c.Request.Context(), clientID)
 	if err != nil {
 		m.clearSession(s)
 		safe := fmt.Sprintf("application for %s %s could not be retrieved", sessionClientID, clientID)


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

We were always using the string "client_id" to try to fetch the OIDC client application from the db :fireworks: 

closes https://github.com/superseriousbusiness/gotosocial/issues/2096

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
