### PR TITLE
[feature] Run ANALYZE after migrations on SQLite

### DIFF
--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -44,6 +44,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/state"
 	"github.com/superseriousbusiness/gotosocial/internal/tracing"
 	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect"
 	"github.com/uptrace/bun/dialect/pgdialect"
 	"github.com/uptrace/bun/dialect/sqlitedialect"
 	"github.com/uptrace/bun/migrate"
@@ -113,6 +114,14 @@ func doMigration(ctx context.Context, db *bun.DB) error {
 	}
 
 	log.Infof(ctx, "MIGRATED DATABASE TO %s", group)
+
+	if db.Dialect().Name() == dialect.SQLite {
+		log.Info(ctx, "running ANALYZE to update table and index statistics")
+		_, err := db.Exec("ANALYZE")
+		if err != nil {
+			log.Warnf(ctx, "ANALYZE failed, query planner may make poor life choices: %s", err)
+		}
+	}
 	return nil
 }
 

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -117,7 +117,7 @@ func doMigration(ctx context.Context, db *bun.DB) error {
 
 	if db.Dialect().Name() == dialect.SQLite {
 		log.Info(ctx, "running ANALYZE to update table and index statistics")
-		_, err := db.Exec("ANALYZE")
+		_, err := db.ExecContext(ctx, "ANALYZE")
 		if err != nil {
 			log.Warnf(ctx, "ANALYZE failed, query planner may make poor life choices: %s", err)
 		}


### PR DESCRIPTION
# Description

This ensures that at the end of migrations, we run ANALYZE if we're using SQLite. This should be relatively quick and guarantees that the table and index statistics have been updated. This helps to ensure the query planner makes better choices when it comes to picking which indexes are used when running queries.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
