### PR TITLE
[chore] Harden up boolptr logic on Accounts, warn if not set

### DIFF
--- a/internal/ap/extract.go
+++ b/internal/ap/extract.go
@@ -492,18 +492,6 @@ func ExtractFields(i WithAttachment) []*gtsmodel.Field {
 	return fields
 }
 
-// ExtractDiscoverable extracts the Discoverable boolean
-// of the given WithDiscoverable interface. Will return
-// an error if Discoverable was nil.
-func ExtractDiscoverable(i WithDiscoverable) (bool, error) {
-	discoverableProp := i.GetTootDiscoverable()
-	if discoverableProp == nil {
-		return false, gtserror.New("discoverable was nil")
-	}
-
-	return discoverableProp.Get(), nil
-}
-
 // ExtractURL extracts the first URI it can find from the
 // given WithURL interface, or an error if no URL was set.
 // The ID of a type will not work, this function wants a URI

--- a/internal/ap/properties.go
+++ b/internal/ap/properties.go
@@ -424,6 +424,8 @@ func SetVotersCount(with WithVotersCount, count int) {
 }
 
 // GetDiscoverable returns the boolean contained in the Discoverable property of 'with'.
+//
+// Returns default 'false' if property unusable or not set.
 func GetDiscoverable(with WithDiscoverable) bool {
 	discoverProp := with.GetTootDiscoverable()
 	if discoverProp == nil || !discoverProp.IsXMLSchemaBoolean() {
@@ -440,6 +442,27 @@ func SetDiscoverable(with WithDiscoverable, discoverable bool) {
 		with.SetTootDiscoverable(discoverProp)
 	}
 	discoverProp.Set(discoverable)
+}
+
+// GetManuallyApprovesFollowers returns the boolean contained in the ManuallyApprovesFollowers property of 'with'.
+//
+// Returns default 'true' if property unusable or not set.
+func GetManuallyApprovesFollowers(with WithManuallyApprovesFollowers) bool {
+	mafProp := with.GetActivityStreamsManuallyApprovesFollowers()
+	if mafProp == nil || !mafProp.IsXMLSchemaBoolean() {
+		return true
+	}
+	return mafProp.Get()
+}
+
+// SetManuallyApprovesFollowers sets the given boolean on the ManuallyApprovesFollowers property of 'with'.
+func SetManuallyApprovesFollowers(with WithManuallyApprovesFollowers, manuallyApprovesFollowers bool) {
+	mafProp := with.GetActivityStreamsManuallyApprovesFollowers()
+	if mafProp == nil {
+		mafProp = streams.NewActivityStreamsManuallyApprovesFollowersProperty()
+		with.SetActivityStreamsManuallyApprovesFollowers(mafProp)
+	}
+	mafProp.Set(manuallyApprovesFollowers)
 }
 
 func getIRIs[T TypeOrIRI](prop Property[T]) []*url.URL {

--- a/internal/db/bundb/account_test.go
+++ b/internal/db/bundb/account_test.go
@@ -336,6 +336,7 @@ func (suite *AccountTestSuite) TestInsertAccountWithDefaults() {
 	suite.Equal("en", newAccount.Language)
 	suite.WithinDuration(time.Now(), newAccount.CreatedAt, 30*time.Second)
 	suite.WithinDuration(time.Now(), newAccount.UpdatedAt, 30*time.Second)
+	suite.True(*newAccount.Locked)
 	suite.False(*newAccount.Memorial)
 	suite.False(*newAccount.Bot)
 	suite.False(*newAccount.Discoverable)

--- a/internal/typeutils/astointernal.go
+++ b/internal/typeutils/astointernal.go
@@ -126,23 +126,9 @@ func (c *Converter) ASRepresentationToAccount(ctx context.Context, accountable a
 	acct.Sensitive = util.Ptr(false)
 	acct.HideCollections = util.Ptr(false)
 
-	// Extract 'manuallyApprovesFollowers', (i.e. locked account)
-	maf := accountable.GetActivityStreamsManuallyApprovesFollowers()
-
-	switch {
-	case maf != nil && !maf.IsXMLSchemaBoolean():
-		log.Warnf(ctx, "unusable manuallyApprovesFollowers for %s", uri)
-		fallthrough
-
-	case maf == nil:
-		// None given, use default.
-		acct.Locked = util.Ptr(true)
-
-	default:
-		// Valid bool provided.
-		locked := maf.Get()
-		acct.Locked = &locked
-	}
+	// Extract 'manuallyApprovesFollowers' aka locked account (default = true).
+	manuallyApprovesFollowers := ap.GetManuallyApprovesFollowers(accountable)
+	acct.Locked = &manuallyApprovesFollowers
 
 	// Extract account discoverability (default = false).
 	discoverable := ap.GetDiscoverable(accountable)

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -217,6 +217,31 @@ func (c *Converter) AccountToAPIAccountPublic(ctx context.Context, a *gtsmodel.A
 		}
 	}
 
+	// Bool ptrs should be set, but warn
+	// and use a default if they're not.
+	var boolPtrDef = func(
+		pName string,
+		p *bool,
+		d bool,
+	) bool {
+		if p != nil {
+			return *p
+		}
+
+		log.Warnf(ctx,
+			"%s ptr was nil, using default %t",
+			pName, d,
+		)
+		return d
+	}
+
+	var (
+		locked       = boolPtrDef("locked", a.Locked, true)
+		discoverable = boolPtrDef("discoverable", a.Discoverable, false)
+		bot          = boolPtrDef("bot", a.Bot, false)
+		enableRSS    = boolPtrDef("enableRSS", a.EnableRSS, false)
+	)
+
 	// Remaining properties are simple and
 	// can be populated directly below.
 
@@ -225,9 +250,9 @@ func (c *Converter) AccountToAPIAccountPublic(ctx context.Context, a *gtsmodel.A
 		Username:       a.Username,
 		Acct:           acct,
 		DisplayName:    a.DisplayName,
-		Locked:         *a.Locked,
-		Discoverable:   *a.Discoverable,
-		Bot:            *a.Bot,
+		Locked:         locked,
+		Discoverable:   discoverable,
+		Bot:            bot,
 		CreatedAt:      util.FormatISO8601(a.CreatedAt),
 		Note:           a.Note,
 		URL:            a.URL,
@@ -243,7 +268,7 @@ func (c *Converter) AccountToAPIAccountPublic(ctx context.Context, a *gtsmodel.A
 		Fields:         fields,
 		Suspended:      !a.SuspendedAt.IsZero(),
 		CustomCSS:      a.CustomCSS,
-		EnableRSS:      *a.EnableRSS,
+		EnableRSS:      enableRSS,
 		Role:           role,
 		Moved:          moved,
 	}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request adds nil ptr checks in the account to api account typeutil conversion functions, which should unclog https://github.com/superseriousbusiness/gotosocial/issues/2527 and https://github.com/superseriousbusiness/gotosocial/issues/2514.

Unfortunately, I couldn't find the issue that was causing those ptrs to be nil in the first place, or even replicate the bug on the testrig. Some warning logs have been added to the nil ptr checks so we can hopefully gather some info on when this happens, while working around the bug.

Also adds a bunch of tests for a typical Honk account, in an attempt to reproduce the bug. The reproduction failed, but the tests are still good to have.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
