### PR TITLE
feat: add Mastodon-compatible HTTP signature fallback

### DIFF
--- a/internal/gtscontext/context.go
+++ b/internal/gtscontext/context.go
@@ -136,7 +136,7 @@ func HTTPSignatureVerifier(ctx context.Context) httpsig.VerifierWithOptions {
 
 // SetHTTPSignatureVerifier stores the given http signature verifier and returns the
 // wrapped context. See HTTPSignatureVerifier() for further information on the verifier value.
-func SetHTTPSignatureVerifier(ctx context.Context, verifier httpsig.Verifier) context.Context {
+func SetHTTPSignatureVerifier(ctx context.Context, verifier httpsig.VerifierWithOptions) context.Context {
 	return context.WithValue(ctx, httpSigVerifierKey, verifier)
 }
 

--- a/internal/transport/signing.go
+++ b/internal/transport/signing.go
@@ -30,13 +30,13 @@ var (
 )
 
 // NewGETSigner returns a new httpsig.Signer instance initialized with GTS GET preferences.
-func NewGETSigner(expiresIn int64) (httpsig.Signer, error) {
+func NewGETSigner(expiresIn int64) (httpsig.SignerWithOptions, error) {
 	sig, _, err := httpsig.NewSigner(prefs, digestAlgo, getHeaders, httpsig.Signature, expiresIn)
 	return sig, err
 }
 
 // NewPOSTSigner returns a new httpsig.Signer instance initialized with GTS POST preferences.
-func NewPOSTSigner(expiresIn int64) (httpsig.Signer, error) {
+func NewPOSTSigner(expiresIn int64) (httpsig.SignerWithOptions, error) {
 	sig, _, err := httpsig.NewSigner(prefs, digestAlgo, postHeaders, httpsig.Signature, expiresIn)
 	return sig, err
 }

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -84,8 +84,8 @@ type transport struct {
 	privkey    crypto.PrivateKey
 
 	signerExp  time.Time
-	getSigner  httpsig.Signer
-	postSigner httpsig.Signer
+	getSigner  httpsig.SignerWithOptions
+	postSigner httpsig.SignerWithOptions
 	signerMu   sync.Mutex
 }
 
@@ -97,7 +97,15 @@ func (t *transport) GET(r *http.Request) (*http.Response, error) {
 	ctx = gtscontext.SetOutgoingPublicKeyID(ctx, t.pubKeyID)
 	r = r.WithContext(ctx) // replace request ctx.
 	r.Header.Set("User-Agent", t.controller.userAgent)
-	return t.controller.client.DoSigned(r, t.signGET())
+
+	resp, err := t.controller.client.DoSigned(r, t.signGET(httpsig.SignatureOption{ExcludeQueryStringFromPathPseudoHeader: false}))
+	if err != nil || resp.StatusCode != http.StatusUnauthorized {
+		return resp, err
+	}
+
+	// try again without the path included in the HTTP signature for better compatibility
+	_ = resp.Body.Close()
+	return t.controller.client.DoSigned(r, t.signGET(httpsig.SignatureOption{ExcludeQueryStringFromPathPseudoHeader: true}))
 }
 
 func (t *transport) POST(r *http.Request, body []byte) (*http.Response, error) {
@@ -112,10 +120,10 @@ func (t *transport) POST(r *http.Request, body []byte) (*http.Response, error) {
 }
 
 // signGET will safely sign an HTTP GET request.
-func (t *transport) signGET() httpclient.SignFunc {
+func (t *transport) signGET(opts httpsig.SignatureOption) httpclient.SignFunc {
 	return func(r *http.Request) (err error) {
 		t.safesign(func() {
-			err = t.getSigner.SignRequest(t.privkey, t.pubKeyID, r, nil)
+			err = t.getSigner.SignRequestWithOptions(t.privkey, t.pubKeyID, r, nil, opts)
 		})
 		return
 	}


### PR DESCRIPTION
# Description
On outgoing `GET` requests that are signed (e.g. authorized fetch), if the initial request fails with `401`, try again, but _without_ the query parameters included in the HTTP signature.

This is primarily useful for compatibility with Mastodon; though hopefully this can be removed in the not-too-distant future, as they've started changing their behavior here.

See #894.

## Checklist
- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
