### PR TITLE
[feature] Poll web view

### DIFF
--- a/internal/api/model/poll.go
+++ b/internal/api/model/poll.go
@@ -17,6 +17,8 @@
 
 package model
 
+import "github.com/superseriousbusiness/gotosocial/internal/language"
+
 // Poll represents a poll attached to a status.
 //
 // swagger:model poll
@@ -113,6 +115,9 @@ type WebPollOption struct {
 
 	// Emojis contained on parent poll.
 	Emojis []Emoji
+
+	// LanguageTag of parent status.
+	LanguageTag *language.Language
 
 	// Share of total votes as a percentage.
 	VoteShare float32

--- a/internal/api/model/poll.go
+++ b/internal/api/model/poll.go
@@ -104,3 +104,11 @@ type PollVoteRequest struct {
 	// indices. Can be strings or integers.
 	ChoicesI []interface{} `json:"choices"`
 }
+
+// WebPollOption models a template-ready poll option entry.
+type WebPollOption struct {
+	PollOption
+	Emojis       []Emoji
+	VoteShare    float64
+	VoteShareStr string
+}

--- a/internal/api/model/poll.go
+++ b/internal/api/model/poll.go
@@ -106,9 +106,17 @@ type PollVoteRequest struct {
 }
 
 // WebPollOption models a template-ready poll option entry.
+//
+// swagger:ignore
 type WebPollOption struct {
 	PollOption
-	Emojis       []Emoji
-	VoteShare    float64
+
+	// Emojis contained on parent poll.
+	Emojis []Emoji
+
+	// Share of total votes as a percentage.
+	VoteShare float32
+
+	// String-formatted version of VoteShare.
 	VoteShareStr string
 }

--- a/internal/api/model/status.go
+++ b/internal/api/model/status.go
@@ -105,8 +105,17 @@ type Status struct {
 	// (used only internally for templating etc).
 
 	// Template-ready language tag + string, based
-	// on *status.Language. Nil for non-web statuses
+	// on *status.Language. Nil for non-web statuses.
+	//
+	// swagger:ignore
 	LanguageTag *language.Language `json:"-"`
+
+	// Template-ready poll options with vote shares
+	// calculated as a percentage of total votes.
+	// Nil for non-web statuses.
+	//
+	// swagger:ignore
+	WebPollOptions []WebPollOption `json:"-"`
 }
 
 /*

--- a/internal/router/template.go
+++ b/internal/router/template.go
@@ -168,6 +168,10 @@ func acctInstance(acct string) string {
 	return ""
 }
 
+func increment(i int) int {
+	return i + 1
+}
+
 func LoadTemplateFunctions(engine *gin.Engine) {
 	engine.SetFuncMap(template.FuncMap{
 		"escape":           escape,
@@ -180,5 +184,6 @@ func LoadTemplateFunctions(engine *gin.Engine) {
 		"timestampPrecise": timestampPrecise,
 		"emojify":          emojify,
 		"acctInstance":     acctInstance,
+		"increment":        increment,
 	})
 }

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -683,7 +683,7 @@ func (c *Converter) StatusToWebStatus(
 		// format them for easier template consumption.
 		totalVotes := poll.VotesCount
 
-		webPollCounts := make([]apimodel.WebPollOption, len(poll.Options))
+		webPollOptions := make([]apimodel.WebPollOption, len(poll.Options))
 		for i, option := range poll.Options {
 			var voteShare float32
 			if totalVotes != 0 &&
@@ -707,16 +707,17 @@ func (c *Converter) StatusToWebStatus(
 			voteShareStr := fmt.Sprintf("%.2f", voteShare)
 			voteShareStr = strings.TrimSuffix(voteShareStr, ".00")
 
-			webPollCount := apimodel.WebPollOption{
+			webPollOption := apimodel.WebPollOption{
 				PollOption:   option,
 				Emojis:       webStatus.Emojis,
+				LanguageTag:  webStatus.LanguageTag,
 				VoteShare:    voteShare,
 				VoteShareStr: voteShareStr,
 			}
-			webPollCounts[i] = webPollCount
+			webPollOptions[i] = webPollOption
 		}
 
-		webStatus.WebPollOptions = webPollCounts
+		webStatus.WebPollOptions = webPollOptions
 	}
 
 	return webStatus, nil

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -685,24 +685,27 @@ func (c *Converter) StatusToWebStatus(
 
 		webPollCounts := make([]apimodel.WebPollOption, len(poll.Options))
 		for i, option := range poll.Options {
-			var voteShare float64
+			var voteShare float32
 			if totalVotes != 0 &&
 				option.VotesCount != 0 {
-				voteShare = (float64(option.VotesCount) / float64(totalVotes)) * 100
+				voteShare = (float32(option.VotesCount) / float32(totalVotes)) * 100
 			}
 
-			var voteShareStr string
-			if voteShare > 0 && voteShare < 100 {
-				// For nicer styling, pad to 5 chars
-				// so that anything between 0% and 100%
-				// is monowidth, eg. "85.33", "05.00".
-				voteShareStr = fmt.Sprintf("%05.2f", voteShare)
-			} else {
-				// Don't pad or bother with precision.
-				// "100" looks nicer than "100.00",
-				// "0" looks nicer than "00.00".
-				voteShareStr = fmt.Sprintf("%.0f", voteShare)
-			}
+			// Format to two decimal points and ditch any
+			// trailing zeroes.
+			//
+			// We want to be precise enough that eg., "1.54%"
+			// is distinct from "1.68%" in polls with loads
+			// of votes.
+			//
+			// However, if we've got eg., a two-option poll
+			// in which each option has half the votes, then
+			// "50%" looks better than "50.00%".
+			//
+			// By the same token, it's pointless to show
+			// "0.00%" or "100.00%".
+			voteShareStr := fmt.Sprintf("%.2f", voteShare)
+			voteShareStr = strings.TrimSuffix(voteShareStr, ".00")
 
 			webPollCount := apimodel.WebPollOption{
 				PollOption:   option,

--- a/testrig/testmodels.go
+++ b/testrig/testmodels.go
@@ -1862,8 +1862,8 @@ func NewTestStatuses() map[string]*gtsmodel.Status {
 		},
 		"local_account_2_status_8": {
 			ID:                       "01HEN2PRXT0TF4YDRA64FZZRN7",
-			URI:                      "http://localhost:8080/users/1happyturtle/statuses/065TKBPE0EJ6X3QDR1AH9DAB8M",
-			URL:                      "http://localhost:8080/@1happyturtle/statuses/065TKBPE0EJ6X3QDR1AH9DAB8M",
+			URI:                      "http://localhost:8080/users/1happyturtle/statuses/01HEN2PRXT0TF4YDRA64FZZRN7",
+			URL:                      "http://localhost:8080/@1happyturtle/statuses/01HEN2PRXT0TF4YDRA64FZZRN7",
 			Content:                  "hey everyone i got stuck in a shed. any ideas for how to get out?",
 			Text:                     "hey everyone i got stuck in a shed. any ideas for how to get out?",
 			AttachmentIDs:            nil,

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -391,6 +391,56 @@ main {
 		}
 	}
 
+	.poll {
+		background-color: $gray2;
+		z-index: 2;
+		
+		display: flex;
+		flex-direction: column;
+		border-radius: $br;
+		padding: 0.5rem;
+		gap: 1rem;
+
+		.poll-option {
+			display: flex;
+			flex-direction: column;
+			gap: 0.1rem;
+
+			label {
+				font-weight: bold;
+				cursor: default;
+			}
+
+			meter {
+				width: 100%;
+			}
+
+			.poll-vote-human-readable {
+				display: flex;
+				flex-wrap: wrap;
+				justify-content: space-between;
+				white-space: nowrap;
+			}
+		}
+
+		.poll-info {
+			background-color: $gray4;
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: space-between;
+			border-radius: $br-inner;
+			padding: 0.25rem;
+			gap: 0.25rem;
+
+			span {
+				justify-self: center;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+		}
+	}
+
 	.info {
 		display: flex;
 		background: $toot-info-bg;

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -415,7 +415,6 @@ main {
 				gap: 0.1rem;
 	
 				label {
-					font-weight: bold;
 					cursor: default;
 				}
 	
@@ -423,7 +422,7 @@ main {
 					width: 100%;
 				}
 	
-				.poll-vote-human-readable {
+				.poll-vote-summary {
 					display: flex;
 					flex-wrap: wrap;
 					justify-content: space-between;

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -399,6 +399,7 @@ main {
 		flex-direction: column;
 		border-radius: $br;
 		padding: 0.5rem;
+		margin: 0;
 		gap: 1rem;
 
 		.poll-option {

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -402,25 +402,33 @@ main {
 		margin: 0;
 		gap: 1rem;
 
-		.poll-option {
+		.poll-options {
+			margin: 0;
+			padding: 0;
 			display: flex;
 			flex-direction: column;
-			gap: 0.1rem;
+			gap: 1rem;
 
-			label {
-				font-weight: bold;
-				cursor: default;
-			}
-
-			meter {
-				width: 100%;
-			}
-
-			.poll-vote-human-readable {
+			.poll-option {
 				display: flex;
-				flex-wrap: wrap;
-				justify-content: space-between;
-				white-space: nowrap;
+				flex-direction: column;
+				gap: 0.1rem;
+	
+				label {
+					font-weight: bold;
+					cursor: default;
+				}
+	
+				meter {
+					width: 100%;
+				}
+	
+				.poll-vote-human-readable {
+					display: flex;
+					flex-wrap: wrap;
+					justify-content: space-between;
+					white-space: nowrap;
+				}
 			}
 		}
 

--- a/web/template/poll.tmpl
+++ b/web/template/poll.tmpl
@@ -1,0 +1,57 @@
+{{- /*
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/ -}}
+
+{{- /*
+		Template for rendering a web view of a poll.
+		To use this template, pass a web view status into it.
+*/ -}}
+
+	<figure class="poll">
+		<figcaption class="poll-info">
+			<span class="poll-expiry">
+				{{- if .Poll.Expired -}}
+					Poll closed&nbsp;{{- .Poll.ExpiresAt | timestampPrecise -}}
+				{{- else if .Poll.ExpiresAt -}}
+					Poll open until&nbsp;{{- .Poll.ExpiresAt | timestampPrecise -}}
+				{{- else -}}
+					Infinite poll (no expiry)
+				{{- end -}}
+			</span>
+			<span class="total-votes">Total votes: {{ .Poll.VotesCount }}</span>
+		</figcaption>
+		<ul class="poll-options">
+		{{- range $index, $pollOption := .WebPollOptions }}
+			<li class="poll-option">
+				<label aria-hidden="true" for="option-{{- increment $index -}}" lang="{{- .LanguageTag.TagStr -}}">{{- emojify .Emojis (noescape $pollOption.Title) -}}</label>
+				<meter aria-hidden="true" id="option-{{- increment $index -}}" min="0" max="100" value="{{- $pollOption.VoteShare -}}">{{- $pollOption.VoteShare -}}&#37;</meter>
+				<div class="sr-only">Option {{ increment $index }}:&nbsp;<span lang="{{ .LanguageTag.TagStr }}">{{ emojify .Emojis (noescape $pollOption.Title) -}}</span></div>
+				<div class="poll-vote-summary">
+					<span class="poll-vote-share">{{- $pollOption.VoteShareStr -}}&#37;</span>
+					<span class="poll-vote-count">
+						{{- if eq $pollOption.VotesCount 1 -}}
+							{{- $pollOption.VotesCount }} vote
+						{{- else -}}
+							{{- $pollOption.VotesCount }} votes
+						{{- end -}}
+					</span>
+				</div>
+			</li>
+		{{- end }}
+		</ul>
+	</figure>

