### PR TITLE
[chore] Re-add indexes, rename account actions indexes

### DIFF
--- a/internal/db/bundb/migrations/20231128140847_remove_duplicate_indices.go
+++ b/internal/db/bundb/migrations/20231128140847_remove_duplicate_indices.go
@@ -157,7 +157,6 @@ func init() {
 				"accounts_id_idx",
 				"accounts_inbox_uri_idx",
 				"accounts_outbox_uri_idx",
-				"accounts_domain_idx",
 				"accounts_uri_idx",
 				"accounts_url_idx",
 				"accounts_followers_uri_idx",
@@ -169,20 +168,15 @@ func init() {
 				"emojis_uri_idx",
 				"instances_domain_idx",
 				"list_entries_id_idx",
-				"list_entries_list_id_idx",
 				"lists_id_idx",
 				"markers_account_id_name_idx",
 				"media_attachments_id_idx",
 				"status_faves_id_idx",
-				"status_faves_account_id_idx",
-				"status_to_tags_tag_id_idx",
 				"statuses_uri_idx",
-				"statuses_account_id_idx", // <- seems counterintuitive, but other indexes include "account_id" as first column
 				"tags_name_idx",
 				"thread_mutes_id_idx",
 				"thread_mutes_thread_id_account_id_idx",
 				"threads_id_idx",
-				"tombstone_uri_idx",
 				"tombstone_uri_idx",
 			} {
 				if _, err := tx.

--- a/internal/db/bundb/migrations/20231130103643_fix_index_whoopsie.go
+++ b/internal/db/bundb/migrations/20231130103643_fix_index_whoopsie.go
@@ -72,7 +72,7 @@ func init() {
 				{
 					index:   "admin_actions_account_id_idx",
 					table:   "admin_actions",
-					columns: []string{"type"},
+					columns: []string{"account_id"},
 				},
 
 				// Recreate indexes that may have been removed

--- a/internal/db/bundb/migrations/20231130103643_fix_index_whoopsie.go
+++ b/internal/db/bundb/migrations/20231130103643_fix_index_whoopsie.go
@@ -1,0 +1,131 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			log.Info(ctx, "renaming / re-adding some indexes; this may take some time, please be patient and don't interrupt this!")
+
+			// Remove misnamed indexes from when
+			// account_actions renamed to admin_actions
+			for _, index := range []string{
+				"account_actions_target_category_idx",
+				"account_actions_target_id_idx",
+				"account_actions_type_idx",
+				"account_actions_account_id_idx",
+			} {
+				if _, err := tx.
+					NewDropIndex().
+					Index(index).
+					IfExists().
+					Exec(ctx); err != nil {
+					return err
+				}
+			}
+
+			type spec struct {
+				index   string
+				table   string
+				columns []string
+			}
+
+			for _, spec := range []spec{
+				// Rename the admin actions indexes.
+				{
+					index:   "admin_actions_target_category_idx",
+					table:   "admin_actions",
+					columns: []string{"target_category"},
+				},
+				{
+					index:   "admin_actions_target_id_idx",
+					table:   "admin_actions",
+					columns: []string{"target_id"},
+				},
+				{
+					index:   "admin_actions_type_idx",
+					table:   "admin_actions",
+					columns: []string{"type"},
+				},
+				{
+					index:   "admin_actions_account_id_idx",
+					table:   "admin_actions",
+					columns: []string{"type"},
+				},
+
+				// Recreate indexes that may have been removed
+				// by a bodged version of the previous migration
+				// (this PR is my penance -- tobi).
+				{
+					index:   "list_entries_list_id_idx",
+					table:   "list_entries",
+					columns: []string{"list_id"},
+				},
+				{
+					index:   "accounts_domain_idx",
+					table:   "accounts",
+					columns: []string{"domain"},
+				},
+				{
+					index:   "status_faves_account_id_idx",
+					table:   "status_faves",
+					columns: []string{"account_id"},
+				},
+				{
+					index:   "statuses_account_id_idx",
+					table:   "statuses",
+					columns: []string{"account_id"},
+				},
+				{
+					index:   "status_to_tags_tag_id_idx",
+					table:   "status_to_tags",
+					columns: []string{"tag_id"},
+				},
+			} {
+				if _, err := tx.
+					NewCreateIndex().
+					Table(spec.table).
+					Index(spec.index).
+					Column(spec.columns...).
+					IfNotExists().
+					Exec(ctx); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request re-adds some indexes that were removed in a previous PR. Postgres query planner seemed likely to manage without those indexes, but sqlite doesn't like going without, so here we are!

Also while I'm doing penance for that previous broken PR, fixed the naming of some other indexes.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
