### PR TITLE
[performance] temporarily cache account status counts to reduce no. account counts

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -51,6 +51,7 @@ func (c *Caches) Init() {
 	log.Infof(nil, "init: %p", c)
 
 	c.initAccount()
+	c.initAccountCounts()
 	c.initAccountNote()
 	c.initApplication()
 	c.initBlock()

--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -38,7 +38,7 @@ type GTSCaches struct {
 
 	// TEMPORARY CACHE TO ALLEVIATE SLOW COUNT QUERIES,
 	// (in time will be removed when these IDs are cached).
-	AccountCounts simple.Cache[string, struct {
+	AccountCounts *simple.Cache[string, struct {
 		Statuses int
 		Pinned   int
 	}]
@@ -209,7 +209,10 @@ func (c *Caches) initAccountCounts() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
-	c.GTS.AccountCounts.Init(0, cap)
+	c.GTS.AccountCounts = simple.New[string, struct {
+		Statuses int
+		Pinned   int
+	}](0, cap)
 }
 
 func (c *Caches) initAccountNote() {

--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -209,7 +209,7 @@ func (c *Caches) initAccountCounts() {
 
 	log.Infof(nil, "cache size = %d", cap)
 
-	c.GTS.AccountCounts.Init(0, c.GTS.Account.Cap())
+	c.GTS.AccountCounts.Init(0, cap)
 }
 
 func (c *Caches) initAccountNote() {

--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -36,6 +36,13 @@ type GTSCaches struct {
 	// AccountNote provides access to the gtsmodel Note database cache.
 	AccountNote structr.Cache[*gtsmodel.AccountNote]
 
+	// TEMPORARY CACHE TO ALLEVIATE SLOW COUNT QUERIES,
+	// (in time will be removed when these IDs are cached).
+	AccountCounts simple.Cache[string, struct {
+		Statuses int
+		Pinned   int
+	}]
+
 	// Application provides access to the gtsmodel Application database cache.
 	Application structr.Cache[*gtsmodel.Application]
 
@@ -190,6 +197,19 @@ func (c *Caches) initAccount() {
 		CopyValue:  copyF,
 		Invalidate: c.OnInvalidateAccount,
 	})
+}
+
+func (c *Caches) initAccountCounts() {
+	// Simply use size of accounts cache,
+	// as this cache will be very small.
+	cap := c.GTS.Account.Cap()
+	if cap == 0 {
+		panic("must be initialized before accounts")
+	}
+
+	log.Infof(nil, "cache size = %d", cap)
+
+	c.GTS.AccountCounts.Init(0, c.GTS.Account.Cap())
 }
 
 func (c *Caches) initAccountNote() {

--- a/internal/cache/invalidate.go
+++ b/internal/cache/invalidate.go
@@ -27,6 +27,9 @@ import (
 // HOOKS TO BE CALLED ON DELETE YOU MUST FIRST POPULATE IT IN THE CACHE.
 
 func (c *Caches) OnInvalidateAccount(account *gtsmodel.Account) {
+	// Invalidate status counts for this account.
+	c.GTS.AccountCounts.Invalidate(account.ID)
+
 	// Invalidate account ID cached visibility.
 	c.Visibility.Invalidate("ItemID", account.ID)
 	c.Visibility.Invalidate("RequesterID", account.ID)

--- a/internal/cache/invalidate.go
+++ b/internal/cache/invalidate.go
@@ -151,6 +151,9 @@ func (c *Caches) OnInvalidatePollVote(vote *gtsmodel.PollVote) {
 }
 
 func (c *Caches) OnInvalidateStatus(status *gtsmodel.Status) {
+	// Invalidate status counts for this account.
+	c.GTS.AccountCounts.Invalidate(status.AccountID)
+
 	// Invalidate status ID cached visibility.
 	c.Visibility.Invalidate("ItemID", status.ID)
 

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -555,7 +555,7 @@ func (a *accountDB) getAccountStatusCounts(ctx context.Context, accountID string
 		var err error
 
 		// Scan database for account statuses.
-		counts.Statuses, err = a.db.NewSelect().
+		counts.Statuses, err = tx.NewSelect().
 			Table("statuses").
 			Where("? = ?", bun.Ident("account_id"), accountID).
 			Count(ctx)
@@ -564,7 +564,7 @@ func (a *accountDB) getAccountStatusCounts(ctx context.Context, accountID string
 		}
 
 		// Scan database for pinned statuses.
-		counts.Pinned, err = a.db.NewSelect().
+		counts.Pinned, err = tx.NewSelect().
 			Table("statuses").
 			Where("? = ?", bun.Ident("account_id"), accountID).
 			Where("? IS NOT NULL", bun.Ident("pinned_at")).

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -532,20 +532,48 @@ func (a *accountDB) GetAccountFaves(ctx context.Context, accountID string) ([]*g
 }
 
 func (a *accountDB) CountAccountStatuses(ctx context.Context, accountID string) (int, error) {
-	return a.db.
-		NewSelect().
-		TableExpr("? AS ?", bun.Ident("statuses"), bun.Ident("status")).
-		Where("? = ?", bun.Ident("status.account_id"), accountID).
-		Count(ctx)
+	counts, err := a.getAccountStatusCounts(ctx, accountID)
+	return counts.Statuses, err
 }
 
 func (a *accountDB) CountAccountPinned(ctx context.Context, accountID string) (int, error) {
-	return a.db.
-		NewSelect().
-		TableExpr("? AS ?", bun.Ident("statuses"), bun.Ident("status")).
-		Where("? = ?", bun.Ident("status.account_id"), accountID).
-		Where("? IS NOT NULL", bun.Ident("status.pinned_at")).
-		Count(ctx)
+	counts, err := a.getAccountStatusCounts(ctx, accountID)
+	return counts.Pinned, err
+}
+
+func (a *accountDB) getAccountStatusCounts(ctx context.Context, accountID string) (struct {
+	Statuses int
+	Pinned   int
+}, error) {
+	// Check for an already cached copy of account status counts.
+	counts, ok := a.state.Caches.GTS.AccountCounts.Get(accountID)
+	if ok {
+		return counts, nil
+	}
+
+	if err := a.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		// Scan database for statuses.
+		if err := a.db.NewSelect().
+			Table("statuses").
+			Where("? = ?", bun.Ident("account_id"), accountID).
+			Scan(ctx, &counts.Statuses); err != nil {
+			return err
+		}
+
+		// Scan database for pinned.
+		return a.db.NewSelect().
+			Table("statuses").
+			Where("? = ?", bun.Ident("account_id"), accountID).
+			Where("? IS NOT NULL", bun.Ident("pinned_at")).
+			Scan(ctx, &counts.Pinned)
+	}); err != nil {
+		return counts, err
+	}
+
+	// Store this account counts result in the cache.
+	a.state.Caches.GTS.AccountCounts.Set(accountID, counts)
+
+	return counts, nil
 }
 
 func (a *accountDB) GetAccountStatuses(ctx context.Context, accountID string, limit int, excludeReplies bool, excludeReblogs bool, maxID string, minID string, mediaOnly bool, publicOnly bool) ([]*gtsmodel.Status, error) {

--- a/internal/db/bundb/drivers.go
+++ b/internal/db/bundb/drivers.go
@@ -141,6 +141,9 @@ func (c *SQLiteConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx dri
 		err = processSQLiteError(err)
 		return err
 	})
+	if err != nil {
+		return nil, err
+	}
 	return &SQLiteTx{Context: ctx, Tx: tx}, nil
 }
 

--- a/internal/db/bundb/drivers.go
+++ b/internal/db/bundb/drivers.go
@@ -311,6 +311,7 @@ func retryOnBusySlow(ctx context.Context, fn func() error) error {
 		select {
 		// Context cancelled.
 		case <-ctx.Done():
+			return ctx.Err()
 
 		// Backoff for some time.
 		case <-time.After(backoff):

--- a/internal/db/bundb/drivers.go
+++ b/internal/db/bundb/drivers.go
@@ -278,9 +278,9 @@ func (stmt *SQLiteStmt) QueryContext(ctx context.Context, args []driver.NamedVal
 type conn interface {
 	driver.Conn
 	driver.ConnPrepareContext
-	driver.Execer
+	driver.Execer //nolint:staticcheck
 	driver.ExecerContext
-	driver.Queryer
+	driver.Queryer //nolint:staticcheck
 	driver.QueryerContext
 	driver.ConnBeginTx
 }

--- a/internal/db/bundb/drivers.go
+++ b/internal/db/bundb/drivers.go
@@ -66,7 +66,10 @@ func (c *PostgreSQLConn) Begin() (driver.Tx, error) {
 func (c *PostgreSQLConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
 	tx, err := c.conn.BeginTx(ctx, opts)
 	err = processPostgresError(err)
-	return tx, err
+	if err != nil {
+		return nil, err
+	}
+	return &PostgreSQLTx{tx}, nil
 }
 
 func (c *PostgreSQLConn) Prepare(query string) (driver.Stmt, error) {


### PR DESCRIPTION
should temporarily help with #1887 until my account status IDs PR is ready (will be post v0.14.0 release)

whilst i was here also ended up changing:
- fixing our database driver wrapping to include stmts (previously they were forgotten, though i'm not sure we actually use any)
- outlining `retryOnBusy()` to have a slow and path set of functions, allowing the fast path (case of just 1 try) to be inlined
- fix return of wrapped tx types on error