--- a/web/template/status.tmpl
+++ b/web/template/status.tmpl
@@ -109,41 +109,7 @@
 		{{end}}
 	</div>
 	{{end}}
-	{{- if .Poll -}}
-	<figure class="poll">
-		<figcaption class="poll-info">
-			<span class="poll-expiry">
-				{{- if .Poll.Expired -}}
-					Poll closed {{.Poll.ExpiresAt | timestampPrecise}}
-				{{- else if .Poll.ExpiresAt -}}
-					Poll open until {{.Poll.ExpiresAt | timestampPrecise}}
-				{{- else -}}
-					Infinite poll (no expiry)
-				{{- end -}}
-			</span>
-			<span class="total-votes">Total votes: {{ .Poll.VotesCount }}</span>
-		</figcaption>
-		<ul class="poll-options">
-		{{- range $index, $pollOption := .WebPollOptions }}
-			<li class="poll-option">
-				<label aria-hidden="true" for="option-{{ increment $index }}">{{- emojify .Emojis (noescape $pollOption.Title) -}}</label>
-				<meter aria-hidden="true" id="option-{{ increment $index }}" min="0" max="100" value="{{ $pollOption.VoteShare }}">{{- $pollOption.VoteShare -}}&#37;</meter>
-				<div class="sr-only">Option {{ increment $index }}: {{ emojify .Emojis (noescape $pollOption.Title) -}}</div>
-				<div class="poll-vote-human-readable">
-					<span class="poll-vote-share">{{- $pollOption.VoteShareStr -}}&#37;</span>
-					<span class="poll-vote-count">
-						{{- if eq $pollOption.VotesCount 1 -}}
-							{{- $pollOption.VotesCount }} vote
-						{{- else -}}
-							{{- $pollOption.VotesCount }} votes
-						{{- end -}}
-					</span>
-				</div>
-			</li>
-		{{- end }}
-		</ul>
-	</figure>
-	{{ end -}}
+	{{- if .Poll -}}{{ template "poll.tmpl" . }}{{ end -}}
 </section>
 <aside class="info">
 	<time datetime="{{.CreatedAt}}">{{.CreatedAt | timestampPrecise}}</time>

