### PR TITLE
[docs] Enhance log-timestamp-format documentation

### DIFF
--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -32,10 +32,11 @@ log-client-ip: true
 # If set to the empty string, the timestamp will be
 # ommitted from the logs entirely.
 #
-# The format must be compatible with Go's time.Layout, as
-# documented on https://pkg.go.dev/time#pkg-constants.
+# This uses the timestamp template format of the golang
+# time.Layout standard library, which is documented at:
+# https://pkg.go.dev/time#pkg-constants
 #
-# Examples: [true, false]
+# Examples: ["2006-01-02T15:04:05.000Z07:00", ""]
 # Default: "02/01/2006 15:04:05.000"
 log-timestamp-format: "02/01/2006 15:04:05.000"
 

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -297,7 +297,7 @@ instance-languages: []
 
 # String. Federation mode to use for this instance.
 #
-# "blocklist" -- open federation by default. Only instances that are explicitly 
+# "blocklist" -- open federation by default. Only instances that are explicitly
 #                blocked will be denied (unless they are also explicitly allowed).
 #
 # "allowlist" -- closed federation by default. Only instances that are explicitly
@@ -469,7 +469,7 @@ media-remote-cache-days: 7
 
 # String. 24hr time of day formatted as hh:mm.
 # Examples: ["14:30", "00:00", "04:00"]
-# Default: "00:00" (midnight). 
+# Default: "00:00" (midnight).
 media-cleanup-from: "00:00"
 
 # Duration. Period between media cleanup runs.
@@ -875,7 +875,7 @@ http-client:
   #
   # THIS SETTING SHOULD BE USED FOR TESTING ONLY! IF YOU TURN THIS
   # ON WHILE RUNNING IN PRODUCTION YOU ARE LEAVING YOUR SERVER WIDE
-  # OPEN TO MAN IN THE MIDDLE ATTACKS! DO NOT CHANGE THIS SETTING 
+  # OPEN TO MAN IN THE MIDDLE ATTACKS! DO NOT CHANGE THIS SETTING
   # UNLESS YOU KNOW EXACTLY WHAT YOU'RE DOING AND WHY YOU'RE DOING IT.
   #
   # Default: false
@@ -1030,7 +1030,7 @@ advanced-sender-multiplier: 2
 # generate a correct Content-Security-Policy, you probably won't need
 # to ever touch this setting, but it's included in the 'spirit of more
 # configurable (usually) means more good'.
-# 
+#
 # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
 #
 # Example: ["s3.example.org", "some-bucket-name.s3.example.org"]

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -40,10 +40,11 @@ log-client-ip: true
 # If set to the empty string, the timestamp will be
 # ommitted from the logs entirely.
 #
-# The format must be compatible with Go's time.Layout, as
-# documented on https://pkg.go.dev/time#pkg-constants.
+# This uses the timestamp template format of the golang
+# time.Layout standard library, which is documented at:
+# https://pkg.go.dev/time#pkg-constants
 #
-# Examples: [true, false]
+# Examples: ["2006-01-02T15:04:05.000Z07:00", ""]
 # Default: "02/01/2006 15:04:05.000"
 log-timestamp-format: "02/01/2006 15:04:05.000"
 


### PR DESCRIPTION
# Description

- use ISO 8601 timestamp and empty string (no timestamp logged) as examples, not [true, false] which isn’t of the right type
- make it clearer that the timestamp template format is imposed by an external standard library, not a GtS invention
    
Having an ISO 8601 example should also make it easier to understand.

Also cleans up whitespace at end of line/file for the touched files.

closes #2455 (hopefully)

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).