### PR TITLE
[chore] Simplify the User-Agent string

### DIFF
--- a/internal/transport/controller.go
+++ b/internal/transport/controller.go
@@ -77,7 +77,7 @@ func NewController(state *state.State, federatingDB federatingdb.DB, clock pub.C
 		clock:     clock,
 		client:    client,
 		trspCache: cache.NewTTL[string, *transport](0, 100, 0),
-		userAgent: fmt.Sprintf("%s (+%s://%s) gotosocial/%s", applicationName, proto, host, version),
+		userAgent: fmt.Sprintf("%s/%s (+%s://%s)", applicationName, version, proto, host),
 		senders:   senders,
 	}
 

--- a/internal/transport/controller.go
+++ b/internal/transport/controller.go
@@ -58,7 +58,6 @@ type controller struct {
 // NewController returns an implementation of the Controller interface for creating new transports
 func NewController(state *state.State, federatingDB federatingdb.DB, clock pub.Clock, client httpclient.SigningClient) Controller {
 	var (
-		applicationName  = config.GetApplicationName()
 		host             = config.GetHost()
 		proto            = config.GetProtocol()
 		version          = config.GetSoftwareVersion()
@@ -77,7 +76,7 @@ func NewController(state *state.State, federatingDB federatingdb.DB, clock pub.C
 		clock:     clock,
 		client:    client,
 		trspCache: cache.NewTTL[string, *transport](0, 100, 0),
-		userAgent: fmt.Sprintf("%s/%s (+%s://%s)", applicationName, version, proto, host),
+		userAgent: fmt.Sprintf("gotosocial/%s (+%s://%s)", version, proto, host),
 		senders:   senders,
 	}
 


### PR DESCRIPTION
# Description

[RFC 9110][1] includes a definition for the format of a user-agent header:

```
User-Agent = product *( RWS ( product / comment ) )
             product         = token ["/" product-version]
             product-version = token
	     comment        = "(" *( ctext / quoted-pair / comment ) ")"
             ctext          = HTAB / SP / %x21-27 / %x2A-5B / %x5D-7E / obs-text
```

An example given in the RFC: `User-Agent: CERN-LineMode/2.15 libwww/2.17b3`

The idea is typically start with the most important `product/version`, add a `(comment)` if necessary and then include any auxiliary products. However, the RFC warns against including too many auxiliary products as those can be unnecessarily revealing.

For automated systems (i.e not a browser), the common and recommended format is `<product></version> (+uri-for-contact)`, followed with any additional `<product>/<version>` pairs that are relevant.

This changes our UA to match that convention more closely. This makes it easier for administrators who do user-agent parsing for statistics or other purposes to correctly identify the version of GoToSocial. Currently tools tend to get confused by the lack of a `/<version>` on the start of our string.

[1]: https://www.rfc-editor.org/rfc/rfc9110.html#name-user-agents

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