--- a/web/template/status.tmpl
+++ b/web/template/status.tmpl
@@ -110,56 +110,41 @@
 	</div>
 	{{end}}
 	{{ if .Poll }}
-	<div class="poll">
+	<figure class="poll">
+		<figcaption class="poll-info">
+			<span class="poll-expiry">
+				{{- if .Poll.Expired -}}
+					Poll closed {{.Poll.ExpiresAt | timestampPrecise}}
+				{{- else if .Poll.ExpiresAt -}}
+					Poll open until {{.Poll.ExpiresAt | timestampPrecise}}
+				{{- else -}}
+					Infinite poll (no expiry)
+				{{- end -}}
+			</span>
+			<span class="poll-votes">Total votes: {{ .Poll.VotesCount }}</span>
+		</figcaption>
 		{{ range $index, $pollOption := .WebPollOptions }}
 		<div class="poll-option">
-			<label for="option-{{ $index }}">
-				{{emojify .Emojis (noescape $pollOption.Title)}}
+			<label aria-hidden="true" for="option-{{ increment $index }}">
+				{{- emojify .Emojis (noescape $pollOption.Title) -}}
 			</label>
-			<meter id="option-{{ $index }}" min="0" max="100" value="{{ $pollOption.VoteShare }}">
-				{{ $pollOption.VoteShareStr }}%
+			<meter aria-hidden="true" id="option-{{ increment $index }}" min="0" max="100" value="{{ $pollOption.VoteShare }}">
+				{{- $pollOption.VoteShare }}&#37;
 			</meter>
