### PR TITLE
[feature] Allow "charset=utf8" in incoming AP POST requests

### DIFF
--- a/docs/federation/federating_with_gotosocial.md
+++ b/docs/federation/federating_with_gotosocial.md
@@ -114,7 +114,7 @@ For more information on acceptable content types, see [the server-to-server inte
 
 GoToSocial will return HTTP status code [202 - Accepted](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202) in response to validly-formed and signed Inbox POST requests.
 
-Invalidly-formed Inbox POST requests will receive a [400 - Bad Request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202) HTTP status code in response. The response body may contain more information on why the GoToSocial server considered the request content to be badly formed. Other servers should not retry delivery of the Activity in case of a code `400` response.
+Invalidly-formed Inbox POST requests will receive a [400 - Bad Request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400) HTTP status code in response. The response body may contain more information on why the GoToSocial server considered the request content to be badly formed. Other servers should not retry delivery of the Activity in case of a code `400` response.
 
 Even if GoToSocial returns a `202` status code, it may not continue processing the Activity delivered, depending on the originator(s), target(s) and type of the Activity. ActivityPub is an extensive protocol, and GoToSocial does not cover every combination of Activity and Object.
 

--- a/docs/federation/federating_with_gotosocial.md
+++ b/docs/federation/federating_with_gotosocial.md
@@ -92,6 +92,32 @@ This ensures that remote servers cannot flood a GoToSocial instance with spuriou
 
 For more details on request throttling and rate limiting behavior, please see the [throttling](../api/throttling.md) and [rate limiting](../api/ratelimiting.md) documents.
 
+## Inbox
+
+GoToSocial implements Inboxes for Actors following the ActivityPub specification [here](https://www.w3.org/TR/activitypub/#inbox).
+
+Remote servers should deliver Activities to a GoToSocial server by making an HTTP POST request to each Inbox of the desired audience of an Activity, as described [here](https://www.w3.org/TR/activitypub/#delivery).
+
+GoToSocial accounts do not currently implement a [sharedInbox](https://www.w3.org/TR/activitypub/#shared-inbox-delivery) endpoint, though this is subject to change. Deduplication of delivered Activities, in case more than one Actor on a GoToSocial server is in the audience for an Activity, is handled on GoToSocial's side.
+
+POSTs to a GoToSocial Actor's inbox must be appropriately [http-signed](#http-signatures) by the delivering Actor.
+
+Accepted Inbox POST `Content-Type` headers are:
+
+- `application/activity+json`
+- `application/activity+json; charset=utf-8`
+- `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`
+
+Inbox POST requests that do not use one of the above `Content-Type` headers will be rejected with HTTP status code [406 - Not Acceptable](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406).
+
+For more information on acceptable content types, see [the server-to-server interactions](https://www.w3.org/TR/activitypub/#server-to-server-interactions) section of the ActivityPub protocol.
+
+GoToSocial will return HTTP status code [202 - Accepted](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202) in response to validly-formed and signed Inbox POST requests.
+
+Invalidly-formed Inbox POST requests will receive a [400 - Bad Request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202) HTTP status code in response. The response body may contain more information on why the GoToSocial server considered the request content to be badly formed. Other servers should not retry delivery of the Activity in case of a code `400` response.
+
+Even if GoToSocial returns a `202` status code, it may not continue processing the Activity delivered, depending on the originator(s), target(s) and type of the Activity. ActivityPub is an extensive protocol, and GoToSocial does not cover every combination of Activity and Object.
+
 ## Outbox
 
 GoToSocial implements Outboxes for Actors (ie., instance accounts) following the ActivityPub specification [here](https://www.w3.org/TR/activitypub/#outbox).

--- a/internal/federation/federatingactor.go
+++ b/internal/federation/federatingactor.go
@@ -126,8 +126,7 @@ func (f *federatingActor) PostInboxScheme(ctx context.Context, w http.ResponseWr
 	// https://www.w3.org/TR/activitypub/#server-to-server-interactions
 	if ct := r.Header.Get("Content-Type"); !IsASMediaType(ct) {
 		const ct1 = "application/activity+json"
-		const ct2 = "application/activity+json;charset=utf-8"
-		const ct3 = "application/ld+json;profile=https://w3.org/ns/activitystreams"
+		const ct2 = "application/ld+json;profile=https://w3.org/ns/activitystreams"
 		err := fmt.Errorf("Content-Type %s not acceptable, this endpoint accepts: [%q %q]", ct, ct1, ct2)
 		return false, gtserror.NewErrorNotAcceptable(err)
 	}

--- a/internal/federation/federatingactor_test.go
+++ b/internal/federation/federatingactor_test.go
@@ -165,6 +165,22 @@ func TestIsASMediaType(t *testing.T) {
 			Expect: true,
 		},
 		{
+			Input:  "application/activity+json; charset=utf-8",
+			Expect: true,
+		},
+		{
+			Input:  "application/activity+json;charset=utf-8",
+			Expect: true,
+		},
+		{
+			Input:  "application/activity+json ;charset=utf-8",
+			Expect: true,
+		},
+		{
+			Input:  "application/activity+json ; charset=utf-8",
+			Expect: true,
+		},
+		{
 			Input:  "application/ld+json;profile=https://www.w3.org/ns/activitystreams",
 			Expect: true,
 		},
@@ -195,6 +211,10 @@ func TestIsASMediaType(t *testing.T) {
 		{
 			Input:  "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"",
 			Expect: true,
+		},
+		{
+			Input:  "application/ld+json",
+			Expect: false,
 		},
 	} {
 		if federation.IsASMediaType(test.Input) != test.Expect {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Update our inbox POST content negotiation to accept `charset=utf8` directive on application/activity+json content type requests.

This isn't really necessary according to the protocol but that's life!

This should allow Bookwyrm POST requests to our inboxes to succeed. See https://github.com/bookwyrm-social/bookwyrm/pull/2812#issuecomment-1865107260

Also added some docs on how to POST successfully to a GoToSocial inbox - https://gotosocial--2564.org.readthedocs.build/en/2564/federation/federating_with_gotosocial/#inbox

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
