### PR TITLE
[feature] Show all follow's replies in home timeline. Resolves #2254

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -204,6 +204,10 @@ definitions:
                 description: Account has enabled RSS feed.
                 type: boolean
                 x-go-name: EnableRSS
+            show_all_replies:
+                description: Account has enabled Show All Replies
+                type: boolean
+                x-go-name: ShowAllReplies
             fields:
                 description: Additional metadata attached to this account's profile.
                 items:
@@ -3627,6 +3631,10 @@ paths:
                 - description: Enable RSS feed for this account's Public posts at `/[username]/feed.rss`
                   in: formData
                   name: enable_rss
+                  type: boolean
+                - description: Enable showing all follow's replies in home timeline
+                  in: formData
+                  name: show_all_replies
                   type: boolean
                 - description: Profile fields to be added to this account's profile
                   in: formData

--- a/docs/user_guide/settings.md
+++ b/docs/user_guide/settings.md
@@ -105,6 +105,16 @@ Turning on the discoverable flag may take a week or more to propagate; your acco
 !!! info
     The discoverable setting is about **discoverability of your account**, not searchability of your posts. It has nothing to do with indexing of your posts for search by Mastodon instances, or other federated instances that use full text search!
 
+### Timelines
+
+#### Show All Replies
+
+Some replies that accounts you follow are ignored by default. This is when this reply is not directly to you, or does not mention other people you follow.  
+However, if you wish to make these replies visible, you can do so by enabling this option.  
+
+!!! info
+    Enabling this option will increase the amount of status visible in your home timeline
+
 ### Advanced
 
 #### Custom CSS

--- a/internal/api/client/accounts/accountupdate.go
+++ b/internal/api/client/accounts/accountupdate.go
@@ -261,7 +261,7 @@ func parseUpdateAccountForm(c *gin.Context) (*apimodel.UpdateCredentialsRequest,
 			form.FieldsAttributes == nil &&
 			form.CustomCSS == nil &&
 			form.EnableRSS == nil &&
-            form.ShowAllReplies == nil) {
+			form.ShowAllReplies == nil) {
 		return nil, errors.New("empty form submitted")
 	}
 

