### PR TITLE
[chore] Allow (internal) callers to set their own freshness window for Accounts + Statuses

### DIFF
--- a/internal/federation/dereferencing/dereferencer.go
+++ b/internal/federation/dereferencing/dereferencer.go
@@ -20,11 +20,49 @@ package dereferencing
 import (
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/superseriousbusiness/gotosocial/internal/media"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
 	"github.com/superseriousbusiness/gotosocial/internal/transport"
 	"github.com/superseriousbusiness/gotosocial/internal/typeutils"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
+)
+
+// FreshnessWindow represents a duration in which a
+// Status or Account is still considered to be "fresh"
+// (ie., not in need of a refresh from remote), if its
+// last FetchedAt value falls within the window.
+//
+// For example, if an Account was FetchedAt 09:00, and it
+// is now 12:00, then it would be considered "fresh"
+// according to DefaultAccountFreshness, but not according
+// to Fresh, which would indicate that the Account requires
+// refreshing from remote.
+type FreshnessWindow time.Duration
+
+var (
+	// 6 hours.
+	//
+	// Default window for doing a
+	// fresh dereference of an Account.
+	DefaultAccountFreshness = util.Ptr(FreshnessWindow(6 * time.Hour))
+
+	// 2 hours.
+	//
+	// Default window for doing a
+	// fresh dereference of a Status.
+	DefaultStatusFreshness = util.Ptr(FreshnessWindow(2 * time.Hour))
+
+	// 5 minutes.
+	//
+	// Fresh is useful when you're wanting
+	// a more up-to-date model of something
+	// that exceeds default freshness windows.
+	//
+	// This is tuned to be quite fresh without
+	// causing loads of dereferencing calls.
+	Fresh = util.Ptr(FreshnessWindow(5 * time.Minute))
 )
 
 // Dereferencer wraps logic and functionality for doing dereferencing

--- a/internal/gtsmodel/status.go
+++ b/internal/gtsmodel/status.go
@@ -205,6 +205,12 @@ func (s *Status) BelongsToAccount(accountID string) bool {
 	return s.AccountID == accountID
 }
 
+// IsLocal returns true if this is a local
+// status (ie., originating from this instance).
+func (s *Status) IsLocal() bool {
+	return s.Local != nil && *s.Local
+}
+
 // StatusToTag is an intermediate struct to facilitate the many2many relationship between a status and one or more tags.
 type StatusToTag struct {
 	StatusID string  `bun:"type:CHAR(26),unique:statustag,nullzero,notnull"`

--- a/internal/processing/common/account.go
+++ b/internal/processing/common/account.go
@@ -66,7 +66,7 @@ func (p *Processor) GetTargetAccountBy(
 			requester.Username,
 			target,
 			nil,
-			false,
+			nil,
 		)
 	}
 

