### PR TITLE
[bugfix/frontend] Fix 'steal this look' emoji promise mapping

### DIFF
--- a/web/source/settings/lib/query/admin/custom-emoji/index.ts
+++ b/web/source/settings/lib/query/admin/custom-emoji/index.ts
@@ -170,28 +170,30 @@ const extended = gtsApi.injectEndpoints({
 				// Search for each listed emoji with the admin
 				// api to get the version that includes an ID.
 				const errors: FetchBaseQueryError[] = [];
-				const withIDs: CustomEmoji[] = (await Promise.all(
-					withoutIDs.map(async(emoji) => {
-						// Request admin view of this emoji.
-						const emojiRes = await fetchWithBQ({
-							url: `/api/v1/admin/custom_emojis`,
-							params: {
-								filter: `domain:${domain},shortcode:${emoji.shortcode}`,
-								limit: 1
-							}
-						});
-
-						if (emojiRes.error) {
-							// Put error in separate array so
-							// the null can be filtered nicely.
-							errors.push(emojiRes.error);
-							return null;
-						}
+				const withIDs: CustomEmoji[] = (
+					await Promise.all(
+						withoutIDs.map(async(emoji) => {
+							// Request admin view of this emoji.
+							const emojiRes = await fetchWithBQ({
+								url: `/api/v1/admin/custom_emojis`,
+								params: {
+									filter: `domain:${domain},shortcode:${emoji.shortcode}`,
+									limit: 1
+								}
+							});
 						
-						// Got it!
-						return emojiRes.data as CustomEmoji;
-					})
-				)).flatMap((emoji) => {
+							if (emojiRes.error) {
+								// Put error in separate array so
+								// the null can be filtered nicely.
+								errors.push(emojiRes.error);
+								return null;
+							}
+							
+							// Got it!
+							return emojiRes.data as CustomEmoji;
+						})
+					)
+				).flatMap((emoji) => {
 					// Remove any nulls.
 					return emoji || [];
 				});


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Error `TypeError: can't define array index property past the end of an array with non-writable length` was popping up in the console when using 'steal this look'.

Turns out I broke it.

So now I fixed it!

Explanation: we were returning an array which was being used in a react component *and then modified while the component was using it*, which is a big react no-no.

Fixed this by awaiting properly in the mutation function, so the returned array doesn't get modified again.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
