### PR TITLE
[bugfix] stop paged endpoints returning null for empty items

### DIFF
--- a/internal/processing/account/block.go
+++ b/internal/processing/account/block.go
@@ -151,6 +151,11 @@ func (p *Processor) BlocksGet(
 		return util.EmptyPageableResponse(), nil
 	}
 
+	// Get the lowest and highest
+	// ID values, used for paging.
+	lo := blocks[count-1].ID
+	hi := blocks[0].ID
+
 	items := make([]interface{}, 0, count)
 
 	for _, block := range blocks {
@@ -164,11 +169,6 @@ func (p *Processor) BlocksGet(
 		// Append target to return items.
 		items = append(items, account)
 	}
-
-	// Get the lowest and highest
-	// ID values, used for paging.
-	lo := blocks[count-1].ID
-	hi := blocks[0].ID
 
 	return paging.PackageResponse(paging.ResponseParams{
 		Items: items,

--- a/internal/processing/common/account.go.go
+++ b/internal/processing/common/account.go.go
@@ -201,9 +201,6 @@ func (p *Processor) GetVisibleAPIAccountsPaged(
 	length int,
 ) []interface{} {
 	accounts := p.getVisibleAPIAccounts(ctx, 3, requester, next, length)
-	if len(accounts) == 0 {
-		return nil
-	}
 	items := make([]interface{}, len(accounts))
 	for i, account := range accounts {
 		items[i] = account


### PR DESCRIPTION
closes #2595 

see for example of how it's happening: https://go.dev/play/p/8SMLbhbJ2sy