--- a/internal/api/client/accounts/accountupdate.go
+++ b/internal/api/client/accounts/accountupdate.go
@@ -120,6 +120,11 @@ import (
 //		description: Enable RSS feed for this account's Public posts at `/[username]/feed.rss`
 //		type: boolean
 //	-
+//		name: show_all_replies
+//		in: formData
+//		description: Enable showing of all follow's replies in home timeline
+//		type: boolean
+//	-
 //		name: fields_attributes
 //		in: formData
 //		description: Profile fields to be added to this account's profile
@@ -255,7 +260,8 @@ func parseUpdateAccountForm(c *gin.Context) (*apimodel.UpdateCredentialsRequest,
 			form.Source.StatusContentType == nil &&
 			form.FieldsAttributes == nil &&
 			form.CustomCSS == nil &&
-			form.EnableRSS == nil) {
+			form.EnableRSS == nil &&
+            form.ShowAllReplies == nil) {
 		return nil, errors.New("empty form submitted")
 	}
 

--- a/internal/api/model/account.go
+++ b/internal/api/model/account.go
@@ -93,6 +93,8 @@ type Account struct {
 	CustomCSS string `json:"custom_css,omitempty"`
 	// Account has enabled RSS feed.
 	EnableRSS bool `json:"enable_rss,omitempty"`
+    // Account has enabled Show All Replies
+	ShowAllReplies bool `json:"show_all_replies,omitempty"`
 	// Role of the account on this instance.
 	// Omitted for remote accounts.
 	Role *AccountRole `json:"role,omitempty"`
@@ -163,6 +165,8 @@ type UpdateCredentialsRequest struct {
 	CustomCSS *string `form:"custom_css" json:"custom_css"`
 	// Enable RSS feed of public toots for this account at /@[username]/feed.rss
 	EnableRSS *bool `form:"enable_rss" json:"enable_rss"`
+    // Enable showing all follow's replies in home timeline
+    ShowAllReplies *bool `form:"show_all_replies" json:"show_all_replies"`
 }
 
 // UpdateSource is to be used specifically in an UpdateCredentialsRequest.

--- a/internal/api/model/account.go
+++ b/internal/api/model/account.go
@@ -93,7 +93,7 @@ type Account struct {
 	CustomCSS string `json:"custom_css,omitempty"`
 	// Account has enabled RSS feed.
 	EnableRSS bool `json:"enable_rss,omitempty"`
-    // Account has enabled Show All Replies
+	// Account has enabled Show All Replies
 	ShowAllReplies bool `json:"show_all_replies,omitempty"`
 	// Role of the account on this instance.
 	// Omitted for remote accounts.
@@ -165,8 +165,8 @@ type UpdateCredentialsRequest struct {
 	CustomCSS *string `form:"custom_css" json:"custom_css"`
 	// Enable RSS feed of public toots for this account at /@[username]/feed.rss
 	EnableRSS *bool `form:"enable_rss" json:"enable_rss"`
-    // Enable showing all follow's replies in home timeline
-    ShowAllReplies *bool `form:"show_all_replies" json:"show_all_replies"`
+	// Enable showing all follow's replies in home timeline
+	ShowAllReplies *bool `form:"show_all_replies" json:"show_all_replies"`
 }
 
 // UpdateSource is to be used specifically in an UpdateCredentialsRequest.

--- a/internal/cache/size.go
+++ b/internal/cache/size.go
@@ -236,6 +236,7 @@ func sizeofAccount() uintptr {
 		HideCollections:         func() *bool { ok := true; return &ok }(),
 		SuspensionOrigin:        exampleID,
 		EnableRSS:               func() *bool { ok := true; return &ok }(),
+		ShowAllReplies:          func() *bool { ok := false; return &ok }(),
 	}))
 }
 

--- a/internal/db/bundb/migrations/20231011163329_add_show_all_replies_functionality.go
+++ b/internal/db/bundb/migrations/20231011163329_add_show_all_replies_functionality.go
@@ -1,0 +1,45 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+	"strings"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		_, err := db.ExecContext(ctx, "ALTER TABLE ? ADD COLUMN ? BOOLEAN DEFAULT false", bun.Ident("accounts"), bun.Ident("show_all_replies"))
+		if err != nil && !(strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "duplicate column name") || strings.Contains(err.Error(), "SQLSTATE 42701")) {
+			return err
+		}
+		return nil
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}

--- a/internal/gtsmodel/account.go
+++ b/internal/gtsmodel/account.go
@@ -82,6 +82,7 @@ type Account struct {
 	HideCollections         *bool            `bun:",default:false"`                 // Hide this account's collections
 	SuspensionOrigin        string           `bun:"type:CHAR(26),nullzero"`         // id of the database entry that caused this account to become suspended -- can be an account ID or a domain block ID
 	EnableRSS               *bool            `bun:",default:false"`                 // enable RSS feed subscription for this account's public posts at [URL]/feed
+	ShowAllReplies          *bool            `bun:",default:false"`                 // enable showing all replies in the home timeline (i.e. a reply from a followed account to an unfollowed account ( Issue #2254 )
 }
 
 // IsLocal returns whether account is a local user account.

--- a/internal/processing/account/delete.go
+++ b/internal/processing/account/delete.go
@@ -466,6 +466,7 @@ func stubbifyAccount(account *gtsmodel.Account, origin string) []string {
 	account.SuspensionOrigin = origin
 	account.HideCollections = util.Ptr(true)
 	account.EnableRSS = util.Ptr(false)
+	account.ShowAllReplies = util.Ptr(false)
 
 	return []string{
 		"fetched_at",
@@ -489,6 +490,7 @@ func stubbifyAccount(account *gtsmodel.Account, origin string) []string {
 		"suspension_origin",
 		"hide_collections",
 		"enable_rss",
+        "show_all_replies",
 	}
 }
 

--- a/internal/processing/account/delete.go
+++ b/internal/processing/account/delete.go
@@ -490,7 +490,7 @@ func stubbifyAccount(account *gtsmodel.Account, origin string) []string {
 		"suspension_origin",
 		"hide_collections",
 		"enable_rss",
-        "show_all_replies",
+		"show_all_replies",
 	}
 }
 

