### PR TITLE
[bugfix] Add missing "local" param in public timeline link headers

### DIFF
--- a/internal/processing/timeline/public.go
+++ b/internal/processing/timeline/public.go
@@ -20,6 +20,7 @@ package timeline
 import (
 	"context"
 	"errors"
+	"strconv"
 
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
@@ -76,5 +77,8 @@ func (p *Processor) PublicTimelineGet(ctx context.Context, authed *oauth.Auth, m
 		NextMaxIDValue: nextMaxIDValue,
 		PrevMinIDValue: prevMinIDValue,
 		Limit:          limit,
+		ExtraQueryParams: []string{
+			"local=" + strconv.FormatBool(local),
+		},
 	})
 }


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Add accidentally-removed "local" param back to public timeline link header.

closes https://github.com/superseriousbusiness/gotosocial/issues/2253

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
