### PR TITLE
[bugfix] Don't copy ptr fields in caches

### DIFF
--- a/internal/cache/gts.go
+++ b/internal/cache/gts.go
@@ -1073,17 +1073,25 @@ func (c *GTSCaches) initUser() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
+	copyF := func(u1 *gtsmodel.User) *gtsmodel.User {
+		u2 := new(gtsmodel.User)
+		*u2 = *u1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/user.go.
+		u2.Account = nil
+
+		return u2
+	}
+
 	c.user = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "AccountID"},
 		{Name: "Email"},
 		{Name: "ConfirmationToken"},
 		{Name: "ExternalID"},
-	}, func(u1 *gtsmodel.User) *gtsmodel.User {
-		u2 := new(gtsmodel.User)
-		*u2 = *u1
-		return u2
-	}, cap)
+	}, copyF, cap)
 
 	c.user.IgnoreErrors(ignoreErrors)
 }

--- a/internal/cache/gts.go
+++ b/internal/cache/gts.go
@@ -306,6 +306,20 @@ func (c *GTSCaches) initAccount() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
+	copyF := func(a1 *gtsmodel.Account) *gtsmodel.Account {
+		a2 := new(gtsmodel.Account)
+		*a2 = *a1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/account.go.
+		a2.AvatarMediaAttachment = nil
+		a2.HeaderMediaAttachment = nil
+		a2.Emojis = nil
+
+		return a2
+	}
+
 	c.account = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "URI"},
@@ -316,11 +330,7 @@ func (c *GTSCaches) initAccount() {
 		{Name: "OutboxURI"},
 		{Name: "FollowersURI"},
 		{Name: "FollowingURI"},
-	}, func(a1 *gtsmodel.Account) *gtsmodel.Account {
-		a2 := new(gtsmodel.Account)
-		*a2 = *a1
-		return a2
-	}, cap)
+	}, copyF, cap)
 
 	c.account.IgnoreErrors(ignoreErrors)
 }
@@ -334,14 +344,23 @@ func (c *GTSCaches) initAccountNote() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
+	copyF := func(n1 *gtsmodel.AccountNote) *gtsmodel.AccountNote {
+		n2 := new(gtsmodel.AccountNote)
+		*n2 = *n1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/relationship_note.go.
+		n2.Account = nil
+		n2.TargetAccount = nil
+
+		return n2
+	}
+
 	c.accountNote = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "AccountID.TargetAccountID"},
-	}, func(n1 *gtsmodel.AccountNote) *gtsmodel.AccountNote {
-		n2 := new(gtsmodel.AccountNote)
-		*n2 = *n1
-		return n2
-	}, cap)
+	}, copyF, cap)
 
 	c.accountNote.IgnoreErrors(ignoreErrors)
 }
@@ -376,17 +395,26 @@ func (c *GTSCaches) initBlock() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
+	copyF := func(b1 *gtsmodel.Block) *gtsmodel.Block {
+		b2 := new(gtsmodel.Block)
+		*b2 = *b1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/relationship_block.go.
+		b2.Account = nil
+		b2.TargetAccount = nil
+
+		return b2
+	}
+
 	c.block = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "URI"},
 		{Name: "AccountID.TargetAccountID"},
 		{Name: "AccountID", Multi: true},
 		{Name: "TargetAccountID", Multi: true},
-	}, func(b1 *gtsmodel.Block) *gtsmodel.Block {
-		b2 := new(gtsmodel.Block)
-		*b2 = *b1
-		return b2
-	}, cap)
+	}, copyF, cap)
 
 	c.block.IgnoreErrors(ignoreErrors)
 }
@@ -436,17 +464,25 @@ func (c *GTSCaches) initEmoji() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
+	copyF := func(e1 *gtsmodel.Emoji) *gtsmodel.Emoji {
+		e2 := new(gtsmodel.Emoji)
+		*e2 = *e1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/emoji.go.
+		e2.Category = nil
+
+		return e2
+	}
+
 	c.emoji = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "URI"},
 		{Name: "Shortcode.Domain", AllowZero: true /* domain can be zero i.e. "" */},
 		{Name: "ImageStaticURL"},
 		{Name: "CategoryID", Multi: true},
