### PR TITLE
[feature] Add snapshot binary builds + uploads

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -81,7 +81,7 @@ steps:
       - yarn run build
 
   - name: snapshot
-    image: superseriousbusiness/gotosocial-drone-build:0.2.0 # https://github.com/superseriousbusiness/gotosocial-drone-build
+    image: superseriousbusiness/gotosocial-drone-build:0.3.0 # https://github.com/superseriousbusiness/gotosocial-drone-build
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -91,16 +91,28 @@ steps:
       DOCKER_USERNAME: gotosocial
       DOCKER_PASSWORD:
         from_secret: gts_docker_password
+      S3_ACCESS_KEY_ID:
+        from_secret: gts_s3_access_key_id
+      S3_SECRET_ACCESS_KEY:
+        from_secret: gts_s3_secret_access_key
+      S3_HOSTNAME: "https://s3.superseriousbusiness.org"
+      S3_BUCKET_NAME: "gotosocial-snapshots"
     commands:
+      # Create a snapshot build with GoReleaser.
       - git fetch --tags
-      - /go/dockerlogin.sh
       - goreleaser release --rm-dist --snapshot
+      
+      # Login to Docker, push Docker image snapshots + manifests.
+      - /go/dockerlogin.sh
       - docker push superseriousbusiness/gotosocial:snapshot-armv6 && 
       - docker push superseriousbusiness/gotosocial:snapshot-armv7
       - docker push superseriousbusiness/gotosocial:snapshot-arm64v8
       - docker push superseriousbusiness/gotosocial:snapshot-amd64
       - docker manifest create superseriousbusiness/gotosocial:snapshot superseriousbusiness/gotosocial:snapshot-armv6 superseriousbusiness/gotosocial:snapshot-armv7 superseriousbusiness/gotosocial:snapshot-amd64 superseriousbusiness/gotosocial:snapshot-arm64v8
       - docker manifest push superseriousbusiness/gotosocial:snapshot
+      
+      # Publish binary .tar.gz snapshots to S3.
+      - /go/snapshot_publish.sh
     when:
       event:
         include:
@@ -110,7 +122,7 @@ steps:
           - main
 
   - name: release
-    image: superseriousbusiness/gotosocial-drone-build:0.2.0 # https://github.com/superseriousbusiness/gotosocial-drone-build
+    image: superseriousbusiness/gotosocial-drone-build:0.3.0 # https://github.com/superseriousbusiness/gotosocial-drone-build
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -169,7 +181,7 @@ clone:
 
 steps:
   - name: mirror
-    image: superseriousbusiness/gotosocial-drone-build:0.2.0
+    image: superseriousbusiness/gotosocial-drone-build:0.3.0
     environment:
       ORIGIN_REPO: https://github.com/superseriousbusiness/gotosocial
       TARGET_REPO: https://codeberg.org/superseriousbusiness/gotosocial
@@ -182,6 +194,6 @@ steps:
 
 ---
 kind: signature
-hmac: 946c2ffd4e79de07a767ec06ebac0a8ca70a03ce5666aae093c9b0af455041d1
+hmac: e821e247781090c24d5c103b0568ecd030c167457432af209c3f44cd0bd68028
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -104,7 +104,7 @@ steps:
       
       # Login to Docker, push Docker image snapshots + manifests.
       - /go/dockerlogin.sh
-      - docker push superseriousbusiness/gotosocial:snapshot-armv6 && 
+      - docker push superseriousbusiness/gotosocial:snapshot-armv6
       - docker push superseriousbusiness/gotosocial:snapshot-armv7
       - docker push superseriousbusiness/gotosocial:snapshot-arm64v8
       - docker push superseriousbusiness/gotosocial:snapshot-amd64
@@ -194,6 +194,6 @@ steps:
 
 ---
 kind: signature
