### PR TITLE
[bugfix] Fix paging for empty items

### DIFF
--- a/internal/processing/account/statuses.go
+++ b/internal/processing/account/statuses.go
@@ -74,21 +74,8 @@ func (p *Processor) StatusesGet(
 		return nil, gtserror.NewErrorInternalError(err)
 	}
 
-	if len(statuses) == 0 {
-		return util.EmptyPageableResponse(), nil
-	}
-
-	// Filtering + serialization process is the same for
-	// both pinned status queries and 'normal' ones.
-	filtered, err := p.filter.StatusesVisible(ctx, requestingAccount, statuses)
-	if err != nil {
-		return nil, gtserror.NewErrorInternalError(err)
-	}
-
-	count := len(filtered)
+	count := len(statuses)
 	if count == 0 {
-		// After filtering there were
-		// no statuses left to serve.
 		return util.EmptyPageableResponse(), nil
 	}
 
@@ -97,9 +84,16 @@ func (p *Processor) StatusesGet(
 
 		// Set next + prev values before filtering and API
 		// converting, so caller can still page properly.
-		nextMaxIDValue = filtered[count-1].ID
-		prevMinIDValue = filtered[0].ID
+		nextMaxIDValue = statuses[count-1].ID
+		prevMinIDValue = statuses[0].ID
 	)
+
+	// Filtering + serialization process is the same for
+	// both pinned status queries and 'normal' ones.
+	filtered, err := p.filter.StatusesVisible(ctx, requestingAccount, statuses)
+	if err != nil {
+		return nil, gtserror.NewErrorInternalError(err)
+	}
 
 	for _, s := range filtered {
 		// Convert filtered statuses to API statuses.

--- a/internal/processing/timeline/public.go
+++ b/internal/processing/timeline/public.go
@@ -20,7 +20,6 @@ package timeline
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
@@ -33,7 +32,7 @@ import (
 func (p *Processor) PublicTimelineGet(ctx context.Context, authed *oauth.Auth, maxID string, sinceID string, minID string, limit int, local bool) (*apimodel.PageableResponse, gtserror.WithCode) {
 	statuses, err := p.state.DB.GetPublicTimeline(ctx, maxID, sinceID, minID, limit, local)
 	if err != nil && !errors.Is(err, db.ErrNoEntries) {
-		err = fmt.Errorf("PublicTimelineGet: db error getting statuses: %w", err)
+		err = gtserror.Newf("db error getting statuses: %w", err)
 		return nil, gtserror.NewErrorInternalError(err)
 	}
 

--- a/internal/util/paging.go
+++ b/internal/util/paging.go
@@ -48,11 +48,6 @@ type PageableResponseParams struct {
 // a bunch of pageable items (notifications, statuses, etc), as well
 // as a Link header to inform callers of where to find next/prev items.
 func PackagePageableResponse(params PageableResponseParams) (*apimodel.PageableResponse, gtserror.WithCode) {
-	if len(params.Items) == 0 {
-		// No items to page through.
-		return EmptyPageableResponse(), nil
-	}
-
 	// Set default paging values, if
 	// they weren't set by the caller.
 	if params.NextMaxIDKey == "" {

--- a/internal/util/paging_test.go
+++ b/internal/util/paging_test.go
@@ -129,9 +129,9 @@ func (suite *PagingSuite) TestPagingNoItems() {
 	}
 
 	suite.Empty(resp.Items)
-	suite.Empty(resp.LinkHeader)
-	suite.Empty(resp.NextLink)
-	suite.Empty(resp.PrevLink)
+	suite.NotEmpty(resp.LinkHeader)
+	suite.NotEmpty(resp.NextLink)
+	suite.NotEmpty(resp.PrevLink)
 }
 
 func TestPagingSuite(t *testing.T) {

--- a/internal/util/paging_test.go
+++ b/internal/util/paging_test.go
@@ -118,6 +118,7 @@ func (suite *PagingSuite) TestPagingNoItems() {
 	config.SetHost("example.org")
 
 	params := util.PageableResponseParams{
+		Path:           "/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses",
 		NextMaxIDValue: "01H11KA1DM2VH3747YDE7FV5HN",
 		PrevMinIDValue: "01H11KBBVRRDYYC5KEPME1NP5R",
 		Limit:          10,
@@ -129,9 +130,9 @@ func (suite *PagingSuite) TestPagingNoItems() {
 	}
 
 	suite.Empty(resp.Items)
-	suite.NotEmpty(resp.LinkHeader)
-	suite.NotEmpty(resp.NextLink)
-	suite.NotEmpty(resp.PrevLink)
+	suite.Equal(`<https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?limit=10&max_id=01H11KA1DM2VH3747YDE7FV5HN>; rel="next", <https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?limit=10&min_id=01H11KBBVRRDYYC5KEPME1NP5R>; rel="prev"`, resp.LinkHeader)
+	suite.Equal(`https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?limit=10&max_id=01H11KA1DM2VH3747YDE7FV5HN`, resp.NextLink)
+	suite.Equal(`https://example.org/api/v1/accounts/01H11KA68PM4NNYJEG0FJQ90R3/statuses?limit=10&min_id=01H11KBBVRRDYYC5KEPME1NP5R`, resp.PrevLink)
 }
 
 func TestPagingSuite(t *testing.T) {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request fixes a bug where paging would stop when all items in a timeline response ended up being filtered out for various reasons (visibility, blocks, etc).

Basically, we were deriving paging headers properly, but then ignoring them in the PackagePageableResponse function when empty items were passed in.

As a fun little bonus, this PR also fixes paging for the public/local timeline to use minID properly. I don't think this was causing any real issues yet, but you never know.

All of the above is more or less just a quick fix 'for now' until we convert everything to the new paging code; but since that process might take a while, it's a worthy fix to do now imo.

closes https://github.com/superseriousbusiness/gotosocial/issues/2213

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
