### PR TITLE
[chore/security] refactor AuthenticateFederatedRequest() to handle account deref + suspension checks

### DIFF
--- a/internal/federation/authenticate.go
+++ b/internal/federation/authenticate.go
@@ -95,12 +95,12 @@ type PubKeyAuth struct {
 // know that this is the user making the dereferencing request, and they can decide
 // to allow or deny the request depending on their settings.
 //
+// This function will handle dereferencing and storage of any new remote accounts
+// and / or instances. The returned PubKeyAuth{}.Owner account will ONLY ever be
+// nil in the case that there is an ongoing handshake involving this account.
+//
 // Note that it is also valid to pass in an empty string here, in which case the
 // keys of the instance account will be used.
-//
-// Also note that this function *does not* dereference the remote account that
-// the signature key is associated with. Other functions should use the returned
-// URL to dereference the remote account, if required.
 func (f *Federator) AuthenticateFederatedRequest(ctx context.Context, requestedUsername string) (*PubKeyAuth, gtserror.WithCode) {
 	// Thanks to the signature check middleware,
 	// we should already have an http signature

--- a/internal/federation/dereferencing/handshake.go
+++ b/internal/federation/dereferencing/handshake.go
@@ -38,8 +38,11 @@ func (d *Dereferencer) Handshaking(username string, remoteAccountID *url.URL) bo
 		return false
 	}
 
+	// Calculate remote account ID str once.
+	remoteIDStr := remoteAccountID.String()
+
 	for _, id := range remoteIDs {
-		if id.String() == remoteAccountID.String() {
+		if id.String() == remoteIDStr {
 			// We are currently handshaking
 			// with the remote account.
 			return true

--- a/internal/federation/federatingprotocol.go
+++ b/internal/federation/federatingprotocol.go
@@ -236,7 +236,7 @@ func (f *Federator) AuthenticatePostInbox(ctx context.Context, w http.ResponseWr
 		// There is a mutal handshake occurring between us and
 		// the owner URI. Return 202 and leave as we can't do
 		// much else until the handshake procedure has finished.
-		w.WriteHeader(http.StatusTooEarly)
+		w.WriteHeader(http.StatusAccepted)
 		return ctx, false, nil
 	}
 

--- a/internal/processing/admin/domainkeysexpire.go
+++ b/internal/processing/admin/domainkeysexpire.go
@@ -71,9 +71,7 @@ func (p *Processor) domainKeysExpireSideEffects(ctx context.Context, domain stri
 	// the public key and update the account.
 	if err := p.rangeDomainAccounts(ctx, domain, func(account *gtsmodel.Account) {
 		account.PublicKeyExpiresAt = expiresAt
-
-		if err := p.state.DB.UpdateAccount(
-			ctx,
+		if err := p.state.DB.UpdateAccount(ctx,
 			account,
 			"public_key_expires_at",
 		); err != nil {

--- a/internal/processing/fedi/common.go
+++ b/internal/processing/fedi/common.go
@@ -61,7 +61,7 @@ func (p *Processor) authenticate(ctx context.Context, requestedUser string) (
 	requester := pubKeyAuth.Owner
 
 	// Check that block does not exist between receiver and requester.
-	blocked, err := p.state.DB.IsBlocked(ctx, receiver.ID, requester.ID)
+	blocked, err := p.state.DB.IsEitherBlocked(ctx, receiver.ID, requester.ID)
 	if err != nil {
 		err := gtserror.Newf("error checking block: %w", err)
 		return nil, nil, gtserror.NewErrorInternalError(err)

--- a/internal/processing/fedi/status.go
+++ b/internal/processing/fedi/status.go
@@ -35,7 +35,6 @@ import (
 // StatusGet handles the getting of a fedi/activitypub representation of a local status.
 // It performs appropriate authentication before returning a JSON serializable interface.
 func (p *Processor) StatusGet(ctx context.Context, requestedUser string, statusID string) (interface{}, gtserror.WithCode) {
-	// Authenticate using http signature.
 	// Authenticate the incoming request, getting related user accounts.
 	requester, receiver, errWithCode := p.authenticate(ctx, requestedUser)
 	if errWithCode != nil {


### PR DESCRIPTION
# Description

Refactors our very crucial .AuthenticateFederatedRequest() function to handle new instance / account dereferencing, along with suspension checks. This reduces the need for these checks (and possibility of them being missed) in other areas of the codebase.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
