### PR TITLE
[bugfix] fix higher-level explicit domain rules causing issues with lower-level domain blocking

### DIFF
--- a/internal/cache/domain/domain.go
+++ b/internal/cache/domain/domain.go
@@ -195,13 +195,11 @@ func (n *node) Match(parts []string) bool {
 
 		if nn == nil {
 			// No match :(
-			fmt.Println("no match")
 			return false
 		}
 
 		if len(nn.child) == 0 {
 			// It's a match!
-			fmt.Println("match!")
 			return true
 		}
 

--- a/internal/cache/domain/domain.go
+++ b/internal/cache/domain/domain.go
@@ -19,10 +19,9 @@ package domain
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"sync/atomic"
-
-	"golang.org/x/exp/slices"
 )
 
 // Cache provides a means of caching domains in memory to reduce
@@ -56,6 +55,24 @@ func (c *Cache) Matches(domain string, load func() ([]string, error)) (bool, err
 		if err != nil {
 			return false, fmt.Errorf("error reloading cache: %w", err)
 		}
+
+		// Ensure the domains being inserted into the cache
+		// are sorted by number of domain parts. i.e. those
+		// with less parts are inserted last, else this can
+		// allow domains to fall through the matching code!
+		slices.SortFunc(domains, func(a, b string) int {
+			const k = +1
+			an := strings.Count(a, ".")
+			bn := strings.Count(b, ".")
+			switch {
+			case an < bn:
+				return +k
+			case an > bn:
+				return -k
+			default:
+				return 0
+			}
+		})
 
 		// Allocate new radix trie
 		// node to store matches.
@@ -94,13 +111,13 @@ type root struct{ root node }
 
 // Add will add the given domain to the radix trie.
 func (r *root) Add(domain string) {
-	r.root.add(strings.Split(domain, "."))
+	r.root.Add(strings.Split(domain, "."))
 }
 
 // Match will return whether the given domain matches
 // an existing stored domain in this radix trie.
 func (r *root) Match(domain string) bool {
-	return r.root.match(strings.Split(domain, "."))
+	return r.root.Match(strings.Split(domain, "."))
 }
 
 // Sort will sort the entire radix trie ensuring that
@@ -114,16 +131,17 @@ func (r *root) Sort() {
 // String returns a string representation of node (and its descendants).
 func (r *root) String() string {
 	buf := new(strings.Builder)
-	r.root.writestr(buf, "")
+	r.root.WriteStr(buf, "")
 	return buf.String()
 }
 
 type node struct {
 	part  string
 	child []*node
+	match bool
 }
 
-func (n *node) add(parts []string) {
+func (n *node) Add(parts []string) {
 	if len(parts) == 0 {
 		panic("invalid domain")
 	}
@@ -165,7 +183,7 @@ func (n *node) add(parts []string) {
 	}
 }
 
-func (n *node) match(parts []string) bool {
+func (n *node) Match(parts []string) bool {
 	for len(parts) > 0 {
 		// Pop next domain part.
 		i := len(parts) - 1
@@ -178,11 +196,13 @@ func (n *node) match(parts []string) bool {
 
 		if nn == nil {
 			// No match :(
+			fmt.Println("no match")
 			return false
 		}
 
 		if len(nn.child) == 0 {
 			// It's a match!
+			fmt.Println("match!")
 			return true
 		}
 
@@ -226,8 +246,16 @@ func (n *node) getChild(part string) *node {
 
 func (n *node) sort() {
 	// Sort this node's slice of child nodes.
-	slices.SortFunc(n.child, func(i, j *node) bool {
-		return i.part < j.part
+	slices.SortFunc(n.child, func(i, j *node) int {
+		const k = -1
+		switch {
+		case i.part < j.part:
+			return +k
+		case i.part > j.part:
+			return -k
+		default:
+			return 0
+		}
 	})
 
 	// Sort each child node's children.
@@ -236,7 +264,7 @@ func (n *node) sort() {
 	}
 }
 
-func (n *node) writestr(buf *strings.Builder, prefix string) {
+func (n *node) WriteStr(buf *strings.Builder, prefix string) {
 	if prefix != "" {
 		// Suffix joining '.'
 		prefix += "."
@@ -251,6 +279,6 @@ func (n *node) writestr(buf *strings.Builder, prefix string) {
 
 	// Iterate through node children.
 	for _, child := range n.child {
-		child.writestr(buf, prefix)
+		child.WriteStr(buf, prefix)
 	}
 }

--- a/internal/cache/domain/domain.go
+++ b/internal/cache/domain/domain.go
@@ -138,7 +138,6 @@ func (r *root) String() string {
 type node struct {
 	part  string
 	child []*node
-	match bool
 }
 
 func (n *node) Add(parts []string) {

--- a/internal/cache/domain/domain_test.go
+++ b/internal/cache/domain/domain_test.go
@@ -28,10 +28,13 @@ func TestCache(t *testing.T) {
 	c := new(domain.Cache)
 
 	cachedDomains := []string{
-		"google.com",
-		"mail.google.com",
-		"google.co.uk",
-		"pleroma.bad.host",
+		"google.com",               //
+		"mail.google.com",          // should be ignored since covered above
+		"dev.mail.google.com",      // same again
+		"google.co.uk",             //
+		"mail.google.co.uk",        //
+		"pleroma.bad.host",         //
+		"pleroma.still.a.bad.host", //
 	}
 
 	loader := func() ([]string, error) {
@@ -39,14 +42,17 @@ func TestCache(t *testing.T) {
 		return cachedDomains, nil
 	}
 
-	// Check a list of known cached domains.
+	// Check a list of known matching domains.
 	for _, domain := range []string{
 		"google.com",
 		"mail.google.com",
+		"dev.mail.google.com",
 		"google.co.uk",
 		"mail.google.co.uk",
 		"pleroma.bad.host",
 		"dev.pleroma.bad.host",
+		"pleroma.still.a.bad.host",
+		"dev.pleroma.still.a.bad.host",
 	} {
 		t.Logf("checking domain matches: %s", domain)
 		if b, _ := c.Matches(domain, loader); !b {
@@ -54,7 +60,7 @@ func TestCache(t *testing.T) {
 		}
 	}
 
-	// Check a list of known uncached domains.
+	// Check a list of known unmatched domains.
 	for _, domain := range []string{
 		"askjeeves.com",
 		"ask-kim.co.uk",
@@ -62,6 +68,7 @@ func TestCache(t *testing.T) {
 		"mail.google.ie",
 		"gts.bad.host",
 		"mastodon.bad.host",
+		"akkoma.still.a.bad.host",
 	} {
 		t.Logf("checking domain isn't matched: %s", domain)
 		if b, _ := c.Matches(domain, loader); b {

--- a/internal/cache/domain/domain_test.go
+++ b/internal/cache/domain/domain_test.go
@@ -29,6 +29,7 @@ func TestCache(t *testing.T) {
 
 	cachedDomains := []string{
 		"google.com",
+		"mail.google.com",
 		"google.co.uk",
 		"pleroma.bad.host",
 	}
@@ -49,7 +50,7 @@ func TestCache(t *testing.T) {
 	} {
 		t.Logf("checking domain matches: %s", domain)
 		if b, _ := c.Matches(domain, loader); !b {
-			t.Errorf("domain should be matched: %s", domain)
+			t.Fatalf("domain should be matched: %s", domain)
 		}
 	}
 
@@ -64,7 +65,7 @@ func TestCache(t *testing.T) {
 	} {
 		t.Logf("checking domain isn't matched: %s", domain)
 		if b, _ := c.Matches(domain, loader); b {
-			t.Errorf("domain should not be matched: %s", domain)
+			t.Fatalf("domain should not be matched: %s", domain)
 		}
 	}
 
@@ -80,6 +81,6 @@ func TestCache(t *testing.T) {
 		t.Log("load: returning known error")
 		return nil, knownErr
 	}); !errors.Is(err, knownErr) {
-		t.Errorf("matches did not return expected error: %v", err)
+		t.Fatalf("matches did not return expected error: %v", err)
 	}
 }


### PR DESCRIPTION
# Description

Turns out the children in the radix trie were being sorted in the wrong direction :woman_facepalming: 

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
