### PR TITLE
[chore] Add script for downloading latest snapshot tar.gz

### DIFF
--- a/scripts/get_latest_snapshot.sh
+++ b/scripts/get_latest_snapshot.sh
@@ -21,7 +21,7 @@ GITHUB_BRANCH="main"
 GITHUB_ENDPOINT="https://${GITHUB_API_HOST}/repos/${GITHUB_ORG}/${GITHUB_REPO}/commits/${GITHUB_BRANCH}"
 
 echo "fetching latest hash from endpoint '${GITHUB_ENDPOINT}'"
-LATEST_HASH="$(curl -s "${GITHUB_ENDPOINT}" | jq -r .sha)"
+LATEST_HASH="$(curl --silent --fail --retry 5 --retry-max-time 180 --max-time 30 "${GITHUB_ENDPOINT}" | jq -r .sha)"
 echo "got latest hash = ${LATEST_HASH}"
 
 MINIO_HOST="s3.superseriousbusiness.org"

--- a/scripts/get_latest_snapshot.sh
+++ b/scripts/get_latest_snapshot.sh
@@ -6,7 +6,7 @@ set -eu
 # the latest snapshot build of GoToSocial from
 # the Minio S3 bucket.
 #
-# Requires curl, jq, and wget.
+# Requires curl and jq.
 #
 # Change the variables below for your particular
 # platform and architecture (default linux amd64). 

--- a/scripts/get_latest_snapshot.sh
+++ b/scripts/get_latest_snapshot.sh
@@ -29,5 +29,5 @@ MINIO_BUCKET="gotosocial-snapshots"
 MINIO_ENDPOINT="https://${MINIO_HOST}/${MINIO_BUCKET}/${LATEST_HASH}/${GTS_FILENAME}"
 
 echo "fetching latest snapshot tar.gz from endpoint '${MINIO_ENDPOINT}'"
-wget --no-verbose -O "./${GTS_FILENAME}" "${MINIO_ENDPOINT}"
+curl --silent --fail --retry 5 --retry-max-time 600 --max-time 1800 "${MINIO_ENDPOINT}" --output "./${GTS_FILENAME}"
 echo "got latest snapshot!"

--- a/scripts/get_latest_snapshot.sh
+++ b/scripts/get_latest_snapshot.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -eu
+
+# Cheeky little convenience script for fetching
+# the latest snapshot build of GoToSocial from
+# the Minio S3 bucket.
+#
+# Requires curl, jq, and wget.
+#
+# Change the variables below for your particular
+# platform and architecture (default linux amd64). 
+GTS_PLATFORM="linux"
+GTS_ARCH="amd64"
+GTS_FILENAME="gotosocial_${GTS_PLATFORM}_${GTS_ARCH}.tar.gz"
+
+GITHUB_API_HOST="api.github.com"
+GITHUB_ORG="superseriousbusiness"
+GITHUB_REPO="gotosocial"
+GITHUB_BRANCH="main"
+GITHUB_ENDPOINT="https://${GITHUB_API_HOST}/repos/${GITHUB_ORG}/${GITHUB_REPO}/commits/${GITHUB_BRANCH}"
+
+echo "fetching latest hash from endpoint '${GITHUB_ENDPOINT}'"
+LATEST_HASH="$(curl -s "${GITHUB_ENDPOINT}" | jq -r .sha)"
+echo "got latest hash = ${LATEST_HASH}"
+
+MINIO_HOST="s3.superseriousbusiness.org"
+MINIO_BUCKET="gotosocial-snapshots"
+MINIO_ENDPOINT="https://${MINIO_HOST}/${MINIO_BUCKET}/${LATEST_HASH}/${GTS_FILENAME}"
+
+echo "fetching latest snapshot tar.gz from endpoint '${MINIO_ENDPOINT}'"
+wget --no-verbose -O "./${GTS_FILENAME}" "${MINIO_ENDPOINT}"
+echo "got latest snapshot!"


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request adds a quick and fairly dirty bash script into the `scripts` directory that folks can use to pull the latest snapshot release tar.gz from our Minio S3 bucket.

I didn't advertise it anywhere in the docs because it's not something we should really 'recommend' to people, but we can at least point it to folks who regularly run snapshots and want a very slightly easier way of doing it.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).