-	}, func(e1 *gtsmodel.Emoji) *gtsmodel.Emoji {
-		e2 := new(gtsmodel.Emoji)
-		*e2 = *e1
-		return e2
-	}, cap)
+	}, copyF, cap)
 
 	c.emoji.IgnoreErrors(ignoreErrors)
 }
@@ -481,17 +517,26 @@ func (c *GTSCaches) initFollow() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
+	copyF := func(f1 *gtsmodel.Follow) *gtsmodel.Follow {
+		f2 := new(gtsmodel.Follow)
+		*f2 = *f1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/relationship_follow.go.
+		f2.Account = nil
+		f2.TargetAccount = nil
+
+		return f2
+	}
+
 	c.follow = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "URI"},
 		{Name: "AccountID.TargetAccountID"},
 		{Name: "AccountID", Multi: true},
 		{Name: "TargetAccountID", Multi: true},
-	}, func(f1 *gtsmodel.Follow) *gtsmodel.Follow {
-		f2 := new(gtsmodel.Follow)
-		*f2 = *f1
-		return f2
-	}, cap)
+	}, copyF, cap)
 
 	c.follow.IgnoreErrors(ignoreErrors)
 }
@@ -519,17 +564,26 @@ func (c *GTSCaches) initFollowRequest() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
+	copyF := func(f1 *gtsmodel.FollowRequest) *gtsmodel.FollowRequest {
+		f2 := new(gtsmodel.FollowRequest)
+		*f2 = *f1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/relationship_follow_req.go.
+		f2.Account = nil
+		f2.TargetAccount = nil
+
+		return f2
+	}
+
 	c.followRequest = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "URI"},
 		{Name: "AccountID.TargetAccountID"},
 		{Name: "AccountID", Multi: true},
 		{Name: "TargetAccountID", Multi: true},
-	}, func(f1 *gtsmodel.FollowRequest) *gtsmodel.FollowRequest {
-		f2 := new(gtsmodel.FollowRequest)
-		*f2 = *f1
-		return f2
-	}, cap)
+	}, copyF, cap)
 
 	c.followRequest.IgnoreErrors(ignoreErrors)
 }
@@ -571,14 +625,23 @@ func (c *GTSCaches) initInstance() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
+	copyF := func(i1 *gtsmodel.Instance) *gtsmodel.Instance {
+		i2 := new(gtsmodel.Instance)
+		*i2 = *i1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/instance.go.
+		i2.DomainBlock = nil
+		i2.ContactAccount = nil
+
+		return i1
+	}
+
 	c.instance = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "Domain"},
-	}, func(i1 *gtsmodel.Instance) *gtsmodel.Instance {
-		i2 := new(gtsmodel.Instance)
-		*i2 = *i1
-		return i1
-	}, cap)
+	}, copyF, cap)
 
 	c.instance.IgnoreErrors(ignoreErrors)
 }
@@ -792,17 +855,35 @@ func (c *GTSCaches) initStatus() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
+	copyF := func(s1 *gtsmodel.Status) *gtsmodel.Status {
+		s2 := new(gtsmodel.Status)
+		*s2 = *s1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/status.go.
+		s2.Account = nil
+		s2.InReplyTo = nil
+		s2.InReplyToAccount = nil
+		s2.BoostOf = nil
+		s2.BoostOfAccount = nil
+		s2.Poll = nil
+		s2.Attachments = nil
+		s2.Tags = nil
+		s2.Mentions = nil
+		s2.Emojis = nil
+		s2.CreatedWithApplication = nil
+
+		return s2
+	}
+
 	c.status = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "URI"},
 		{Name: "URL"},
 		{Name: "BoostOfID.AccountID"},
 		{Name: "ThreadID", Multi: true},
-	}, func(s1 *gtsmodel.Status) *gtsmodel.Status {
-		s2 := new(gtsmodel.Status)
-		*s2 = *s1
-		return s2
-	}, cap)
+	}, copyF, cap)
 
 	c.status.IgnoreErrors(ignoreErrors)
 }

