### PR TITLE
[docs] Correct wrong tracing transport option

### DIFF
--- a/docs/advanced/tracing.md
+++ b/docs/advanced/tracing.md
@@ -12,7 +12,7 @@ You'll need the files in [`example/tracing`][ext]. Once you have those you can r
 tracing-enabled: true
 tracing-transport: "grpc"
 tracing-endpoint: "localhost:4317"
-tracing-insecure: true
+tracing-insecure-transport: true
 ```
 
 [otel]: https://opentelemetry.io/


### PR DESCRIPTION
# Description

The Advanced docs section on Tracing shows a wrong option relating to tracing transport security, the actual option is `tracing-insecure-transport` instead of `tracing-insecure`. 
https://github.com/superseriousbusiness/gotosocial/blob/138cbe4d602838d0b4d431cb934d533cf5516ea9/internal/config/config.go#L141


## Checklist

- [X] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