+			<div class="sr-only">Option {{ increment $index }}: {{ emojify .Emojis (noescape $pollOption.Title) -}}</div>
 			<div class="poll-vote-human-readable">
 				<span class="poll-vote-count">
-					{{ if eq $pollOption.VotesCount 1 }}
-						{{ $pollOption.VotesCount }} vote
-					{{ else }}
-						{{ $pollOption.VotesCount }} votes
-					{{ end }}
+					{{- if eq $pollOption.VotesCount 1 -}}
+						{{- $pollOption.VotesCount }} vote
+					{{- else -}}
+						{{- $pollOption.VotesCount }} votes
+					{{- end -}}
 				</span>
-				<span class="poll-vote-share">
-					{{ $pollOption.VoteShareStr }}%
-				</span>
+				<span class="poll-vote-share">{{- $pollOption.VoteShareStr -}}&#37;</span>
 			</div>
 		</div>
 		{{ end }}
-		<div class="poll-info">
-			<span class="poll-votes">
-				Total:
-				{{ if eq .Poll.VotesCount 0 }}
-					No votes
-				{{ else if eq .Poll.VotesCount 1 }}
-					1 vote
-				{{ else }}
-					{{ .Poll.VotesCount }} votes
-				{{ end }}
-				{{ if .Poll.Multiple }}
-					(multiple choice)
-				{{ end }}
-			</span>
-			<span class="poll-expiry">
-				{{ if .Poll.Expired }}
-					Poll closed
-					<time datetime="{{.Poll.ExpiresAt}}">{{.Poll.ExpiresAt | timestampPrecise}}</time>
-				{{ else if .Poll.ExpiresAt }}
-					Poll open until
-					<time datetime="{{.Poll.ExpiresAt}}">{{.Poll.ExpiresAt | timestampPrecise}}</time>
-				{{ else }}
-					Infinite poll (no expiry)
-				{{ end }}
-			</span>
-		</div>
-	</div>
+	</figure>
 	{{ end }}
 </section>
 <aside class="info">

