### PR TITLE
Fix EmptyJSONObject/EmptyJSONArray

### DIFF
--- a/internal/api/util/response.go
+++ b/internal/api/util/response.go
@@ -51,8 +51,8 @@ var (
 	ErrorRateLimited = mustJSON(map[string]string{
 		"error": "rate limit reached",
 	})
-	EmptyJSONObject = []byte{'{', '}'}
-	EmptyJSONArray  = []byte{'[', ']'}
+	EmptyJSONObject = json.RawMessage(`{}`)
+	EmptyJSONArray  = json.RawMessage(`[]`)
 
 	// write buffer pool.
 	bufPool sync.Pool

--- a/internal/api/util/response.go
+++ b/internal/api/util/response.go
@@ -51,8 +51,8 @@ var (
 	ErrorRateLimited = mustJSON(map[string]string{
 		"error": "rate limit reached",
 	})
-	EmptyJSONObject = mustJSON("{}")
-	EmptyJSONArray  = mustJSON("[]")
+	EmptyJSONObject = []byte{'{', '}'}
+	EmptyJSONArray  = []byte{'[', ']'}
 
 	// write buffer pool.
 	bufPool sync.Pool


### PR DESCRIPTION
These are meant to be the bytes representing an empty object and array in JSON: `{}` and `[]`. They are actually the strings `"{}"` and `"[]"`. This causes clients expecting an object or array to not be able to parse the response.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
