### PR TITLE
[bugfix/frontend] Add `nosubmit` option to form fields; use it when instance custom CSS disabled

### DIFF
--- a/web/source/settings/lib/form/get-form-mutations.ts
+++ b/web/source/settings/lib/form/get-form-mutations.ts
@@ -27,6 +27,12 @@ export default function getFormMutations(
 	const mutationData: Array<[string, any]> = [];
 	
 	Object.values(form).forEach((field) => {
+		if (field.nosubmit) {
+			// Completely ignore
+			// this field.
+			return;
+		}
+		
 		if ("selectedValues" in field) {
 			// FieldArrayInputHook.
 			const selected = field.selectedValues();

--- a/web/source/settings/lib/form/submit.ts
+++ b/web/source/settings/lib/form/submit.ts
@@ -87,10 +87,10 @@ export default function useFormSubmit(
 			if (e.nativeEvent.submitter) {
 				// We want the name of the element that was invoked to submit this form,
 				// which will be something that extends HTMLElement, though we don't know
-				// what at this point.
+				// what at this point. If it's an empty string, fall back to undefined.
 				// 
 				// See: https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent/submitter
-				action = (e.nativeEvent.submitter as Object as { name: string }).name;
+				action = (e.nativeEvent.submitter as Object as { name: string }).name || undefined;
 			} else {
 				// No submitter defined. Fall back
 				// to just use the FormSubmitEvent.

--- a/web/source/settings/lib/form/text.tsx
+++ b/web/source/settings/lib/form/text.tsx
@@ -39,7 +39,8 @@ export default function useTextInput(
 		dontReset = false,
 		validator,
 		showValidation = true,
-		initValidation
+		initValidation,
+		nosubmit = false,
 	}: HookOpts<string>
 ): TextFormInputHook {
 	const [text, setText] = useState(initialValue);
@@ -91,6 +92,7 @@ export default function useTextInput(
 		reset,
 		name,
 		Name: "", // Will be set by inputHook function.
+		nosubmit,
 		value: text,
 		ref: textRef,
 		setter: setText,

--- a/web/source/settings/lib/form/types.ts
+++ b/web/source/settings/lib/form/types.ts
@@ -39,6 +39,13 @@ export interface HookOpts<T = any> {
 	initialValue?: T,
 	defaultValue?: T,
 	
+	/**
+	 * If true, don't submit this field as
+	 * part of a mutation query's body.
+	 * 
+	 * Useful for 'internal' form fields.
+	 */
+	nosubmit?: boolean,
 	dontReset?: boolean,
 	validator?,
 	showValidation?: boolean,
@@ -88,6 +95,14 @@ export interface FormInputHook<T = any> {
 	 * to have been changed from the default / initial value.
 	 */
 	hasChanged: () => boolean;
+
+	/**
+	 * If true, don't submit this field as
+	 * part of a mutation query's body.
+	 * 
+	 * Useful for 'internal' form fields.
+	 */
+	nosubmit?: boolean;
 }
 
 interface _withReset {

--- a/web/source/settings/lib/query/query-modifiers.ts
+++ b/web/source/settings/lib/query/query-modifiers.ts
@@ -90,7 +90,7 @@ function makeCacheMutation(action: Action): CacheMutation {
 					);
 				} catch (e) {
 					// eslint-disable-next-line no-console
-					console.error(`rolling back pessimistic update of ${queryName}: ${e}`);
+					console.error(`rolling back pessimistic update of ${queryName}: ${JSON.stringify(e)}`);
 				}
 			}
 		};

--- a/web/source/settings/user/profile.js
+++ b/web/source/settings/user/profile.js
@@ -79,7 +79,7 @@ function UserProfileForm({ data: profile }) {
 		header: useFileInput("header", { withPreview: true }),
 		displayName: useTextInput("display_name", { source: profile }),
 		note: useTextInput("note", { source: profile, valueSelector: (p) => p.source?.note }),
-		customCSS: useTextInput("custom_css", { source: profile }),
+		customCSS: useTextInput("custom_css", { source: profile, nosubmit: !instanceConfig.allowCustomCSS }),
 		bot: useBoolInput("bot", { source: profile }),
 		locked: useBoolInput("locked", { source: profile }),
 		discoverable: useBoolInput("discoverable", { source: profile}),
@@ -190,7 +190,7 @@ function UserProfileForm({ data: profile }) {
 			</div>
 			<TextArea
 				field={form.customCSS}
-				label="Custom CSS"
+				label={`Custom CSS` + (!instanceConfig.allowCustomCSS ? ` (not enabled on this instance)` : ``)}
 				className="monospace"
 				rows={8}
 				disabled={!instanceConfig.allowCustomCSS}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

When custom CSS is not enabled on an instance, submitting any custom CSS update (even if it's just an empty string) returns a 400 error since custom CSS is not allowed.

Previously, we were getting around this by just not generating a form field at all for custom CSS when it was disabled on the instance. When I refactored some of the frontend stuff, I made it so the form field was shown, but was not enabled and couldn't be updated by users. This causes empty `custom_css` to be sent along to the instance when doing profile updates, meaning the update always fails.

To get around this, this PR adds a new `nosubmit` option to form hooks. If set to `true`, then the hook fields become 'internal' and won't be submitted as part of mutation data. This means they can still be shown, but become essentially "read only".

With this change, it's possible to update profiles on instances that don't have custom CSS enabled, again.

Change also fixes a couple very small bugs that cropped up while I was looking for the issue.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