--- a/internal/cache/gts.go
+++ b/internal/cache/gts.go
@@ -655,13 +655,22 @@ func (c *GTSCaches) initList() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
-	c.list = result.New([]result.Lookup{
-		{Name: "ID"},
-	}, func(l1 *gtsmodel.List) *gtsmodel.List {
+	copyF := func(l1 *gtsmodel.List) *gtsmodel.List {
 		l2 := new(gtsmodel.List)
 		*l2 = *l1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/list.go.
+		l2.Account = nil
+		l2.ListEntries = nil
+
 		return l2
-	}, cap)
+	}
+
+	c.list = result.New([]result.Lookup{
+		{Name: "ID"},
+	}, copyF, cap)
 
 	c.list.IgnoreErrors(ignoreErrors)
 }
@@ -675,15 +684,23 @@ func (c *GTSCaches) initListEntry() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
+	copyF := func(l1 *gtsmodel.ListEntry) *gtsmodel.ListEntry {
+		l2 := new(gtsmodel.ListEntry)
+		*l2 = *l1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/list.go.
+		l2.Follow = nil
+
+		return l2
+	}
+
 	c.listEntry = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "ListID", Multi: true},
 		{Name: "FollowID", Multi: true},
-	}, func(l1 *gtsmodel.ListEntry) *gtsmodel.ListEntry {
-		l2 := new(gtsmodel.ListEntry)
-		*l2 = *l1
-		return l2
-	}, cap)
+	}, copyF, cap)
 
 	c.listEntry.IgnoreErrors(ignoreErrors)
 }
@@ -737,13 +754,23 @@ func (c *GTSCaches) initMention() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
-	c.mention = result.New([]result.Lookup{
-		{Name: "ID"},
-	}, func(m1 *gtsmodel.Mention) *gtsmodel.Mention {
+	copyF := func(m1 *gtsmodel.Mention) *gtsmodel.Mention {
 		m2 := new(gtsmodel.Mention)
 		*m2 = *m1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/mention.go.
+		m2.Status = nil
+		m2.OriginAccount = nil
+		m2.TargetAccount = nil
+
 		return m2
-	}, cap)
+	}
+
+	c.mention = result.New([]result.Lookup{
+		{Name: "ID"},
+	}, copyF, cap)
 
 	c.mention.IgnoreErrors(ignoreErrors)
 }
@@ -757,14 +784,24 @@ func (c *GTSCaches) initNotification() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
+	copyF := func(n1 *gtsmodel.Notification) *gtsmodel.Notification {
+		n2 := new(gtsmodel.Notification)
+		*n2 = *n1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/notification.go.
+		n2.Status = nil
+		n2.OriginAccount = nil
+		n2.TargetAccount = nil
+
+		return n2
+	}
+
 	c.notification = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "NotificationType.TargetAccountID.OriginAccountID.StatusID"},
-	}, func(n1 *gtsmodel.Notification) *gtsmodel.Notification {
-		n2 := new(gtsmodel.Notification)
-		*n2 = *n1
-		return n2
-	}, cap)
+	}, copyF, cap)
 
 	c.notification.IgnoreErrors(ignoreErrors)
 }
@@ -778,14 +815,22 @@ func (c *GTSCaches) initPoll() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
+	copyF := func(p1 *gtsmodel.Poll) *gtsmodel.Poll {
+		p2 := new(gtsmodel.Poll)
+		*p2 = *p1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/poll.go.
+		p2.Status = nil
+
+		return p2
+	}
+
 	c.poll = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "StatusID"},
-	}, func(p1 *gtsmodel.Poll) *gtsmodel.Poll {
-		p2 := new(gtsmodel.Poll)
-		*p2 = *p1
-		return p2
-	}, cap)
+	}, copyF, cap)
 
 	c.poll.IgnoreErrors(ignoreErrors)
 }
