### PR TITLE
[bugfix] Don't try to update suspended accounts

### DIFF
--- a/internal/federation/dereferencing/account.go
+++ b/internal/federation/dereferencing/account.go
@@ -42,6 +42,11 @@ import (
 // accountUpToDate returns whether the given account model is both updateable (i.e.
 // non-instance remote account) and whether it needs an update based on `fetched_at`.
 func accountUpToDate(account *gtsmodel.Account) bool {
+	if !account.SuspendedAt.IsZero() {
+		// Can't update suspended accounts.
+		return true
+	}
+
 	if account.IsLocal() {
 		// Can't update local accounts.
 		return true
@@ -331,6 +336,11 @@ func (d *Dereferencer) enrichAccountSafely(
 	account *gtsmodel.Account,
 	apubAcc ap.Accountable,
 ) (*gtsmodel.Account, ap.Accountable, error) {
+	// Noop if account has been suspended.
+	if !account.SuspendedAt.IsZero() {
+		return account, nil, nil
+	}
+
 	// By default use account.URI
 	// as the per-URI deref lock.
 	uriStr := account.URI

--- a/internal/federation/federatingprotocol.go
+++ b/internal/federation/federatingprotocol.go
@@ -288,6 +288,13 @@ func (f *Federator) AuthenticatePostInbox(ctx context.Context, w http.ResponseWr
 		return nil, false, err
 	}
 
+	if !requestingAccount.SuspendedAt.IsZero() {
+		// Account was marked as suspended by a
+		// local admin action. Stop request early.
+		w.WriteHeader(http.StatusForbidden)
+		return ctx, false, nil
+	}
+
 	// We have everything we need now, set the requesting
 	// and receiving accounts on the context for later use.
 	ctx = gtscontext.SetRequestingAccount(ctx, requestingAccount)


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request fixes a bug where accounts that were suspended via the admin panel could become marked as unsuspended again on refresh of the account.

Bug only affected specifically-targeted accounts, not accounts that were blocked by a domain block action. All the account's relationships and posts and media and stuff were still deleted just fine by the side effects.

For good measure, add some early checks to bail fedi requests if a remote account was marked as suspended locally.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
