### PR TITLE
[bugfix] wrap bun.Tx to add our own error processing

### DIFF
--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -298,7 +298,7 @@ func (a *accountDB) PutAccount(ctx context.Context, account *gtsmodel.Account) e
 		// It is safe to run this database transaction within cache.Store
 		// as the cache does not attempt a mutex lock until AFTER hook.
 		//
-		return a.db.RunInTx(ctx, func(tx bun.Tx) error {
+		return a.db.RunInTx(ctx, func(tx Tx) error {
 			// create links between this account and any emojis it uses
 			for _, i := range account.EmojiIDs {
 				if _, err := tx.NewInsert().Model(&gtsmodel.AccountToEmoji{
@@ -327,7 +327,7 @@ func (a *accountDB) UpdateAccount(ctx context.Context, account *gtsmodel.Account
 		// It is safe to run this database transaction within cache.Store
 		// as the cache does not attempt a mutex lock until AFTER hook.
 		//
-		return a.db.RunInTx(ctx, func(tx bun.Tx) error {
+		return a.db.RunInTx(ctx, func(tx Tx) error {
 			// create links between this account and any emojis it uses
 			// first clear out any old emoji links
 			if _, err := tx.
@@ -375,7 +375,7 @@ func (a *accountDB) DeleteAccount(ctx context.Context, id string) error {
 		return err
 	}
 
-	return a.db.RunInTx(ctx, func(tx bun.Tx) error {
+	return a.db.RunInTx(ctx, func(tx Tx) error {
 		// clear out any emoji links
 		if _, err := tx.
 			NewDelete().

--- a/internal/db/bundb/emoji.go
+++ b/internal/db/bundb/emoji.go
@@ -105,7 +105,7 @@ func (e *emojiDB) DeleteEmojiByID(ctx context.Context, id string) error {
 		return err
 	}
 
-	return e.db.RunInTx(ctx, func(tx bun.Tx) error {
+	return e.db.RunInTx(ctx, func(tx Tx) error {
 		// Delete relational links between this emoji
 		// and any statuses using it, returning the
 		// status IDs so we can later update them.

--- a/internal/db/bundb/list.go
+++ b/internal/db/bundb/list.go
@@ -206,7 +206,7 @@ func (l *listDB) DeleteListByID(ctx context.Context, id string) error {
 		}
 	}()
 
-	return l.db.RunInTx(ctx, func(tx bun.Tx) error {
+	return l.db.RunInTx(ctx, func(tx Tx) error {
 		// Delete all entries attached to list.
 		if _, err := tx.NewDelete().
 			Table("list_entries").
@@ -423,7 +423,7 @@ func (l *listDB) PutListEntries(ctx context.Context, entries []*gtsmodel.ListEnt
 	}()
 
 	// Finally, insert each list entry into the database.
-	return l.db.RunInTx(ctx, func(tx bun.Tx) error {
+	return l.db.RunInTx(ctx, func(tx Tx) error {
 		for _, entry := range entries {
 			entry := entry // rescope
 			if err := l.state.Caches.GTS.ListEntry().Store(entry, func() error {

--- a/internal/db/bundb/marker.go
+++ b/internal/db/bundb/marker.go
@@ -87,7 +87,7 @@ func (m *markerDB) UpdateMarker(ctx context.Context, marker *gtsmodel.Marker) er
 		// Optimistic concurrency control: start a transaction, try to update a row with a previously retrieved version.
 		// If the update in the transaction fails to actually change anything, another update happened concurrently, and
 		// this update should be retried by the caller, which in this case involves sending HTTP 409 to the API client.
-		return m.db.RunInTx(ctx, func(tx bun.Tx) error {
+		return m.db.RunInTx(ctx, func(tx Tx) error {
 			result, err := tx.NewUpdate().
 				Model(marker).
 				WherePK().

--- a/internal/db/bundb/media.go
+++ b/internal/db/bundb/media.go
@@ -122,7 +122,7 @@ func (m *mediaDB) DeleteAttachment(ctx context.Context, id string) error {
 	defer m.state.Caches.GTS.Media().Invalidate("ID", id)
 
 	// Delete media attachment in new transaction.
-	err = m.db.RunInTx(ctx, func(tx bun.Tx) error {
+	err = m.db.RunInTx(ctx, func(tx Tx) error {
 		if media.AccountID != "" {
 			var account gtsmodel.Account
 

--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -276,7 +276,7 @@ func (s *statusDB) PutStatus(ctx context.Context, status *gtsmodel.Status) error
 		// It is safe to run this database transaction within cache.Store
 		// as the cache does not attempt a mutex lock until AFTER hook.
 		//
-		return s.db.RunInTx(ctx, func(tx bun.Tx) error {
+		return s.db.RunInTx(ctx, func(tx Tx) error {
 			// create links between this status and any emojis it uses
 			for _, i := range status.EmojiIDs {
 				if _, err := tx.
@@ -342,7 +342,7 @@ func (s *statusDB) UpdateStatus(ctx context.Context, status *gtsmodel.Status, co
 		// It is safe to run this database transaction within cache.Store
 		// as the cache does not attempt a mutex lock until AFTER hook.
 		//
-		return s.db.RunInTx(ctx, func(tx bun.Tx) error {
+		return s.db.RunInTx(ctx, func(tx Tx) error {
 			// create links between this status and any emojis it uses
 			for _, i := range status.EmojiIDs {
 				if _, err := tx.
@@ -420,7 +420,7 @@ func (s *statusDB) DeleteStatusByID(ctx context.Context, id string) error {
 	// On return ensure status invalidated from cache.
 	defer s.state.Caches.GTS.Status().Invalidate("ID", id)
 
-	return s.db.RunInTx(ctx, func(tx bun.Tx) error {
+	return s.db.RunInTx(ctx, func(tx Tx) error {
 		// delete links between this status and any emojis it uses
 		if _, err := tx.
 			NewDelete().


### PR DESCRIPTION
# Description

Until now we have just been wrapping the bun database to add our own error processing hook, but we were forgetting the transactions! (agghhh!!!) Bun transactions are now properly wrapped to give our own error processing so that we may do nice, reasonable things like `if errors.Is(err, db.ErrAlreadyExists)` within transactions.

I desperately need to try adding SQLITE_BUSY retries into the modernc.org/sqlite package, and for the error processing, figuring out how to hook that in as a neater upstream fix to `uptrace/bun`... Because this wrapping situation is getting out of hand.

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