@@ -799,15 +844,24 @@ func (c *GTSCaches) initPollVote() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
+	copyF := func(v1 *gtsmodel.PollVote) *gtsmodel.PollVote {
+		v2 := new(gtsmodel.PollVote)
+		*v2 = *v1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/poll.go.
+		v2.Account = nil
+		v2.Poll = nil
+
+		return v2
+	}
+
 	c.pollVote = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "PollID.AccountID"},
 		{Name: "PollID", Multi: true},
-	}, func(v1 *gtsmodel.PollVote) *gtsmodel.PollVote {
-		v2 := new(gtsmodel.PollVote)
-		*v2 = *v1
-		return v2
-	}, cap)
+	}, copyF, cap)
 
 	c.pollVote.IgnoreErrors(ignoreErrors)
 }
@@ -835,13 +889,25 @@ func (c *GTSCaches) initReport() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
-	c.report = result.New([]result.Lookup{
-		{Name: "ID"},
-	}, func(r1 *gtsmodel.Report) *gtsmodel.Report {
+	copyF := func(r1 *gtsmodel.Report) *gtsmodel.Report {
 		r2 := new(gtsmodel.Report)
 		*r2 = *r1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/report.go.
+		r2.Account = nil
+		r2.TargetAccount = nil
+		r2.Statuses = nil
+		r2.Rules = nil
+		r2.ActionTakenByAccount = nil
+
 		return r2
-	}, cap)
+	}
+
+	c.report = result.New([]result.Lookup{
+		{Name: "ID"},
+	}, copyF, cap)
 
 	c.report.IgnoreErrors(ignoreErrors)
 }
@@ -897,15 +963,25 @@ func (c *GTSCaches) initStatusFave() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
+	copyF := func(f1 *gtsmodel.StatusFave) *gtsmodel.StatusFave {
+		f2 := new(gtsmodel.StatusFave)
+		*f2 = *f1
+
+		// Don't include ptr fields that
+		// will be populated separately.
+		// See internal/db/bundb/statusfave.go.
+		f2.Account = nil
+		f2.TargetAccount = nil
+		f2.Status = nil
+
+		return f2
+	}
+
 	c.statusFave = result.New([]result.Lookup{
 		{Name: "ID"},
 		{Name: "AccountID.StatusID"},
 		{Name: "StatusID", Multi: true},
-	}, func(f1 *gtsmodel.StatusFave) *gtsmodel.StatusFave {
-		f2 := new(gtsmodel.StatusFave)
-		*f2 = *f1
-		return f2
-	}, cap)
+	}, copyF, cap)
 
 	c.statusFave.IgnoreErrors(ignoreErrors)
 }

--- a/internal/db/bundb/instance.go
+++ b/internal/db/bundb/instance.go
@@ -173,14 +173,14 @@ func (i *instanceDB) getInstance(ctx context.Context, lookup string, dbQuery fun
 	}
 
 	// Further populate the instance fields where applicable.
-	if err := i.populateInstance(ctx, instance); err != nil {
+	if err := i.PopulateInstance(ctx, instance); err != nil {
 		return nil, err
 	}
 
 	return instance, nil
 }
 
