### PR TITLE
[feature/oidc] Add support for very basic RBAC

### DIFF
--- a/docs/configuration/oidc.md
+++ b/docs/configuration/oidc.md
@@ -80,6 +80,12 @@ oidc-scopes:
 oidc-link-existing: false
 
 # Array of string. If the returned ID token contains a 'groups' claim that matches one of the
+# groups in oidc-allowed-groups, then this user will be granted access on the GtS instance. If the array is empty,
+# then all groups will be granted permission.
+# Default: []
+oidc-allowed-groups: []
+
+# Array of string. If the returned ID token contains a 'groups' claim that matches one of the
 # groups in oidc-admin-groups, then this user will be granted admin rights on the GtS instance
 # Default: []
 oidc-admin-groups: []

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -696,6 +696,12 @@ oidc-scopes:
 oidc-link-existing: false
 
 # Array of string. If the returned ID token contains a 'groups' claim that matches one of the
+# groups in oidc-allowed-groups, then this user will be granted access on the GtS instance. If the array is empty,
+# then all groups will be granted permission.
+# Default: []
+oidc-allowed-groups: []
+
+# Array of string. If the returned ID token contains a 'groups' claim that matches one of the
 # groups in oidc-admin-groups, then this user will be granted admin rights on the GtS instance
 # Default: []
 oidc-admin-groups: []

--- a/internal/api/auth/callback_test.go
+++ b/internal/api/auth/callback_test.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/superseriousbusiness/gotosocial/testrig"
+)
+
+func TestNotInAdminGroup(t *testing.T) {
+	testrig.InitTestConfig()
+	// Test if user has allowed group but not in admin group
+	groups := []string{"group1", "group2", "allowedRole"}
+
+	got := adminGroup(groups)
+	want := false
+
+	if got != want {
+		t.Errorf("got %t, wanted %t", got, want)
+	}
+}
+
+func TestInAdminGroup(t *testing.T) {
+	testrig.InitTestConfig()
+	// Test if user has admin group
+	groups := []string{"group1", "group2", "adminRole"}
+
+	got := adminGroup(groups)
+	want := true
+
+	if got != want {
+		t.Errorf("got %t, wanted %t", got, want)
+	}
+}
+
+func TestNotInAllowedGroup(t *testing.T) {
+	testrig.InitTestConfig()
+	// Test if user has admin group but not in allowed group
+	groups := []string{"group1", "group2", "adminRole"}
+
+	got := allowedGroup(groups)
+	want := false
+
+	if got != want {
+		t.Errorf("got %t, wanted %t", got, want)
+	}
+}
+
+func TestInAllowedGroup(t *testing.T) {
+	testrig.InitTestConfig()
+	// Test if user has allowed group
+	groups := []string{"group1", "group2", "allowedRole"}
+
+	got := allowedGroup(groups)
+	want := true
+
+	if got != want {
+		t.Errorf("got %t, wanted %t", got, want)
+	}
+}

