### PR TITLE
[bugfix/frontend] Normalize header sizes

### DIFF
--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -154,22 +154,22 @@ main {
 		.content {
 			h1 {
 				margin: 0;
-				font-size: 2rem;
+				font-size: 1.8rem;
 			}
 
 			h2 {
 				margin: 0;
-				font-size: 1.75rem;
+				font-size: 1.6rem;
 			}
 
 			h3 {
 				margin: 0;
-				font-size: 1.5rem;
+				font-size: 1.4rem;
 			}
 
 			h4 {
 				margin: 0;
-				font-size: 1.25rem;
+				font-size: 1.2rem;
 			}
 
 			h5 {

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -152,7 +152,33 @@ main {
 		}
 
 		.content {
+			h1 {
+				margin: 0;
+				font-size: 2rem;
+			}
+
+			h2 {
+				margin: 0;
+				font-size: 1.75rem;
+			}
+
+			h3 {
+				margin: 0;
+				font-size: 1.5rem;
+			}
+
+			h4 {
+				margin: 0;
+				font-size: 1.25rem;
+			}
+
+			h5 {
+				margin: 0;
+				font-size: 1rem;
+			}
+
 			word-break: break-word;
+			line-height: initial;
 
 			blockquote {
 				padding: 0.5rem 0 0.5rem 0.5rem;


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates CSS for headings inside statuses, to ensure that they're sensibly sized. Previously, our h1 inside statuses was being overridden by normalization in base.css, and h5 was styled to be even smaller than body text, which is just a bit silly!

![Screenshot of a test post that uses h1 through h5. They're progressively smaller.](https://github.com/superseriousbusiness/gotosocial/assets/31960611/f442e6cf-ff97-425f-a59f-68315f8fa25b)


closes https://github.com/superseriousbusiness/gotosocial/issues/2150

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
