### PR TITLE
[bugfix/chore] `Announce` reliability updates

### DIFF
--- a/internal/federation/dereferencing/announce.go
+++ b/internal/federation/dereferencing/announce.go
@@ -48,11 +48,11 @@ func (d *Dereferencer) EnrichAnnounce(
 	}
 
 	// Parse the boost target status URI.
-	targetURIObj, err := url.Parse(boost.BoostOfURI)
+	targetURIObj, err := url.Parse(targetURI)
 	if err != nil {
 		return nil, gtserror.Newf(
 			"couldn't parse boost target status URI %s: %w",
-			boost.BoostOfURI, err,
+			targetURI, err,
 		)
 	}
 

--- a/internal/federation/dereferencing/announce.go
+++ b/internal/federation/dereferencing/announce.go
@@ -56,14 +56,6 @@ func (d *Dereferencer) EnrichAnnounce(
 		)
 	}
 
-	// Ensure target status isn't from a blocked host.
-	if blocked, err := d.state.DB.IsDomainBlocked(ctx, targetURIObj.Host); err != nil {
-		return nil, gtserror.Newf("error checking blocked domain: %w", err)
-	} else if blocked {
-		err = gtserror.Newf("%s is blocked", targetURIObj.Host)
-		return nil, gtserror.SetUnretrievable(err)
-	}
-
 	// Fetch/deref status being boosted.
 	var target *gtsmodel.Status
 
@@ -72,6 +64,9 @@ func (d *Dereferencer) EnrichAnnounce(
 		target, err = d.state.DB.GetStatusByURI(ctx, targetURI)
 	} else {
 		// This is a remote status, we need to dereference it.
+		//
+		// d.GetStatusByURI will handle domain block checking for us,
+		// so we don't try to deref an announce target on a blocked host.
 		target, _, err = d.GetStatusByURI(ctx, requestUser, targetURIObj)
 	}
 

--- a/internal/federation/dereferencing/announce.go
+++ b/internal/federation/dereferencing/announce.go
@@ -20,66 +20,119 @@ package dereferencing
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/url"
 
 	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/id"
 )
 
