### PR TITLE
[bugfix] Extract description as `summary` first, fall back to `name`

### DIFF
--- a/internal/ap/extract.go
+++ b/internal/ap/extract.go
@@ -600,10 +600,21 @@ func ExtractAttachment(i Attachmentable) (*gtsmodel.MediaAttachment, error) {
 
 	return &gtsmodel.MediaAttachment{
 		RemoteURL:   remoteURL.String(),
-		Description: ExtractName(i),
+		Description: ExtractDescription(i),
 		Blurhash:    ExtractBlurhash(i),
 		Processing:  gtsmodel.ProcessingStatusReceived,
 	}, nil
+}
+
+// ExtractDescription extracts the image description
+// of an attachmentable, if present. Will try the
+// 'summary' prop first, then fall back to 'name'.
+func ExtractDescription(i Attachmentable) string {
+	if summary := ExtractSummary(i); summary != "" {
+		return summary
+	}
+
+	return ExtractName(i)
 }
 
 // ExtractBlurhash extracts the blurhash string value

--- a/internal/ap/interfaces.go
+++ b/internal/ap/interfaces.go
@@ -164,6 +164,7 @@ type Attachmentable interface {
 	WithMediaType
 	WithURL
 	WithName
+	WithSummary
 	WithBlurhash
 }
 


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Honk provides both `name` and `summary` in their attachments. Unlike many other AP implementations, they actually use these correctly, so "name" is the name of the file, and "summary" is the image description. Previously, we were only checking the "name" field to parse image description, since this is what most other implementations use. This PR fixes this to check "summary" first and fall back to "name".

Closes https://github.com/superseriousbusiness/gotosocial/issues/2302

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
