### PR TITLE
[bugfix] Fix dereferencing ancestors on new status create

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -50,10 +50,6 @@ Take a look at the [list of open bugs](https://github.com/superseriousbusiness/g
 
 These warnings are caused by Mastodon forgetting to take query parameters into account when signing HTTP requests. Fixes on both Mastodon and GoToSocial sides are in the works, and other instance software is expected to follow.
 
-## Warnings “status not yet deref'd” in the logs
-
-The warning is mostly to say that the derived visibility of the given status may not be entirely accurate due to a parent not being dereferenced yet, so do not worry about it.
-
 ## Will you support tables in Markdown?
 
 Not at the moment, as most clients handle them terribly.

--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -222,7 +222,7 @@ func (d *Dereferencer) RefreshStatus(
 		d.dereferenceThread(ctx,
 			requestUser,
 			uri,
-			status,
+			latest,
 			statusable,
 			isNew,
 		)

--- a/internal/visibility/home_timeline.go
+++ b/internal/visibility/home_timeline.go
@@ -156,7 +156,7 @@ func (f *Filter) isStatusHomeTimelineable(ctx context.Context, owner *gtsmodel.A
 
 		// Check parent is deref'd.
 		if next.InReplyToID == "" {
-			log.Warnf(ctx, "status not yet deref'd: %s", next.InReplyToURI)
+			log.Debugf(ctx, "status not (yet) deref'd: %s", next.InReplyToURI)
 			return false, cache.SentinelError
 		}
 

--- a/internal/visibility/public_timeline.go
+++ b/internal/visibility/public_timeline.go
@@ -95,7 +95,7 @@ func (f *Filter) isStatusPublicTimelineable(ctx context.Context, requester *gtsm
 		// Fetch next parent to lookup.
 		parentID := parent.InReplyToID
 		if parentID == "" {
-			log.Warnf(ctx, "status not yet deref'd: %s", parent.InReplyToURI)
+			log.Debugf(ctx, "status not (yet) deref'd: %s", parent.InReplyToURI)
 			return false, cache.SentinelError
 		}
 


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Likely fix for https://github.com/superseriousbusiness/gotosocial/issues/2460.

Looks like on new status creates, we were passing the "barebones" status into the dereferenceThread function, which did not include the correct inReplyToURI values. This should fix it by passing in the properly dereferenced and populated status instead.

As a result of this fix, more followers-only posts were showing up in the timeline, even when the post they reply to is not visible. This PR fixes that too, by not assuming that 404 always means deleted when trying to deref a status. Many implementations (including Mastodon) just return 404 when we don't have permission to view a status because of its visibility settings, so we need to take account of that by leaving the in_reply_to_uri in place in such cases for visibility filtering purposes.

The PR also tones down the "status not deref'd" warnings to debug level instead, since they represent a legitimate state that GtS can and will end up in when checking visibility.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
