### PR TITLE
[feature] Ratelimit + serve emoji images on separate router group

### DIFF
--- a/cmd/gotosocial/action/testrig/testrig.go
+++ b/cmd/gotosocial/action/testrig/testrig.go
@@ -83,6 +83,13 @@ var Start action.GTSAction = func(ctx context.Context) error {
 
 	testrig.StandardDBSetup(state.DB, nil)
 
+	// Get the instance account
+	// (we'll need this later).
+	instanceAccount, err := state.DB.GetInstanceAccount(ctx, "")
+	if err != nil {
+		return fmt.Errorf("error retrieving instance account: %w", err)
+	}
+
 	if os.Getenv("GTS_STORAGE_BACKEND") == "s3" {
 		var err error
 		state.Storage, err = storage.NewS3Storage()
@@ -225,6 +232,7 @@ var Start action.GTSAction = func(ctx context.Context) error {
 	clientModule.Route(router)
 	metricsModule.Route(router)
 	fileserverModule.Route(router)
+	fileserverModule.RouteEmojis(router, instanceAccount.ID)
 	wellKnownModule.Route(router)
 	nodeInfoModule.Route(router)
 	activityPubModule.Route(router)

--- a/internal/api/fileserver/fileserver.go
+++ b/internal/api/fileserver/fileserver.go
@@ -33,8 +33,8 @@ const (
 	MediaSizeKey = "media_size"
 	// FileNameKey is the actual filename being sought. Will usually be a UUID then something like .jpeg
 	FileNameKey = "file_name"
-	// FileServePath is the fileserve path minus the 'fileserver' prefix.
-	FileServePath = "/:" + AccountIDKey + "/:" + MediaTypeKey + "/:" + MediaSizeKey + "/:" + FileNameKey
+	// FileServePath is the fileserve path minus the 'fileserver/:account_id/:media_type' prefix.
+	FileServePath = "/:" + MediaSizeKey + "/:" + FileNameKey
 )
 
 type Module struct {

--- a/web/source/settings/admin/emoji/local/overview.js
+++ b/web/source/settings/admin/emoji/local/overview.js
@@ -64,6 +64,11 @@ module.exports = function EmojiOverview({ }) {
 				You can either upload them here directly, or copy from those already
 				present on other (known) instances through the <Link to={`./remote`}>Remote Emoji</Link> page.
 			</p>
+			<p>
+				<strong>Be warned!</strong> If you upload more than about 300-400 custom emojis in
+				total on your instance, this may lead to rate-limiting issues for users and clients
+				if they try to load all the emoji images at once (which is what many clients do).
+			</p>
 			{content}
 		</>
 	);


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request serves the `emojis` part of the fileserver under a separate router group, applying separate rate-limiting (2 x configured rate limit). This should help with cases where someone has uploaded a few hundred custom emojis, and ends up getting rate-limited when using the emoji picker (which loads all emoji images at once, basically).

Also adds a warning to the emoji upload page recommending admins limit emoji use to ~ 300-400 custom emojis.

closes https://github.com/superseriousbusiness/gotosocial/issues/2537

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x ] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
