### PR TITLE
[bugfix] move SQLite pragmas into connection string

### DIFF
--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -436,7 +436,7 @@ func buildSQLiteAddress(addr string) string {
 	//   through to the transpiled C code.
 	//
 	// - The SQLite shim we interface with adds support for setting ANY of the
-	//   configuration options via query arguments, though using a special `_pragma`
+	//   configuration options via query arguments, through using a special `_pragma`
 	//   query key that specifies SQLite PRAGMAs to set upon opening each connection.
 	//   As such you will see below that most config is set with the `_pragma` key.
 	//

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -28,7 +28,6 @@ import (
 	"net/url"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -449,30 +448,28 @@ func buildSQLiteAddress(addr string) string {
 		prefs.Add("cache", "shared")
 	}
 
-	if timeout := config.GetDbSqliteBusyTimeout(); timeout > 0 {
+	if dur := config.GetDbSqliteBusyTimeout(); dur > 0 {
 		// Set the user provided SQLite busy timeout
 		// NOTE: MUST BE SET BEFORE THE JOURNAL MODE.
-		t := strconv.FormatInt(timeout.Milliseconds(), 10)
-		prefs.Add("busy_timeout", t)
+		prefs.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", dur.Milliseconds()))
 	}
 
 	if mode := config.GetDbSqliteJournalMode(); mode != "" {
 		// Set the user provided SQLite journal mode.
-		prefs.Add("journal_mode", mode)
+		prefs.Add("_pragma", fmt.Sprintf("journal_mode(%s)", mode))
 	}
 
 	if mode := config.GetDbSqliteSynchronous(); mode != "" {
 		// Set the user provided SQLite synchronous mode.
-		prefs.Add("synchronous", mode)
+		prefs.Add("_pragma", fmt.Sprintf("synchronous(%s)", mode))
 	}
 
-	if size := config.GetDbSqliteCacheSize(); size > 0 {
+	if sz := config.GetDbSqliteCacheSize(); sz > 0 {
 		// Set the user provided SQLite cache size (in kibibytes)
 		// Prepend a '-' character to this to indicate to sqlite
 		// that we're giving kibibytes rather than num pages.
 		// https://www.sqlite.org/pragma.html#pragma_cache_size
-		s := "-" + strconv.FormatUint(uint64(size/bytesize.KiB), 10)
-		prefs.Add("cache_size", s)
+		prefs.Add("_pragma", fmt.Sprintf("cache_size(-%d)", uint64(sz/bytesize.KiB)))
 	}
 
 	var b strings.Builder

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -445,6 +445,7 @@ func buildSQLiteAddress(addr string) string {
 	//   configuration options are set across _all_ of our SQLite connections, given
 	//   that we are a multi-threaded (not directly in a C way) application and that
 	//   each connection is a separate SQLite instance opening the same database.
+	//   And the `database/sql` package provides transparent connection pooling.
 	//   Some data is shared between connections, for example the `journal_mode`
 	//   as that is set in a bit of the file header, but to be sure with the other
 	//   settings we just add them all to the connection URI string.


### PR DESCRIPTION
# Description

As the title says really! Moves the SQLite connection pragmas into the connection string, just to ensure that all our connection preferences are set on every created new connection, considering that it's a little unclear what data is shared across SQLite connections. These are set using the `_pragma` URI query key as specified in the `modernc.org/sqlite.Driver{}.Open()` documentation.

An example of a connection string with this:
`timestamp="01/09/2023 09:02:20.915" func=bundb.sqliteConn level=INFO msg="connected to SQLITE database with address file:/data/sqlite.db?_pragma=busy_timeout%28300000%29&_pragma=journal_mode%28WAL%29&_pragma=synchronous%28NORMAL%29&_pragma=cache_size%28-8192%29&_txlock=immediate"`

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