-func (i *instanceDB) populateInstance(ctx context.Context, instance *gtsmodel.Instance) error {
+func (i *instanceDB) PopulateInstance(ctx context.Context, instance *gtsmodel.Instance) error {
 	var (
 		err  error
 		errs = gtserror.NewMultiError(2)

--- a/internal/db/emoji.go
+++ b/internal/db/emoji.go
@@ -32,13 +32,17 @@ const EmojiAllDomains string = "all"
 type Emoji interface {
 	// PutEmoji puts one emoji in the database.
 	PutEmoji(ctx context.Context, emoji *gtsmodel.Emoji) error
+	
 	// UpdateEmoji updates the given columns of one emoji.
 	// If no columns are specified, every column is updated.
 	UpdateEmoji(ctx context.Context, emoji *gtsmodel.Emoji, columns ...string) error
+	
 	// DeleteEmojiByID deletes one emoji by its database ID.
 	DeleteEmojiByID(ctx context.Context, id string) error
+	
 	// GetEmojisByIDs gets emojis for the given IDs.
 	GetEmojisByIDs(ctx context.Context, ids []string) ([]*gtsmodel.Emoji, error)
+	
 	// GetUseableEmojis gets all emojis which are useable by accounts on this instance.
 	GetUseableEmojis(ctx context.Context) ([]*gtsmodel.Emoji, error)
 
@@ -53,23 +57,35 @@ type Emoji interface {
 
 	// GetEmojisBy gets emojis based on given parameters. Useful for admin actions.
 	GetEmojisBy(ctx context.Context, domain string, includeDisabled bool, includeEnabled bool, shortcode string, maxShortcodeDomain string, minShortcodeDomain string, limit int) ([]*gtsmodel.Emoji, error)
+	
 	// GetEmojiByID gets a specific emoji by its database ID.
 	GetEmojiByID(ctx context.Context, id string) (*gtsmodel.Emoji, error)
+	
+	// PopulateEmoji populates the struct pointers on the given emoji.
+	PopulateEmoji(ctx context.Context, emoji *gtsmodel.Emoji) error
+	
 	// GetEmojiByShortcodeDomain gets an emoji based on its shortcode and domain.
 	// For local emoji, domain should be an empty string.
 	GetEmojiByShortcodeDomain(ctx context.Context, shortcode string, domain string) (*gtsmodel.Emoji, error)
+	
 	// GetEmojiByURI returns one emoji based on its ActivityPub URI.
 	GetEmojiByURI(ctx context.Context, uri string) (*gtsmodel.Emoji, error)
+	
 	// GetEmojiByStaticURL gets an emoji using the URL of the static version of the emoji image.
 	GetEmojiByStaticURL(ctx context.Context, imageStaticURL string) (*gtsmodel.Emoji, error)
+	
 	// PutEmojiCategory puts one new emoji category in the database.
 	PutEmojiCategory(ctx context.Context, emojiCategory *gtsmodel.EmojiCategory) error
+	
 	// GetEmojiCategoriesByIDs gets emoji categories for given IDs.
 	GetEmojiCategoriesByIDs(ctx context.Context, ids []string) ([]*gtsmodel.EmojiCategory, error)
+	
 	// GetEmojiCategories gets a slice of the names of all existing emoji categories.
 	GetEmojiCategories(ctx context.Context) ([]*gtsmodel.EmojiCategory, error)
+	
 	// GetEmojiCategory gets one emoji category by its id.
 	GetEmojiCategory(ctx context.Context, id string) (*gtsmodel.EmojiCategory, error)
+	
 	// GetEmojiCategoryByName gets one emoji category by its name.
 	GetEmojiCategoryByName(ctx context.Context, name string) (*gtsmodel.EmojiCategory, error)
 }

--- a/internal/db/emoji.go
+++ b/internal/db/emoji.go
@@ -32,17 +32,17 @@ const EmojiAllDomains string = "all"
 type Emoji interface {
 	// PutEmoji puts one emoji in the database.
 	PutEmoji(ctx context.Context, emoji *gtsmodel.Emoji) error
-	
+
 	// UpdateEmoji updates the given columns of one emoji.
 	// If no columns are specified, every column is updated.
 	UpdateEmoji(ctx context.Context, emoji *gtsmodel.Emoji, columns ...string) error
-	
+
 	// DeleteEmojiByID deletes one emoji by its database ID.
 	DeleteEmojiByID(ctx context.Context, id string) error
-	
+
 	// GetEmojisByIDs gets emojis for the given IDs.
 	GetEmojisByIDs(ctx context.Context, ids []string) ([]*gtsmodel.Emoji, error)
-	
+
 	// GetUseableEmojis gets all emojis which are useable by accounts on this instance.
 	GetUseableEmojis(ctx context.Context) ([]*gtsmodel.Emoji, error)
 
@@ -57,35 +57,35 @@ type Emoji interface {
 
 	// GetEmojisBy gets emojis based on given parameters. Useful for admin actions.
 	GetEmojisBy(ctx context.Context, domain string, includeDisabled bool, includeEnabled bool, shortcode string, maxShortcodeDomain string, minShortcodeDomain string, limit int) ([]*gtsmodel.Emoji, error)
-	
+
 	// GetEmojiByID gets a specific emoji by its database ID.
 	GetEmojiByID(ctx context.Context, id string) (*gtsmodel.Emoji, error)
-	
+
 	// PopulateEmoji populates the struct pointers on the given emoji.
 	PopulateEmoji(ctx context.Context, emoji *gtsmodel.Emoji) error
-	
+
 	// GetEmojiByShortcodeDomain gets an emoji based on its shortcode and domain.
 	// For local emoji, domain should be an empty string.
 	GetEmojiByShortcodeDomain(ctx context.Context, shortcode string, domain string) (*gtsmodel.Emoji, error)
-	
+
 	// GetEmojiByURI returns one emoji based on its ActivityPub URI.
 	GetEmojiByURI(ctx context.Context, uri string) (*gtsmodel.Emoji, error)
-	
+
 	// GetEmojiByStaticURL gets an emoji using the URL of the static version of the emoji image.
 	GetEmojiByStaticURL(ctx context.Context, imageStaticURL string) (*gtsmodel.Emoji, error)
-	
+
 	// PutEmojiCategory puts one new emoji category in the database.
 	PutEmojiCategory(ctx context.Context, emojiCategory *gtsmodel.EmojiCategory) error
-	
+
 	// GetEmojiCategoriesByIDs gets emoji categories for given IDs.
 	GetEmojiCategoriesByIDs(ctx context.Context, ids []string) ([]*gtsmodel.EmojiCategory, error)
-	
+
 	// GetEmojiCategories gets a slice of the names of all existing emoji categories.
 	GetEmojiCategories(ctx context.Context) ([]*gtsmodel.EmojiCategory, error)
-	
+
 	// GetEmojiCategory gets one emoji category by its id.
 	GetEmojiCategory(ctx context.Context, id string) (*gtsmodel.EmojiCategory, error)
-	
+
 	// GetEmojiCategoryByName gets one emoji category by its name.
 	GetEmojiCategoryByName(ctx context.Context, name string) (*gtsmodel.EmojiCategory, error)
 }

--- a/internal/db/instance.go
+++ b/internal/db/instance.go
@@ -40,6 +40,9 @@ type Instance interface {
 	// GetInstanceByID returns the instance entry corresponding to the given id, if it exists.
 	GetInstanceByID(ctx context.Context, id string) (*gtsmodel.Instance, error)
 
+	// PopulateInstance populates the struct pointers on the given instance.
+	PopulateInstance(ctx context.Context, instance *gtsmodel.Instance) error
+
 	// PutInstance inserts the given instance into the database.
 	PutInstance(ctx context.Context, instance *gtsmodel.Instance) error
 

--- a/internal/db/notification.go
+++ b/internal/db/notification.go
@@ -37,6 +37,9 @@ type Notification interface {
 	// Since not all notifications are about a status, statusID can be an empty string.
 	GetNotification(ctx context.Context, notificationType gtsmodel.NotificationType, targetAccountID string, originAccountID string, statusID string) (*gtsmodel.Notification, error)
 
+	// PopulateNotification ensures that the notification's struct fields are populated.
+	PopulateNotification(ctx context.Context, notif *gtsmodel.Notification) error
+
 	// PutNotification will insert the given notification into the database.
 	PutNotification(ctx context.Context, notif *gtsmodel.Notification) error
 

--- a/internal/db/relationship.go
+++ b/internal/db/relationship.go
@@ -184,4 +184,7 @@ type Relationship interface {
 
 	// PutNote creates or updates a private note.
 	PutNote(ctx context.Context, note *gtsmodel.AccountNote) error
+
+	// PopulateNote populates the struct pointers on the given note.
+	PopulateNote(ctx context.Context, note *gtsmodel.AccountNote) error
 }

--- a/internal/db/user.go
+++ b/internal/db/user.go
@@ -27,31 +27,31 @@ import (
 type User interface {
 	// GetAllUsers returns all local user accounts, or an error if something goes wrong.
 	GetAllUsers(ctx context.Context) ([]*gtsmodel.User, error)
-	
+
 	// GetUserByID returns one user with the given ID, or an error if something goes wrong.
 	GetUserByID(ctx context.Context, id string) (*gtsmodel.User, error)
-	
+
 	// GetUserByAccountID returns one user by its account ID, or an error if something goes wrong.
 	GetUserByAccountID(ctx context.Context, accountID string) (*gtsmodel.User, error)
-	
+
 	// GetUserByID returns one user with the given email address, or an error if something goes wrong.
 	GetUserByEmailAddress(ctx context.Context, emailAddress string) (*gtsmodel.User, error)
-	
+
 	// GetUserByExternalID returns one user with the given external id, or an error if something goes wrong.
 	GetUserByExternalID(ctx context.Context, id string) (*gtsmodel.User, error)
-	
+
 	// GetUserByConfirmationToken returns one user by its confirmation token, or an error if something goes wrong.
 	GetUserByConfirmationToken(ctx context.Context, confirmationToken string) (*gtsmodel.User, error)
-	
+
 	// PopulateUser populates the struct pointers on the given user.
 	PopulateUser(ctx context.Context, user *gtsmodel.User) error
 
 	// PutUser will attempt to place user in the database
 	PutUser(ctx context.Context, user *gtsmodel.User) error
-	
+
 	// UpdateUser updates one user by its primary key, updating either only the specified columns, or all of them.
 	UpdateUser(ctx context.Context, user *gtsmodel.User, columns ...string) error
-	
+
 	// DeleteUserByID deletes one user by its ID.
 	DeleteUserByID(ctx context.Context, userID string) error
 }

--- a/internal/db/user.go
+++ b/internal/db/user.go
@@ -27,20 +27,31 @@ import (
 type User interface {
 	// GetAllUsers returns all local user accounts, or an error if something goes wrong.
 	GetAllUsers(ctx context.Context) ([]*gtsmodel.User, error)
+	
 	// GetUserByID returns one user with the given ID, or an error if something goes wrong.
 	GetUserByID(ctx context.Context, id string) (*gtsmodel.User, error)
+	
 	// GetUserByAccountID returns one user by its account ID, or an error if something goes wrong.
 	GetUserByAccountID(ctx context.Context, accountID string) (*gtsmodel.User, error)
+	
 	// GetUserByID returns one user with the given email address, or an error if something goes wrong.
 	GetUserByEmailAddress(ctx context.Context, emailAddress string) (*gtsmodel.User, error)
+	
 	// GetUserByExternalID returns one user with the given external id, or an error if something goes wrong.
 	GetUserByExternalID(ctx context.Context, id string) (*gtsmodel.User, error)
+	
 	// GetUserByConfirmationToken returns one user by its confirmation token, or an error if something goes wrong.
 	GetUserByConfirmationToken(ctx context.Context, confirmationToken string) (*gtsmodel.User, error)
+	
+	// PopulateUser populates the struct pointers on the given user.
+	PopulateUser(ctx context.Context, user *gtsmodel.User) error
+
 	// PutUser will attempt to place user in the database
 	PutUser(ctx context.Context, user *gtsmodel.User) error
+	
 	// UpdateUser updates one user by its primary key, updating either only the specified columns, or all of them.
 	UpdateUser(ctx context.Context, user *gtsmodel.User, columns ...string) error
+	
 	// DeleteUserByID deletes one user by its ID.
 	DeleteUserByID(ctx context.Context, userID string) error
 }


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This PR fixes the following scenario:

- Some of my statuses get cached after database calls.
- My account model is attached to those statuses.
- I update my profile picture.
- The statuses still show the old profile picture, on both the web view and via the API.

Essentially, what was happening in the above scenario is that the old account model was being kept on the cached statuses, and those statuses weren't being invalidated when the account model was updated.

There are two possible approaches to fixing this:

1. Invalidate all cache entries that contain a pointer to a given account (or whatever) when that account (or whatever) updates; OR --
2. Don't return cached struct pointers when copying a cached model and giving it to the caller.

This PR takes the second approach, on the basis that it will lead to fewer database calls than the first approach, and preclude super complicated cache invalidation logic.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
