### PR TITLE
[chore] Disable Move API endpoints for now until Move is fully implemented in the backend

### DIFF
--- a/internal/api/client/accounts/accountmove.go
+++ b/internal/api/client/accounts/accountmove.go
@@ -31,6 +31,8 @@ import (
 //
 // Move your account to another account.
 //
+// NOT IMPLEMENTED YET!
+//
 //	---
 //	tags:
 //	- accounts

--- a/internal/api/client/accounts/accounts.go
+++ b/internal/api/client/accounts/accounts.go
@@ -113,5 +113,5 @@ func (m *Module) Route(attachHandler func(method string, path string, f ...gin.H
 
 	// migration handlers
 	attachHandler(http.MethodPost, AliasPath, m.AccountAliasPOSTHandler)
-	attachHandler(http.MethodPost, MovePath, m.AccountMovePOSTHandler)
+	// attachHandler(http.MethodPost, MovePath, m.AccountMovePOSTHandler) // todo: enable this only when Move is completed
 }

--- a/web/source/settings/user/migration.tsx
+++ b/web/source/settings/user/migration.tsx
@@ -190,11 +190,13 @@ function MoveForm({ data: profile }) {
 				</a>
 			</div>
 			<TextInput
+				disabled={true}
 				field={form.movedToURI}
 				label="Move target URI"
 				placeholder="https://example.org/users/my_new_account"
 			/>
 			<TextInput
+				disabled={true}
 				type="password"
 				name="password"
 				field={form.password}

--- a/web/source/settings/user/migration.tsx
+++ b/web/source/settings/user/migration.tsx
@@ -48,7 +48,7 @@ function UserMigrationForm({ data: profile }) {
 			<h2>Account Migration Settings</h2>
 			<div className="info">
 				<i className="fa fa-fw fa-exclamation-triangle" aria-hidden="true"></i>
-				<b>Moving your account to another instance isn't implemented yet, <a href="https://github.com/superseriousbusiness/gotosocial/issues/130" target="_blank" rel="noopener noreferrer">see here for progress</a></b>
+				<b>Moving your account to another instance, or moving an account from another instance to your account, isn't implemented yet! <a href="https://github.com/superseriousbusiness/gotosocial/issues/130" target="_blank" rel="noopener noreferrer">See here for progress</a>.</b>
 			</div>
 			<p>
 				The following settings allow you to <strong>alias</strong> your account to another account

--- a/web/source/settings/user/migration.tsx
+++ b/web/source/settings/user/migration.tsx
@@ -46,6 +46,10 @@ function UserMigrationForm({ data: profile }) {
 	return (
 		<>
 			<h2>Account Migration Settings</h2>
+			<div className="info">
+				<i className="fa fa-fw fa-exclamation-triangle" aria-hidden="true"></i>
+				<b>Moving your account to another instance isn't implemented yet, <a href="https://github.com/superseriousbusiness/gotosocial/issues/130" target="_blank" rel="noopener noreferrer">see here for progress</a></b>
+			</div>
 			<p>
 				The following settings allow you to <strong>alias</strong> your account to another account
 				elsewhere, and to <strong>move</strong> your followers and following lists to another account.
@@ -197,7 +201,7 @@ function MoveForm({ data: profile }) {
 				label="Confirm account password"
 			/>
 			<MutationButton
-				disabled={false}
+				disabled={true}
 				label="Confirm account move"
 				result={result}
 			/>


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request adds a warning to the migration user settings page that Move isn't actually implemented yet, and also comments out mounting the Move API endpoint. It still lets people set aliases on their accounts if they want though, since it might be useful to test that.

Since we decided to put Move back to 0.15.0 instead of 0.14.0, this will make the 0.14.0 release a bit easier to manage, and a bit less confusing for users.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
