### PR TITLE
[bugfix] fix flakey paging test

### DIFF
--- a/internal/paging/page_test.go
+++ b/internal/paging/page_test.go
@@ -30,6 +30,17 @@ import (
 // random reader according to current-time source seed.
 var randRd = rand.New(rand.NewSource(time.Now().Unix()))
 
+// randIntnPlus1 returns a POSITIVE integer between 1  and n (inclusive).
+func randIntnPlus1(n int) int {
+	for {
+		o := randRd.Intn(n + 1)
+		if o == 0 {
+			continue
+		}
+		return o
+	}
+}
+
 type Case struct {
 	// Name is the test case name.
 	Name string
@@ -64,7 +75,7 @@ func TestPage(t *testing.T) {
 			out := c.Page.Page(c.Input)
 
 			// Log the results for case of error returns.
-			t.Logf("\ninput=%v\noutput=%v\nexpected=%v", c.Input, out, c.Expect)
+			t.Logf("%s\npage=%+v input=%v expect=%v output=%v", c.Name, c.Page, c.Input, c.Expect, out)
 
 			// Check paged output is as expected.
 			if !slices.Equal(out, c.Expect) {
@@ -110,7 +121,7 @@ var cases = []Case{
 		// Select random parameters in slice.
 		minIdx := randRd.Intn(len(ids))
 		maxIdx := randRd.Intn(len(ids))
-		limit := randRd.Intn(len(ids))
+		limit := randIntnPlus1(len(ids))
 
 		// Select the boundaries.
 		minID := ids[minIdx]

--- a/internal/paging/page_test.go
+++ b/internal/paging/page_test.go
@@ -30,17 +30,6 @@ import (
 // random reader according to current-time source seed.
 var randRd = rand.New(rand.NewSource(time.Now().Unix()))
 
-// randIntnPlus1 returns a POSITIVE integer between 1  and n (inclusive).
-func randIntnPlus1(n int) int {
-	for {
-		o := randRd.Intn(n + 1)
-		if o == 0 {
-			continue
-		}
-		return o
-	}
-}
-
 type Case struct {
 	// Name is the test case name.
 	Name string
@@ -121,7 +110,7 @@ var cases = []Case{
 		// Select random parameters in slice.
 		minIdx := randRd.Intn(len(ids))
 		maxIdx := randRd.Intn(len(ids))
-		limit := randIntnPlus1(len(ids))
+		limit := randRd.Intn(len(ids)) + 1
 
 		// Select the boundaries.
 		minID := ids[minIdx]


### PR DESCRIPTION
# Description

The paging test was incorrectly using a randomly generated limit which it was expecting to be > 0, but sometimes could be 0.

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