-func (d *Dereferencer) DereferenceAnnounce(ctx context.Context, announce *gtsmodel.Status, requestingUsername string) error {
-	if announce.BoostOf == nil {
-		// we can't do anything unfortunately
-		return errors.New("DereferenceAnnounce: no URI to dereference")
+// EnrichAnnounceSafely enriches the given boost wrapper status
+// by either fetching from the DB or dereferencing the target
+// status, populating the boost wrapper's fields based on the
+// target status, and then storing the wrapper in the database.
+// It uses per-URI locks to ensure the boost is only enriched once.
+//
+// The provided boost wrapper status must have BoostOfURI set.
+func (d *Dereferencer) EnrichAnnounceSafely(
+	ctx context.Context,
+	boost *gtsmodel.Status,
+	requestUser string,
+) error {
+	targetURI := boost.BoostOfURI
+	if targetURI == "" {
+		// We can't do anything.
+		return gtserror.Newf("no URI to dereference")
 	}
 
-	// Parse the boosted status' URI
-	boostedURI, err := url.Parse(announce.BoostOf.URI)
+	// Parse the boost target status URI.
+	targetURIObj, err := url.Parse(boost.BoostOfURI)
 	if err != nil {
-		return fmt.Errorf("DereferenceAnnounce: couldn't parse boosted status URI %s: %s", announce.BoostOf.URI, err)
+		return gtserror.Newf(
+			"couldn't parse boost target status URI %s: %w",
+			boost.BoostOfURI, err,
+		)
 	}
 
-	// Check whether the originating status is from a blocked host
-	if blocked, err := d.state.DB.IsDomainBlocked(ctx, boostedURI.Host); blocked || err != nil {
-		return fmt.Errorf("DereferenceAnnounce: domain %s is blocked", boostedURI.Host)
+	// Ensure target status isn't from a blocked host.
+	if blocked, err := d.state.DB.IsDomainBlocked(ctx, targetURIObj.Host); err != nil {
+		return gtserror.Newf("error checking blocked domain: %w", err)
+	} else if blocked {
+		err = gtserror.Newf("%s is blocked", targetURIObj.Host)
+		return gtserror.SetUnretrievable(err)
 	}
 
-	var boostedStatus *gtsmodel.Status
+	// Acquire per-URI deref lock; safely defer in
+	// case of panic. Important: use the URI of the
+	// BOOST WRAPPER for this, not the target's URI;
+	// the latter will be locked by d.GetStatusByURI.
+	unlock := d.state.FedLocks.Lock(boost.URI)
+	defer unlock()
 
-	if boostedURI.Host == config.GetHost() {
+	// Fetch/deref status being boosted.
+	var target *gtsmodel.Status
+
+	if targetURIObj.Host == config.GetHost() {
 		// This is a local status, fetch from the database
-		status, err := d.state.DB.GetStatusByURI(ctx, boostedURI.String())
-		if err != nil {
-			return fmt.Errorf("DereferenceAnnounce: error fetching local status %q: %v", announce.BoostOf.URI, err)
-		}
-
-		// Set boosted status
-		boostedStatus = status
+		target, err = d.state.DB.GetStatusByURI(ctx, targetURI)
 	} else {
-		// This is a boost of a remote status, we need to dereference it.
-		status, _, err := d.GetStatusByURI(ctx, requestingUsername, boostedURI)
-		if err != nil {
-			return fmt.Errorf("DereferenceAnnounce: error dereferencing remote status with id %s: %s", announce.BoostOf.URI, err)
-		}
-
-		// Set boosted status
-		boostedStatus = status
+		// This is a remote status, we need to dereference it.
+		target, _, err = d.GetStatusByURI(ctx, requestUser, targetURIObj)
 	}
 
-	announce.Content = boostedStatus.Content
-	announce.ContentWarning = boostedStatus.ContentWarning
-	announce.ActivityStreamsType = boostedStatus.ActivityStreamsType
-	announce.Sensitive = boostedStatus.Sensitive
-	announce.Language = boostedStatus.Language
-	announce.Text = boostedStatus.Text
-	announce.BoostOfID = boostedStatus.ID
-	announce.BoostOfAccountID = boostedStatus.AccountID
-	announce.Visibility = boostedStatus.Visibility
-	announce.Federated = boostedStatus.Federated
-	announce.Boostable = boostedStatus.Boostable
-	announce.Replyable = boostedStatus.Replyable
-	announce.Likeable = boostedStatus.Likeable
-	announce.BoostOf = boostedStatus
+	if err != nil {
+		return gtserror.Newf(
+			"error getting boost target status %s: %w",
+			targetURI, err,
+		)
+	}
 
-	return nil
+	// Generate an ID for the boost wrapper status.
+	boost.ID, err = id.NewULIDFromTime(boost.CreatedAt)
+	if err != nil {
+		return gtserror.Newf("error generating id: %w", err)
+	}
+
+	// Populate remaining fields on
+	// the boost wrapper using target.
+	boost.Content = target.Content
+	boost.ContentWarning = target.ContentWarning
+	boost.ActivityStreamsType = target.ActivityStreamsType
+	boost.Sensitive = target.Sensitive
+	boost.Language = target.Language
+	boost.Text = target.Text
+	boost.BoostOfID = target.ID
+	boost.BoostOf = target
+	boost.BoostOfAccountID = target.AccountID
+	boost.BoostOfAccount = target.Account
+	boost.Visibility = target.Visibility
+	boost.Federated = target.Federated
+	boost.Boostable = target.Boostable
+	boost.Replyable = target.Replyable
+	boost.Likeable = target.Likeable
+
+	// Store the boost wrapper status.
+	switch err = d.state.DB.PutStatus(ctx, boost); {
+	case err == nil:
+		// All good baby.
+
+	case errors.Is(err, db.ErrAlreadyExists):
+		// DATA RACE! We likely lost out to another goroutine
+		// in a call to db.Put(Status). Look again in DB by URI.
+		boost, err = d.state.DB.GetStatusByURI(ctx, boost.URI)
+		if err != nil {
+			err = gtserror.Newf(
+				"error getting boost wrapper status %s from database after race: %w",
+				boost.URI, err,
+			)
+		}
+
+	default:
+		// Proper database error.
+		err = gtserror.Newf("db error inserting status: %w", err)
+	}
+
+	return err
 }

--- a/internal/federation/federatingdb/announce_test.go
+++ b/internal/federation/federatingdb/announce_test.go
@@ -50,8 +50,10 @@ func (suite *AnnounceTestSuite) TestNewAnnounce() {
 	suite.True(ok)
 	suite.Equal(announcingAccount.ID, boost.AccountID)
 
-	// only the URI will be set on the boosted status because it still needs to be dereferenced
-	suite.NotEmpty(boost.BoostOf.URI)
+	// only the URI will be set for the boosted status
+	// because it still needs to be dereferenced
+	suite.Nil(boost.BoostOf)
+	suite.Equal("http://example.org/users/Some_User/statuses/afaba698-5740-4e32-a702-af61aa543bc1", boost.BoostOfURI)
 }
 
 func (suite *AnnounceTestSuite) TestAnnounceTwice() {
@@ -81,8 +83,10 @@ func (suite *AnnounceTestSuite) TestAnnounceTwice() {
 		return nil
 	})
 
-	// only the URI will be set on the boosted status because it still needs to be dereferenced
-	suite.NotEmpty(boost.BoostOf.URI)
+	// only the URI will be set for the boosted status
+	// because it still needs to be dereferenced
+	suite.Nil(boost.BoostOf)
+	suite.Equal("http://example.org/users/Some_User/statuses/afaba698-5740-4e32-a702-af61aa543bc1", boost.BoostOfURI)
 
 	ctx2 := createTestContext(receivingAccount2, announcingAccount)
 	announce2 := suite.testActivities["announce_forwarded_1_turtle"]

--- a/internal/gtsmodel/status.go
+++ b/internal/gtsmodel/status.go
@@ -50,6 +50,7 @@ type Status struct {
 	InReplyTo                *Status            `bun:"-"`                                                           // status corresponding to inReplyToID
 	InReplyToAccount         *Account           `bun:"rel:belongs-to"`                                              // account corresponding to inReplyToAccountID
 	BoostOfID                string             `bun:"type:CHAR(26),nullzero"`                                      // id of the status this status is a boost of
+	BoostOfURI               string             `bun:"-"`                                                           // URI of the status this status is a boost of; field not inserted in the db, just for dereferencing purposes.
 	BoostOfAccountID         string             `bun:"type:CHAR(26),nullzero"`                                      // id of the account that owns the boosted status
 	BoostOf                  *Status            `bun:"-"`                                                           // status that corresponds to boostOfID
 	BoostOfAccount           *Account           `bun:"rel:belongs-to"`                                              // account that corresponds to boostOfAccountID

--- a/internal/processing/common/status.go
+++ b/internal/processing/common/status.go
@@ -119,34 +119,22 @@ func (p *Processor) GetVisibleTargetStatus(
 	return target, nil
 }
 
-// GetVisibleTargetStatusUnwrapped is like GetVisibleTargetStatus,
-// but if targetID points to a boost wrapper status, that status
-// will be 'unwrapped' to return the boosted status instead.
-func (p *Processor) GetVisibleTargetStatusUnwrapped(
+// UnwrapIfBoost "unwraps" the given status if
+// it's a boost wrapper, by returning the boosted
+// status it targets (pending visibility checks).
+//
+// Just returns the input status if it's not a boost.
+func (p *Processor) UnwrapIfBoost(
 	ctx context.Context,
 	requester *gtsmodel.Account,
-	targetID string,
-) (
 	status *gtsmodel.Status,
-	errWithCode gtserror.WithCode,
-) {
-	target, errWithCode := p.GetVisibleTargetStatus(ctx,
-		requester,
-		targetID,
-	)
-	if errWithCode != nil {
-		return nil, errWithCode
+) (*gtsmodel.Status, gtserror.WithCode) {
+	if status.BoostOfID == "" {
+		return status, nil
 	}
 
-	if target.BoostOfID == "" {
-		// Already unwrapped.
-		return target, nil
-	}
-
-	// Return boosted status.
 	return p.GetVisibleTargetStatus(ctx,
-		requester,
-		target.BoostOfID,
+		requester, status.BoostOfID,
 	)
 }
 

--- a/internal/processing/common/status.go
+++ b/internal/processing/common/status.go
@@ -119,6 +119,37 @@ func (p *Processor) GetVisibleTargetStatus(
 	return target, nil
 }
 
+// GetVisibleTargetStatusUnwrapped is like GetVisibleTargetStatus,
+// but if targetID points to a boost wrapper status, that status
+// will be 'unwrapped' to return the boosted status instead.
+func (p *Processor) GetVisibleTargetStatusUnwrapped(
+	ctx context.Context,
+	requester *gtsmodel.Account,
+	targetID string,
+) (
+	status *gtsmodel.Status,
+	errWithCode gtserror.WithCode,
+) {
+	target, errWithCode := p.GetVisibleTargetStatus(ctx,
+		requester,
+		targetID,
+	)
+	if errWithCode != nil {
+		return nil, errWithCode
+	}
+
+	if target.BoostOfID == "" {
+		// Already unwrapped.
+		return target, nil
+	}
+
+	// Return boosted status.
+	return p.GetVisibleTargetStatus(ctx,
+		requester,
+		target.BoostOfID,
+	)
+}
+
 // GetAPIStatus fetches the appropriate API status model for target.
 func (p *Processor) GetAPIStatus(
 	ctx context.Context,

--- a/internal/processing/fedi/status.go
+++ b/internal/processing/fedi/status.go
@@ -51,6 +51,11 @@ func (p *Processor) StatusGet(ctx context.Context, requestedUser string, statusI
 		return nil, gtserror.NewErrorNotFound(errors.New(text))
 	}
 
+	if status.BoostOfID != "" {
+		const text = "status is a boost wrapper"
+		return nil, gtserror.NewErrorNotFound(errors.New(text))
+	}
+
 	visible, err := p.filter.StatusVisible(ctx, requester, status)
 	if err != nil {
 		return nil, gtserror.NewErrorInternalError(err)
@@ -103,6 +108,11 @@ func (p *Processor) StatusRepliesGet(
 	// Ensure status is by receiving account.
 	if status.AccountID != receiver.ID {
 		const text = "status does not belong to receiving account"
+		return nil, gtserror.NewErrorNotFound(errors.New(text))
+	}
+
+	if status.BoostOfID != "" {
+		const text = "status is a boost wrapper"
 		return nil, gtserror.NewErrorNotFound(errors.New(text))
 	}
 

--- a/internal/processing/status/boost.go
+++ b/internal/processing/status/boost.go
@@ -38,11 +38,20 @@ func (p *Processor) BoostCreate(
 	application *gtsmodel.Application,
 	targetID string,
 ) (*apimodel.Status, gtserror.WithCode) {
-	// Ensure we're not targeting a boost wrapper status.
-	target, errWithCode := p.c.GetVisibleTargetStatusUnwrapped(
+	// Get target status and ensure it's not a boost.
+	target, errWithCode := p.c.GetVisibleTargetStatus(
 		ctx,
 		requester,
 		targetID,
+	)
+	if errWithCode != nil {
+		return nil, errWithCode
+	}
+
+	target, errWithCode = p.c.UnwrapIfBoost(
+		ctx,
+		requester,
+		target,
 	)
 	if errWithCode != nil {
 		return nil, errWithCode
@@ -98,11 +107,20 @@ func (p *Processor) BoostRemove(
 	application *gtsmodel.Application,
 	targetID string,
 ) (*apimodel.Status, gtserror.WithCode) {
-	// Ensure we're not targeting a boost wrapper status.
-	target, errWithCode := p.c.GetVisibleTargetStatusUnwrapped(
+	// Get target status and ensure it's not a boost.
+	target, errWithCode := p.c.GetVisibleTargetStatus(
 		ctx,
 		requester,
 		targetID,
+	)
+	if errWithCode != nil {
+		return nil, errWithCode
+	}
+
+	target, errWithCode = p.c.UnwrapIfBoost(
+		ctx,
+		requester,
+		target,
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/status/fave.go
+++ b/internal/processing/status/fave.go
@@ -66,7 +66,7 @@ func (p *Processor) getFaveableStatus(
 		return nil, nil, gtserror.NewErrorForbidden(err, err.Error())
 	}
 
-	fave, err := p.state.DB.GetStatusFave(ctx, requester.ID, targetID)
+	fave, err := p.state.DB.GetStatusFave(ctx, requester.ID, target.ID)
 	if err != nil && !errors.Is(err, db.ErrNoEntries) {
 		err = fmt.Errorf("getFaveTarget: error checking existing fave: %w", err)
 		return nil, nil, gtserror.NewErrorInternalError(err)

--- a/internal/processing/workers/fromfediapi.go
+++ b/internal/processing/workers/fromfediapi.go
@@ -340,11 +340,13 @@ func (p *fediAPI) CreateAnnounce(ctx context.Context, fMsg messages.FromFediAPI)
 	// that this will handle storing the boost in
 	// the db, and dereferencing the target status
 	// ancestors / descendants where appropriate.
-	if err := p.federate.EnrichAnnounceSafely(
+	var err error
+	boost, err = p.federate.EnrichAnnounce(
 		ctx,
 		boost,
 		fMsg.ReceivingAccount.Username,
-	); err != nil {
+	)
+	if err != nil {
 		if gtserror.IsUnretrievable(err) {
 			// Boosted status domain blocked, nothing to do.
 			log.Debugf(ctx, "skipping announce: %v", err)

--- a/internal/processing/workers/fromfediapi_test.go
+++ b/internal/processing/workers/fromfediapi_test.go
@@ -45,9 +45,7 @@ func (suite *FromFediAPITestSuite) TestProcessFederationAnnounce() {
 	boostingAccount := suite.testAccounts["remote_account_1"]
 	announceStatus := &gtsmodel.Status{}
 	announceStatus.URI = "https://example.org/some-announce-uri"
-	announceStatus.BoostOf = &gtsmodel.Status{
-		URI: boostedStatus.URI,
-	}
+	announceStatus.BoostOfURI = boostedStatus.URI
 	announceStatus.CreatedAt = time.Now()
 	announceStatus.UpdatedAt = time.Now()
 	announceStatus.AccountID = boostingAccount.ID

--- a/internal/typeutils/astointernal.go
+++ b/internal/typeutils/astointernal.go
@@ -558,12 +558,12 @@ func (c *Converter) ASAnnounceToStatus(
 	}
 
 	if boost != nil {
-		// We already have this status,
+		// We already have this boost,
 		// no need to proceed further.
 		return boost, isNew, nil
 	}
 
-	// Create status with URI
+	// Create boost with URI
 	boost = new(gtsmodel.Status)
 	boost.URI = uri
 	isNew = true
@@ -576,7 +576,7 @@ func (c *Converter) ASAnnounceToStatus(
 	}
 
 	// Set the URI of the boosted status on
-	// the new status, for later dereferencing.
+	// the boost, for later dereferencing.
 	boost.BoostOfURI = boostOf[0].String()
 
 	// Extract published time for the boost,
@@ -619,9 +619,9 @@ func (c *Converter) ASAnnounceToStatus(
 	boost.MentionIDs = make([]string, 0)
 	boost.EmojiIDs = make([]string, 0)
 
-	// Remaining fields on the boost status will be taken
-	// from the boosted status; it's not our job to do all
-	// that dereferencing here.
+	// Remaining fields on the boost will be
+	// taken from the target status; it's not
+	// our job to do all that dereferencing here.
 	return boost, isNew, nil
 }
 

--- a/internal/typeutils/astointernal.go
+++ b/internal/typeutils/astointernal.go
@@ -527,29 +527,15 @@ func (c *Converter) ASBlockToBlock(ctx context.Context, blockable ap.Blockable) 
 	}, nil
 }
 
-// ASAnnounceToStatus converts an activitystreams 'announce' into a status.
-//
-// The returned bool indicates whether this status is new (true) or not new (false).
-//
-// In other words, if the status is already in the database with the ID set on the announceable, then that will be returned,
-// the returned bool will be false, and no further processing is necessary. If the returned bool is true, indicating
-// that this is a new announce, then further processing will be necessary, because the returned status will be bareboned and
-// require further dereferencing.
-//
-// This is useful when multiple users on an instance might receive the same boost, and we only want to process the boost once.
-//
-// NOTE -- this is different from one status being boosted multiple times! In this case, new boosts should indeed be created.
-//
-// Implementation note: this function creates and returns a boost WRAPPER
-// status which references the boosted status in its BoostOf field. No
-// dereferencing is done on the boosted status by this function. Callers
-// should look at `status.BoostOf` to see the status being boosted, and do
-// dereferencing on it as appropriate.
-//
-// The returned boolean indicates whether or not the boost has already been
-// seen before by this instance. If it was, then status.BoostOf should be a
-// fully filled-out status. If not, then only status.BoostOf.URI will be set.
-func (c *Converter) ASAnnounceToStatus(ctx context.Context, announceable ap.Announceable) (*gtsmodel.Status, bool, error) {
+// ASAnnounceToStatus converts an activitystreams 'announce' into a boost
+// wrapper status. The returned bool indicates whether this boost is new
+// (true) or not. If new, callers should use `status.BoostOfURI` to see the
+// status being boosted, and do dereferencing on it as appropriate. If not
+// new, then the boost has already been fully processed and can be ignored.
+func (c *Converter) ASAnnounceToStatus(
+	ctx context.Context,
+	announceable ap.Announceable,
+) (*gtsmodel.Status, bool, error) {
 	// Default assume
 	// we already have.
 	isNew := false
@@ -565,21 +551,21 @@ func (c *Converter) ASAnnounceToStatus(ctx context.Context, announceable ap.Anno
 	uri := uriObj.String()
 
 	// Check if we already have this boost in the database.
-	status, err := c.state.DB.GetStatusByURI(ctx, uri)
+	boost, err := c.state.DB.GetStatusByURI(ctx, uri)
 	if err != nil && !errors.Is(err, db.ErrNoEntries) {
 		err = gtserror.Newf("db error trying to get status with uri %s: %w", uri, err)
 		return nil, isNew, err
 	}
 
-	if status != nil {
+	if boost != nil {
 		// We already have this status,
 		// no need to proceed further.
-		return status, isNew, nil
+		return boost, isNew, nil
 	}
 
-	// Create DB status with URI
-	status = new(gtsmodel.Status)
-	status.URI = uri
+	// Create status with URI
+	boost = new(gtsmodel.Status)
+	boost.URI = uri
 	isNew = true
 
 	// Get the URI of the boosted status.
@@ -591,21 +577,20 @@ func (c *Converter) ASAnnounceToStatus(ctx context.Context, announceable ap.Anno
 
 	// Set the URI of the boosted status on
 	// the new status, for later dereferencing.
-	status.BoostOf = new(gtsmodel.Status)
-	status.BoostOf.URI = boostOf[0].String()
+	boost.BoostOfURI = boostOf[0].String()
 
 	// Extract published time for the boost,
 	// zero-time will fall back to db defaults.
 	if pub := ap.GetPublished(announceable); !pub.IsZero() {
-		status.CreatedAt = pub
-		status.UpdatedAt = pub
+		boost.CreatedAt = pub
+		boost.UpdatedAt = pub
 	} else {
 		log.Warnf(ctx, "unusable published property on %s", uri)
 	}
 
 	// Extract and load the boost actor account,
 	// (this MUST already be in database by now).
-	status.Account, err = c.getASActorAccount(ctx,
+	boost.Account, err = c.getASActorAccount(ctx,
 		uri,
 		announceable,
 	)
@@ -614,13 +599,13 @@ func (c *Converter) ASAnnounceToStatus(ctx context.Context, announceable ap.Anno
 	}
 
 	// Set the related status<->account fields.
-	status.AccountURI = status.Account.URI
-	status.AccountID = status.Account.ID
+	boost.AccountURI = boost.Account.URI
+	boost.AccountID = boost.Account.ID
 
 	// Calculate intended visibility of the boost.
-	status.Visibility, err = ap.ExtractVisibility(
+	boost.Visibility, err = ap.ExtractVisibility(
 		announceable,
-		status.Account.FollowersURI,
+		boost.Account.FollowersURI,
 	)
 	if err != nil {
 		err := gtserror.Newf("error extracting status visibility for %s: %w", uri, err)
@@ -629,15 +614,15 @@ func (c *Converter) ASAnnounceToStatus(ctx context.Context, announceable ap.Anno
 
 	// Below IDs will all be included in the
 	// boosted status, so set them empty here.
-	status.AttachmentIDs = make([]string, 0)
-	status.TagIDs = make([]string, 0)
-	status.MentionIDs = make([]string, 0)
-	status.EmojiIDs = make([]string, 0)
+	boost.AttachmentIDs = make([]string, 0)
+	boost.TagIDs = make([]string, 0)
+	boost.MentionIDs = make([]string, 0)
+	boost.EmojiIDs = make([]string, 0)
 
 	// Remaining fields on the boost status will be taken
 	// from the boosted status; it's not our job to do all
 	// that dereferencing here.
-	return status, isNew, nil
+	return boost, isNew, nil
 }
 
 // ASFlagToReport converts a remote activitystreams 'flag' representation into a gts model report.

--- a/internal/typeutils/internal.go
+++ b/internal/typeutils/internal.go
@@ -19,90 +19,86 @@ package typeutils
 
 import (
 	"context"
-	"time"
 
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/id"
 	"github.com/superseriousbusiness/gotosocial/internal/uris"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
 
-// FollowRequestToFollow just converts a follow request into a follow, that's it! No bells and whistles.
-func (c *Converter) FollowRequestToFollow(ctx context.Context, f *gtsmodel.FollowRequest) *gtsmodel.Follow {
-	showReblogs := *f.ShowReblogs
-	notify := *f.Notify
+// FollowRequestToFollow just converts a follow request
+// into a follow, that's it! No bells and whistles.
+func (c *Converter) FollowRequestToFollow(
+	ctx context.Context,
+	fr *gtsmodel.FollowRequest,
+) *gtsmodel.Follow {
 	return &gtsmodel.Follow{
-		ID:              f.ID,
-		CreatedAt:       f.CreatedAt,
-		UpdatedAt:       f.UpdatedAt,
-		AccountID:       f.AccountID,
-		TargetAccountID: f.TargetAccountID,
-		ShowReblogs:     &showReblogs,
-		URI:             f.URI,
-		Notify:          &notify,
+		ID:              fr.ID,
+		CreatedAt:       fr.CreatedAt,
+		UpdatedAt:       fr.UpdatedAt,
+		AccountID:       fr.AccountID,
+		TargetAccountID: fr.TargetAccountID,
+		ShowReblogs:     util.Ptr(*fr.ShowReblogs),
+		URI:             fr.URI,
+		Notify:          util.Ptr(*fr.Notify),
 	}
 }
 
-// StatusToBoost wraps the given status into a boosting status.
-func (c *Converter) StatusToBoost(ctx context.Context, s *gtsmodel.Status, boostingAccount *gtsmodel.Account) (*gtsmodel.Status, error) {
-	// the wrapper won't use the same ID as the boosted status so we generate some new UUIDs
-	accountURIs := uris.GenerateURIsForAccount(boostingAccount.Username)
-	boostWrapperStatusID := id.NewULID()
-	boostWrapperStatusURI := accountURIs.StatusesURI + "/" + boostWrapperStatusID
-	boostWrapperStatusURL := accountURIs.StatusesURL + "/" + boostWrapperStatusID
+// StatusToBoost wraps the target status into a
+// boost wrapper status owned by the requester.
+func (c *Converter) StatusToBoost(
+	ctx context.Context,
+	target *gtsmodel.Status,
+	booster *gtsmodel.Account,
+	applicationID string,
+) (*gtsmodel.Status, error) {
+	// The boost won't use the same IDs as the
+	// target so we need to generate new ones.
+	boostID := id.NewULID()
+	accountURIs := uris.GenerateURIsForAccount(booster.Username)
 
-	local := true
-	if boostingAccount.Domain != "" {
-		local = false
-	}
+	boost := &gtsmodel.Status{
+		ID:  boostID,
+		URI: accountURIs.StatusesURI + "/" + boostID,
+		URL: accountURIs.StatusesURL + "/" + boostID,
 
-	sensitive := *s.Sensitive
-	federated := *s.Federated
-	boostable := *s.Boostable
-	replyable := *s.Replyable
-	likeable := *s.Likeable
+		// Inherit some fields from the booster account.
+		Local:                    util.Ptr(booster.IsLocal()),
+		AccountID:                booster.ID,
+		Account:                  booster,
+		AccountURI:               booster.URI,
+		CreatedWithApplicationID: applicationID,
 
-	boostWrapperStatus := &gtsmodel.Status{
-		ID:  boostWrapperStatusID,
-		URI: boostWrapperStatusURI,
-		URL: boostWrapperStatusURL,
-
-		// the boosted status is not created now, but the boost certainly is
-		CreatedAt:  time.Now(),
-		UpdatedAt:  time.Now(),
-		Local:      &local,
-		AccountID:  boostingAccount.ID,
-		AccountURI: boostingAccount.URI,
-
-		// replies can be boosted, but boosts are never replies
+		// Replies can be boosted, but
+		// boosts are never replies.
 		InReplyToID:        "",
 		InReplyToAccountID: "",
 
-		// these will all be wrapped in the boosted status so set them empty here
+		// These will all be wrapped in the
+		// boosted status so set them empty.
 		AttachmentIDs: []string{},
 		TagIDs:        []string{},
 		MentionIDs:    []string{},
 		EmojiIDs:      []string{},
 
-		// the below fields will be taken from the target status
-		Content:             s.Content,
-		ContentWarning:      s.ContentWarning,
-		ActivityStreamsType: s.ActivityStreamsType,
-		Sensitive:           &sensitive,
-		Language:            s.Language,
-		Text:                s.Text,
-		BoostOfID:           s.ID,
-		BoostOfAccountID:    s.AccountID,
-		Visibility:          s.Visibility,
-		Federated:           &federated,
-		Boostable:           &boostable,
-		Replyable:           &replyable,
-		Likeable:            &likeable,
-
-		// attach these here for convenience -- the boosted status/account won't go in the DB
-		// but they're needed in the processor and for the frontend. Since we have them, we can
-		// attach them so we don't need to fetch them again later (save some DB calls)
-		BoostOf: s,
+		// Remaining fields all
+		// taken from boosted status.
+		Content:             target.Content,
+		ContentWarning:      target.ContentWarning,
+		ActivityStreamsType: target.ActivityStreamsType,
+		Sensitive:           util.Ptr(*target.Sensitive),
+		Language:            target.Language,
+		Text:                target.Text,
+		BoostOfID:           target.ID,
+		BoostOf:             target,
+		BoostOfAccountID:    target.AccountID,
+		BoostOfAccount:      target.Account,
+		Visibility:          target.Visibility,
+		Federated:           util.Ptr(*target.Federated),
+		Boostable:           util.Ptr(*target.Boostable),
+		Replyable:           util.Ptr(*target.Replyable),
+		Likeable:            util.Ptr(*target.Likeable),
 	}
 
-	return boostWrapperStatus, nil
+	return boost, nil
 }

--- a/internal/typeutils/internaltoas_test.go
+++ b/internal/typeutils/internaltoas_test.go
@@ -724,10 +724,11 @@ func (suite *InternalToASTestSuite) TestSelfBoostFollowersOnlyToAS() {
 	testStatus := suite.testStatuses["local_account_1_status_5"]
 	testAccount := suite.testAccounts["local_account_1"]
 
-	boostWrapperStatus, err := suite.typeconverter.StatusToBoost(ctx, testStatus, testAccount)
+	boostWrapperStatus, err := suite.typeconverter.StatusToBoost(ctx, testStatus, testAccount, "")
 	suite.NoError(err)
 	suite.NotNil(boostWrapperStatus)
 
+	// Set some fields to predictable values for the test.
 	boostWrapperStatus.ID = "01G74JJ1KS331G2JXHRMZCE0ER"
 	boostWrapperStatus.URI = "http://localhost:8080/users/the_mighty_zork/statuses/01G74JJ1KS331G2JXHRMZCE0ER"
 	boostWrapperStatus.CreatedAt = testrig.TimeMustParse("2022-06-09T13:12:00Z")

--- a/internal/web/thread.go
+++ b/internal/web/thread.go
@@ -20,6 +20,7 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -120,6 +121,13 @@ func (m *Module) threadGETHandler(c *gin.Context) {
 	// Ensure status actually belongs to target account.
 	if status.GetAccountID() != targetAccount.ID {
 		err := fmt.Errorf("target account %s does not own status %s", targetUsername, targetStatusID)
+		apiutil.WebErrorHandler(c, gtserror.NewErrorNotFound(err), instanceGet)
+		return
+	}
+
+	// Don't render boosts/reblogs as top-level statuses.
+	if status.Reblog != nil {
+		err := errors.New("status is a boost wrapper / reblog")
 		apiutil.WebErrorHandler(c, gtserror.NewErrorNotFound(err), instanceGet)
 		return
 	}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

- ~~Use per-URI deref locks for Announce dereferences to avoid races.~~
- Use new `BoostOfURI` field on statuses for doing Announce derefs (new field not stored in the db).
- Ensure faves and boosts are redirected properly to top-level status when the fave or boost was created targeting the ID of a boost wrapper.
- Don't serve boost wrappers via the web UI or the fedi API.
- Use `Unretrievable` to do noop nicely when a boost target is on a blocked domain.
- Fail to serialize boost via the client API if BoostOfID is set but BoostOf is not (for whatever reason).

This is rather a hodge-podge of fixes and updates. It MAY resolve https://github.com/superseriousbusiness/gotosocial/issues/2394 but we'll have to run it for a while to see, since I couldn't actually definitely identify the root cause of that bug.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