--- a/web/template/status.tmpl
+++ b/web/template/status.tmpl
@@ -109,6 +109,58 @@
 		{{end}}
 	</div>
 	{{end}}
+	{{ if .Poll }}
+	<div class="poll">
+		{{ range $index, $pollOption := .WebPollOptions }}
+		<div class="poll-option">
+			<label for="option-{{ $index }}">
+				{{emojify .Emojis (noescape $pollOption.Title)}}
+			</label>
+			<meter id="option-{{ $index }}" min="0" max="100" value="{{ $pollOption.VoteShare }}">
+				{{ $pollOption.VoteShareStr }}%
+			</meter>
+			<div class="poll-vote-human-readable">
+				<span class="poll-vote-count">
+					{{ if eq $pollOption.VotesCount 1 }}
+						{{ $pollOption.VotesCount }} vote
+					{{ else }}
+						{{ $pollOption.VotesCount }} votes
+					{{ end }}
+				</span>
+				<span class="poll-vote-share">
+					{{ $pollOption.VoteShareStr }}%
+				</span>
+			</div>
+		</div>
+		{{ end }}
+		<div class="poll-info">
+			<span class="poll-votes">
+				Total:
+				{{ if eq .Poll.VotesCount 0 }}
+					No votes
+				{{ else if eq .Poll.VotesCount 1 }}
+					1 vote
+				{{ else }}
+					{{ .Poll.VotesCount }} votes
+				{{ end }}
+				{{ if .Poll.Multiple }}
+					(multiple choice)
+				{{ end }}
+			</span>
+			<span class="poll-expiry">
+				{{ if .Poll.Expired }}
+					Poll closed
+					<time datetime="{{.Poll.ExpiresAt}}">{{.Poll.ExpiresAt | timestampPrecise}}</time>
+				{{ else if .Poll.ExpiresAt }}
+					Poll open until
+					<time datetime="{{.Poll.ExpiresAt}}">{{.Poll.ExpiresAt | timestampPrecise}}</time>
+				{{ else }}
+					Infinite poll (no expiry)
+				{{ end }}
+			</span>
+		</div>
+	</div>
+	{{ end }}
 </section>
 <aside class="info">
 	<time datetime="{{.CreatedAt}}">{{.CreatedAt | timestampPrecise}}</time>

--- a/web/template/status.tmpl
+++ b/web/template/status.tmpl
@@ -133,6 +133,7 @@
 			</meter>
 			<div class="sr-only">Option {{ increment $index }}: {{ emojify .Emojis (noescape $pollOption.Title) -}}</div>
 			<div class="poll-vote-human-readable">
+				<span class="poll-vote-share">{{- $pollOption.VoteShareStr -}}&#37;</span>
 				<span class="poll-vote-count">
 					{{- if eq $pollOption.VotesCount 1 -}}
 						{{- $pollOption.VotesCount }} vote
@@ -140,7 +141,6 @@
 						{{- $pollOption.VotesCount }} votes
 					{{- end -}}
 				</span>
-				<span class="poll-vote-share">{{- $pollOption.VoteShareStr -}}&#37;</span>
 			</div>
 		</div>
 		{{ end }}

--- a/web/template/status.tmpl
+++ b/web/template/status.tmpl
@@ -109,7 +109,7 @@
 		{{end}}
 	</div>
 	{{end}}
-	{{ if .Poll }}
+	{{- if .Poll -}}
 	<figure class="poll">
 		<figcaption class="poll-info">
 			<span class="poll-expiry">
@@ -121,31 +121,29 @@
 					Infinite poll (no expiry)
 				{{- end -}}
 			</span>
-			<span class="poll-votes">Total votes: {{ .Poll.VotesCount }}</span>
+			<span class="total-votes">Total votes: {{ .Poll.VotesCount }}</span>
 		</figcaption>
