### PR TITLE
[bugfix] misc dereferencer fixes

### DIFF
--- a/internal/federation/dereferencing/account.go
+++ b/internal/federation/dereferencing/account.go
@@ -552,6 +552,16 @@ func (d *Dereferencer) enrichAccount(
 		}
 	}
 
+	if latestAcc.Domain == "" {
+		// ensure we have a domain set by this point,
+		// otherwise it gets stored as a local user!
+		//
+		// TODO: there is probably a more granular way
+		// way of checking this in each of the above parts,
+		// and honestly it could do with a smol refactor.
+		return nil, nil, gtserror.Newf("empty domain for %s", uri)
+	}
+
 	// Ensure ID is set and update fetch time.
 	latestAcc.ID = account.ID
 	latestAcc.FetchedAt = time.Now()

--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -135,12 +135,13 @@ func (d *Dereferencer) getStatusByURI(ctx context.Context, requestUser string, u
 		}, nil)
 	}
 
-	// Check whether needs update.
 	if statusUpToDate(status, false) {
-		// This is existing up-to-date status, ensure it is populated.
+		// This is an existing status that is up-to-date,
+		// before returning ensure it is fully populated.
 		if err := d.state.DB.PopulateStatus(ctx, status); err != nil {
 			log.Errorf(ctx, "error populating existing status: %v", err)
 		}
+
 		return status, nil, false, nil
 	}
 
@@ -170,8 +171,10 @@ func (d *Dereferencer) RefreshStatus(
 	statusable ap.Statusable,
 	force bool,
 ) (*gtsmodel.Status, ap.Statusable, error) {
-	// Check whether status needs update.
-	if statusUpToDate(status, force) {
+	// If no incoming data is provided,
+	// check whether status needs update.
+	if statusable == nil &&
+		statusUpToDate(status, force) {
 		return status, nil, nil
 	}
 
@@ -215,8 +218,10 @@ func (d *Dereferencer) RefreshStatusAsync(
 	statusable ap.Statusable,
 	force bool,
 ) {
-	// Check whether status needs update.
-	if statusUpToDate(status, force) {
+	// If no incoming data is provided,
+	// check whether status needs update.
+	if statusable == nil &&
+		statusUpToDate(status, force) {
 		return
 	}
 


### PR DESCRIPTION
# Description

- fixes issue of new statusUpToDate() checks skipping status edits made in < 5mins after creation (as noted + tracked down by @Sentynel in matrix, thank you!). now we only perform the up-to-date check if no incoming data is provided, i.e. if we need to make an outgoing dereference request.
- updates account dereferencing up-to-date logic to match that of statuses
- adds a check after all webfingering + dereferencing in the account dereferencer for an empty domain #2474 

the migration itself i'm thinking we write after christmas, as it will involve dropping accounts with NULL domain entries, which is VERY SCARY IN CASE WE DROP LOCAL USER ACCOUNTS. i'm thinking we perform a double check by parsing the account uris and checking the host field maybe??

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
