### PR TITLE
[docs] Add a few things to the FAQ.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -45,3 +45,15 @@ Take a look at the [list of open bugs](https://github.com/superseriousbusiness/g
 - scheduling posts
 - account migration
 - shared block lists across servers
+
+## Warnings “authentication NOT PASSED for public key” in the log
+
+These warnings are caused by Mastodon forgetting to take query parameters into account when signing HTTP requests. Fixes on both Mastodon and GoToSocial sides are in the works, and other instance software is expected to follow.
+
+## Warnings “status not yet deref'd” in the logs
+
+The warning is mostly to say that the derived visibility of the given status may not be entirely accurate due to a parent not being dereferenced yet, so do not worry about it.
+
+## Will you support tables in Markdown?
+
+Not at the moment, as most clients handle them terribly.


### PR DESCRIPTION
# Description

Add a few things to the FAQ that are answers that were recently given to me or others or popped up in some past release notes to make them found more easily.

At this point, though, I wonder if we shouldn’t put the individual questions into `h3`s and whip up a couple of question categories (UI/UX, operational/warnings, federation, general(like the alpha question), …).

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).