### PR TITLE
[chore] chore rationalise http return codes for activitypub handlers

### DIFF
--- a/internal/api/activitypub/users/inboxpost_test.go
+++ b/internal/api/activitypub/users/inboxpost_test.go
@@ -478,15 +478,17 @@ func (suite *InboxPostTestSuite) TestPostEmptyCreate() {
 		targetAccount     = suite.testAccounts["local_account_1"]
 	)
 
-	// Post a create with no object.
+	// Post a create with no object, this
+	// should get accepted and silently dropped
+	// as the lack of ID marks it as transient.
 	create := streams.NewActivityStreamsCreate()
 
 	suite.inboxPost(
 		create,
 		requestingAccount,
 		targetAccount,
-		http.StatusBadRequest,
-		`{"error":"Bad Request: missing ActivityStreams id property"}`,
+		http.StatusAccepted,
+		`{"status":"Accepted"}`,
 		suite.signatureCheck,
 	)
 }

--- a/internal/federation/federatingactor.go
+++ b/internal/federation/federatingactor.go
@@ -143,10 +143,12 @@ func (f *federatingActor) PostInboxScheme(ctx context.Context, w http.ResponseWr
 		have not yet applied authorization (ie., blocks).
 	*/
 
-	// Obtain the activity; reject unknown activities.
-	activity, errWithCode := ap.ResolveIncomingActivity(r)
+	// Resolve the activity, rejecting badly formatted / transient.
+	activity, ok, errWithCode := ap.ResolveIncomingActivity(r)
 	if errWithCode != nil {
 		return false, errWithCode
+	} else if !ok { // transient
+		return false, nil
 	}
 
 	// Set additional context data. Primarily this means

--- a/internal/federation/federatingdb/reject.go
+++ b/internal/federation/federatingdb/reject.go
@@ -45,16 +45,11 @@ func (f *federatingDB) Reject(ctx context.Context, reject vocab.ActivityStreamsR
 		return nil // Already processed.
 	}
 
-	rejectObject := reject.GetActivityStreamsObject()
-	if rejectObject == nil {
-		return errors.New("Reject: no object set on vocab.ActivityStreamsReject")
-	}
+	for _, obj := range ap.ExtractObjects(reject) {
 
-	for iter := rejectObject.Begin(); iter != rejectObject.End(); iter = iter.Next() {
-		// check if the object is an IRI
-		if iter.IsIRI() {
+		if obj.IsIRI() {
 			// we have just the URI of whatever is being rejected, so we need to find out what it is
-			rejectedObjectIRI := iter.GetIRI()
+			rejectedObjectIRI := obj.GetIRI()
 			if uris.IsFollowPath(rejectedObjectIRI) {
 				// REJECT FOLLOW
 				followReq, err := f.state.DB.GetFollowRequestByURI(ctx, rejectedObjectIRI.String())
@@ -71,15 +66,10 @@ func (f *federatingDB) Reject(ctx context.Context, reject vocab.ActivityStreamsR
 			}
 		}
 
-		// check if iter is an AP object / type
-		if iter.GetType() == nil {
-			continue
-		}
-
-		if iter.GetType().GetTypeName() == ap.ActivityFollow {
+		if t := obj.GetType(); t != nil {
 			// we have the whole object so we can figure out what we're rejecting
 			// REJECT FOLLOW
-			asFollow, ok := iter.GetType().(vocab.ActivityStreamsFollow)
+			asFollow, ok := t.(vocab.ActivityStreamsFollow)
 			if !ok {
 				return errors.New("Reject: couldn't parse follow into vocab.ActivityStreamsFollow")
 			}

--- a/internal/federation/federatingdb/undo.go
+++ b/internal/federation/federatingdb/undo.go
@@ -78,7 +78,7 @@ func (f *federatingDB) Undo(ctx context.Context, undo vocab.ActivityStreamsUndo)
 		}
 	}
 
-	return nil
+	return errs.Combine()
 }
 
 func (f *federatingDB) undoFollow(


### PR DESCRIPTION
We do this by dropping transient activities (those with missing ID property) instead of returning 400 bad request, since they are *technically* valid activitypub data.

Also some other misc fixes / cleanup i noticed while in the code