### PR TITLE
[bugfix] Update poll delete/update db queries

### DIFF
--- a/internal/db/bundb/migrations/20231110142330_small_poll_table_tweaks.go
+++ b/internal/db/bundb/migrations/20231110142330_small_poll_table_tweaks.go
@@ -44,7 +44,7 @@ func init() {
 				Table("polls").
 				Column("expires_at_new").
 				Set("? = ?", bun.Ident("expires_at_new"), bun.Ident("expires_at")).
-				Where("1"). // bun gets angry performing update over all rows
+				Where("TRUE"). // bun gets angry performing update over all rows
 				Exec(ctx); err != nil {
 				return err
 			}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates our db queries a little bit for polls:

- Don't bother checking for db.ErrNoEntries on delete, since this is never returned; use RowsAffected instead. You can never recover from an error inside a transaction, so checking for an ErrNoEntries and continuing would cause the next query to fail anyways.
- Fix choices slice return -- you can't do LIMIT on a Delete using bun, so bun doesn't know that only one row will be deleted, so you have to select into a slice of slices.
- Select fewer columns where possible (v. small performance tweak).

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
