### PR TITLE
[bugfix] Make screenreaders read out Language of posts properly

### DIFF
--- a/web/template/status.tmpl
+++ b/web/template/status.tmpl
@@ -90,7 +90,8 @@
 		</div>
 		{{- end }}
 		{{- if .LanguageTag.DisplayStr }}
-		<div class="stats-item language" title="Language: {{ .LanguageTag.DisplayStr }}">{{ .LanguageTag.TagStr }}</div>
+		<div aria-hidden="true" class="stats-item language" title="Language: {{ .LanguageTag.DisplayStr }}">{{ .LanguageTag.TagStr }}</div>
+		<div class="sr-only">Language: {{ .LanguageTag.DisplayStr -}}</div>
 		{{- end }}
 	</div>
 </aside>

--- a/web/template/status.tmpl
+++ b/web/template/status.tmpl
@@ -69,7 +69,15 @@
 	{{- end }}
 </section>
 <aside class="info">
-	<time datetime="{{- .CreatedAt -}}">{{- .CreatedAt | timestampPrecise -}}</time>
+	<dl class="sr-only">
+		<dt>Published<dt>
+		<dd>{{- .CreatedAt | timestampPrecise -}}</dd>
+		{{- if .LanguageTag.DisplayStr }}
+		<dt>Language</dt>
+		<dd>{{ .LanguageTag.DisplayStr }}</dd>
+		{{- end }}
+	</dl>
+	<time aria-hidden="true" datetime="{{- .CreatedAt -}}">{{- .CreatedAt | timestampPrecise -}}</time>
 	<div class="stats" role="group">
 		<div class="stats-item">
 			<span aria-hidden="true"><i class="fa fa-reply-all"></i> {{ .RepliesCount -}}</span>
@@ -91,7 +99,6 @@
 		{{- end }}
 		{{- if .LanguageTag.DisplayStr }}
 		<div aria-hidden="true" class="stats-item language" title="Language: {{ .LanguageTag.DisplayStr }}">{{ .LanguageTag.TagStr }}</div>
-		<div class="sr-only">Language: {{ .LanguageTag.DisplayStr -}}</div>
 		{{- end }}
 	</div>
 </aside>


### PR DESCRIPTION
Quick change to ensure that instead of just reading `en` for language, which is meaningless, screenreaders (at least, the Ubuntu default one I tested) will now read `language, engels left paren english right paren` for `Language: Engels (English)`, which is actually helpful! Also makes it so the published time is read nicely too.