### PR TITLE
[bugfix] use a much shorter refresh limit for statuses with polls

### DIFF
--- a/internal/cache/gts.go
+++ b/internal/cache/gts.go
@@ -947,6 +947,7 @@ func (c *GTSCaches) initStatus() {
 		{Name: "ID"},
 		{Name: "URI"},
 		{Name: "URL"},
+		{Name: "PollID"},
 		{Name: "BoostOfID.AccountID"},
 		{Name: "ThreadID", Multi: true},
 	}, copyF, cap)

--- a/internal/db/bundb/migrations/20231215115920_add_status_poll_index.go
+++ b/internal/db/bundb/migrations/20231215115920_add_status_poll_index.go
@@ -33,7 +33,6 @@ func init() {
 			}
 
 			for _, spec := range []spec{
-				// Rename the admin actions indexes.
 				{
 					index:   "statuses_poll_id_idx",
 					table:   "statuses",

--- a/internal/db/bundb/migrations/20231215115920_add_status_poll_index.go
+++ b/internal/db/bundb/migrations/20231215115920_add_status_poll_index.go
@@ -1,0 +1,67 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			type spec struct {
+				index   string
+				table   string
+				columns []string
+			}
+
+			for _, spec := range []spec{
+				// Rename the admin actions indexes.
+				{
+					index:   "statuses_poll_id_idx",
+					table:   "statuses",
+					columns: []string{"poll_id"},
+				},
+			} {
+				if _, err := tx.
+					NewCreateIndex().
+					Table(spec.table).
+					Index(spec.index).
+					Column(spec.columns...).
+					IfNotExists().
+					Exec(ctx); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}

--- a/internal/db/bundb/poll.go
+++ b/internal/db/bundb/poll.go
@@ -50,20 +50,6 @@ func (p *pollDB) GetPollByID(ctx context.Context, id string) (*gtsmodel.Poll, er
 	)
 }
 
-func (p *pollDB) GetPollByStatusID(ctx context.Context, statusID string) (*gtsmodel.Poll, error) {
-	return p.getPoll(
-		ctx,
-		"StatusID",
-		func(poll *gtsmodel.Poll) error {
-			return p.db.NewSelect().
-				Model(poll).
-				Where("? = ?", bun.Ident("poll.status_id"), statusID).
-				Scan(ctx)
-		},
-		statusID,
-	)
-}
-
 func (p *pollDB) getPoll(ctx context.Context, lookup string, dbQuery func(*gtsmodel.Poll) error, keyParts ...any) (*gtsmodel.Poll, error) {
 	// Fetch poll from database cache with loader callback
 	poll, err := p.state.Caches.GTS.Poll().Load(lookup, func() (*gtsmodel.Poll, error) {

--- a/internal/db/bundb/poll_test.go
+++ b/internal/db/bundb/poll_test.go
@@ -67,10 +67,6 @@ func (suite *PollTestSuite) TestGetPollBy() {
 			"id": func() (*gtsmodel.Poll, error) {
 				return suite.db.GetPollByID(ctx, poll.ID)
 			},
-
-			"status_id": func() (*gtsmodel.Poll, error) {
-				return suite.db.GetPollByStatusID(ctx, poll.StatusID)
-			},
 		} {
 
 			// Clear database caches.
@@ -286,10 +282,6 @@ func (suite *PollTestSuite) TestDeletePoll() {
 
 		// Ensure that afterwards we cannot fetch poll.
 		_, err = suite.db.GetPollByID(ctx, poll.ID)
-		suite.ErrorIs(err, db.ErrNoEntries)
-
-		// Or again by the status it's attached to.
-		_, err = suite.db.GetPollByStatusID(ctx, poll.StatusID)
 		suite.ErrorIs(err, db.ErrNoEntries)
 	}
 }

--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -87,6 +87,17 @@ func (s *statusDB) GetStatusByURL(ctx context.Context, url string) (*gtsmodel.St
 	)
 }
 
+func (s *statusDB) GetStatusByPollID(ctx context.Context, pollID string) (*gtsmodel.Status, error) {
+	return s.getStatus(
+		ctx,
+		"PollID",
+		func(status *gtsmodel.Status) error {
+			return s.db.NewSelect().Model(status).Where("? = ?", bun.Ident("status.poll_id"), pollID).Scan(ctx)
+		},
+		pollID,
+	)
+}
+
 func (s *statusDB) GetStatusBoost(ctx context.Context, boostOfID string, byAccountID string) (*gtsmodel.Status, error) {
 	return s.getStatus(
 		ctx,

--- a/internal/db/poll.go
+++ b/internal/db/poll.go
@@ -27,9 +27,6 @@ type Poll interface {
 	// GetPollByID fetches the Poll with given ID from the database.
 	GetPollByID(ctx context.Context, id string) (*gtsmodel.Poll, error)
 
-	// GetPollByStatusID fetches the Poll with given status ID column value from the database.
-	GetPollByStatusID(ctx context.Context, statusID string) (*gtsmodel.Poll, error)
-
 	// GetOpenPolls fetches all local Polls in the database with an unset `closed_at` column.
 	GetOpenPolls(ctx context.Context) ([]*gtsmodel.Poll, error)
 

--- a/internal/db/status.go
+++ b/internal/db/status.go
@@ -25,14 +25,17 @@ import (
 
 // Status contains functions for getting statuses, creating statuses, and checking various other fields on statuses.
 type Status interface {
-	// GetStatusByID returns one status from the database, with no rel fields populated, only their linking ID / URIs
+	// GetStatusByID fetches the status from the database with matching id column.
 	GetStatusByID(ctx context.Context, id string) (*gtsmodel.Status, error)
 
-	// GetStatusByURI returns one status from the database, with no rel fields populated, only their linking ID / URIs
+	// GetStatusByURI fetches the status from the database with matching uri column.
 	GetStatusByURI(ctx context.Context, uri string) (*gtsmodel.Status, error)
 
-	// GetStatusByURL returns one status from the database, with no rel fields populated, only their linking ID / URIs
+	// GetStatusByURL fetches the status from the database with matching url column.
 	GetStatusByURL(ctx context.Context, uri string) (*gtsmodel.Status, error)
+
+	// GetStatusByPollID fetches the status from the database with matching poll_id column.
+	GetStatusByPollID(ctx context.Context, pollID string) (*gtsmodel.Status, error)
 
 	// GetStatusBoost fetches the status whose boost_of_id column refers to boostOfID, authored by given account ID.
 	GetStatusBoost(ctx context.Context, boostOfID string, byAccountID string) (*gtsmodel.Status, error)

--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -46,8 +46,19 @@ func statusUpToDate(status *gtsmodel.Status) bool {
 		return true
 	}
 
-	// If this status was updated recently (last interval), we return as-is.
-	if next := status.FetchedAt.Add(2 * time.Hour); time.Now().Before(next) {
+	// Default limit we allow
+	// statuses to be refreshed.
+	limit := 2 * time.Hour
+
+	if status.PollID != "" {
+		// We specifically allow statuses with
+		// polls to be refreshed on a much shorter
+		// time to ensure up-to-date poll info.
+		limit = 5 * time.Minute
+	}
+
+	// If this status was updated recently (within limit), return as-is.
+	if next := status.FetchedAt.Add(limit); time.Now().Before(next) {
 		return true
 	}
 

--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -50,10 +50,10 @@ func statusUpToDate(status *gtsmodel.Status, force bool) bool {
 	// statuses to be refreshed.
 	limit := 2 * time.Hour
 
-	if force || status.PollID != "" {
-		// We specifically allow statuses with
-		// polls (or with 'force' flag set) to be
-		// refreshed on a much shorter time frame.
+	if force {
+		// We specifically allow the force flag
+		// to force an early refresh (on a much
+		// smaller cooldown period).
 		limit = 5 * time.Minute
 	}
 

--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -171,7 +171,7 @@ func (d *Dereferencer) RefreshStatus(
 	force bool,
 ) (*gtsmodel.Status, ap.Statusable, error) {
 	// Check whether status needs update.
-	if !force && statusUpToDate(status, force) {
+	if statusUpToDate(status, force) {
 		return status, nil, nil
 	}
 
@@ -216,7 +216,7 @@ func (d *Dereferencer) RefreshStatusAsync(
 	force bool,
 ) {
 	// Check whether status needs update.
-	if !force && statusUpToDate(status, force) {
+	if statusUpToDate(status, force) {
 		return
 	}
 

--- a/internal/processing/common/status.go
+++ b/internal/processing/common/status.go
@@ -74,7 +74,7 @@ func (p *Processor) GetTargetStatusBy(
 				requester.Username,
 				target,
 				nil,
-				true,
+				true, // force
 			)
 			if err != nil {
 				log.Errorf(ctx, "error refreshing status: %v", err)
@@ -85,7 +85,7 @@ func (p *Processor) GetTargetStatusBy(
 				requester.Username,
 				target,
 				nil,
-				true,
+				false, // force
 			)
 		}
 	}

--- a/internal/processing/common/status.go
+++ b/internal/processing/common/status.go
@@ -30,12 +30,12 @@ import (
 
 // GetTargetStatusBy fetches the target status with db load function, given the authorized (or, nil) requester's
 // account. This returns an approprate gtserror.WithCode accounting for not found and visibility to requester.
-// The upToDate argument allows specifying whether the returned copy MUST be up-to-date.
+// The refresh argument allows specifying whether the returned copy should be force refreshed.
 func (p *Processor) GetTargetStatusBy(
 	ctx context.Context,
 	requester *gtsmodel.Account,
 	getTargetFromDB func() (*gtsmodel.Status, error),
-	upToDate bool,
+	refresh bool,
 ) (
 	status *gtsmodel.Status,
 	visible bool,
@@ -68,7 +68,7 @@ func (p *Processor) GetTargetStatusBy(
 			requester.Username,
 			target,
 			nil,
-			upToDate,
+			refresh,
 		)
 		if err != nil {
 			log.Errorf(ctx, "error refreshing status: %v", err)
@@ -84,7 +84,7 @@ func (p *Processor) GetVisibleTargetStatusBy(
 	ctx context.Context,
 	requester *gtsmodel.Account,
 	getTargetFromDB func() (*gtsmodel.Status, error),
-	upToDate bool,
+	refresh bool,
 ) (
 	status *gtsmodel.Status,
 	errWithCode gtserror.WithCode,
@@ -93,7 +93,7 @@ func (p *Processor) GetVisibleTargetStatusBy(
 	target, visible, errWithCode := p.GetTargetStatusBy(ctx,
 		requester,
 		getTargetFromDB,
-		upToDate,
+		refresh,
 	)
 	if errWithCode != nil {
 		return nil, errWithCode
@@ -117,14 +117,14 @@ func (p *Processor) GetVisibleTargetStatus(
 	ctx context.Context,
 	requester *gtsmodel.Account,
 	targetID string,
-	upToDate bool,
+	refresh bool,
 ) (
 	status *gtsmodel.Status,
 	errWithCode gtserror.WithCode,
 ) {
 	return p.GetVisibleTargetStatusBy(ctx, requester, func() (*gtsmodel.Status, error) {
 		return p.state.DB.GetStatusByID(ctx, targetID)
-	}, upToDate)
+	}, refresh)
 }
 
 // UnwrapIfBoost "unwraps" the given status if

--- a/internal/processing/common/status.go
+++ b/internal/processing/common/status.go
@@ -64,12 +64,15 @@ func (p *Processor) GetTargetStatusBy(
 
 	if requester != nil && visible {
 		// Ensure remote status is up-to-date.
-		p.federator.RefreshStatus(ctx,
+		_, _, err := p.federator.RefreshStatus(ctx,
 			requester.Username,
 			target,
 			nil,
 			upToDate,
 		)
+		if err != nil {
+			log.Errorf(ctx, "error refreshing status: %v", err)
+		}
 	}
 
 	return target, visible, nil

--- a/internal/processing/fedi/status.go
+++ b/internal/processing/fedi/status.go
@@ -100,7 +100,7 @@ func (p *Processor) StatusRepliesGet(
 	status, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requester,
 		statusID,
-		false, // upToDate
+		false, // refresh
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/fedi/status.go
+++ b/internal/processing/fedi/status.go
@@ -100,6 +100,7 @@ func (p *Processor) StatusRepliesGet(
 	status, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requester,
 		statusID,
+		false, // upToDate
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/polls/poll.go
+++ b/internal/processing/polls/poll.go
@@ -21,7 +21,6 @@ import (
 	"context"
 
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
-	"github.com/superseriousbusiness/gotosocial/internal/federation"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/processing/common"
@@ -34,7 +33,6 @@ type Processor struct {
 	c *common.Processor
 
 	state     *state.State
-	federator *federation.Federator
 	converter *typeutils.Converter
 }
 

--- a/internal/processing/polls/poll.go
+++ b/internal/processing/polls/poll.go
@@ -53,7 +53,7 @@ func (p *Processor) getTargetPoll(ctx context.Context, requester *gtsmodel.Accou
 		func() (*gtsmodel.Status, error) {
 			return p.state.DB.GetStatusByPollID(ctx, targetID)
 		},
-		true, // upToDate
+		true, // refresh
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/status/bookmark.go
+++ b/internal/processing/status/bookmark.go
@@ -30,7 +30,11 @@ import (
 )
 
 func (p *Processor) getBookmarkableStatus(ctx context.Context, requestingAccount *gtsmodel.Account, targetStatusID string) (*gtsmodel.Status, string, gtserror.WithCode) {
-	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx, requestingAccount, targetStatusID)
+	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
+		requestingAccount,
+		targetStatusID,
+		false, // upToDate
+	)
 	if errWithCode != nil {
 		return nil, "", errWithCode
 	}

--- a/internal/processing/status/bookmark.go
+++ b/internal/processing/status/bookmark.go
@@ -33,7 +33,7 @@ func (p *Processor) getBookmarkableStatus(ctx context.Context, requestingAccount
 	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requestingAccount,
 		targetStatusID,
-		false, // upToDate
+		false, // refresh
 	)
 	if errWithCode != nil {
 		return nil, "", errWithCode

--- a/internal/processing/status/boost.go
+++ b/internal/processing/status/boost.go
@@ -43,6 +43,7 @@ func (p *Processor) BoostCreate(
 		ctx,
 		requester,
 		targetID,
+		false, // upToDate
 	)
 	if errWithCode != nil {
 		return nil, errWithCode
@@ -112,6 +113,7 @@ func (p *Processor) BoostRemove(
 		ctx,
 		requester,
 		targetID,
+		false, // upToDate
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/status/boost.go
+++ b/internal/processing/status/boost.go
@@ -43,7 +43,7 @@ func (p *Processor) BoostCreate(
 		ctx,
 		requester,
 		targetID,
-		false, // upToDate
+		false, // refresh
 	)
 	if errWithCode != nil {
 		return nil, errWithCode
@@ -113,7 +113,7 @@ func (p *Processor) BoostRemove(
 		ctx,
 		requester,
 		targetID,
-		false, // upToDate
+		false, // refresh
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/status/fave.go
+++ b/internal/processing/status/fave.go
@@ -47,6 +47,7 @@ func (p *Processor) getFaveableStatus(
 		ctx,
 		requester,
 		targetID,
+		false, // upToDate
 	)
 	if errWithCode != nil {
 		return nil, nil, errWithCode
@@ -149,7 +150,11 @@ func (p *Processor) FaveRemove(ctx context.Context, requestingAccount *gtsmodel.
 
 // FavedBy returns a slice of accounts that have liked the given status, filtered according to privacy settings.
 func (p *Processor) FavedBy(ctx context.Context, requestingAccount *gtsmodel.Account, targetStatusID string) ([]*apimodel.Account, gtserror.WithCode) {
-	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx, requestingAccount, targetStatusID)
+	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
+		requestingAccount,
+		targetStatusID,
+		false, // upToDate
+	)
 	if errWithCode != nil {
 		return nil, errWithCode
 	}

--- a/internal/processing/status/fave.go
+++ b/internal/processing/status/fave.go
@@ -47,7 +47,7 @@ func (p *Processor) getFaveableStatus(
 		ctx,
 		requester,
 		targetID,
-		false, // upToDate
+		false, // refresh
 	)
 	if errWithCode != nil {
 		return nil, nil, errWithCode
@@ -153,7 +153,7 @@ func (p *Processor) FavedBy(ctx context.Context, requestingAccount *gtsmodel.Acc
 	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requestingAccount,
 		targetStatusID,
-		false, // upToDate
+		false, // refresh
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/status/get.go
+++ b/internal/processing/status/get.go
@@ -31,7 +31,7 @@ func (p *Processor) Get(ctx context.Context, requestingAccount *gtsmodel.Account
 	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requestingAccount,
 		targetStatusID,
-		false, // upToDate
+		false, // refresh
 	)
 	if errWithCode != nil {
 		return nil, errWithCode
@@ -45,7 +45,7 @@ func (p *Processor) WebGet(ctx context.Context, targetStatusID string) (*apimode
 	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		nil, // requester
 		targetStatusID,
-		false, // upToDate
+		false, // refresh
 	)
 	if errWithCode != nil {
 		return nil, errWithCode
@@ -68,7 +68,7 @@ func (p *Processor) contextGet(
 	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requestingAccount,
 		targetStatusID,
-		false, // upToDate
+		false, // refresh
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/status/get.go
+++ b/internal/processing/status/get.go
@@ -28,7 +28,11 @@ import (
 
 // Get gets the given status, taking account of privacy settings and blocks etc.
 func (p *Processor) Get(ctx context.Context, requestingAccount *gtsmodel.Account, targetStatusID string) (*apimodel.Status, gtserror.WithCode) {
-	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx, requestingAccount, targetStatusID)
+	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
+		requestingAccount,
+		targetStatusID,
+		false, // upToDate
+	)
 	if errWithCode != nil {
 		return nil, errWithCode
 	}
@@ -38,7 +42,11 @@ func (p *Processor) Get(ctx context.Context, requestingAccount *gtsmodel.Account
 
 // WebGet gets the given status for web use, taking account of privacy settings.
 func (p *Processor) WebGet(ctx context.Context, targetStatusID string) (*apimodel.Status, gtserror.WithCode) {
-	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx, nil, targetStatusID)
+	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
+		nil, // requester
+		targetStatusID,
+		false, // upToDate
+	)
 	if errWithCode != nil {
 		return nil, errWithCode
 	}
@@ -57,7 +65,11 @@ func (p *Processor) contextGet(
 	targetStatusID string,
 	convert func(context.Context, *gtsmodel.Status, *gtsmodel.Account) (*apimodel.Status, error),
 ) (*apimodel.Context, gtserror.WithCode) {
-	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx, requestingAccount, targetStatusID)
+	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
+		requestingAccount,
+		targetStatusID,
+		false, // upToDate
+	)
 	if errWithCode != nil {
 		return nil, errWithCode
 	}

--- a/internal/processing/status/mute.go
+++ b/internal/processing/status/mute.go
@@ -41,7 +41,11 @@ func (p *Processor) getMuteableStatus(
 	requestingAccount *gtsmodel.Account,
 	targetStatusID string,
 ) (*gtsmodel.Status, gtserror.WithCode) {
-	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx, requestingAccount, targetStatusID)
+	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
+		requestingAccount,
+		targetStatusID,
+		false, // upToDate
+	)
 	if errWithCode != nil {
 		return nil, errWithCode
 	}

--- a/internal/processing/status/mute.go
+++ b/internal/processing/status/mute.go
@@ -44,7 +44,7 @@ func (p *Processor) getMuteableStatus(
 	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requestingAccount,
 		targetStatusID,
-		false, // upToDate
+		false, // refresh
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/status/pin.go
+++ b/internal/processing/status/pin.go
@@ -39,7 +39,11 @@ const allowedPinnedCount = 10
 //   - Status is public, unlisted, or followers-only.
 //   - Status is not a boost.
 func (p *Processor) getPinnableStatus(ctx context.Context, requestingAccount *gtsmodel.Account, targetStatusID string) (*gtsmodel.Status, gtserror.WithCode) {
-	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx, requestingAccount, targetStatusID)
+	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
+		requestingAccount,
+		targetStatusID,
+		false, // upToDate
+	)
 	if errWithCode != nil {
 		return nil, errWithCode
 	}

--- a/internal/processing/status/pin.go
+++ b/internal/processing/status/pin.go
@@ -42,7 +42,7 @@ func (p *Processor) getPinnableStatus(ctx context.Context, requestingAccount *gt
 	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requestingAccount,
 		targetStatusID,
-		false, // upToDate
+		false, // refresh
 	)
 	if errWithCode != nil {
 		return nil, errWithCode


### PR DESCRIPTION
# Description

Adds an upToDate flag to the common processor target status fetching functions, which specifies whether to force a refresh of the given status. We use this to then force a refresh within the poll handler.

The dereferencer has also been updated to enforce a 5 minute cooldown on the force flag, so spamming the refresh button can't accidentally DOS another server, (or us acciddentally passing a force refresh flag elsewhere...)

This also updates the common processor functions to refresh the status synchronously instead of async when the flag is provided, which should help with issues of content "pop-in".

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
