### PR TITLE
[chore] refactor extractFromCtx a bit

### DIFF
--- a/internal/federation/federatingdb/create.go
+++ b/internal/federation/federatingdb/create.go
@@ -63,27 +63,30 @@ func (f *federatingDB) Create(ctx context.Context, asType vocab.Type) error {
 			Trace("entering Create")
 	}
 
-	receivingAccount, requestingAccount, internal := extractFromCtx(ctx)
-	if internal {
+	activityContext := getActivityContext(ctx)
+	if activityContext.internal {
 		return nil // Already processed.
 	}
+
+	requestingAcct := activityContext.requestingAcct
+	receivingAcct := activityContext.receivingAcct
 
 	switch asType.GetTypeName() {
 	case ap.ActivityBlock:
 		// BLOCK SOMETHING
-		return f.activityBlock(ctx, asType, receivingAccount, requestingAccount)
+		return f.activityBlock(ctx, asType, receivingAcct, requestingAcct)
 	case ap.ActivityCreate:
 		// CREATE SOMETHING
-		return f.activityCreate(ctx, asType, receivingAccount, requestingAccount)
+		return f.activityCreate(ctx, asType, receivingAcct, requestingAcct)
 	case ap.ActivityFollow:
 		// FOLLOW SOMETHING
-		return f.activityFollow(ctx, asType, receivingAccount, requestingAccount)
+		return f.activityFollow(ctx, asType, receivingAcct, requestingAcct)
 	case ap.ActivityLike:
 		// LIKE SOMETHING
-		return f.activityLike(ctx, asType, receivingAccount, requestingAccount)
+		return f.activityLike(ctx, asType, receivingAcct, requestingAcct)
 	case ap.ActivityFlag:
 		// FLAG / REPORT SOMETHING
-		return f.activityFlag(ctx, asType, receivingAccount, requestingAccount)
+		return f.activityFlag(ctx, asType, receivingAcct, requestingAcct)
 	}
 
 	return nil

--- a/internal/federation/federatingdb/delete.go
+++ b/internal/federation/federatingdb/delete.go
@@ -40,30 +40,33 @@ func (f *federatingDB) Delete(ctx context.Context, id *url.URL) error {
 		}...)
 	l.Debug("entering Delete")
 
-	receivingAccount, requestingAccount, internal := extractFromCtx(ctx)
-	if internal {
+	activityContext := getActivityContext(ctx)
+	if activityContext.internal {
 		return nil // Already processed.
 	}
 
+	requestingAcct := activityContext.requestingAcct
+	receivingAcct := activityContext.receivingAcct
+
 	// in a delete we only get the URI, we can't know if we have a status or a profile or something else,
 	// so we have to try a few different things...
-	if s, err := f.state.DB.GetStatusByURI(ctx, id.String()); err == nil && requestingAccount.ID == s.AccountID {
+	if s, err := f.state.DB.GetStatusByURI(ctx, id.String()); err == nil && requestingAcct.ID == s.AccountID {
 		l.Debugf("uri is for STATUS with id: %s", s.ID)
 		f.state.Workers.EnqueueFediAPI(ctx, messages.FromFediAPI{
 			APObjectType:     ap.ObjectNote,
 			APActivityType:   ap.ActivityDelete,
 			GTSModel:         s,
-			ReceivingAccount: receivingAccount,
+			ReceivingAccount: receivingAcct,
 		})
 	}
 
-	if a, err := f.state.DB.GetAccountByURI(ctx, id.String()); err == nil && requestingAccount.ID == a.ID {
+	if a, err := f.state.DB.GetAccountByURI(ctx, id.String()); err == nil && requestingAcct.ID == a.ID {
 		l.Debugf("uri is for ACCOUNT with id %s", a.ID)
 		f.state.Workers.EnqueueFediAPI(ctx, messages.FromFediAPI{
 			APObjectType:     ap.ObjectProfile,
 			APActivityType:   ap.ActivityDelete,
 			GTSModel:         a,
-			ReceivingAccount: receivingAccount,
+			ReceivingAccount: receivingAcct,
 		})
 	}
 

--- a/internal/federation/federatingdb/reject.go
+++ b/internal/federation/federatingdb/reject.go
@@ -40,10 +40,13 @@ func (f *federatingDB) Reject(ctx context.Context, reject vocab.ActivityStreamsR
 		l.Debug("entering Reject")
 	}
 
-	receivingAccount, requestingAccount, internal := extractFromCtx(ctx)
-	if internal {
+	activityContext := getActivityContext(ctx)
+	if activityContext.internal {
 		return nil // Already processed.
 	}
+
+	requestingAcct := activityContext.requestingAcct
+	receivingAcct := activityContext.receivingAcct
 
 	for _, obj := range ap.ExtractObjects(reject) {
 
@@ -59,13 +62,13 @@ func (f *federatingDB) Reject(ctx context.Context, reject vocab.ActivityStreamsR
 
 				// Make sure the creator of the original follow
 				// is the same as whatever inbox this landed in.
-				if followReq.AccountID != receivingAccount.ID {
+				if followReq.AccountID != receivingAcct.ID {
 					return errors.New("Reject: follow account and inbox account were not the same")
 				}
 
 				// Make sure the target of the original follow
 				// is the same as the account making the request.
-				if followReq.TargetAccountID != requestingAccount.ID {
+				if followReq.TargetAccountID != requestingAcct.ID {
 					return errors.New("Reject: follow target account and requesting account were not the same")
 				}
 
@@ -89,13 +92,13 @@ func (f *federatingDB) Reject(ctx context.Context, reject vocab.ActivityStreamsR
 
 			// Make sure the creator of the original follow
 			// is the same as whatever inbox this landed in.
-			if gtsFollow.AccountID != receivingAccount.ID {
+			if gtsFollow.AccountID != receivingAcct.ID {
 				return errors.New("Reject: follow account and inbox account were not the same")
 			}
 
 			// Make sure the target of the original follow
 			// is the same as the account making the request.
-			if gtsFollow.TargetAccountID != requestingAccount.ID {
+			if gtsFollow.TargetAccountID != requestingAcct.ID {
 				return errors.New("Reject: follow target account and requesting account were not the same")
 			}
 

--- a/internal/federation/federatingdb/update.go
+++ b/internal/federation/federatingdb/update.go
@@ -53,17 +53,20 @@ func (f *federatingDB) Update(ctx context.Context, asType vocab.Type) error {
 		l.Debug("entering Update")
 	}
 
-	receivingAccount, requestingAccount, internal := extractFromCtx(ctx)
-	if internal {
+	activityContext := getActivityContext(ctx)
+	if activityContext.internal {
 		return nil // Already processed.
 	}
 
+	requestingAcct := activityContext.requestingAcct
+	receivingAcct := activityContext.receivingAcct
+
 	if accountable, ok := ap.ToAccountable(asType); ok {
-		return f.updateAccountable(ctx, receivingAccount, requestingAccount, accountable)
+		return f.updateAccountable(ctx, receivingAcct, requestingAcct, accountable)
 	}
 
 	if statusable, ok := ap.ToStatusable(asType); ok {
-		return f.updateStatusable(ctx, receivingAccount, requestingAccount, statusable)
+		return f.updateStatusable(ctx, receivingAcct, requestingAcct, statusable)
 	}
 
 	return nil


### PR DESCRIPTION
A little chore PR that comes out of the Move stuff I've been doing. PRing it separately here to avoid the Move PR becoming too big.

Just refactors extractFromCtx -> getActivityContext and simplifies the return type. No actual logic changes, but there might be in the Move PR.