### PR TITLE
[bugfix] fix header filter migration for postgres

### DIFF
--- a/internal/gtsmodel/headerfilter.go
+++ b/internal/gtsmodel/headerfilter.go
@@ -45,8 +45,8 @@ type HeaderFilterBlock struct{ HeaderFilter }
 // matching regex, and details about its creation.
 type HeaderFilter struct {
 	ID        string    `bun:"type:CHAR(26),pk,nullzero,notnull,unique"`                    // ID of this item in the database
-	Header    string    `bun:",nullzero,notnull,unique:header_regex"`                       // Request header this filter pertains to
-	Regex     string    `bun:",nullzero,notnull,unique:header_regex"`                       // Request header value matching regular expression
+	Header    string    `bun:",nullzero,notnull"`                                           // Request header this filter pertains to. Must be unique with Regex.
+	Regex     string    `bun:",nullzero,notnull"`                                           // Request header value matching regular expression. Must be unique with Header.
 	AuthorID  string    `bun:"type:CHAR(26),nullzero,notnull"`                              // Account ID of the creator of this filter
 	Author    *Account  `bun:"-"`                                                           // Account corresponding to AuthorID
 	CreatedAt time.Time `bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"` // when was item created


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Previously postgres migrations for header filters would fail to execute because two identically named constraints were attempting to be created, one on each header filter filterType table (blocks, allows).

This fixes that by creating the constraints separately, with unique names. 

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
