### PR TITLE
[docs]  statuses-query-pinned  #2250

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -3305,7 +3305,7 @@ paths:
                 - default: false
                   description: Show only pinned statuses. In other words, exclude statuses that are not pinned to the given account ID.
                   in: query
-                  name: pinned_only
+                  name: pinned
                   type: boolean
                 - default: false
                   description: Show only statuses with media attachments.

--- a/internal/api/client/accounts/statuses.go
+++ b/internal/api/client/accounts/statuses.go
@@ -86,7 +86,7 @@ import (
 //		in: query
 //		required: false
 //	-
-//		name: pinned_only
+//		name: pinned
 //		type: boolean
 //		description: Show only pinned statuses. In other words, exclude statuses that are not pinned to the given account ID.
 //		default: false


### PR DESCRIPTION
# Description

API Docs error: /api/v1/accounts/{id}/statuses

Query PinnedKey
Mastodon API Docs: pinned
GoToSocial API: pinned
GoToSocial API Docs: pinned_only

This pull request implements xyz or fixes abc.

closes #2250 

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
