### PR TITLE
[bugfix] Let templates deref pointers, as a treat

### DIFF
--- a/internal/router/template.go
+++ b/internal/router/template.go
@@ -22,6 +22,7 @@ import (
 	"html/template"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"time"
 	"unsafe"
@@ -180,6 +181,19 @@ func isNil(i interface{}) bool {
 	return (*eface)(unsafe.Pointer(&i)).data == nil
 }
 
+// deref returns the dereferenced value of
+// its input. To ensure you don't pass nil
+// pointers into this func, use isNil first.
+func deref(i any) any {
+	vOf := reflect.ValueOf(i)
+	if vOf.Kind() != reflect.Pointer {
+		// Not a pointer.
+		return i
+	}
+
+	return vOf.Elem()
+}
+
 func LoadTemplateFunctions(engine *gin.Engine) {
 	engine.SetFuncMap(template.FuncMap{
 		"escape":           escape,
@@ -194,5 +208,6 @@ func LoadTemplateFunctions(engine *gin.Engine) {
 		"acctInstance":     acctInstance,
 		"increment":        increment,
 		"isNil":            isNil,
+		"deref":            deref,
 	})
 }

--- a/web/template/status_poll.tmpl
+++ b/web/template/status_poll.tmpl
@@ -50,15 +50,17 @@
 					{{- if isNil $pollOption.VotesCount }}
 					Results not yet published.
 					{{- else -}}
+					{{- with deref $pollOption.VotesCount }}
 					<span class="poll-vote-share">{{- $pollOption.VoteShareStr -}}&#37;</span>
 					<span class="poll-vote-count">
-						{{- if eq $pollOption.VotesCount 1 -}}
-							{{- $pollOption.VotesCount }} vote
+						{{- if eq . 1 -}}
+							{{- . }} vote
 						{{- else -}}
-							{{- $pollOption.VotesCount }} votes
+							{{- . }} votes
 						{{- end -}}
 					</span>
 					{{- end -}}
+					{{- end }}
 				</div>
 			</li>
 		{{- end }}


### PR DESCRIPTION
Little fix to a bug I wrote in the previous commit. While you can use the value of *int for templating without any further ado, you can't compare *int with 0 or 1 in go templates; you have to dereference the pointer first.