### PR TITLE
[bugfix] fix possible mutex lockup during streaming code

### DIFF
--- a/internal/api/client/streaming/stream.go
+++ b/internal/api/client/streaming/stream.go
@@ -354,10 +354,13 @@ func (m *Module) writeToWSConn(
 
 	for {
 		// Wrap stream context with timeout to send a ping.
-		ctx, _ := context.WithTimeout(stream.Context(), ping)
+		ctx, cncl := context.WithTimeout(stream.Context(), ping)
 
 		// Block on receipt of next message.
 		msg, ok, open := stream.Recv(ctx)
+
+		// Stop timer.
+		cncl()
 
 		if !open {
 			// Stream was

--- a/internal/api/client/streaming/stream.go
+++ b/internal/api/client/streaming/stream.go
@@ -368,19 +368,20 @@ loop:
 		// Stop timer.
 		cncl()
 
-		switch {
-		case pingctx.Err() != nil:
-			l.Trace("writing websocket ping")
+		if !ok {
+			if pingctx.Err() != nil {
+				// The ping context timed out!
+				l.Trace("writing websocket ping")
 
-			// Wrapped context time-out, send a keep-alive "ping".
-			if err := wsConn.WriteControl(websocket.PingMessage, nil, time.Time{}); err != nil {
-				l.Debugf("error writing websocket ping: %v", err)
-				break
+				// Wrapped context time-out, send a keep-alive "ping".
+				if err := wsConn.WriteControl(websocket.PingMessage, nil, time.Time{}); err != nil {
+					l.Debugf("error writing websocket ping: %v", err)
+					break
+				}
+
+				continue loop
 			}
 
-			continue loop
-
-		case !ok:
 			// Stream was
 			// closed.
 			return

--- a/internal/api/client/streaming/stream.go
+++ b/internal/api/client/streaming/stream.go
@@ -266,6 +266,10 @@ func (m *Module) handleWSConn(l *log.Entry, wsConn *websocket.Conn, stream *stre
 	// to be closed.
 	<-ctx.Done()
 
+	// Close stream
+	// straightaway.
+	stream.Close()
+
 	// Tidy up underlying websocket connection.
 	if err := wsConn.Close(); err != nil {
 		l.Errorf("error closing websocket connection: %v", err)

--- a/internal/api/client/streaming/stream.go
+++ b/internal/api/client/streaming/stream.go
@@ -302,12 +302,12 @@ func (m *Module) readFromWSConn(
 		if err := wsConn.ReadJSON(&msg); err != nil {
 			// Only log an error if something weird happened.
 			// See: https://www.rfc-editor.org/rfc/rfc6455.html#section-11.7
-			if websocket.IsUnexpectedCloseError(err, []int{
+			if !websocket.IsCloseError(err, []int{
 				websocket.CloseNormalClosure,
 				websocket.CloseGoingAway,
 				websocket.CloseNoStatusReceived,
 			}...) {
-				l.Errorf("error reading from websocket: %v", err)
+				l.Errorf("error during websocket read: %v", err)
 			}
 
 			// The connection is gone; no

--- a/internal/api/client/streaming/stream.go
+++ b/internal/api/client/streaming/stream.go
@@ -247,11 +247,17 @@ func (m *Module) StreamGETHandler(c *gin.Context) {
 func (m *Module) handleWSConn(l *log.Entry, wsConn *websocket.Conn, stream *streampkg.Stream) {
 	// Read messages coming from the Websocket
 	// client connection into the server.
-	go m.readFromWSConn(wsConn, stream, l)
+	go func() {
+		defer stream.Close()
+		m.readFromWSConn(wsConn, stream, l)
+	}()
 
 	// Write messages coming from the processor
 	// into the Websocket client connection.
-	go m.writeToWSConn(wsConn, stream, m.dTicker, l)
+	go func() {
+		defer stream.Close()
+		m.writeToWSConn(wsConn, stream, m.dTicker, l)
+	}()
 
 	// Wait for stream to close.
 	<-stream.Context().Done()

--- a/internal/api/client/streaming/stream.go
+++ b/internal/api/client/streaming/stream.go
@@ -202,7 +202,7 @@ func (m *Module) StreamGETHandler(c *gin.Context) {
 	// functions pass messages into a channel, which we can
 	// then read from and put into a websockets connection.
 	stream, errWithCode := m.processor.Stream().Open(
-		c.Request.Context(),
+		context.Background(), // use new ctx for async Stream{}
 		account,
 		streamType,
 	)

--- a/internal/api/client/streaming/stream.go
+++ b/internal/api/client/streaming/stream.go
@@ -202,7 +202,7 @@ func (m *Module) StreamGETHandler(c *gin.Context) {
 	// functions pass messages into a channel, which we can
 	// then read from and put into a websockets connection.
 	stream, errWithCode := m.processor.Stream().Open(
-		context.Background(), // use new ctx for async Stream{}
+		c.Request.Context(), // this ctx is only used for logging
 		account,
 		streamType,
 	)

--- a/internal/processing/stream/notification.go
+++ b/internal/processing/stream/notification.go
@@ -36,6 +36,9 @@ func (p *Processor) Notify(ctx context.Context, account *gtsmodel.Account, notif
 	p.streams.Post(ctx, account.ID, stream.Message{
 		Payload: byteutil.B2S(b),
 		Event:   stream.EventTypeNotification,
-		Stream:  []string{stream.TimelineNotifications, stream.TimelineHome},
+		Stream: []string{
+			stream.TimelineNotifications,
+			stream.TimelineHome,
+		},
 	})
 }

--- a/internal/processing/stream/notification.go
+++ b/internal/processing/stream/notification.go
@@ -24,6 +24,7 @@ import (
 	"codeberg.org/gruf/go-byteutil"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/stream"
 )
 
@@ -31,7 +32,8 @@ import (
 func (p *Processor) Notify(ctx context.Context, account *gtsmodel.Account, notif *apimodel.Notification) {
 	b, err := json.Marshal(notif)
 	if err != nil {
-		panic(err) // this should never happen
+		log.Errorf(ctx, "error marshaling json: %v", err)
+		return
 	}
 	p.streams.Post(ctx, account.ID, stream.Message{
 		Payload: byteutil.B2S(b),

--- a/internal/processing/stream/notification_test.go
+++ b/internal/processing/stream/notification_test.go
@@ -49,10 +49,11 @@ func (suite *NotificationTestSuite) TestStreamNotification() {
 		Account:   followAccountAPIModel,
 	}
 
-	err = suite.streamProcessor.Notify(notification, account)
-	suite.NoError(err)
+	suite.streamProcessor.Notify(context.Background(), account, notification)
 
-	msg := <-openStream.Messages
+	msg, argCtx, strCtx := openStream.Recv(context.Background())
+	suite.True(argCtx && strCtx)
+
 	dst := new(bytes.Buffer)
 	err = json.Indent(dst, []byte(msg.Payload), "", "  ")
 	suite.NoError(err)

--- a/internal/processing/stream/notification_test.go
+++ b/internal/processing/stream/notification_test.go
@@ -51,8 +51,8 @@ func (suite *NotificationTestSuite) TestStreamNotification() {
 
 	suite.streamProcessor.Notify(context.Background(), account, notification)
 
-	msg, argCtx, strCtx := openStream.Recv(context.Background())
-	suite.True(argCtx && strCtx)
+	msg, ok := openStream.Recv(context.Background())
+	suite.True(ok)
 
 	dst := new(bytes.Buffer)
 	err = json.Indent(dst, []byte(msg.Payload), "", "  ")

--- a/internal/processing/stream/open.go
+++ b/internal/processing/stream/open.go
@@ -34,5 +34,5 @@ func (p *Processor) Open(ctx context.Context, account *gtsmodel.Account, streamT
 		{"streamType", streamType},
 	}...)
 	l.Debug("received open stream request")
-	return p.streams.Open(ctx, account.ID, streamType), nil
+	return p.streams.Open(account.ID, streamType), nil
 }

--- a/internal/processing/stream/open.go
+++ b/internal/processing/stream/open.go
@@ -19,13 +19,10 @@ package stream
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"codeberg.org/gruf/go-kv"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
-	"github.com/superseriousbusiness/gotosocial/internal/id"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/stream"
 )
@@ -37,97 +34,5 @@ func (p *Processor) Open(ctx context.Context, account *gtsmodel.Account, streamT
 		{"streamType", streamType},
 	}...)
 	l.Debug("received open stream request")
-
-	var (
-		streamID string
-		err      error
-	)
-
-	// Each stream needs a unique ID so we know to close it.
-	streamID, err = id.NewRandomULID()
-	if err != nil {
-		return nil, gtserror.NewErrorInternalError(fmt.Errorf("error generating stream id: %w", err))
-	}
-
-	// Each stream can be subscibed to multiple types.
-	// Record them in a set, and include the initial one
-	// if it was given to us.
-	streamTypes := map[string]any{}
-	if streamType != "" {
-		streamTypes[streamType] = true
-	}
-
-	newStream := &stream.Stream{
-		ID:          streamID,
-		StreamTypes: streamTypes,
-		Messages:    make(chan *stream.Message, 100),
-		Hangup:      make(chan interface{}, 1),
-		Connected:   true,
-	}
-	go p.waitToCloseStream(account, newStream)
-
-	v, ok := p.streamMap.Load(account.ID)
-	if ok {
-		// There is an entry in the streamMap
-		// for this account. Parse it out.
-		streamsForAccount, ok := v.(*stream.StreamsForAccount)
-		if !ok {
-			return nil, gtserror.NewErrorInternalError(errors.New("stream map error"))
-		}
-
-		// Append new stream to existing entry.
-		streamsForAccount.Lock()
-		streamsForAccount.Streams = append(streamsForAccount.Streams, newStream)
-		streamsForAccount.Unlock()
-	} else {
-		// There is no entry in the streamMap for
-		// this account yet. Create one and store it.
-		p.streamMap.Store(account.ID, &stream.StreamsForAccount{
-			Streams: []*stream.Stream{
-				newStream,
-			},
-		})
-	}
-
-	return newStream, nil
-}
-
-// waitToCloseStream waits until the hangup channel is closed for the given stream.
-// It then iterates through the map of streams stored by the processor, removes the stream from it,
-// and then closes the messages channel of the stream to indicate that the channel should no longer be read from.
-func (p *Processor) waitToCloseStream(account *gtsmodel.Account, thisStream *stream.Stream) {
-	<-thisStream.Hangup // wait for a hangup message
-
-	// lock the stream to prevent more messages being put in it while we work
-	thisStream.Lock()
-	defer thisStream.Unlock()
-
-	// indicate the stream is no longer connected
-	thisStream.Connected = false
-
-	// load and parse the entry for this account from the stream map
-	v, ok := p.streamMap.Load(account.ID)
-	if !ok || v == nil {
-		return
-	}
-	streamsForAccount, ok := v.(*stream.StreamsForAccount)
-	if !ok {
-		return
-	}
-
-	// lock the streams for account while we remove this stream from its slice
-	streamsForAccount.Lock()
-	defer streamsForAccount.Unlock()
-
-	// put everything into modified streams *except* the stream we're removing
-	modifiedStreams := []*stream.Stream{}
-	for _, s := range streamsForAccount.Streams {
-		if s.ID != thisStream.ID {
-			modifiedStreams = append(modifiedStreams, s)
-		}
-	}
-	streamsForAccount.Streams = modifiedStreams
-
-	// finally close the messages channel so no more messages can be read from it
-	close(thisStream.Messages)
+	return p.streams.Open(ctx, account.ID, streamType), nil
 }

--- a/internal/processing/stream/statusupdate.go
+++ b/internal/processing/stream/statusupdate.go
@@ -24,6 +24,7 @@ import (
 	"codeberg.org/gruf/go-byteutil"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/stream"
 )
 
@@ -31,7 +32,8 @@ import (
 func (p *Processor) StatusUpdate(ctx context.Context, account *gtsmodel.Account, status *apimodel.Status, streamType string) {
 	b, err := json.Marshal(status)
 	if err != nil {
-		panic(err) // this should never happen
+		log.Errorf(ctx, "error marshaling json: %v", err)
+		return
 	}
 	p.streams.Post(ctx, account.ID, stream.Message{
 		Payload: byteutil.B2S(b),

--- a/internal/processing/stream/statusupdate.go
+++ b/internal/processing/stream/statusupdate.go
@@ -18,21 +18,24 @@
 package stream
 
 import (
+	"context"
 	"encoding/json"
-	"fmt"
 
+	"codeberg.org/gruf/go-byteutil"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/stream"
 )
 
-// StatusUpdate streams the given edited status to any open, appropriate
-// streams belonging to the given account.
-func (p *Processor) StatusUpdate(s *apimodel.Status, account *gtsmodel.Account, streamTypes []string) error {
-	bytes, err := json.Marshal(s)
+// StatusUpdate streams the given edited status to any open, appropriate streams belonging to the given account.
+func (p *Processor) StatusUpdate(ctx context.Context, account *gtsmodel.Account, status *apimodel.Status, streamType string) {
+	b, err := json.Marshal(status)
 	if err != nil {
-		return fmt.Errorf("error marshalling status to json: %s", err)
+		panic(err) // this should never happen
 	}
-
-	return p.toAccount(string(bytes), stream.EventTypeStatusUpdate, streamTypes, account.ID)
+	p.streams.Post(ctx, account.ID, stream.Message{
+		Payload: byteutil.B2S(b),
+		Event:   stream.EventTypeStatusUpdate,
+		Stream:  []string{streamType},
+	})
 }

--- a/internal/processing/stream/statusupdate_test.go
+++ b/internal/processing/stream/statusupdate_test.go
@@ -42,10 +42,11 @@ func (suite *StatusUpdateTestSuite) TestStreamNotification() {
 	apiStatus, err := typeutils.NewConverter(&suite.state).StatusToAPIStatus(context.Background(), editedStatus, account)
 	suite.NoError(err)
 
-	err = suite.streamProcessor.StatusUpdate(apiStatus, account, []string{stream.TimelineHome})
-	suite.NoError(err)
+	suite.streamProcessor.StatusUpdate(context.Background(), account, apiStatus, stream.TimelineHome)
 
-	msg := <-openStream.Messages
+	msg, argCtx, strCtx := openStream.Recv(context.Background())
+	suite.True(argCtx && strCtx)
+
 	dst := new(bytes.Buffer)
 	err = json.Indent(dst, []byte(msg.Payload), "", "  ")
 	suite.NoError(err)

--- a/internal/processing/stream/statusupdate_test.go
+++ b/internal/processing/stream/statusupdate_test.go
@@ -44,8 +44,8 @@ func (suite *StatusUpdateTestSuite) TestStreamNotification() {
 
 	suite.streamProcessor.StatusUpdate(context.Background(), account, apiStatus, stream.TimelineHome)
 
-	msg, argCtx, strCtx := openStream.Recv(context.Background())
-	suite.True(argCtx && strCtx)
+	msg, ok := openStream.Recv(context.Background())
+	suite.True(ok)
 
 	dst := new(bytes.Buffer)
 	err = json.Indent(dst, []byte(msg.Payload), "", "  ")

--- a/internal/processing/stream/stream.go
+++ b/internal/processing/stream/stream.go
@@ -18,8 +18,6 @@
 package stream
 
 import (
-	"sync"
-
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
 	"github.com/superseriousbusiness/gotosocial/internal/stream"
@@ -28,53 +26,13 @@ import (
 type Processor struct {
 	state       *state.State
 	oauthServer oauth.Server
-	streamMap   *sync.Map
+	streams     stream.Streams
 }
 
 func New(state *state.State, oauthServer oauth.Server) Processor {
 	return Processor{
 		state:       state,
 		oauthServer: oauthServer,
-		streamMap:   &sync.Map{},
+		streams:     stream.Streams{},
 	}
-}
-
-// toAccount streams the given payload with the given event type to any streams currently open for the given account ID.
-func (p *Processor) toAccount(payload string, event string, streamTypes []string, accountID string) error {
-	// Load all streams open for this account.
-	v, ok := p.streamMap.Load(accountID)
-	if !ok {
-		return nil // No entry = nothing to stream.
-	}
-	streamsForAccount := v.(*stream.StreamsForAccount)
-
-	streamsForAccount.Lock()
-	defer streamsForAccount.Unlock()
-
-	for _, s := range streamsForAccount.Streams {
-		s.Lock()
-		defer s.Unlock()
-
-		if !s.Connected {
-			continue
-		}
-
-	typeLoop:
-		for _, streamType := range streamTypes {
-			if _, found := s.StreamTypes[streamType]; found {
-				s.Messages <- &stream.Message{
-					Stream:  []string{streamType},
-					Event:   string(event),
-					Payload: payload,
-				}
-
-				// Break out to the outer loop,
-				// to avoid sending duplicates of
-				// the same event to the same stream.
-				break typeLoop
-			}
-		}
-	}
-
-	return nil
 }

--- a/internal/processing/stream/update.go
+++ b/internal/processing/stream/update.go
@@ -24,6 +24,7 @@ import (
 	"codeberg.org/gruf/go-byteutil"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/stream"
 )
 
@@ -31,7 +32,8 @@ import (
 func (p *Processor) Update(ctx context.Context, account *gtsmodel.Account, status *apimodel.Status, streamType string) {
 	b, err := json.Marshal(status)
 	if err != nil {
-		panic(err) // this should never happen
+		log.Errorf(ctx, "error marshaling json: %v", err)
+		return
 	}
 	p.streams.Post(ctx, account.ID, stream.Message{
 		Payload: byteutil.B2S(b),

--- a/internal/processing/stream/update.go
+++ b/internal/processing/stream/update.go
@@ -18,20 +18,24 @@
 package stream
 
 import (
+	"context"
 	"encoding/json"
-	"fmt"
 
+	"codeberg.org/gruf/go-byteutil"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/stream"
 )
 
 // Update streams the given update to any open, appropriate streams belonging to the given account.
-func (p *Processor) Update(s *apimodel.Status, account *gtsmodel.Account, streamTypes []string) error {
-	bytes, err := json.Marshal(s)
+func (p *Processor) Update(ctx context.Context, account *gtsmodel.Account, status *apimodel.Status, streamType string) {
+	b, err := json.Marshal(status)
 	if err != nil {
-		return fmt.Errorf("error marshalling status to json: %s", err)
+		panic(err) // this should never happen
 	}
-
-	return p.toAccount(string(bytes), stream.EventTypeUpdate, streamTypes, account.ID)
+	p.streams.Post(ctx, account.ID, stream.Message{
+		Payload: byteutil.B2S(b),
+		Event:   stream.EventTypeUpdate,
+		Stream:  []string{streamType},
+	})
 }

--- a/internal/processing/workers/fromclientapi_test.go
+++ b/internal/processing/workers/fromclientapi_test.go
@@ -122,8 +122,7 @@ func (suite *FromClientAPITestSuite) checkStreamed(
 	ctx, cncl := context.WithTimeout(ctx, time.Second*5)
 	defer cncl()
 
-	msg, argCtx, strCtx := str.Recv(context.Background())
-	ok := (argCtx && strCtx)
+	msg, ok := str.Recv(ctx)
 
 	if expectMessage && !ok {
 		suite.FailNow("expected a message but message was not received")

--- a/internal/processing/workers/fromclientapi_test.go
+++ b/internal/processing/workers/fromclientapi_test.go
@@ -116,23 +116,21 @@ func (suite *FromClientAPITestSuite) checkStreamed(
 	expectPayload string,
 	expectEventType string,
 ) {
-	var msg *stream.Message
-streamLoop:
-	for {
-		select {
-		case msg = <-str.Messages:
-			break streamLoop // Got it.
-		case <-time.After(5 * time.Second):
-			break streamLoop // Didn't get it.
-		}
+
+	// Set a 5s timeout on context.
+	ctx := context.Background()
+	ctx, cncl := context.WithTimeout(ctx, time.Second*5)
+	defer cncl()
+
+	msg, argCtx, strCtx := str.Recv(context.Background())
+	ok := (argCtx && strCtx)
+
+	if expectMessage && !ok {
+		suite.FailNow("expected a message but message was not received")
 	}
 
-	if expectMessage && msg == nil {
-		suite.FailNow("expected a message but message was nil")
-	}
-
-	if !expectMessage && msg != nil {
-		suite.FailNow("expected no message but message was not nil")
+	if !expectMessage && ok {
+		suite.FailNow("expected no message but message was received")
 	}
 
 	if expectPayload != "" && msg.Payload != expectPayload {

--- a/internal/processing/workers/fromfediapi_test.go
+++ b/internal/processing/workers/fromfediapi_test.go
@@ -130,14 +130,9 @@ func (suite *FromFediAPITestSuite) TestProcessReplyMention() {
 	suite.Equal(replyingStatus.ID, notif.StatusID)
 	suite.False(*notif.Read)
 
-	// the notification should be streamed
-	var msg *stream.Message
-	select {
-	case msg = <-wssStream.Messages:
-		// fine
-	case <-time.After(5 * time.Second):
-		suite.FailNow("no message from wssStream")
-	}
+	ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
+	msg, argCtx, strCtx := wssStream.Recv(ctx)
+	suite.True(argCtx && strCtx)
 
 	suite.Equal(stream.EventTypeNotification, msg.Event)
 	suite.NotEmpty(msg.Payload)
@@ -203,14 +198,10 @@ func (suite *FromFediAPITestSuite) TestProcessFave() {
 	suite.Equal(fave.StatusID, notif.StatusID)
 	suite.False(*notif.Read)
 
-	// 2. a notification should be streamed
-	var msg *stream.Message
-	select {
-	case msg = <-wssStream.Messages:
-		// fine
-	case <-time.After(5 * time.Second):
-		suite.FailNow("no message from wssStream")
-	}
+	ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
+	msg, argCtx, strCtx := wssStream.Recv(ctx)
+	suite.True(argCtx && strCtx)
+
 	suite.Equal(stream.EventTypeNotification, msg.Event)
 	suite.NotEmpty(msg.Payload)
 	suite.EqualValues([]string{stream.TimelineNotifications}, msg.Stream)
@@ -277,7 +268,10 @@ func (suite *FromFediAPITestSuite) TestProcessFaveWithDifferentReceivingAccount(
 	suite.False(*notif.Read)
 
 	// 2. no notification should be streamed to the account that received the fave message, because they weren't the target
-	suite.Empty(wssStream.Messages)
+	ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
+	_, argCtx, strCtx := wssStream.Recv(ctx)
+	suite.True(strCtx)
+	suite.False(argCtx)
 }
 
 func (suite *FromFediAPITestSuite) TestProcessAccountDelete() {
@@ -405,14 +399,10 @@ func (suite *FromFediAPITestSuite) TestProcessFollowRequestLocked() {
 	})
 	suite.NoError(err)
 
-	// a notification should be streamed
-	var msg *stream.Message
-	select {
-	case msg = <-wssStream.Messages:
-		// fine
-	case <-time.After(5 * time.Second):
-		suite.FailNow("no message from wssStream")
-	}
+	ctx, _ = context.WithTimeout(ctx, time.Second*5)
+	msg, argCtx, strCtx := wssStream.Recv(context.Background())
+	suite.True(argCtx && strCtx)
+
 	suite.Equal(stream.EventTypeNotification, msg.Event)
 	suite.NotEmpty(msg.Payload)
 	suite.EqualValues([]string{stream.TimelineHome}, msg.Stream)
@@ -503,14 +493,10 @@ func (suite *FromFediAPITestSuite) TestProcessFollowRequestUnlocked() {
 	suite.Equal(originAccount.URI, accept.To)
 	suite.Equal("Accept", accept.Type)
 
-	// a notification should be streamed
-	var msg *stream.Message
-	select {
-	case msg = <-wssStream.Messages:
-		// fine
-	case <-time.After(5 * time.Second):
-		suite.FailNow("no message from wssStream")
-	}
+	ctx, _ = context.WithTimeout(ctx, time.Second*5)
+	msg, argCtx, strCtx := wssStream.Recv(context.Background())
+	suite.True(argCtx && strCtx)
+
 	suite.Equal(stream.EventTypeNotification, msg.Event)
 	suite.NotEmpty(msg.Payload)
 	suite.EqualValues([]string{stream.TimelineHome}, msg.Stream)

--- a/internal/processing/workers/fromfediapi_test.go
+++ b/internal/processing/workers/fromfediapi_test.go
@@ -136,7 +136,7 @@ func (suite *FromFediAPITestSuite) TestProcessReplyMention() {
 
 	suite.Equal(stream.EventTypeNotification, msg.Event)
 	suite.NotEmpty(msg.Payload)
-	suite.EqualValues([]string{stream.TimelineNotifications, stream.TimelineHome}, msg.Stream)
+	suite.EqualValues([]string{stream.TimelineHome}, msg.Stream)
 	notifStreamed := &apimodel.Notification{}
 	err = json.Unmarshal([]byte(msg.Payload), notifStreamed)
 	suite.NoError(err)
@@ -204,7 +204,7 @@ func (suite *FromFediAPITestSuite) TestProcessFave() {
 
 	suite.Equal(stream.EventTypeNotification, msg.Event)
 	suite.NotEmpty(msg.Payload)
-	suite.EqualValues([]string{stream.TimelineNotifications, stream.TimelineHome}, msg.Stream)
+	suite.EqualValues([]string{stream.TimelineNotifications}, msg.Stream)
 }
 
 // TestProcessFaveWithDifferentReceivingAccount ensures that when an account receives a fave that's for
@@ -404,7 +404,7 @@ func (suite *FromFediAPITestSuite) TestProcessFollowRequestLocked() {
 
 	suite.Equal(stream.EventTypeNotification, msg.Event)
 	suite.NotEmpty(msg.Payload)
-	suite.EqualValues([]string{stream.TimelineNotifications, stream.TimelineHome}, msg.Stream)
+	suite.EqualValues([]string{stream.TimelineHome}, msg.Stream)
 	notif := &apimodel.Notification{}
 	err = json.Unmarshal([]byte(msg.Payload), notif)
 	suite.NoError(err)
@@ -498,7 +498,7 @@ func (suite *FromFediAPITestSuite) TestProcessFollowRequestUnlocked() {
 
 	suite.Equal(stream.EventTypeNotification, msg.Event)
 	suite.NotEmpty(msg.Payload)
-	suite.EqualValues([]string{stream.TimelineNotifications, stream.TimelineHome}, msg.Stream)
+	suite.EqualValues([]string{stream.TimelineHome}, msg.Stream)
 	notif := &apimodel.Notification{}
 	err = json.Unmarshal([]byte(msg.Payload), notif)
 	suite.NoError(err)

--- a/internal/processing/workers/fromfediapi_test.go
+++ b/internal/processing/workers/fromfediapi_test.go
@@ -131,12 +131,12 @@ func (suite *FromFediAPITestSuite) TestProcessReplyMention() {
 	suite.False(*notif.Read)
 
 	ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
-	msg, argCtx, strCtx := wssStream.Recv(ctx)
-	suite.True(argCtx && strCtx)
+	msg, ok := wssStream.Recv(ctx)
+	suite.True(ok)
 
 	suite.Equal(stream.EventTypeNotification, msg.Event)
 	suite.NotEmpty(msg.Payload)
-	suite.EqualValues([]string{stream.TimelineHome}, msg.Stream)
+	suite.EqualValues([]string{stream.TimelineNotifications, stream.TimelineHome}, msg.Stream)
 	notifStreamed := &apimodel.Notification{}
 	err = json.Unmarshal([]byte(msg.Payload), notifStreamed)
 	suite.NoError(err)
@@ -199,12 +199,12 @@ func (suite *FromFediAPITestSuite) TestProcessFave() {
 	suite.False(*notif.Read)
 
 	ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
-	msg, argCtx, strCtx := wssStream.Recv(ctx)
-	suite.True(argCtx && strCtx)
+	msg, ok := wssStream.Recv(ctx)
+	suite.True(ok)
 
 	suite.Equal(stream.EventTypeNotification, msg.Event)
 	suite.NotEmpty(msg.Payload)
-	suite.EqualValues([]string{stream.TimelineNotifications}, msg.Stream)
+	suite.EqualValues([]string{stream.TimelineNotifications, stream.TimelineHome}, msg.Stream)
 }
 
 // TestProcessFaveWithDifferentReceivingAccount ensures that when an account receives a fave that's for
@@ -269,9 +269,8 @@ func (suite *FromFediAPITestSuite) TestProcessFaveWithDifferentReceivingAccount(
 
 	// 2. no notification should be streamed to the account that received the fave message, because they weren't the target
 	ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
-	_, argCtx, strCtx := wssStream.Recv(ctx)
-	suite.True(strCtx)
-	suite.False(argCtx)
+	_, ok := wssStream.Recv(ctx)
+	suite.False(ok)
 }
 
 func (suite *FromFediAPITestSuite) TestProcessAccountDelete() {
@@ -400,12 +399,12 @@ func (suite *FromFediAPITestSuite) TestProcessFollowRequestLocked() {
 	suite.NoError(err)
 
 	ctx, _ = context.WithTimeout(ctx, time.Second*5)
-	msg, argCtx, strCtx := wssStream.Recv(context.Background())
-	suite.True(argCtx && strCtx)
+	msg, ok := wssStream.Recv(context.Background())
+	suite.True(ok)
 
 	suite.Equal(stream.EventTypeNotification, msg.Event)
 	suite.NotEmpty(msg.Payload)
-	suite.EqualValues([]string{stream.TimelineHome}, msg.Stream)
+	suite.EqualValues([]string{stream.TimelineNotifications, stream.TimelineHome}, msg.Stream)
 	notif := &apimodel.Notification{}
 	err = json.Unmarshal([]byte(msg.Payload), notif)
 	suite.NoError(err)
@@ -413,7 +412,7 @@ func (suite *FromFediAPITestSuite) TestProcessFollowRequestLocked() {
 	suite.Equal(originAccount.ID, notif.Account.ID)
 
 	// no messages should have been sent out, since we didn't need to federate an accept
-	suite.Empty(suite.httpClient.SentMessages)
+	suite.Empty(&suite.httpClient.SentMessages)
 }
 
 func (suite *FromFediAPITestSuite) TestProcessFollowRequestUnlocked() {
@@ -494,12 +493,12 @@ func (suite *FromFediAPITestSuite) TestProcessFollowRequestUnlocked() {
 	suite.Equal("Accept", accept.Type)
 
 	ctx, _ = context.WithTimeout(ctx, time.Second*5)
-	msg, argCtx, strCtx := wssStream.Recv(context.Background())
-	suite.True(argCtx && strCtx)
+	msg, ok := wssStream.Recv(context.Background())
+	suite.True(ok)
 
 	suite.Equal(stream.EventTypeNotification, msg.Event)
 	suite.NotEmpty(msg.Payload)
-	suite.EqualValues([]string{stream.TimelineHome}, msg.Stream)
+	suite.EqualValues([]string{stream.TimelineNotifications, stream.TimelineHome}, msg.Stream)
 	notif := &apimodel.Notification{}
 	err = json.Unmarshal([]byte(msg.Payload), notif)
 	suite.NoError(err)

--- a/internal/processing/workers/surfacenotify.go
+++ b/internal/processing/workers/surfacenotify.go
@@ -394,10 +394,7 @@ func (s *surface) notify(
 	if err != nil {
 		return gtserror.Newf("error converting notification to api representation: %w", err)
 	}
-
-	if err := s.stream.Notify(apiNotif, targetAccount); err != nil {
-		return gtserror.Newf("error streaming notification to account: %w", err)
-	}
+	s.stream.Notify(ctx, targetAccount, apiNotif)
 
 	return nil
 }

--- a/internal/processing/workers/surfacetimeline.go
+++ b/internal/processing/workers/surfacetimeline.go
@@ -348,11 +348,7 @@ func (s *surface) timelineStatus(
 		err = gtserror.Newf("error converting status %s to frontend representation: %w", status.ID, err)
 		return true, err
 	}
-
-	if err := s.stream.Update(apiStatus, account, []string{streamType}); err != nil {
-		err = gtserror.Newf("error streaming update for status %s: %w", status.ID, err)
-		return true, err
-	}
+	s.stream.Update(ctx, account, apiStatus, streamType)
 
 	return true, nil
 }
@@ -363,12 +359,11 @@ func (s *surface) deleteStatusFromTimelines(ctx context.Context, statusID string
 	if err := s.state.Timelines.Home.WipeItemFromAllTimelines(ctx, statusID); err != nil {
 		return err
 	}
-
 	if err := s.state.Timelines.List.WipeItemFromAllTimelines(ctx, statusID); err != nil {
 		return err
 	}
-
-	return s.stream.Delete(statusID)
+	s.stream.Delete(ctx, statusID)
+	return nil
 }
 
 // invalidateStatusFromTimelines does cache invalidation on the given status by
@@ -555,11 +550,6 @@ func (s *surface) timelineStreamStatusUpdate(
 		err = gtserror.Newf("error converting status %s to frontend representation: %w", status.ID, err)
 		return err
 	}
-
-	if err := s.stream.StatusUpdate(apiStatus, account, []string{streamType}); err != nil {
-		err = gtserror.Newf("error streaming update for status %s: %w", status.ID, err)
-		return err
-	}
-
+	s.stream.StatusUpdate(ctx, account, apiStatus, streamType)
 	return nil
 }


### PR DESCRIPTION
# Description

This fixes an issue I have noticed a few times on my own instance. It rewrites Stream{} to use much less mutex locking, and updates related code calling it.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
