### PR TITLE
[bugfix] Correctly handle range > content-length

### DIFF
--- a/internal/api/fileserver/servefile.go
+++ b/internal/api/fileserver/servefile.go
@@ -206,10 +206,11 @@ func serveFileRange(rw http.ResponseWriter, r *http.Request, src io.Reader, rng 
 			return
 		}
 
-		if end > size {
+		if end >= size {
 			// According to the http spec if end >= size the server should return the rest of the file
 			// https://www.rfc-editor.org/rfc/rfc9110#section-14.1.2-6
 			end = size - 1
+			endRng = strconv.FormatInt(end, 10)
 		}
 	} else {
 		// No end supplied, implying file end


### PR DESCRIPTION
# Description

Hi I found this bug in Pleroma/Akkoma's MediaProxy. Currently GTS instance returns incorrect range headers when suffix length is larger than content-length:

```bash
$ url="https://goblin.technology/fileserver/01BPSX2MKCRVMD4YN4D71G9CP5/attachment/original/01E4BA3HFHWN7GDE2Y89F0J563.png"
$ curl -r 0-1048576 -X GET -I $url | grep Content-Range
Content-Range: bytes 0-1048576/11021
```

The correct range header should be `bytes 0-11020/11021`,  which only requires formatting correct `endRng` when range > content-length.

Related issue(closed but not actually fixed): #1978 

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
