### PR TITLE
[bugfix] ensure the 'Closing' flag doesn't get cached

### DIFF
--- a/internal/cache/gts.go
+++ b/internal/cache/gts.go
@@ -824,6 +824,11 @@ func (c *GTSCaches) initPoll() {
 		// See internal/db/bundb/poll.go.
 		p2.Status = nil
 
+		// Don't include ephemeral fields
+		// which are only expected to be
+		// set on ONE poll instance.
+		p2.Closing = false
+
 		return p2
 	}
 


### PR DESCRIPTION
# Description

Ensures the ephemeral `poll.Closing` flag isn't cached. This is only expected to be set on a singular instance of polls!

closes #2437 

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
