### PR TITLE
[bugfix] Narrow search scope for accounts starting with '@'; don't `LOWER` SQLite text searches

### DIFF
--- a/internal/db/bundb/search_test.go
+++ b/internal/db/bundb/search_test.go
@@ -37,6 +37,24 @@ func (suite *SearchTestSuite) TestSearchAccountsTurtleAny() {
 	suite.Len(accounts, 1)
 }
 
+func (suite *SearchTestSuite) TestSearchAccounts1HappyWithPrefix() {
+	testAccount := suite.testAccounts["local_account_1"]
+
+	// Query will just look for usernames that start with "1happy".
+	accounts, err := suite.db.SearchForAccounts(context.Background(), testAccount.ID, "@1happy", "", "", 10, false, 0)
+	suite.NoError(err)
+	suite.Len(accounts, 1)
+}
+
+func (suite *SearchTestSuite) TestSearchAccounts1HappyNoPrefix() {
+	testAccount := suite.testAccounts["local_account_1"]
+
+	// Query will do the full coalesce.
+	accounts, err := suite.db.SearchForAccounts(context.Background(), testAccount.ID, "1happy", "", "", 10, false, 0)
+	suite.NoError(err)
+	suite.Len(accounts, 1)
+}
+
 func (suite *SearchTestSuite) TestSearchAccountsTurtleFollowing() {
 	testAccount := suite.testAccounts["local_account_1"]
 


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request tightens up our search logic a little:

- Don't use LOWER for SQLite `LIKE` searches. SQLite LIKE search is case-insensitive anyway, and LOWER is expensive. Postgres still uses LOWER.
- Passing a query string starting with `@` into the accounts search DB function will make it only look for accounts that *start with* the text after the `@`. This is a shitload faster than doing a full wildcard search, and is more suitable for an autocomplete-style search anyway. The leading `@` is stripped properly when doing a search like this.
- Searches that start with `@` will return early after looking for accounts, and not proceed to full text search (unless the search query parameters are used to indicate explicitly that the search is not looking for accounts).

closes https://github.com/superseriousbusiness/gotosocial/issues/2411

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