-		{{ range $index, $pollOption := .WebPollOptions }}
-		<div class="poll-option">
-			<label aria-hidden="true" for="option-{{ increment $index }}">
-				{{- emojify .Emojis (noescape $pollOption.Title) -}}
-			</label>
-			<meter aria-hidden="true" id="option-{{ increment $index }}" min="0" max="100" value="{{ $pollOption.VoteShare }}">
-				{{- $pollOption.VoteShare }}&#37;
-			</meter>
-			<div class="sr-only">Option {{ increment $index }}: {{ emojify .Emojis (noescape $pollOption.Title) -}}</div>
-			<div class="poll-vote-human-readable">
-				<span class="poll-vote-share">{{- $pollOption.VoteShareStr -}}&#37;</span>
-				<span class="poll-vote-count">
-					{{- if eq $pollOption.VotesCount 1 -}}
-						{{- $pollOption.VotesCount }} vote
-					{{- else -}}
-						{{- $pollOption.VotesCount }} votes
-					{{- end -}}
-				</span>
-			</div>
-		</div>
-		{{ end }}
+		<ul class="poll-options">
+		{{- range $index, $pollOption := .WebPollOptions }}
+			<li class="poll-option">
+				<label aria-hidden="true" for="option-{{ increment $index }}">{{- emojify .Emojis (noescape $pollOption.Title) -}}</label>
+				<meter aria-hidden="true" id="option-{{ increment $index }}" min="0" max="100" value="{{ $pollOption.VoteShare }}">{{- $pollOption.VoteShare -}}&#37;</meter>
+				<div class="sr-only">Option {{ increment $index }}: {{ emojify .Emojis (noescape $pollOption.Title) -}}</div>
+				<div class="poll-vote-human-readable">
+					<span class="poll-vote-share">{{- $pollOption.VoteShareStr -}}&#37;</span>
+					<span class="poll-vote-count">
+						{{- if eq $pollOption.VotesCount 1 -}}
+							{{- $pollOption.VotesCount }} vote
+						{{- else -}}
+							{{- $pollOption.VotesCount }} votes
+						{{- end -}}
+					</span>
+				</div>
+			</li>
+		{{- end }}
+		</ul>
 	</figure>
-	{{ end }}
+	{{ end -}}
 </section>
 <aside class="info">
 	<time datetime="{{.CreatedAt}}">{{.CreatedAt | timestampPrecise}}</time>


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request adds a template + web view for rendering status polls in the frontend.

Produced HTML for a poll looks like this:

```html
<figure class="poll">
	<figcaption class="poll-info">
		<span class="poll-expiry">Poll closed&nbsp;Aug 28, 2021, 10:40</span>
		<span class="total-votes">Total votes: 2</span>
	</figcaption>
	<ul class="poll-options">
		<li class="poll-option">
			<label aria-hidden="true" for="option-1" lang="en">50:50</label>
			<meter aria-hidden="true" id="option-1" min="0" max="100" value="0">0&#37;</meter>
			<div class="sr-only">Option 1:&nbsp;<span lang="en">50:50</span></div>
			<div class="poll-vote-summary">
				<span class="poll-vote-share">0&#37;</span>
				<span class="poll-vote-count">0 votes</span>
			</div>
		</li>
		<li class="poll-option">
			<label aria-hidden="true" for="option-2" lang="en">phone a friend</label>
			<meter aria-hidden="true" id="option-2" min="0" max="100" value="50">50&#37;</meter>
			<div class="sr-only">Option 2:&nbsp;<span lang="en">phone a friend</span></div>
			<div class="poll-vote-summary">
				<span class="poll-vote-share">50&#37;</span>
				<span class="poll-vote-count">1 vote</span>
			</div>
		</li>
		<li class="poll-option">
			<label aria-hidden="true" for="option-3" lang="en">ask the audience</label>
			<meter aria-hidden="true" id="option-3" min="0" max="100" value="50">50&#37;</meter>
			<div class="sr-only">Option 3:&nbsp;<span lang="en">ask the audience</span></div>
			<div class="poll-vote-summary">
				<span class="poll-vote-share">50&#37;</span>
				<span class="poll-vote-count">1 vote</span>
			</div>
		</li>
	</ul>
</figure>
```

And it's styled in the frontend like this:

![image](https://github.com/superseriousbusiness/gotosocial/assets/31960611/a773ff8d-2ca3-494c-a7cd-8d8e3195b849)

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
