### PR TITLE
[bugfix] parent status replied to status not dereferenced sometimes

### DIFF
--- a/internal/federation/dereferencing/account.go
+++ b/internal/federation/dereferencing/account.go
@@ -1065,11 +1065,17 @@ func (d *Dereferencer) dereferenceAccountFeatured(ctx context.Context, requestUs
 		// we still know it was *meant* to be pinned.
 		statusURIs = append(statusURIs, statusURI)
 
+		// Search for status by URI. Note this may return an existing model
+		// we have stored with an error from attempted update, so check both.
 		status, _, _, err := d.getStatusByURI(ctx, requestUser, statusURI)
 		if err != nil {
-			// We couldn't get the status, bummer. Just log + move on, we can try later.
 			log.Errorf(ctx, "error getting status from featured collection %s: %v", statusURI, err)
-			continue
+
+			if status == nil {
+				// This is only unactionable
+				// if no status was returned.
+				continue
+			}
 		}
 
 		// If the status was already pinned, we don't need to do anything.

--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -41,7 +41,7 @@ import (
 // statusUpToDate returns whether the given status model is both updateable
 // (i.e. remote status) and whether it needs an update based on `fetched_at`.
 func statusUpToDate(status *gtsmodel.Status, force bool) bool {
-	if *status.Local {
+	if status.Local != nil && *status.Local {
 		// Can't update local statuses.
 		return true
 	}

--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -69,16 +69,24 @@ func statusUpToDate(status *gtsmodel.Status, force bool) bool {
 // is beyond a certain interval, the status will be dereferenced. In the case of dereferencing, some low-priority status information may be enqueued for asynchronous fetching,
 // e.g. dereferencing the status thread. Param 'syncParent' = true indicates to fetch status ancestors synchronously. An ActivityPub object indicates the status was dereferenced.
 func (d *Dereferencer) GetStatusByURI(ctx context.Context, requestUser string, uri *url.URL) (*gtsmodel.Status, ap.Statusable, error) {
-	// Fetch and dereference status if necessary.
+
+	// Fetch and dereference / update status if necessary.
 	status, statusable, isNew, err := d.getStatusByURI(ctx,
 		requestUser,
 		uri,
 	)
-	if err != nil {
-		return nil, nil, err
-	}
 
-	if statusable != nil {
+	if err != nil {
+		if status == nil {
+			// err with no existing
+			// status for fallback.
+			return nil, nil, err
+		}
+
+		log.Errorf(ctx, "error updating status %s: %v", uri, err)
+
+	} else if statusable != nil {
+
 		// Deref parents + children.
 		d.dereferenceThread(ctx,
 			requestUser,
@@ -92,7 +100,7 @@ func (d *Dereferencer) GetStatusByURI(ctx context.Context, requestUser string, u
 	return status, statusable, nil
 }
 
-// getStatusByURI is a package internal form of .GetStatusByURI() that doesn't bother dereferencing the whole thread on update.
+// getStatusByURI is a package internal form of .GetStatusByURI() that doesn't dereference thread on update, and may return an existing status with error on failed re-fetch.
 func (d *Dereferencer) getStatusByURI(ctx context.Context, requestUser string, uri *url.URL) (*gtsmodel.Status, ap.Statusable, bool, error) {
 	var (
 		status *gtsmodel.Status
@@ -100,8 +108,9 @@ func (d *Dereferencer) getStatusByURI(ctx context.Context, requestUser string, u
 		err    error
 	)
 
-	// Search the database for existing status with URI.
+	// Search the database for existing by URI.
 	status, err = d.state.DB.GetStatusByURI(
+
 		// request a barebones object, it may be in the
 		// db but with related models not yet dereferenced.
 		gtscontext.SetBarebones(ctx),
@@ -112,7 +121,7 @@ func (d *Dereferencer) getStatusByURI(ctx context.Context, requestUser string, u
 	}
 
 	if status == nil {
-		// Else, search the database for existing by URL.
+		// Else, search database for existing by URL.
 		status, err = d.state.DB.GetStatusByURL(
 			gtscontext.SetBarebones(ctx),
 			uriStr,
@@ -123,14 +132,16 @@ func (d *Dereferencer) getStatusByURI(ctx context.Context, requestUser string, u
 	}
 
 	if status == nil {
-		// Ensure that this isn't a search for a local status.
-		if uri.Host == config.GetHost() || uri.Host == config.GetAccountDomain() {
-			return nil, nil, false, gtserror.SetUnretrievable(err) // this will be db.ErrNoEntries
+		// Ensure not a failed search for a local
+		// status, if so we know it doesn't exist.
+		if uri.Host == config.GetHost() ||
+			uri.Host == config.GetAccountDomain() {
+			return nil, nil, false, gtserror.SetUnretrievable(err)
 		}
 
 		// Create and pass-through a new bare-bones model for deref.
 		return d.enrichStatusSafely(ctx, requestUser, uri, &gtsmodel.Status{
-			Local: func() *bool { var false bool; return &false }(),
+			Local: util.Ptr(false),
 			URI:   uriStr,
 		}, nil)
 	}
@@ -145,21 +156,22 @@ func (d *Dereferencer) getStatusByURI(ctx context.Context, requestUser string, u
 		return status, nil, false, nil
 	}
 
-	// Try to update + deref existing status model.
+	// Try to deref and update existing status model.
 	latest, statusable, isNew, err := d.enrichStatusSafely(ctx,
 		requestUser,
 		uri,
 		status,
 		nil,
 	)
-	if err != nil {
-		log.Errorf(ctx, "error enriching remote status: %v", err)
 
-		// Fallback to existing status.
-		return status, nil, false, nil
+	if err != nil {
+		// fallback to the
+		// existing status.
+		latest = status
+		statusable = nil
 	}
 
-	return latest, statusable, isNew, nil
+	return latest, statusable, isNew, err
 }
 
 // RefreshStatus is functionally equivalent to GetStatusByURI(), except that it requires a pre

--- a/internal/federation/dereferencing/thread.go
+++ b/internal/federation/dereferencing/thread.go
@@ -119,13 +119,7 @@ func (d *Dereferencer) DereferenceStatusAncestors(ctx context.Context, username 
 
 		// Fetch parent status by current's reply URI, this handles
 		// case of existing (updating if necessary) or a new status.
-		parent, update, _, err := d.getStatusByURI(ctx, username, uri)
-
-		if err == nil && update == nil {
-			// A parent status already existed
-			// and was up-to-date, return here.
-			return nil
-		}
+		parent, _, _, err := d.getStatusByURI(ctx, username, uri)
 
 		// Check for a returned HTTP code via error.
 		switch code := gtserror.StatusCode(err); {
@@ -170,7 +164,6 @@ func (d *Dereferencer) DereferenceStatusAncestors(ctx context.Context, username 
 			current.InReplyToAccount = parent.Account
 			current.InReplyToURI = parent.URI
 			current.InReplyToID = parent.ID
-			current.InReplyTo = parent
 			if err := d.state.DB.UpdateStatus(ctx,
 				current,
 				"in_reply_to_id",
@@ -182,6 +175,7 @@ func (d *Dereferencer) DereferenceStatusAncestors(ctx context.Context, username 
 		}
 
 		// Set next parent to use.
+		current.InReplyTo = parent
 		current = current.InReplyTo
 	}
 

--- a/internal/federation/dereferencing/thread.go
+++ b/internal/federation/dereferencing/thread.go
@@ -19,7 +19,6 @@ package dereferencing
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/url"
 
@@ -27,8 +26,6 @@ import (
 	"github.com/superseriousbusiness/activity/pub"
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
-	"github.com/superseriousbusiness/gotosocial/internal/db"
-	"github.com/superseriousbusiness/gotosocial/internal/gtscontext"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
@@ -101,143 +98,86 @@ func (d *Dereferencer) DereferenceStatusAncestors(ctx context.Context, username 
 			return nil
 		}
 
-		// Add new log fields for this iteration.
-		l = l.WithFields(kv.Fields{
-			{"current", current.URI},
-			{"parent", current.InReplyToURI},
-		}...)
-		l.Trace("following status ancestors")
+		l = l.WithField("parent", current.InReplyToURI)
+		l.Trace("following status ancestor")
 
-		// Check whether this parent has already been deref'd.
-		if _, ok := derefdStatuses[current.InReplyToURI]; ok {
-			l.Warn("self referencing status ancestors")
+		// Parse status parent URI for later use.
+		uri, err := url.Parse(current.InReplyToURI)
+		if err != nil {
+			l.Warnf("invalid uri: %v", err)
 			return nil
 		}
 
-		// Add this status URI to map of deref'd.
-		derefdStatuses[current.URI] = struct{}{}
+		// Check whether this parent has already been deref'd.
+		if _, ok := derefdStatuses[current.InReplyToURI]; ok {
+			l.Warn("self referencing status ancestor")
+			return nil
+		}
 
-		if current.InReplyToID != "" {
-			// We already have an InReplyToID set. This means
-			// the status's parent has, at some point, been
-			// inserted into the database, either because it
-			// is a status from our instance, or a status from
-			// remote that we've dereferenced before, or found
-			// out about in some other way.
-			//
-			// Working on this assumption, check if the parent
-			// status exists, either as a copy pinned on the
-			// current status, or in the database.
+		// Add this status's parent URI to map of deref'd.
+		derefdStatuses[current.InReplyToURI] = struct{}{}
 
-			if current.InReplyTo != nil {
-				// We have the parent already, and the child
-				// doesn't need to be updated; keep iterating
-				// from this parent upwards.
-				current = current.InReplyTo
-				continue
-			}
-
-			// Parent isn't pinned to this status (yet), see
-			// if we can get it from the db (we should be
-			// able to, since it has an ID already).
-			parent, err := d.state.DB.GetStatusByID(
-				gtscontext.SetBarebones(ctx),
-				current.InReplyToID,
+		if current.InReplyTo != nil {
+			// We already have the parent for current status,
+			// ensure we have an up-to-date copy by enriching.
+			current.InReplyTo, _, _, err = d.enrichStatusSafely(ctx,
+				username,
+				uri,
+				current.InReplyTo,
+				nil,
 			)
-			if err != nil && !errors.Is(err, db.ErrNoEntries) {
-				// Real db error, stop.
-				return gtserror.Newf("db error getting status %s: %w", current.InReplyToID, err)
-			}
-
-			if parent != nil {
-				// We got the parent from the db, and the child
-				// doesn't need to be updated; keep iterating
-				// from this parent upwards.
-				current.InReplyTo = parent
-				current = parent
-				continue
-			}
-
-			// If we arrive here, we know this child *did* have
-			// a parent at some point, but it no longer exists in
-			// the database, presumably because it's been deleted
-			// by another action.
-			//
-			// TODO: clean this up in a nightly task.
-			l.Warn("orphaned status (parent no longer exists)")
-			return nil // Cannot iterate further.
+		} else {
+			// Fetch the parent status by its URI, this handles case
+			// of existing parent we already deref'd, or updating it!
+			current.InReplyTo, _, _, err = d.getStatusByURI(ctx, username, uri)
 		}
 
-		// If we reach this point, we know the status has
-		// an InReplyToURI set, but it doesn't yet have an
-		// InReplyToID, which means that the parent status
-		// has not yet been dereferenced.
-		inReplyToURI, err := url.Parse(current.InReplyToURI)
-		if err != nil || inReplyToURI == nil {
-			// Parent URI is not something we can handle.
-			l.Warn("orphaned status (invalid InReplyToURI)")
-			return nil //nolint:nilerr
-		}
-
-		// Parent URI is valid, try to get it.
-		// getStatusByURI guards against the following conditions:
-		//   - refetching recently fetched statuses (recursion!)
-		//   - remote domain is blocked (will return unretrievable)
-		//   - any http type error for a new status returns unretrievable
-		parent, _, _, err := d.getStatusByURI(ctx, username, inReplyToURI)
-		if err == nil {
-			// We successfully fetched the parent.
-			// Update current status with new info.
-			current.InReplyToID = parent.ID
-			current.InReplyToAccountID = parent.AccountID
-			if err := d.state.DB.UpdateStatus(
-				ctx, current,
+		// Check for a returned HTTP code via error.
+		// Status codes 404 and 410 incicate the status does not exist anymore.
+		// Gone (410) is the preferred for deletion, but we accept NotFound too.
+		switch code := gtserror.StatusCode(err); {
+		case code == http.StatusNotFound, code == http.StatusGone:
+			current.InReplyToID = ""
+			current.InReplyToURI = ""
+			current.InReplyToAccountID = ""
+			current.InReplyTo = nil
+			current.InReplyToAccount = nil
+			if err := d.state.DB.UpdateStatus(ctx,
+				current,
 				"in_reply_to_id",
+				"in_reply_to_uri",
 				"in_reply_to_account_id",
 			); err != nil {
 				return gtserror.Newf("db error updating status %s: %w", current.ID, err)
 			}
 
-			// Mark parent as next status to
-			// work on, and keep iterating.
-			current = parent
-			continue
-		}
+		// An error was returned for a status during
+		// an attempted NEW dereference, return here.
+		case err != nil && current.InReplyToID == "":
+			return gtserror.Newf("error dereferencing new %s: %w", uri, err)
 
-		// We could not fetch the parent, check if we can do anything
-		// useful with the error. For example, HTTP status code returned
-		// from remote may indicate that the parent has been deleted.
-		switch code := gtserror.StatusCode(err); {
-		case code == http.StatusGone:
-			// 410 means the status has definitely been deleted.
-			// Update this status to reflect that, then bail.
-			l.Debug("orphaned status: parent returned 410 Gone")
+		// An error was returned for an existing parent,
+		// we simply treat this as a temporary situation.
+		case err != nil:
+			l.Errorf("error getting parent: %v", err)
 
-			current.InReplyToURI = ""
-			if err := d.state.DB.UpdateStatus(
-				ctx, current,
-				"in_reply_to_uri",
+		// -> by this point, err == nil
+
+		// The ID has changed for currently stored parent ID
+		// (which may be empty, if new!) and fetched version.
+		//
+		// Update the current's inReplyTo fields to parent.
+		case current.InReplyToID != current.InReplyTo.ID:
+			current.InReplyToID = current.InReplyTo.ID
+			current.InReplyToAccountID = current.InReplyTo.AccountID
+			current.InReplyToAccount = current.InReplyTo.Account
+			if err := d.state.DB.UpdateStatus(ctx,
+				current,
+				"in_reply_to_id",
+				"in_reply_to_account_id",
 			); err != nil {
 				return gtserror.Newf("db error updating status %s: %w", current.ID, err)
 			}
-
-			return nil
-
-		case code != 0:
-			// We had a code, but not one indicating deletion, log the code
-			// but don't return error or update the status; we can try again later.
-			l.Warnf("orphaned status: http error dereferencing parent: %v)", err)
-			return nil
-
-		case gtserror.IsUnretrievable(err):
-			// Not retrievable for some other reason, so just
-			// bail for now; we can try again later if necessary.
-			l.Warnf("orphaned status: parent unretrievable: %v)", err)
-			return nil
-
-		default:
-			// Some other error that stops us in our tracks.
-			return gtserror.Newf("error dereferencing parent %s: %w", current.InReplyToURI, err)
 		}
 	}
 

--- a/internal/visibility/home_timeline.go
+++ b/internal/visibility/home_timeline.go
@@ -99,10 +99,13 @@ func (f *Filter) isStatusHomeTimelineable(ctx context.Context, owner *gtsmodel.A
 	}
 
 	var (
-		next      = status
-		oneAuthor = true // Assume one author until proven otherwise.
-		// visible bool
-		notVisible bool
+		// iterated-over
+		// loop status.
+		next = status
+
+		// assume one author
+		// until proven otherwise.
+		oneAuthor = true
 	)
 
 	for {
@@ -120,6 +123,8 @@ func (f *Filter) isStatusHomeTimelineable(ctx context.Context, owner *gtsmodel.A
 			visible = true
 			break
 		}
+
+		var notVisible bool
 
 		// Check whether status in conversation is explicitly relevant to timeline
 		// owner (i.e. includes mutals), or is explicitly invisible (i.e. blocked).


### PR DESCRIPTION
# Description

- simplifies DereferenceStatusAncestors() -- as part of this it should also perform more self-correction in the case of setting / unsetting parent status IDs
- handle status acceptibility check even on status forwards
- update API of get{Account,Status}ByURI() to return error even if an old database model was returned, to allow caller to handle the error themselves for logging / further actions etc
- updates home timeline visibility checks to also check for threads that should be explicitly NOT visible

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
