### PR TITLE
[feature] Support Actor URIs for webfinger queries

### DIFF
--- a/internal/api/wellknown/webfinger/webfingerget_test.go
+++ b/internal/api/wellknown/webfinger/webfingerget_test.go
@@ -61,7 +61,7 @@ func (suite *WebfingerGetTestSuite) finger(requestPath string) string {
 	// Result should always use the
 	// webfinger content-type.
 	if ct := result.Header.Get("content-type"); ct != string(apiutil.AppJRDJSON) {
-		suite.FailNow("", "expected content type %s, got %s", apiutil.AppJRDJSON, ct)
+		suite.FailNow("", "expected: content type %s, got %s: %s", apiutil.AppJRDJSON, ct)
 	}
 
 	b, err := io.ReadAll(result.Body)
@@ -141,6 +141,45 @@ func (suite *WebfingerGetTestSuite) TestFingerUser() {
     }
   ]
 }`, resp)
+}
+
+func (suite *WebfingerGetTestSuite) TestFingerUserActorURI() {
+	targetAccount := suite.testAccounts["local_account_1"]
+	host := config.GetHost()
+
+	tests := []struct {
+		resource string
+	}{
+		{resource: fmt.Sprintf("https://%s/@%s", host, targetAccount.Username)},
+		{resource: fmt.Sprintf("https://%s/users/%s", host, targetAccount.Username)},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		suite.Run(tt.resource, func() {
+			requestPath := fmt.Sprintf("/%s?resource=%s", webfinger.WebfingerBasePath, tt.resource)
+			resp := suite.finger(requestPath)
+			suite.Equal(`{
+  "subject": "acct:the_mighty_zork@localhost:8080",
+  "aliases": [
+    "http://localhost:8080/users/the_mighty_zork",
+    "http://localhost:8080/@the_mighty_zork"
+  ],
+  "links": [
+    {
+      "rel": "http://webfinger.net/rel/profile-page",
+      "type": "text/html",
+      "href": "http://localhost:8080/@the_mighty_zork"
+    },
+    {
+      "rel": "self",
+      "type": "application/activity+json",
+      "href": "http://localhost:8080/users/the_mighty_zork"
+    }
+  ]
+}`, resp)
+		})
+	}
 }
 
 func (suite *WebfingerGetTestSuite) TestFingerUserWithDifferentAccountDomainByHost() {

--- a/internal/api/wellknown/webfinger/webfingerget_test.go
+++ b/internal/api/wellknown/webfinger/webfingerget_test.go
@@ -61,7 +61,7 @@ func (suite *WebfingerGetTestSuite) finger(requestPath string) string {
 	// Result should always use the
 	// webfinger content-type.
 	if ct := result.Header.Get("content-type"); ct != string(apiutil.AppJRDJSON) {
-		suite.FailNow("", "expected: content type %s, got %s: %s", apiutil.AppJRDJSON, ct)
+		suite.FailNow("", "expected content type %s, got %s", apiutil.AppJRDJSON, ct)
 	}
 
 	b, err := io.ReadAll(result.Body)

--- a/internal/util/namestring.go
+++ b/internal/util/namestring.go
@@ -79,12 +79,8 @@ func ExtractWebfingerParts(webfinger string) (username, host string, err error) 
 		return "", "", fmt.Errorf("unsupported scheme: %s for resource: %s", u.Scheme, orig)
 	}
 
-	userDomain := strings.Split(
-		strings.TrimPrefix(
-			u.Opaque,
-			"@",
-		),
-		"@")
+	stripped := strings.TrimPrefix(u.Opaque, "@")
+	userDomain := strings.Split(stripped, "@")
 	if len(userDomain) != 2 {
 		return "", "", fmt.Errorf("failed to extract user and domain from: %s", orig)
 	}

--- a/internal/util/namestring.go
+++ b/internal/util/namestring.go
@@ -19,6 +19,7 @@ package util
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/superseriousbusiness/gotosocial/internal/regexes"
@@ -40,19 +41,87 @@ func ExtractNamestringParts(mention string) (username, host string, err error) {
 	}
 }
 
-// ExtractWebfingerParts returns username test_user and
-// domain example.org from a string like acct:test_user@example.org,
-// or acct:@test_user@example.org.
+// ExtractWebfingerParts returns the username and domain from either an
+// account query or an actor URI.
 //
-// If nothing is extracted, it will return an error.
+// All implementations in the wild generate webfinger account resource
+// queries with the "acct" scheme and without a leading "@"" on the username.
+// This is also the format the "subject" in a webfinger response adheres to.
+//
+// Despite this fact, we're being permissive about a single leading @. This
+// makes a query for acct:user@domain.tld and acct:@user@domain.tld
+// equivalent. But a query for acct:@@user@domain.tld will have its username
+// returned with the @ prefix.
+//
+// We also permit a resource of user@domain.tld or @user@domain.tld, without
+// a scheme. In that case it gets interpreted as if it was using the "acct"
+// scheme.
+//
+// When parsing fails, an error is returned.
 func ExtractWebfingerParts(webfinger string) (username, host string, err error) {
-	// remove the acct: prefix if it's present
-	webfinger = strings.TrimPrefix(webfinger, "acct:")
+	orig := webfinger
 
-	// prepend an @ if necessary
-	if webfinger[0] != '@' {
-		webfinger = "@" + webfinger
+	u, oerr := url.ParseRequestURI(webfinger)
+	if oerr != nil {
+		// Most likely reason for failing to parse is if the "acct" scheme was
+		// missing but a :port was included. So try an extra time with the scheme.
+		u, err = url.ParseRequestURI("acct:" + webfinger)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to parse %s with acct sheme: %w", orig, oerr)
+		}
 	}
 
-	return ExtractNamestringParts(webfinger)
+	if u.Scheme == "http" || u.Scheme == "https" {
+		return ExtractWebfingerPartsFromURI(u)
+	}
+
+	if u.Scheme != "acct" {
+		return "", "", fmt.Errorf("unsupported scheme: %s for resource: %s", u.Scheme, orig)
+	}
+
+	userDomain := strings.Split(
+		strings.TrimPrefix(
+			u.Opaque,
+			"@",
+		),
+		"@")
+	if len(userDomain) != 2 {
+		return "", "", fmt.Errorf("failed to extract user and domain from: %s", orig)
+	}
+	return userDomain[0], userDomain[1], nil
+}
+
+// ExtractWebfingerPartsFromURI returns the user and domain extracted from
+// the passed in URI. The URI should be an actor URI.
+//
+// The domain returned is the hostname, and the user will be extracted
+// from either /@test_user or /users/test_user. These two paths match the
+// "aliasses" we include in our webfinger response and are also present in
+// our "links".
+//
+// Like with ExtractWebfingerParts, we're being permissive about a single
+// leading @.
+//
+// Errors are returned in case we end up with an empty domain or username.
+func ExtractWebfingerPartsFromURI(uri *url.URL) (username, host string, err error) {
+	host = uri.Host
+	if host == "" {
+		return "", "", fmt.Errorf("failed to extract domain from: %s", uri)
+	}
+
+	// strip any leading slashes
+	path := strings.TrimLeft(uri.Path, "/")
+	segs := strings.Split(path, "/")
+	if segs[0] == "users" {
+		username = segs[1]
+	} else {
+		username = segs[0]
+	}
+
+	username = strings.TrimPrefix(username, "@")
+	if username == "" {
+		return "", "", fmt.Errorf("failed to extract username from: %s", uri)
+	}
+
+	return
 }

--- a/internal/util/namestring_test.go
+++ b/internal/util/namestring_test.go
@@ -100,37 +100,30 @@ func (suite *NamestringSuite) TestExtractWebfingerPartsFromURI() {
 	}
 }
 
-func (suite *NamestringSuite) TestExtractNamestringParts1() {
-	namestring := "@stonerkitty.monster@stonerkitty.monster"
-	username, host, err := util.ExtractNamestringParts(namestring)
-	suite.NoError(err)
+func (suite *NamestringSuite) TestExtractNamestring() {
+	tests := []struct {
+		in, username, host, err string
+	}{
+		{in: "@stonerkitty.monster@stonerkitty.monster", username: "stonerkitty.monster", host: "stonerkitty.monster"},
+		{in: "@stonerkitty.monster", username: "stonerkitty.monster"},
+		{in: "@someone@somewhere", username: "someone", host: "somewhere"},
+		{in: "", err: "couldn't match mention "},
+	}
 
-	suite.Equal("stonerkitty.monster", username)
-	suite.Equal("stonerkitty.monster", host)
-}
-
-func (suite *NamestringSuite) TestExtractNamestringParts2() {
-	namestring := "@stonerkitty.monster"
-	username, host, err := util.ExtractNamestringParts(namestring)
-	suite.NoError(err)
-
-	suite.Equal("stonerkitty.monster", username)
-	suite.Empty(host)
-}
-
-func (suite *NamestringSuite) TestExtractNamestringParts3() {
-	namestring := "@someone@somewhere"
-	username, host, err := util.ExtractNamestringParts(namestring)
-	suite.NoError(err)
-
-	suite.Equal("someone", username)
-	suite.Equal("somewhere", host)
-}
-
-func (suite *NamestringSuite) TestExtractNamestringParts4() {
-	namestring := ""
-	_, _, err := util.ExtractNamestringParts(namestring)
-	suite.EqualError(err, "couldn't match mention ")
+	for _, tt := range tests {
+		tt := tt
+		suite.Run(tt.in, func() {
+			suite.T().Parallel()
+			username, host, err := util.ExtractNamestringParts(tt.in)
+			if tt.err != "" {
+				suite.EqualError(err, tt.err)
+			} else {
+				suite.NoError(err)
+				suite.Equal(tt.username, username)
+				suite.Equal(tt.host, host)
+			}
+		})
+	}
 }
 
 func TestNamestringSuite(t *testing.T) {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

It's now possible to pass an Actor URI as the resource to query for when doing a webfinger query. The code now extracts the username and domain from the URI. The URI needs to be fully qualified, including having a scheme of http or https to be recognised as such.

The acct scheme is handled as we used to, including dealing with an erroneous leading @ on the username. We retain the ability to handle resources without a scheme by parsing them again with the acct scheme if the original parse failed. This can happen due to parsing ambiguities when dealing with a string like `user@domain.tld:port`.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