-hmac: e821e247781090c24d5c103b0568ecd030c167457432af209c3f44cd0bd68028
+hmac: 74653d67ed44ceefb7e19d6125d4a457e6308b5ef627df6325d72a0cc7d7cc0a
 
 ...

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ We package our stable releases for both binary builds and Docker containers, so 
 
 Check our [releases page](https://github.com/superseriousbusiness/gotosocial/releases) and our [getting started](https://docs.gotosocial.org/en/latest/getting_started/) documentation.
 
-The Docker image `superseriousbusiness/gotosocial:latest` will always correspond to the latest stable release.
+The Docker image `superseriousbusiness/gotosocial:latest` will always correspond to the latest stable release. Since this tag is overwritten frequently, you may want to use Docker CLI flag `--pull always` to ensure that you always have the most up-to-date image every time you run using this tag. Alternatively, run `docker pull superseriousbusiness/gotosocial:latest` manually just before use.
 
 ### Snapshots
 
@@ -231,7 +231,7 @@ Please be warned that you do so at your own risk! We try to keep main working pr
 
 #### Docker
 
-To run from main using Docker, use the `snapshot` Docker tag. The Docker image `superseriousbusiness/gotosocial:snapshot` will always correspond to the latest commit on main. Since this tag is overwritten frequently, you may want to use Docker CLI flag `--pull always` to ensure that you always have the most up-to-date image every time you run using this tag.
+To run from main using Docker, use the `snapshot` Docker tag. The Docker image `superseriousbusiness/gotosocial:snapshot` will always correspond to the latest commit on main. Since this tag is overwritten frequently, you may want to use Docker CLI flag `--pull always` to ensure that you always have the most up-to-date image every time you run using this tag. Alternatively, run `docker pull superseriousbusiness/gotosocial:snapshot` manually just before use.
 
 #### Binary release .tar.gz
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Here's a screenshot of the instance landing page!
   - [Federation Issues](#federation-issues)
 - [Contributing](#contributing)
 - [Building](#building)
+- [Releases](#releases)
+  - [Stable](#stable)
+  - [Snapshots](#snapshots)
+    - [Docker](#docker)
+    - [Binary release .tar.gz](#binary-release-targz)
 - [Contact](#contact)
 - [Credits](#credits)
   - [Libraries](#libraries)
@@ -207,6 +212,32 @@ You would like to contribute to GtS? Great! ❤️❤️❤️ Check out the iss
 ## Building
 
 Instructions for building GoToSocial from source are in the [CONTRIBUTING.md](./CONTRIBUTING.md) file.
+
+## Releases
+
+### Stable
+
+We package our stable releases for both binary builds and Docker containers, so that you don't have to build from source yourself.
+
+Check our [releases page](https://github.com/superseriousbusiness/gotosocial/releases) and our [getting started](https://docs.gotosocial.org/en/latest/getting_started/) documentation.
+
+The Docker image `superseriousbusiness/gotosocial:latest` will always correspond to the latest stable release.
+
+### Snapshots
+
+We also make snapshot builds every time something is merged into the main branch, so you can run from whatever code is on main if you wish.
+
+Please be warned that you do so at your own risk! We try to keep main working properly, but we make absolutely no guarantees. Take a stable release instead if you're unsure.
+
+#### Docker
+
+To run from main using Docker, use the `snapshot` Docker tag. The Docker image `superseriousbusiness/gotosocial:snapshot` will always correspond to the latest commit on main.
+
+#### Binary release .tar.gz
+
+To run from main using a binary release, download the appropriate .tar.gz file for your architecture from our [self-hosted Minio S3 repository](https://minio.s3.superseriousbusiness.org/browser/gotosocial-snapshots).
+
+Snapshot binary releases in the S3 bucket are keyed by Github commit hash. To get the latest one, sort by Last Modified, or check out the list of commits [here](https://github.com/superseriousbusiness/gotosocial/commits/main), copy the SHA of the latest one, and paste it in the Minio console filter. Snapshot binary releases are expired after 28 days, to keep our hosting costs down.
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Please be warned that you do so at your own risk! We try to keep main working pr
 
 #### Docker
 
-To run from main using Docker, use the `snapshot` Docker tag. The Docker image `superseriousbusiness/gotosocial:snapshot` will always correspond to the latest commit on main.
+To run from main using Docker, use the `snapshot` Docker tag. The Docker image `superseriousbusiness/gotosocial:snapshot` will always correspond to the latest commit on main. Since this tag is overwritten frequently, you may want to use Docker CLI flag `--pull always` to ensure that you always have the most up-to-date image every time you run using this tag.
 
 #### Binary release .tar.gz
 

--- a/docs/getting_started/installation/metal.md
+++ b/docs/getting_started/installation/metal.md
@@ -38,8 +38,8 @@ tar -xzf gotosocial_0.5.2_linux_amd64.tar.gz
 
 This will put the `gotosocial` binary in your current directory, in addition to the `web` folder, which contains assets for the web frontend, and an `example` folder, which contains a sample configuration file.
 
-!!! note
-    NOT RECOMMENDED: If you want to use a snapshot build of GoToSocial based on whatever code is currently on main, you can download recent binary .tar.gz files from https://minio.s3.superseriousbusiness.org/browser/gotosocial-snapshots (keyed by commit hash). Only do this if you know what you're doing, otherwise just take a stable release.
+!!! danger
+    If you prefer to use a snapshot build of GoToSocial based on whatever code is currently on main, you can download recent binary .tar.gz files from https://minio.s3.superseriousbusiness.org/browser/gotosocial-snapshots (keyed by commit hash). Only do this if you know what you're doing, otherwise just take a stable release.
 
 ## Edit Configuration File
 

--- a/docs/getting_started/installation/metal.md
+++ b/docs/getting_started/installation/metal.md
@@ -38,6 +38,9 @@ tar -xzf gotosocial_0.5.2_linux_amd64.tar.gz
 
 This will put the `gotosocial` binary in your current directory, in addition to the `web` folder, which contains assets for the web frontend, and an `example` folder, which contains a sample configuration file.
 
+!!! note
+    NOT RECOMMENDED: If you want to use a snapshot build of GoToSocial based on whatever code is currently on main, you can download recent binary .tar.gz files from https://minio.s3.superseriousbusiness.org/browser/gotosocial-snapshots (keyed by commit hash). Only do this if you know what you're doing, otherwise just take a stable release.
+
 ## Edit Configuration File
 
 Copy the configuration file from the example folder into your current directory:

--- a/docs/getting_started/releases.md
+++ b/docs/getting_started/releases.md
@@ -3,6 +3,7 @@
 GoToSocial can be installed in a number of different ways. We publish official binary releases as well as container images. A number of third-party packages are maintained by different distributions and some people have created additional deployment tooling to make it easy to deploy GoToSocial yourself.
 
 ## Binary releases
+
 We publish binary builds for Linux to [our GitHub project](https://github.com/superseriousbusiness/gotosocial/releases):
 
 * 32-bit Intel/AMD (i386/x86)
@@ -19,6 +20,12 @@ For FreeBSD we publish:
 We also publish container images [on the Docker Hub](https://hub.docker.com/r/superseriousbusiness/gotosocial).
 
 Containers are released for the same Linux platforms as our binary releases, with the exception of 32-bit Intel/AMD.
+
+## Snapshots
+
+We publish snapshot binary builds and Docker images of whatever is currently on main.
+
+We always recommend using a stable release instead, but if you want to live on the edge (at your own risk!) then see the [snapshots](https://github.com/superseriousbusiness/gotosocial#snapshots) section on our GitHub repo for more information.
 
 ## Third-party
 


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request adds an extra step to our snapshot process (triggered when a PR is merged into main) to publish binary tar.gz snapshots to s3.superseriousbusiness.org, so that folks don't have to build their own snapshots if they want to try running from current main.

This brings our binary snapshot process in line with the docker snapshot image process.

~~Draft right now, because I want to add a few things to the docs explaining how to download these snapshot binaries.~~

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have made any necessary changes to documentation.
