### PR TITLE
[bugfix] Fix wrong notification type sent for poll end

### DIFF
--- a/internal/processing/workers/surfacenotify.go
+++ b/internal/processing/workers/surfacenotify.go
@@ -320,7 +320,7 @@ func (s *surface) notifyPollClose(ctx context.Context, status *gtsmodel.Status) 
 		// notify voter that
 		// poll has been closed.
 		if err := s.notify(ctx,
-			gtsmodel.NotificationMention,
+			gtsmodel.NotificationPoll,
 			vote.Account,
 			status.Account,
 			status.ID,


### PR DESCRIPTION
We'd set the wrong notification type for a voted-in poll ending; this fixes that!

https://docs.joinmastodon.org/methods/notifications/