### PR TITLE
[docs] add fail2ban example regex in the doc

### DIFF
--- a/docs/advanced/security/firewall.md
+++ b/docs/advanced/security/firewall.md
@@ -82,3 +82,9 @@ Both SSHGuard and fail2ban ship with "backends" that can target iptables and nft
 * [ArchWiki](https://wiki.archlinux.org/title/sshguard) on sshguard
 * [FreeBSD manual](https://man.freebsd.org/cgi/man.cgi?query=sshguard&sektion=8&manpath=FreeBSD+13.2-RELEASE+and+Ports) for sshguard
 * [SSHGuard setup](https://manpages.ubuntu.com/manpages/lunar/en/man7/sshguard-setup.7.html) manual for Ubuntu
+
+For fail2ban, you can use the following regex, which triggers fail2ban on failed logins and not another 'Unauthorized' errors (API for example):
+
+```regex
+statusCode=401 path=/auth/sign_in clientIP=<HOST> .* msg=\"Unauthorized:
+```


### PR DESCRIPTION
# Description

This pull request add an example of regex for fail2ban, to make it easier for novices to configure it
This regex ignores failed API attempts, as it's not relevant

I don't know if it's also applicable to SSHGuard because I don't know it
That's explain why I didn't made a SSHGuard example too

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.