--- a/internal/processing/fedi/status.go
+++ b/internal/processing/fedi/status.go
@@ -100,7 +100,7 @@ func (p *Processor) StatusRepliesGet(
 	status, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requester,
 		statusID,
-		false, // refresh
+		nil, // default freshness
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/polls/poll.go
+++ b/internal/processing/polls/poll.go
@@ -53,7 +53,7 @@ func (p *Processor) getTargetPoll(ctx context.Context, requester *gtsmodel.Accou
 		func() (*gtsmodel.Status, error) {
 			return p.state.DB.GetStatusByPollID(ctx, targetID)
 		},
-		true, // refresh
+		nil, // default freshness
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/status/bookmark.go
+++ b/internal/processing/status/bookmark.go
@@ -33,7 +33,7 @@ func (p *Processor) getBookmarkableStatus(ctx context.Context, requestingAccount
 	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requestingAccount,
 		targetStatusID,
-		false, // refresh
+		nil, // default freshness
 	)
 	if errWithCode != nil {
 		return nil, "", errWithCode

--- a/internal/processing/status/boost.go
+++ b/internal/processing/status/boost.go
@@ -43,7 +43,7 @@ func (p *Processor) BoostCreate(
 		ctx,
 		requester,
 		targetID,
-		false, // refresh
+		nil, // default freshness
 	)
 	if errWithCode != nil {
 		return nil, errWithCode
@@ -113,7 +113,7 @@ func (p *Processor) BoostRemove(
 		ctx,
 		requester,
 		targetID,
-		false, // refresh
+		nil, // default freshness
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/status/fave.go
+++ b/internal/processing/status/fave.go
@@ -47,7 +47,7 @@ func (p *Processor) getFaveableStatus(
 		ctx,
 		requester,
 		targetID,
-		false, // refresh
+		nil, // default freshness
 	)
 	if errWithCode != nil {
 		return nil, nil, errWithCode
@@ -153,7 +153,7 @@ func (p *Processor) FavedBy(ctx context.Context, requestingAccount *gtsmodel.Acc
 	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requestingAccount,
 		targetStatusID,
-		false, // refresh
+		nil, // default freshness
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/status/get.go
+++ b/internal/processing/status/get.go
@@ -32,7 +32,7 @@ func (p *Processor) Get(ctx context.Context, requestingAccount *gtsmodel.Account
 	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requestingAccount,
 		targetStatusID,
-		false, // refresh
+		nil, // default freshness
 	)
 	if errWithCode != nil {
 		return nil, errWithCode
@@ -46,7 +46,7 @@ func (p *Processor) WebGet(ctx context.Context, targetStatusID string) (*apimode
 	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		nil, // requester
 		targetStatusID,
-		false, // refresh
+		nil, // default freshness
 	)
 	if errWithCode != nil {
 		return nil, errWithCode
@@ -69,7 +69,7 @@ func (p *Processor) contextGet(
 	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requestingAccount,
 		targetStatusID,
-		false, // refresh
+		nil, // default freshness
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/status/mute.go
+++ b/internal/processing/status/mute.go
@@ -44,7 +44,7 @@ func (p *Processor) getMuteableStatus(
 	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requestingAccount,
 		targetStatusID,
-		false, // refresh
+		nil, // default freshness
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/status/pin.go
+++ b/internal/processing/status/pin.go
@@ -42,7 +42,7 @@ func (p *Processor) getPinnableStatus(ctx context.Context, requestingAccount *gt
 	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
 		requestingAccount,
 		targetStatusID,
-		false, // refresh
+		nil, // default freshness
 	)
 	if errWithCode != nil {
 		return nil, errWithCode

--- a/internal/processing/workers/fromfediapi.go
+++ b/internal/processing/workers/fromfediapi.go
@@ -23,6 +23,8 @@ import (
 	"codeberg.org/gruf/go-kv"
 	"codeberg.org/gruf/go-logger/v2/level"
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
+	"github.com/superseriousbusiness/gotosocial/internal/federation/dereferencing"
+
 	"github.com/superseriousbusiness/gotosocial/internal/gtscontext"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
@@ -179,7 +181,8 @@ func (p *fediAPI) CreateStatus(ctx context.Context, fMsg messages.FromFediAPI) e
 			fMsg.ReceivingAccount.Username,
 			bareStatus,
 			statusable,
-			true,
+			// Force refresh within 5min window.
+			dereferencing.Fresh,
 		)
 		if err != nil {
 			return gtserror.Newf("error processing new status %s: %w", bareStatus.URI, err)
@@ -487,7 +490,8 @@ func (p *fediAPI) UpdateAccount(ctx context.Context, fMsg messages.FromFediAPI) 
 		fMsg.ReceivingAccount.Username,
 		account,
 		apubAcc,
-		true, // Force refresh.
+		// Force refresh within 5min window.
+		dereferencing.Fresh,
 	)
 	if err != nil {
 		log.Errorf(ctx, "error refreshing account: %v", err)
@@ -512,7 +516,8 @@ func (p *fediAPI) UpdateStatus(ctx context.Context, fMsg messages.FromFediAPI) e
 		fMsg.ReceivingAccount.Username,
 		existing,
 		apStatus,
-		true,
+		// Force refresh within 5min window.
+		dereferencing.Fresh,
 	)
 	if err != nil {
 		log.Errorf(ctx, "error refreshing status: %v", err)


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request implements super-duper force refresh of accounts and statuses, by allowing callers to the dereferencing functions to specify what they consider to be "fresh enough" for their purposes, instead of a simple bool. 

This will be required for `Move`, which necessitates that we have a very up to date version of the target and origin accounts of a Move. I don't wanna lower the account/status force deref cooldown of 5 mins globally, so passing in a custom duration to the refresh functions (but providing consts for callers to use) seemed like a good way of doing things.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
