### PR TITLE
[bugfix] Don't return Internal Server Error when searching for URIs that don't return AP JSON

### DIFF
--- a/internal/ap/resolve.go
+++ b/internal/ap/resolve.go
@@ -67,18 +67,18 @@ func putMap(m map[string]any) {
 func bytesToType(
 	ctx context.Context,
 	b []byte,
-	raw *map[string]any,
+	raw map[string]any,
 ) (vocab.Type, error) {
 	// Unmarshal the raw JSON bytes into a "raw" map.
 	// This will fail if the input is not parseable
 	// as JSON; eg., a remote has returned HTML as a
 	// fallback response to an ActivityPub JSON request.
-	if err := json.Unmarshal(b, raw); err != nil {
+	if err := json.Unmarshal(b, &raw); err != nil {
 		return nil, gtserror.NewfAt(3, "error unmarshalling bytes into json: %w", err)
 	}
 
 	// Resolve an ActivityStreams type.
-	t, err := streams.ToType(ctx, *raw)
+	t, err := streams.ToType(ctx, raw)
 	if err != nil {
 		return nil, gtserror.NewfAt(3, "error resolving json into ap vocab type: %w", err)
 	}
@@ -153,7 +153,7 @@ func ResolveStatusable(ctx context.Context, b []byte) (Statusable, error) {
 
 	// Convert raw bytes to an AP type.
 	// This will also populate the map.
-	t, err := bytesToType(ctx, b, &raw)
+	t, err := bytesToType(ctx, b, raw)
 	if err != nil {
 		return nil, gtserror.SetWrongType(err)
 	}
@@ -194,7 +194,7 @@ func ResolveAccountable(ctx context.Context, b []byte) (Accountable, error) {
 
 	// Convert raw bytes to an AP type.
 	// This will also populate the map.
-	t, err := bytesToType(ctx, b, &raw)
+	t, err := bytesToType(ctx, b, raw)
 	if err != nil {
 		return nil, gtserror.SetWrongType(err)
 	}

--- a/internal/ap/resolve_test.go
+++ b/internal/ap/resolve_test.go
@@ -47,6 +47,29 @@ func (suite *ResolveTestSuite) TestResolveDocumentAsAccountable() {
 	suite.Nil(accountable)
 }
 
+func (suite *ResolveTestSuite) TestResolveHTMLAsAccountable() {
+	b := []byte(`<!DOCTYPE html>
+	<title>.</title>`)
+
+	accountable, err := ap.ResolveAccountable(context.Background(), b)
+	suite.True(gtserror.IsWrongType(err))
+	suite.EqualError(err, "ResolveAccountable: error unmarshalling bytes into json: invalid character '<' looking for beginning of value")
+	suite.Nil(accountable)
+}
+
+func (suite *ResolveTestSuite) TestResolveNonAPJSONAsAccountable() {
+	b := []byte(`{
+  "@context": "definitely a legit context muy lord",
+  "type": "definitely an account muy lord",
+  "pee pee":"poo poo"
+}`)
+
+	accountable, err := ap.ResolveAccountable(context.Background(), b)
+	suite.True(gtserror.IsWrongType(err))
+	suite.EqualError(err, "ResolveAccountable: error resolving json into ap vocab type: activity stream did not match any known types")
+	suite.Nil(accountable)
+}
+
 func TestResolveTestSuite(t *testing.T) {
 	suite.Run(t, &ResolveTestSuite{})
 }

--- a/internal/gtserror/error.go
+++ b/internal/gtserror/error.go
@@ -55,9 +55,15 @@ func SetUnretrievable(err error) error {
 	return errors.WithValue(err, unrtrvableKey, struct{}{})
 }
 
-// IsWrongType checks error for a stored "wrong type" flag. Wrong type
-// indicates that an ActivityPub URI returned a type we weren't expecting:
-// Statusable instead of Accountable, or vice versa, for example.
+// IsWrongType checks error for a stored "wrong type" flag.
+// Wrong type indicates that an ActivityPub URI returned a
+// type we weren't expecting. For example:
+//
+//   - HTML instead of JSON.
+//   - Normal JSON instead of ActivityPub JSON.
+//   - Statusable instead of Accountable.
+//   - Accountable instead of Statusable.
+//   - etc.
 func IsWrongType(err error) bool {
 	_, ok := errors.Value(err, wrongTypeKey).(struct{})
 	return ok


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This PR fixes an issue where searching for a URL that doesn't return valid AP JSON would return an Internal Server Error to the caller. Instead, failures to parse AP JSON from a dereference now return WrongType instead, which is checked for in the search processor.

Relates to https://github.com/superseriousbusiness/gotosocial/issues/2491, since that was triggering the bug, as threads.net doesn't return valid AP in response to our requests.

This could also be triggered just by putting something like "https://example.org" in the search bar. 

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
