### PR TITLE
[chore/bugfix] Fix double gzip on prometheus endpoint

### DIFF
--- a/cmd/gotosocial/action/server/server.go
+++ b/cmd/gotosocial/action/server/server.go
@@ -317,13 +317,13 @@ var Start action.GTSAction = func(ctx context.Context) error {
 	fsThrottle := middleware.Throttle(cpuMultiplier, retryAfter)  // fileserver / web templates
 	pkThrottle := middleware.Throttle(cpuMultiplier, retryAfter)  // throttle public key endpoint separately
 
-	gzip := middleware.Gzip() // applied to all except fileserver and metrics
+	gzip := middleware.Gzip() // applied to all except fileserver
 
 	// these should be routed in order;
 	// apply throttling *after* rate limiting
 	authModule.Route(router, clLimit, clThrottle, gzip)
 	clientModule.Route(router, clLimit, clThrottle, gzip)
-	metricsModule.Route(router, clLimit, clThrottle)
+	metricsModule.Route(router, clLimit, clThrottle, gzip)
 	fileserverModule.Route(router, fsLimit, fsThrottle)
 	wellKnownModule.Route(router, gzip, s2sLimit, s2sThrottle)
 	nodeInfoModule.Route(router, s2sLimit, s2sThrottle, gzip)

--- a/cmd/gotosocial/action/server/server.go
+++ b/cmd/gotosocial/action/server/server.go
@@ -293,6 +293,7 @@ var Start action.GTSAction = func(ctx context.Context) error {
 	var (
 		authModule        = api.NewAuth(dbService, processor, idp, routerSession, sessionName) // auth/oauth paths
 		clientModule      = api.NewClient(dbService, processor)                                // api client endpoints
+		metricsModule     = api.NewMetrics()                                                   // Metrics endpoints
 		fileserverModule  = api.NewFileserver(processor)                                       // fileserver endpoints
 		wellKnownModule   = api.NewWellKnown(processor)                                        // .well-known endpoints
 		nodeInfoModule    = api.NewNodeInfo(processor)                                         // nodeinfo endpoint
@@ -316,12 +317,13 @@ var Start action.GTSAction = func(ctx context.Context) error {
 	fsThrottle := middleware.Throttle(cpuMultiplier, retryAfter)  // fileserver / web templates
 	pkThrottle := middleware.Throttle(cpuMultiplier, retryAfter)  // throttle public key endpoint separately
 
-	gzip := middleware.Gzip() // applied to all except fileserver
+	gzip := middleware.Gzip() // applied to all except fileserver and metrics
 
 	// these should be routed in order;
 	// apply throttling *after* rate limiting
 	authModule.Route(router, clLimit, clThrottle, gzip)
 	clientModule.Route(router, clLimit, clThrottle, gzip)
+	metricsModule.Route(router, clLimit, clThrottle)
 	fileserverModule.Route(router, fsLimit, fsThrottle)
 	wellKnownModule.Route(router, gzip, s2sLimit, s2sThrottle)
 	nodeInfoModule.Route(router, s2sLimit, s2sThrottle, gzip)

--- a/cmd/gotosocial/action/testrig/testrig.go
+++ b/cmd/gotosocial/action/testrig/testrig.go
@@ -212,6 +212,7 @@ var Start action.GTSAction = func(ctx context.Context) error {
 	var (
 		authModule        = api.NewAuth(state.DB, processor, idp, routerSession, sessionName) // auth/oauth paths
 		clientModule      = api.NewClient(state.DB, processor)                                // api client endpoints
+		metricsModule     = api.NewMetrics()                                                  // Metrics endpoints
 		fileserverModule  = api.NewFileserver(processor)                                      // fileserver endpoints
 		wellKnownModule   = api.NewWellKnown(processor)                                       // .well-known endpoints
 		nodeInfoModule    = api.NewNodeInfo(processor)                                        // nodeinfo endpoint
@@ -222,6 +223,7 @@ var Start action.GTSAction = func(ctx context.Context) error {
 	// these should be routed in order
 	authModule.Route(router)
 	clientModule.Route(router)
+	metricsModule.Route(router)
 	fileserverModule.Route(router)
 	wellKnownModule.Route(router)
 	nodeInfoModule.Route(router)

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -1,0 +1,59 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api/metrics"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/router"
+)
+
+type Metrics struct {
+	metrics *metrics.Module
+}
+
+func (mt *Metrics) Route(r *router.Router, m ...gin.HandlerFunc) {
+	if !config.GetMetricsEnabled() {
+		// Noop: metrics
+		// not enabled.
+		return
+	}
+
+	// Create new group on top level "metrics" prefix.
+	metricsGroup := r.AttachGroup("metrics")
+	metricsGroup.Use(m...)
+
+	// Attach basic auth if enabled.
+	if config.GetMetricsAuthEnabled() {
+		var (
+			username = config.GetMetricsAuthUsername()
+			password = config.GetMetricsAuthPassword()
+			accounts = gin.Accounts{username: password}
+		)
+		metricsGroup.Use(gin.BasicAuth(accounts))
+	}
+
+	mt.metrics.Route(metricsGroup.Handle)
+}
+
+func NewMetrics() *Metrics {
+	return &Metrics{
+		metrics: metrics.New(),
+	}
+}

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/superseriousbusiness/gotosocial/internal/api/metrics"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/middleware"
 	"github.com/superseriousbusiness/gotosocial/internal/router"
 )
 
@@ -38,6 +39,12 @@ func (mt *Metrics) Route(r *router.Router, m ...gin.HandlerFunc) {
 	// Create new group on top level "metrics" prefix.
 	metricsGroup := r.AttachGroup("metrics")
 	metricsGroup.Use(m...)
+	metricsGroup.Use(
+		middleware.CacheControl(middleware.CacheControlConfig{
+			// Never cache metrics responses.
+			Directives: []string{"no-store"},
+		}),
+	)
 
 	// Attach basic auth if enabled.
 	if config.GetMetricsAuthEnabled() {

--- a/internal/api/metrics/metrics.go
+++ b/internal/api/metrics/metrics.go
@@ -15,19 +15,24 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package web
+package metrics
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-const (
-	metricsPath = "/metrics"
-	metricsUser = "metrics"
-)
+type Module struct{}
 
-func (m *Module) metricsGETHandler(c *gin.Context) {
-	h := promhttp.Handler()
-	h.ServeHTTP(c.Writer, c.Request)
+func New() *Module {
+	return &Module{}
+}
+
+func (m *Module) Route(attachHandler func(method string, path string, f ...gin.HandlerFunc) gin.IRoutes) {
+	attachHandler(http.MethodGet, "", func(c *gin.Context) {
+		// Defer all "/metrics" handling to prom.
+		promhttp.Handler().ServeHTTP(c.Writer, c.Request)
+	})
 }

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -110,19 +110,6 @@ func (m *Module) Route(r *router.Router, mi ...gin.HandlerFunc) {
 	r.AttachHandler(http.MethodGet, domainBlockListPath, m.domainBlockListGETHandler)
 	r.AttachHandler(http.MethodGet, tagsPath, m.tagGETHandler)
 
-	// Prometheus metrics export endpoint
-	if config.GetMetricsEnabled() {
-		metricsGroup := r.AttachGroup(metricsPath)
-		metricsGroup.Use(mi...)
-		// Attach basic auth if enabled
-		if config.GetMetricsAuthEnabled() {
-			metricsGroup.Use(gin.BasicAuth(gin.Accounts{
-				config.GetMetricsAuthUsername(): config.GetMetricsAuthPassword(),
-			}))
-		}
-		metricsGroup.Handle(http.MethodGet, "", m.metricsGETHandler)
-	}
-
 	// Attach redirects from old endpoints to current ones for backwards compatibility
 	r.AttachHandler(http.MethodGet, "/auth/edit", func(c *gin.Context) { c.Redirect(http.StatusMovedPermanently, userPanelPath) })
 	r.AttachHandler(http.MethodGet, "/user", func(c *gin.Context) { c.Redirect(http.StatusMovedPermanently, userPanelPath) })


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

The default prometheus handler we were using encodes using gzip if requested. However we were *also* enabling our gzip middleware, meaning things got double gzip encoded and therefore didn't work.

This PR fixes that by disabling compression on promhttp and using our own gzip middleware as well.

Also moves the metrics handling out of web and into its own API module, for consistency.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