--- a/internal/api/auth/callback_test.go
+++ b/internal/api/auth/callback_test.go
@@ -6,54 +6,40 @@ import (
 	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
-func TestNotInAdminGroup(t *testing.T) {
+func TestAdminGroup(t *testing.T) {
 	testrig.InitTestConfig()
-	// Test if user has allowed group but not in admin group
-	groups := []string{"group1", "group2", "allowedRole"}
-
-	got := adminGroup(groups)
-	want := false
-
-	if got != want {
-		t.Errorf("got %t, wanted %t", got, want)
+	for _, test := range []struct {
+		name     string
+		groups   []string
+		expected bool
+	}{
+		{name: "not in admin group", groups: []string{"group1", "group2", "allowedRole"}, expected: false},
+		{name: "in admin group", groups: []string{"group1", "group2", "adminRole"}, expected: true},
+	} {
+		test := test // loopvar capture
+		t.Run(test.name, func(t *testing.T) {
+			if got := adminGroup(test.groups); got != test.expected {
+				t.Fatalf("got: %t, wanted: %t", got, test.expected)
+			}
+		})
 	}
 }
 
-func TestInAdminGroup(t *testing.T) {
+func TestAllowedGroup(t *testing.T) {
 	testrig.InitTestConfig()
-	// Test if user has admin group
-	groups := []string{"group1", "group2", "adminRole"}
-
-	got := adminGroup(groups)
-	want := true
-
-	if got != want {
-		t.Errorf("got %t, wanted %t", got, want)
-	}
-}
-
-func TestNotInAllowedGroup(t *testing.T) {
-	testrig.InitTestConfig()
-	// Test if user has admin group but not in allowed group
-	groups := []string{"group1", "group2", "adminRole"}
-
-	got := allowedGroup(groups)
-	want := false
-
-	if got != want {
-		t.Errorf("got %t, wanted %t", got, want)
-	}
-}
-
-func TestInAllowedGroup(t *testing.T) {
-	testrig.InitTestConfig()
-	// Test if user has allowed group
-	groups := []string{"group1", "group2", "allowedRole"}
-
-	got := allowedGroup(groups)
-	want := true
-
-	if got != want {
-		t.Errorf("got %t, wanted %t", got, want)
+	for _, test := range []struct {
+		name     string
+		groups   []string
+		expected bool
+	}{
+		{name: "not in allowed group", groups: []string{"group1", "group2", "adminRole"}, expected: false},
+		{name: "in allowed group", groups: []string{"group1", "group2", "allowedRole"}, expected: true},
+	} {
+		test := test // loopvar capture
+		t.Run(test.name, func(t *testing.T) {
+			if got := allowedGroup(test.groups); got != test.expected {
+				t.Fatalf("got: %t, wanted: %t", got, test.expected)
+			}
+		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,6 +133,7 @@ type Configuration struct {
 	OIDCClientSecret     string   `name:"oidc-client-secret" usage:"ClientSecret of GoToSocial, as registered with the OIDC provider."`
 	OIDCScopes           []string `name:"oidc-scopes" usage:"OIDC scopes."`
 	OIDCLinkExisting     bool     `name:"oidc-link-existing" usage:"link existing user accounts to OIDC logins based on the stored email value"`
+	OIDCAllowedGroups    []string `name:"oidc-allowed-groups" usage:"Membership of one of the listed groups allows access to GtS. If this is empty, all groups are allowed."`
 	OIDCAdminGroups      []string `name:"oidc-admin-groups" usage:"Membership of one of the listed groups makes someone a GtS admin"`
 
 	TracingEnabled           bool   `name:"tracing-enabled" usage:"Enable OTLP Tracing"`

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -1975,6 +1975,31 @@ func GetOIDCLinkExisting() bool { return global.GetOIDCLinkExisting() }
 // SetOIDCLinkExisting safely sets the value for global configuration 'OIDCLinkExisting' field
 func SetOIDCLinkExisting(v bool) { global.SetOIDCLinkExisting(v) }
 
+// GetOIDCAllowedGroups safely fetches the Configuration value for state's 'OIDCAllowedGroups' field
+func (st *ConfigState) GetOIDCAllowedGroups() (v []string) {
+	st.mutex.RLock()
+	v = st.config.OIDCAllowedGroups
+	st.mutex.RUnlock()
+	return
+}
+
+// SetOIDCAllowedGroups safely sets the Configuration value for state's 'OIDCAllowedGroups' field
+func (st *ConfigState) SetOIDCAllowedGroups(v []string) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.OIDCAllowedGroups = v
+	st.reloadToViper()
+}
+
+// OIDCAllowedGroupsFlag returns the flag name for the 'OIDCAllowedGroups' field
+func OIDCAllowedGroupsFlag() string { return "oidc-allowed-groups" }
+
+// GetOIDCAllowedGroups safely fetches the value for global configuration 'OIDCAllowedGroups' field
+func GetOIDCAllowedGroups() []string { return global.GetOIDCAllowedGroups() }
+
+// SetOIDCAllowedGroups safely sets the value for global configuration 'OIDCAllowedGroups' field
+func SetOIDCAllowedGroups(v []string) { global.SetOIDCAllowedGroups(v) }
+
 // GetOIDCAdminGroups safely fetches the Configuration value for state's 'OIDCAdminGroups' field
 func (st *ConfigState) GetOIDCAdminGroups() (v []string) {
 	st.mutex.RLock()

--- a/test/envparsing.sh
+++ b/test/envparsing.sh
@@ -118,6 +118,9 @@ EXPECT=$(cat << "EOF"
     "oidc-admin-groups": [
         "steamy"
     ],
+    "oidc-allowed-groups": [
+        "sloths"
+    ],
     "oidc-client-id": "1234",
     "oidc-client-secret": "shhhh its a secret",
     "oidc-enabled": true,
@@ -251,6 +254,7 @@ GTS_OIDC_CLIENT_ID='1234' \
 GTS_OIDC_CLIENT_SECRET='shhhh its a secret' \
 GTS_OIDC_SCOPES='read,write' \
 GTS_OIDC_LINK_EXISTING=true \
+GTS_OIDC_ALLOWED_GROUPS='sloths' \
 GTS_OIDC_ADMIN_GROUPS='steamy' \
 GTS_SMTP_HOST='example.com' \
 GTS_SMTP_PORT=4269 \

--- a/testrig/config.go
+++ b/testrig/config.go
@@ -119,6 +119,8 @@ var testDefaults = config.Configuration{
 	OIDCClientSecret:     "",
 	OIDCScopes:           []string{oidc.ScopeOpenID, "profile", "email", "groups"},
 	OIDCLinkExisting:     false,
+	OIDCAdminGroups:      []string{"adminRole"},
+	OIDCAllowedGroups:    []string{"allowedRole"},
 
 	SMTPHost:               "",
 	SMTPPort:               0,


### PR DESCRIPTION
# Description

This pull request implements checking roles for all OpenID users logging in against a list of allowed roles. If the list of roles is empty, then the check is skipped. Only one role has to match to pass.

Closes https://github.com/superseriousbusiness/gotosocial/issues/1915

Future: revalidate "admin" claim on login (the role may have changed); if user is part of admin group, bypass check.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
