### PR TITLE
[bugfix] Move `follow.show_reblogs` check further up to avoid showing unwanted reblogs in home timeline

### DIFF
--- a/internal/processing/workers/surfacetimeline.go
+++ b/internal/processing/workers/surfacetimeline.go
@@ -91,9 +91,13 @@ func (s *surface) timelineAndNotifyStatusForFollowers(
 	)
 
 	for _, follow := range follows {
-		// Do an initial rough-grained check to see if the
-		// status is timelineable for this follower at all
-		// based on its visibility and who it replies to etc.
+		// Check to see if the status is timelineable for this follower,
+		// taking account of its visibility, who it replies to, and, if
+		// it's a reblog, whether follower account wants to see reblogs.
+		//
+		// If it's not timelineable, we can just stop early, since lists
+		// are prettymuch subsets of the home timeline, so if it shouldn't
+		// appear there, it shouldn't appear in lists either.
 		timelineable, err := s.filter.StatusHomeTimelineable(
 			ctx, follow.Account, status,
 		)
@@ -104,17 +108,6 @@ func (s *surface) timelineAndNotifyStatusForFollowers(
 
 		if !timelineable {
 			// Nothing to do.
-			continue
-		}
-
-		if boost && !*follow.ShowReblogs {
-			// Status is a boost, but the owner of
-			// this follow doesn't want to see boosts
-			// from this account. We can safely skip
-			// everything, then, because we also know
-			// that the follow owner won't want to be
-			// have the status put in any list timelines,
-			// or be notified about the status either.
 			continue
 		}
 

--- a/internal/visibility/home_timeline_test.go
+++ b/internal/visibility/home_timeline_test.go
@@ -55,6 +55,38 @@ func (suite *StatusStatusHomeTimelineableTestSuite) TestFollowingStatusHomeTimel
 	suite.True(timelineable)
 }
 
+func (suite *StatusStatusHomeTimelineableTestSuite) TestFollowingBoostedStatusHomeTimelineable() {
+	ctx := context.Background()
+
+	testStatus := suite.testStatuses["admin_account_status_4"]
+	testAccount := suite.testAccounts["local_account_1"]
+	timelineable, err := suite.filter.StatusHomeTimelineable(ctx, testAccount, testStatus)
+	suite.NoError(err)
+
+	suite.True(timelineable)
+}
+
+func (suite *StatusStatusHomeTimelineableTestSuite) TestFollowingBoostedStatusHomeTimelineableNoReblogs() {
+	ctx := context.Background()
+
+	// Update follow to indicate that local_account_1
+	// doesn't want to see reblogs by admin_account.
+	follow := &gtsmodel.Follow{}
+	*follow = *suite.testFollows["local_account_1_admin_account"]
+	follow.ShowReblogs = util.Ptr(false)
+
+	if err := suite.db.UpdateFollow(ctx, follow, "show_reblogs"); err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	testStatus := suite.testStatuses["admin_account_status_4"]
+	testAccount := suite.testAccounts["local_account_1"]
+	timelineable, err := suite.filter.StatusHomeTimelineable(ctx, testAccount, testStatus)
+	suite.NoError(err)
+
+	suite.False(timelineable)
+}
+
 func (suite *StatusStatusHomeTimelineableTestSuite) TestNotFollowingStatusHomeTimelineable() {
 	testStatus := suite.testStatuses["remote_account_1_status_1"]
 	testAccount := suite.testAccounts["local_account_1"]


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request moves the check for reblogged status visibility out of `internal/processing/workers/surfacetimeline.go` and puts it in `internal/visibility/home_timeline.go`.

The latter is called not just for streaming of new statuses, but for building timelines by getting statuses out of the db, as well. This should help filter out unwanted reblogs, and also avoids splitting up status visibility logic across two very different packages.

closes https://github.com/superseriousbusiness/gotosocial/issues/2131

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
