### PR TITLE
[bugfix] fix poll total vote double count

### DIFF
--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -1484,6 +1484,9 @@ func (c *Converter) PollToAPIPoll(ctx context.Context, requester *gtsmodel.Accou
 		// disabled, or the requester is the author
 		// do we actually populate the vote counts.
 
+		// If we voted in this poll, we'll have set totalVotes
+		// earlier. Reset here to avoid double counting.
+		totalVotes = 0
 		if *poll.Multiple {
 			// The total number of voters are only
 			// provided in the case of a multiple


### PR DESCRIPTION
# Description

In the case where the requesting user had voted in a poll, we would double count their votes towards the overall count of votes. This happens because we calculate a vote count of our own votes in case we can't see all the votes, but this isn't cleared before processing in the case where we _can_ see all the votes, resulting in a double count.

closes #2463

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
