### PR TITLE
[bugfix] Ensure activities sender always = activities actor

### DIFF
--- a/internal/federation/federatingdb/reject.go
+++ b/internal/federation/federatingdb/reject.go
@@ -40,7 +40,7 @@ func (f *federatingDB) Reject(ctx context.Context, reject vocab.ActivityStreamsR
 		l.Debug("entering Reject")
 	}
 
-	receivingAccount, _, internal := extractFromCtx(ctx)
+	receivingAccount, requestingAccount, internal := extractFromCtx(ctx)
 	if internal {
 		return nil // Already processed.
 	}
@@ -57,9 +57,16 @@ func (f *federatingDB) Reject(ctx context.Context, reject vocab.ActivityStreamsR
 					return fmt.Errorf("Reject: couldn't get follow request with id %s from the database: %s", rejectedObjectIRI.String(), err)
 				}
 
-				// make sure the addressee of the original follow is the same as whatever inbox this landed in
+				// Make sure the creator of the original follow
+				// is the same as whatever inbox this landed in.
 				if followReq.AccountID != receivingAccount.ID {
-					return errors.New("Reject: follow object account and inbox account were not the same")
+					return errors.New("Reject: follow account and inbox account were not the same")
+				}
+
+				// Make sure the target of the original follow
+				// is the same as the account making the request.
+				if followReq.TargetAccountID != requestingAccount.ID {
+					return errors.New("Reject: follow target account and requesting account were not the same")
 				}
 
 				return f.state.DB.RejectFollowRequest(ctx, followReq.AccountID, followReq.TargetAccountID)
@@ -80,9 +87,16 @@ func (f *federatingDB) Reject(ctx context.Context, reject vocab.ActivityStreamsR
 				return fmt.Errorf("Reject: error converting asfollow to gtsfollow: %s", err)
 			}
 
-			// make sure the addressee of the original follow is the same as whatever inbox this landed in
+			// Make sure the creator of the original follow
+			// is the same as whatever inbox this landed in.
 			if gtsFollow.AccountID != receivingAccount.ID {
-				return errors.New("Reject: follow object account and inbox account were not the same")
+				return errors.New("Reject: follow account and inbox account were not the same")
+			}
+
+			// Make sure the target of the original follow
+			// is the same as the account making the request.
+			if gtsFollow.TargetAccountID != requestingAccount.ID {
+				return errors.New("Reject: follow target account and requesting account were not the same")
 			}
 
 			return f.state.DB.RejectFollowRequest(ctx, gtsFollow.AccountID, gtsFollow.TargetAccountID)


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Close some gaps where remote accounts could theoretically deliver Activities to GtS inboxes imitating other accounts (Follow, Announce, Like, Block).

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
