### PR TITLE
[performance] Tweak media attachment cleanup; replace stale index

### DIFF
--- a/internal/db/bundb/media_test.go
+++ b/internal/db/bundb/media_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
-	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
 type MediaTestSuite struct {
@@ -43,20 +42,12 @@ func (suite *MediaTestSuite) TestGetOlder() {
 	suite.Len(attachments, 2)
 }
 
-func (suite *MediaTestSuite) TestGetAvisAndHeaders() {
+func (suite *MediaTestSuite) TestGetCachedAttachmentsOlderThan() {
 	ctx := context.Background()
 
-	attachments, err := suite.db.GetAvatarsAndHeaders(ctx, "", 20)
+	attachments, err := suite.db.GetCachedAttachmentsOlderThan(ctx, time.Now(), 20)
 	suite.NoError(err)
-	suite.Len(attachments, 3)
-}
-
-func (suite *MediaTestSuite) TestGetLocalUnattachedOlderThan() {
-	ctx := context.Background()
-
-	attachments, err := suite.db.GetLocalUnattachedOlderThan(ctx, testrig.TimeMustParse("2090-06-04T13:12:00Z"), 10)
-	suite.NoError(err)
-	suite.Len(attachments, 1)
+	suite.Len(attachments, 2)
 }
 
 func TestMediaTestSuite(t *testing.T) {

--- a/internal/db/bundb/migrations/20230821075342_attachment_cleanup_updates.go
+++ b/internal/db/bundb/migrations/20230821075342_attachment_cleanup_updates.go
@@ -1,0 +1,61 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			log.Info(ctx, "dropping previous media attachment cleanup index, please wait and don't interrupt it (this may take a while)")
+			if _, err := tx.
+				NewDropIndex().
+				Index("media_attachments_cleanup_idx").
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			log.Info(ctx, "creating new media attachment cleanup index, please wait and don't interrupt it (this may take a while)")
+			if _, err := tx.
+				NewCreateIndex().
+				Table("media_attachments").
+				Index("media_attachments_cleanup_idx").
+				Column("cached", "created_at").
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}

--- a/internal/db/media.go
+++ b/internal/db/media.go
@@ -50,24 +50,4 @@ type Media interface {
 	// GetCachedAttachmentsOlderThan gets limit n remote attachments (including avatars and headers) older than
 	// the given time. These will be returned in order of attachment.created_at descending (i.e. newest to oldest).
 	GetCachedAttachmentsOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, error)
-
-	// CountRemoteOlderThan is like GetRemoteOlderThan, except instead of getting limit n attachments,
-	// it just counts how many remote attachments in the database (including avatars and headers) meet
-	// the olderThan criteria.
-	CountRemoteOlderThan(ctx context.Context, olderThan time.Time) (int, error)
-
-	// GetAvatarsAndHeaders fetches limit n avatars and headers with an id < maxID. These headers
-	// and avis may be in use or not; the caller should check this if it's important.
-	GetAvatarsAndHeaders(ctx context.Context, maxID string, limit int) ([]*gtsmodel.MediaAttachment, error)
-
-	// GetLocalUnattachedOlderThan fetches limit n local media attachments (including avatars and headers), older than
-	// the given time, which aren't header or avatars, and aren't attached to a status. In other words, attachments which were
-	// uploaded but never used for whatever reason, or attachments that were attached to a status which was subsequently deleted.
-	//
-	// These will be returned in order of attachment.created_at descending (newest to oldest in other words).
-	GetLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time, limit int) ([]*gtsmodel.MediaAttachment, error)
-
-	// CountLocalUnattachedOlderThan is like GetLocalUnattachedOlderThan, except instead of getting limit n attachments,
-	// it just counts how many local attachments in the database meet the olderThan criteria.
-	CountLocalUnattachedOlderThan(ctx context.Context, olderThan time.Time) (int, error)
 }


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates our uncacheing logic a little bit:

Replaces old index which included fields we aren't using anymore during the cleanup. New index includes only the used ones, as suggested by sqlite `.expert`. For SQLite, it is massively faster since it doesn't create a temporary index anymore. Seems to not make much difference for Postgres, which was fine anyway, but we should keep an eye on this.

When uncacheing remote media, treat headers/avatars and status attachments differently. Ie., don't let recent *account* fetch prevent *status attachment* uncaches, and vice versa, since the two aren't related.

My suspicion is that with the previous logic, if you follow an account that posts semi-frequently, you end up not uncacheing their old status attachments properly, because your instance fetches their account often enough to return early on the following:

```go
	account, missing, err := m.getRelatedAccount(ctx, media)
	if err != nil {
		return false, err
	} else if missing {
		l.Debug("skipping due to missing account")
		return false, nil
	}

	if account != nil && account.FetchedAt.After(after) {
		l.Debug("skipping due to recently fetched account")
		return false, nil
	}
```

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