--- a/internal/processing/account/update.go
+++ b/internal/processing/account/update.go
@@ -262,6 +262,10 @@ func (p *Processor) Update(ctx context.Context, account *gtsmodel.Account, form 
 		account.EnableRSS = form.EnableRSS
 	}
 
+	if form.ShowAllReplies != nil {
+		account.ShowAllReplies = form.ShowAllReplies
+	}
+
 	err := p.state.DB.UpdateAccount(ctx, account)
 	if err != nil {
 		return nil, gtserror.NewErrorInternalError(fmt.Errorf("could not update account %s: %s", account.ID, err))

--- a/internal/typeutils/astointernal.go
+++ b/internal/typeutils/astointernal.go
@@ -147,6 +147,10 @@ func (c *Converter) ASRepresentationToAccount(ctx context.Context, accountable a
 	enableRSS := false
 	acct.EnableRSS = &enableRSS
 
+    // assume they don't want all replies shown on the home timeline
+    showAllReplies := false
+    acct.ShowAllReplies = &showAllReplies
+
 	// url property
 	url, err := ap.ExtractURL(accountable)
 	if err == nil {

--- a/internal/typeutils/astointernal.go
+++ b/internal/typeutils/astointernal.go
@@ -147,9 +147,9 @@ func (c *Converter) ASRepresentationToAccount(ctx context.Context, accountable a
 	enableRSS := false
 	acct.EnableRSS = &enableRSS
 
-    // assume they don't want all replies shown on the home timeline
-    showAllReplies := false
-    acct.ShowAllReplies = &showAllReplies
+	// assume they don't want all replies shown on the home timeline
+	showAllReplies := false
+	acct.ShowAllReplies = &showAllReplies
 
 	// url property
 	url, err := ap.ExtractURL(accountable)

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -233,7 +233,7 @@ func (c *Converter) AccountToAPIAccountPublic(ctx context.Context, a *gtsmodel.A
 		Suspended:      !a.SuspendedAt.IsZero(),
 		CustomCSS:      a.CustomCSS,
 		EnableRSS:      *a.EnableRSS,
-        ShowAllReplies: *a.ShowAllReplies,
+		ShowAllReplies: *a.ShowAllReplies,
 		Role:           role,
 	}
 

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -233,6 +233,7 @@ func (c *Converter) AccountToAPIAccountPublic(ctx context.Context, a *gtsmodel.A
 		Suspended:      !a.SuspendedAt.IsZero(),
 		CustomCSS:      a.CustomCSS,
 		EnableRSS:      *a.EnableRSS,
+        ShowAllReplies: *a.ShowAllReplies,
 		Role:           role,
 	}
 

--- a/internal/visibility/home_timeline.go
+++ b/internal/visibility/home_timeline.go
@@ -162,8 +162,8 @@ func (f *Filter) isStatusHomeTimelineable(ctx context.Context, owner *gtsmodel.A
 	}
 
 	if next != status && !oneAuthor && !included && !converstn {
-        paulscool := true
-        if paulscool {
+        // An account may wish to see replies from their follow's even if they're not part of it
+        if *owner.ShowAllReplies {
             return true, nil
         }
 		log.Trace(ctx, "ignoring visible reply in conversation irrelevant to owner")

--- a/internal/visibility/home_timeline.go
+++ b/internal/visibility/home_timeline.go
@@ -161,11 +161,7 @@ func (f *Filter) isStatusHomeTimelineable(ctx context.Context, owner *gtsmodel.A
 		}
 	}
 
-	if next != status && !oneAuthor && !included && !converstn {
-        // An account may wish to see replies from their follow's even if they're not part of it
-        if *owner.ShowAllReplies {
-            return true, nil
-        }
+	if next != status && !oneAuthor && !included && !converstn && !*owner.ShowAllReplies {
 		log.Trace(ctx, "ignoring visible reply in conversation irrelevant to owner")
 		return false, nil
 	}

--- a/internal/visibility/home_timeline.go
+++ b/internal/visibility/home_timeline.go
@@ -162,6 +162,10 @@ func (f *Filter) isStatusHomeTimelineable(ctx context.Context, owner *gtsmodel.A
 	}
 
 	if next != status && !oneAuthor && !included && !converstn {
+        paulscool := true
+        if paulscool {
+            return true, nil
+        }
 		log.Trace(ctx, "ignoring visible reply in conversation irrelevant to owner")
 		return false, nil
 	}

--- a/internal/visibility/public_timeline.go
+++ b/internal/visibility/public_timeline.go
@@ -112,7 +112,7 @@ func (f *Filter) isStatusPublicTimelineable(ctx context.Context, requester *gtsm
 			// This is not a single author reply-chain-thread,
 			// instead is an actualy conversation. Don't timeline.
 			log.Trace(ctx, "ignoring multi-author reply-chain")
-			return false, nil
+            return false, nil
 		}
 	}
 

--- a/internal/visibility/public_timeline.go
+++ b/internal/visibility/public_timeline.go
@@ -112,7 +112,7 @@ func (f *Filter) isStatusPublicTimelineable(ctx context.Context, requester *gtsm
 			// This is not a single author reply-chain-thread,
 			// instead is an actualy conversation. Don't timeline.
 			log.Trace(ctx, "ignoring multi-author reply-chain")
-            return false, nil
+			return false, nil
 		}
 	}
 

--- a/testrig/testmodels.go
+++ b/testrig/testmodels.go
@@ -326,6 +326,7 @@ func NewTestAccounts() map[string]*gtsmodel.Account {
 			HideCollections:         util.Ptr(false),
 			SuspensionOrigin:        "",
 			EnableRSS:               util.Ptr(false),
+			ShowAllReplies:          util.Ptr(false),
 		},
 		"unconfirmed_account": {
 			ID:                      "01F8MH0BBE4FHXPH513MBVFHB0",
@@ -365,6 +366,7 @@ func NewTestAccounts() map[string]*gtsmodel.Account {
 			HideCollections:         util.Ptr(false),
 			SuspensionOrigin:        "",
 			EnableRSS:               util.Ptr(false),
+			ShowAllReplies:          util.Ptr(false),
 		},
 		"admin_account": {
 			ID:                      "01F8MH17FWEB39HZJ76B6VXSKF",
@@ -405,6 +407,7 @@ func NewTestAccounts() map[string]*gtsmodel.Account {
 			HideCollections:         util.Ptr(false),
 			SuspensionOrigin:        "",
 			EnableRSS:               util.Ptr(true),
+			ShowAllReplies:          util.Ptr(false),
 		},
 		"local_account_1": {
 			ID:                      "01F8MH1H7YV1Z7D2C8K2730QBF",
@@ -445,6 +448,7 @@ func NewTestAccounts() map[string]*gtsmodel.Account {
 			HideCollections:         util.Ptr(false),
 			SuspensionOrigin:        "",
 			EnableRSS:               util.Ptr(true),
+			ShowAllReplies:          util.Ptr(false),
 		},
 		"local_account_2": {
 			ID:                      "01F8MH5NBDF2MV7CTC4Q5128HF",
@@ -504,6 +508,7 @@ func NewTestAccounts() map[string]*gtsmodel.Account {
 			HideCollections:       util.Ptr(false),
 			SuspensionOrigin:      "",
 			EnableRSS:             util.Ptr(false),
+			ShowAllReplies:        util.Ptr(false),
 		},
 		"remote_account_1": {
 			ID:                    "01F8MH5ZK5VRH73AKHQM6Y9VNX",
@@ -541,6 +546,7 @@ func NewTestAccounts() map[string]*gtsmodel.Account {
 			HideCollections:       util.Ptr(false),
 			SuspensionOrigin:      "",
 			EnableRSS:             util.Ptr(false),
+			ShowAllReplies:        util.Ptr(false),
 		},
 		"remote_account_2": {
 			ID:                    "01FHMQX3GAABWSM0S2VZEC2SWC",
@@ -616,6 +622,7 @@ func NewTestAccounts() map[string]*gtsmodel.Account {
 			SuspensionOrigin:        "",
 			HeaderMediaAttachmentID: "01PFPMWK2FF0D9WMHEJHR07C3R",
 			EnableRSS:               util.Ptr(false),
+			ShowAllReplies:          util.Ptr(false),
 		},
 		"remote_account_4": {
 			ID:                      "07GZRBAEMBNKGZ8Z9VSKSXKR98",
@@ -653,6 +660,7 @@ func NewTestAccounts() map[string]*gtsmodel.Account {
 			SuspensionOrigin:        "",
 			HeaderMediaAttachmentID: "",
 			EnableRSS:               util.Ptr(false),
+			ShowAllReplies:          util.Ptr(false),
 		},
 	}
 

--- a/web/source/settings/user/profile.js
+++ b/web/source/settings/user/profile.js
@@ -186,7 +186,7 @@ function UserProfileForm({ data: profile }) {
 					rel="noreferrer"
 				>
 					Learn more about these settings (opens in a new tab)
-                </a>
+				</a>
 			</div>
 			<Checkbox
 				field={form.showAllReplies}

--- a/web/source/settings/user/profile.js
+++ b/web/source/settings/user/profile.js
@@ -61,6 +61,7 @@ function UserProfileForm({ data: profile }) {
 		- file avatar
 		- file header
 		- bool enable_rss
+		- bool show_all_replies
 		- string custom_css (if enabled)
 	*/
 
@@ -82,6 +83,7 @@ function UserProfileForm({ data: profile }) {
 		locked: useBoolInput("locked", { source: profile }),
 		discoverable: useBoolInput("discoverable", { source: profile}),
 		enableRSS: useBoolInput("enable_rss", { source: profile }),
+		showAllReplies: useBoolInput("show_all_replies", { source: profile }),
 		fields: useFieldArrayInput("fields_attributes", {
 			defaultValue: profile?.source?.fields,
 			length: instanceConfig.maxPinnedFields
@@ -173,6 +175,14 @@ function UserProfileForm({ data: profile }) {
 			<Checkbox
 				field={form.enableRSS}
 				label="Enable RSS feed of Public posts"
+			/>
+
+			<div className="form-section-docs">
+				<h3>Timelines</h3>
+			</div>
+			<Checkbox
+				field={form.showAllReplies}
+				label="Enable showing all follow's replies in home timeline"
 			/>
 
 			<div className="form-section-docs">

--- a/web/source/settings/user/profile.js
+++ b/web/source/settings/user/profile.js
@@ -179,6 +179,14 @@ function UserProfileForm({ data: profile }) {
 
 			<div className="form-section-docs">
 				<h3>Timelines</h3>
+				<a
+					href="https://docs.gotosocial.org/en/latest/user_guide/settings/#timelines"
+					target="_blank"
+					className="docslink"
+					rel="noreferrer"
+				>
+					Learn more about these settings (opens in a new tab)
+                </a>
 			</div>
 			<Checkbox
 				field={form.showAllReplies}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request implements an account configurable option to show all follow's replies in their home timeline.
GoToSocial by default does not show replies made by someone the account follow's if that reply does not relate to the account i.e. it's a direct reply to an unfollowed account, or does not contain mentioned of anyone else the account follows.
This is a perfectly reasonable default, however, it does limit how someone can organically "explore" the fediverse by seeing what people they follow are replying to. 
I have added a setting available in /settings/user/profile where someone can enable the visibility of these replies in their home timeline if they want them.
This option is then checked in `/internal/visibility/home_timeline.go` when checking the visibility of a status and skips the block that ignores the conversation "irrelevant to owner"

closes #2254 


## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
