### PR TITLE
[chore] Run `ANALYZE` for SQLite after latest migrations

### DIFF
--- a/internal/db/bundb/migrations/20231208152242_sqlite_analyze.go
+++ b/internal/db/bundb/migrations/20231208152242_sqlite_analyze.go
@@ -1,0 +1,51 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		if db.Dialect().Name() != dialect.SQLite {
+			// No need to run this on
+			// other types than SQLite.
+			return nil
+		}
+
+		log.Info(ctx, "running ANALYZE on SQLite database for optimization; this may take some time, please be patient and don't interrupt this!")
+		if _, err := db.ExecContext(ctx, "ANALYZE"); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return nil
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
See https://github.com/superseriousbusiness/gotosocial/issues/2425 for more details.

We may want to run VACUUM as well, but since this can take quite a long time (10-15 minutes-ish), it might be better not to, but instead tell folks to run it manually. I'm not entirely sure yet.