### PR TITLE
[chore] Move `DoOnce` func wrapper to util

### DIFF
--- a/internal/federation/dereferencing/account.go
+++ b/internal/federation/dereferencing/account.go
@@ -37,6 +37,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/media"
 	"github.com/superseriousbusiness/gotosocial/internal/transport"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
 
 // accountUpToDate returns whether the given account model is both updateable (i.e.
@@ -384,7 +385,7 @@ func (d *Dereferencer) enrichAccountSafely(
 	// to safely defer in case of panic, while still
 	// performing more granular unlocks when needed.
 	unlock := d.state.FedLocks.Lock(uriStr)
-	unlock = doOnce(unlock)
+	unlock = util.DoOnce(unlock)
 	defer unlock()
 
 	// Perform status enrichment with passed vars.
@@ -735,7 +736,7 @@ func (d *Dereferencer) fetchRemoteAccountAvatar(ctx context.Context, tsport tran
 
 	// Acquire lock for derefs map.
 	unlock := d.state.FedLocks.Lock(latestAcc.AvatarRemoteURL)
-	unlock = doOnce(unlock)
+	unlock = util.DoOnce(unlock)
 	defer unlock()
 
 	// Look for an existing dereference in progress.
@@ -821,7 +822,7 @@ func (d *Dereferencer) fetchRemoteAccountHeader(ctx context.Context, tsport tran
 
 	// Acquire lock for derefs map.
 	unlock := d.state.FedLocks.Lock(latestAcc.HeaderRemoteURL)
-	unlock = doOnce(unlock)
+	unlock = util.DoOnce(unlock)
 	defer unlock()
 
 	// Look for an existing dereference in progress.

--- a/internal/federation/dereferencing/emoji.go
+++ b/internal/federation/dereferencing/emoji.go
@@ -28,6 +28,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/id"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/media"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
 
 func (d *Dereferencer) GetRemoteEmoji(ctx context.Context, requestingUsername string, remoteURL string, shortcode string, domain string, id string, emojiURI string, ai *media.AdditionalEmojiInfo, refresh bool) (*media.ProcessingEmoji, error) {
@@ -44,7 +45,7 @@ func (d *Dereferencer) GetRemoteEmoji(ctx context.Context, requestingUsername st
 
 	// Acquire lock for derefs map.
 	unlock := d.state.FedLocks.Lock(remoteURL)
-	unlock = doOnce(unlock)
+	unlock = util.DoOnce(unlock)
 	defer unlock()
 
 	// first check if we're already processing this emoji

--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -295,7 +295,7 @@ func (d *Dereferencer) enrichStatusSafely(
 	// to safely defer in case of panic, while still
 	// performing more granular unlocks when needed.
 	unlock := d.state.FedLocks.Lock(uriStr)
-	unlock = doOnce(unlock)
+	unlock = util.DoOnce(unlock)
 	defer unlock()
 
 	// Perform status enrichment with passed vars.

--- a/internal/federation/dereferencing/util.go
+++ b/internal/federation/dereferencing/util.go
@@ -23,17 +23,6 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 )
 
-// doOnce wraps a function to only perform it once.
-func doOnce(fn func()) func() {
-	var once int32
-	return func() {
-		if once == 0 {
-			fn()
-			once = 1
-		}
-	}
-}
-
 // pollChanged returns whether a poll has changed in way that
 // indicates that this should be an entirely new poll. i.e. if
 // the available options have changed, or the expiry has increased.

--- a/internal/util/sync.go
+++ b/internal/util/sync.go
@@ -1,0 +1,29 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package util
+
+// DoOnce wraps a function to only perform it once.
+func DoOnce(fn func()) func() {
+	var once int32
+	return func() {
+		if once == 0 {
+			fn()
+			once = 1
+		}
+	}
+}


### PR DESCRIPTION
`Move` will also require the v. nice little `doOnce` function we had in the dereferencer, so this PR just puts it in the util package in advance of that (to keep the `Move` PR simpler).