### PR TITLE
[bugfix] always go through status parent dereferencing on isNew, even on data-race

### DIFF
--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -297,8 +297,8 @@ func (d *Dereferencer) enrichStatusSafely(
 		// We leave 'isNew' set so that caller
 		// still dereferences parents, otherwise
 		// the version we pass back may not have
-		// these dereferenced yet (since those
-		// happen OUTSIDE the federator lock).
+		// these attached as inReplyTos yet (since
+		// those happen OUTSIDE federator lock).
 		//
 		// TODO: performance-wise, this won't be
 		// great. should improve this if we can!

--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -251,7 +251,11 @@ func (d *Dereferencer) enrichStatusSafely(
 ) (*gtsmodel.Status, ap.Statusable, bool, error) {
 	uriStr := status.URI
 
-	if status.ID != "" {
+	var isNew bool
+
+	// Check if this is a new status (to us).
+	if isNew = (status.ID == ""); !isNew {
+
 		// This is an existing status, first try to populate it. This
 		// is required by the checks below for existing tags, media etc.
 		if err := d.state.DB.PopulateStatus(ctx, status); err != nil {
@@ -265,9 +269,6 @@ func (d *Dereferencer) enrichStatusSafely(
 	unlock := d.state.FedLocks.Lock(uriStr)
 	unlock = doOnce(unlock)
 	defer unlock()
-
-	// This is a NEW status (to us).
-	isNew := (status.ID == "")
 
 	// Perform status enrichment with passed vars.
 	latest, apubStatus, err := d.enrichStatus(ctx,
@@ -292,7 +293,15 @@ func (d *Dereferencer) enrichStatusSafely(
 		// otherwise this indicates WE
 		// enriched the status.
 		apubStatus = nil
-		isNew = false
+
+		// We leave 'isNew' set so that caller
+		// still dereferences parents, otherwise
+		// the version we pass back may not have
+		// these dereferenced yet (since those
+		// happen OUTSIDE the federator lock).
+		//
+		// TODO: performance-wise, this won't be
+		// great. should improve this if we can!
 
 		// DATA RACE! We likely lost out to another goroutine
 		// in a call to db.Put(Status). Look again in DB by URI.

--- a/internal/processing/workers/fromfediapi.go
+++ b/internal/processing/workers/fromfediapi.go
@@ -19,7 +19,6 @@ package workers
 
 import (
 	"context"
-	"net/url"
 
 	"codeberg.org/gruf/go-kv"
 	"codeberg.org/gruf/go-logger/v2/level"
@@ -167,25 +166,6 @@ func (p *fediAPI) CreateStatus(ctx context.Context, fMsg messages.FromFediAPI) e
 
 	if err != nil {
 		return gtserror.Newf("error extracting status from federatorMsg: %w", err)
-	}
-
-	if status.Account == nil || status.Account.IsRemote() {
-		// Either no account attached yet, or a remote account.
-		// Both situations we need to parse account URI to fetch it.
-		accountURI, err := url.Parse(status.AccountURI)
-		if err != nil {
-			return gtserror.Newf("error parsing account uri: %w", err)
-		}
-
-		// Ensure that account for this status has been deref'd.
-		status.Account, _, err = p.federate.GetAccountByURI(
-			ctx,
-			fMsg.ReceivingAccount.Username,
-			accountURI,
-		)
-		if err != nil {
-			return gtserror.Newf("error getting account by uri: %w", err)
-		}
 	}
 
 	if status.InReplyToID != "" {


### PR DESCRIPTION
# Description

As the title says really. This isn't ideal, but it's the only (easy) way of handling this right now, without performing a parent dereference within mutex lock and possibly risk lock-ups if there's any threads that end up self-referencing. This shouldn't happen *too* often so performance impact shouldn't be much, especially as all of those statuses will also just return fetched_at as too new (all of which will be cache hits).

Also removes the dereference account step _after_ dereferencing status in the fedi API worker, as to reach that point the account must already have been dereferenced / refreshed.

Closes #2396 

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
