### PR TITLE
Update Feditext URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Though most apps that implement the Mastodon API should work, GoToSocial works r
 
 * [Tusky](https://tusky.app/) for Android
 * [Semaphore](https://semaphore.social/) in the browser
-* [Feditext](https://fedi.software/@Feditext) (beta) on iOS, iPadOS and macOS
+* [Feditext](https://github.com/feditext/feditext) (beta) on iOS, iPadOS and macOS
 
 If you've used Mastodon with any of these apps before, you'll find using GoToSocial a breeze.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 ## Where's the user interface?
 
-GoToSocial is just a bare server for the most part and is designed to be used thru external applications. [Semaphore](https://semaphore.social/) in the browser, [Tusky](https://tusky.app/) for Android and [Feditext](https://fedi.software/@Feditext) for iOS, iPadOS and macOS are the best-supported. Anything that supports the Mastodon API should work, other than the features GoToSocial doesn't yet have. Permalinks and profile pages are served directly through GoToSocial as well as the settings panel, but most interaction goes through the apps.
+GoToSocial is just a bare server for the most part and is designed to be used thru external applications. [Semaphore](https://semaphore.social/) in the browser, [Tusky](https://tusky.app/) for Android and [Feditext](https://github.com/feditext/feditext) for iOS, iPadOS and macOS are the best-supported. Anything that supports the Mastodon API should work, other than the features GoToSocial doesn't yet have. Permalinks and profile pages are served directly through GoToSocial as well as the settings panel, but most interaction goes through the apps.
 
 ## Why aren't my posts showing up on my profile page?
 

--- a/web/template/index_apps.tmpl
+++ b/web/template/index_apps.tmpl
@@ -75,7 +75,7 @@
                 <div class="applist-text">
                     <p><strong>Feditext</strong> (beta) is a beautiful client for iOS, iPadOS and macOS.</p>
                     <a
-                        href="https://fedi.software/@Feditext"
+                        href="https://github.com/feditext/feditext"
                         rel="nofollow noreferrer noopener"
                         target="_blank"
                     >


### PR DESCRIPTION
# Description

Updates Feditext links to point to the app's GitHub repo.

Fixes #2567

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
