### PR TITLE
Make GtS reported version SemVer-compatible

### DIFF
--- a/cmd/gotosocial/main.go
+++ b/cmd/gotosocial/main.go
@@ -77,6 +77,7 @@ func main() {
 }
 
 // version will build a version string from binary's stored build information.
+// It is SemVer-compatible so long as Version is SemVer-compatible.
 func version() string {
 	// Read build information from binary
 	build, ok := godebug.ReadBuildInfo()
@@ -115,5 +116,5 @@ func version() string {
 		}
 	}
 
-	return strings.Join(info, " ")
+	return strings.Join(info, "+")
 }


### PR DESCRIPTION
# Description

This pull request makes GtS's version string compatible with SemVer by concatenating the VCS metadata with the version using a plus sign (SemVer's build tag separator) instead of a space. It relies on `main.Version` being set to a SemVer-compatible version, which should be the case for release and most development builds.

Fixes #1953

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
