### PR TITLE
[chore/frontend] Make line-height a wee little bit bigger

### DIFF
--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -152,33 +152,38 @@ main {
 		}
 
 		.content {
+			word-break: break-word;
+			line-height: 1.6rem;
+
 			h1 {
 				margin: 0;
 				font-size: 1.8rem;
+				line-height: initial;
 			}
 
 			h2 {
 				margin: 0;
 				font-size: 1.6rem;
+				line-height: initial;
 			}
 
 			h3 {
 				margin: 0;
 				font-size: 1.4rem;
+				line-height: initial;
 			}
 
 			h4 {
 				margin: 0;
 				font-size: 1.2rem;
+				line-height: initial;
 			}
 
 			h5 {
 				margin: 0;
 				font-size: 1rem;
+				line-height: initial;
 			}
-
-			word-break: break-word;
-			line-height: initial;
 
 			blockquote {
 				padding: 0.5rem 0 0.5rem 0.5rem;


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates status CSS to make line height just a little bit bigger, so that wall-of-text statuses are a bit easier on the eyes.

Before:

![Wall of lorem ipsum](https://github.com/superseriousbusiness/gotosocial/assets/31960611/0edc0b3b-59d0-46cd-822f-40a6b474f5a0)

After:

![Wall of lorem ipsum that's arguably slightly more readable](https://github.com/superseriousbusiness/gotosocial/assets/31960611/c2fe4aea-9463-4239-8557-88a403f9634e)


## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
