### PR TITLE
[bugfix] Use ptr for instance stats entries to avoid skipping 0 values

### DIFF
--- a/internal/api/model/instancev1.go
+++ b/internal/api/model/instancev1.go
@@ -74,7 +74,7 @@ type InstanceV1 struct {
 	// URLs of interest for client applications.
 	URLs InstanceV1URLs `json:"urls,omitempty"`
 	// Statistics about the instance: number of posts, accounts, etc.
-	Stats map[string]int `json:"stats,omitempty"`
+	Stats map[string]*int `json:"stats,omitempty"`
 	// URL of the instance avatar/banner image.
 	// example: https://example.org/files/instance/thumbnail.jpeg
 	Thumbnail string `json:"thumbnail"`

--- a/internal/api/model/instancev1.go
+++ b/internal/api/model/instancev1.go
@@ -74,6 +74,8 @@ type InstanceV1 struct {
 	// URLs of interest for client applications.
 	URLs InstanceV1URLs `json:"urls,omitempty"`
 	// Statistics about the instance: number of posts, accounts, etc.
+	// Values are pointers because we don't want to skip 0 values when
+	// rendering stats via web templates.
 	Stats map[string]*int `json:"stats,omitempty"`
 	// URL of the instance avatar/banner image.
 	// example: https://example.org/files/instance/thumbnail.jpeg

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -1024,24 +1024,24 @@ func (c *Converter) InstanceToAPIV1Instance(ctx context.Context, i *gtsmodel.Ins
 	instance.URLs.StreamingAPI = "wss://" + i.Domain
 
 	// statistics
-	stats := make(map[string]int, 3)
+	stats := make(map[string]*int, 3)
 	userCount, err := c.state.DB.CountInstanceUsers(ctx, i.Domain)
 	if err != nil {
 		return nil, fmt.Errorf("InstanceToAPIV1Instance: db error getting counting instance users: %w", err)
 	}
-	stats["user_count"] = userCount
+	stats["user_count"] = util.Ptr(userCount)
 
 	statusCount, err := c.state.DB.CountInstanceStatuses(ctx, i.Domain)
 	if err != nil {
 		return nil, fmt.Errorf("InstanceToAPIV1Instance: db error getting counting instance statuses: %w", err)
 	}
-	stats["status_count"] = statusCount
+	stats["status_count"] = util.Ptr(statusCount)
 
 	domainCount, err := c.state.DB.CountInstanceDomains(ctx, i.Domain)
 	if err != nil {
 		return nil, fmt.Errorf("InstanceToAPIV1Instance: db error getting counting instance domains: %w", err)
 	}
-	stats["domain_count"] = domainCount
+	stats["domain_count"] = util.Ptr(domainCount)
 	instance.Stats = stats
 
 	// thumbnail

--- a/web/template/page_header.tmpl
+++ b/web/template/page_header.tmpl
@@ -26,7 +26,7 @@ Instance Logo
 {{- end -}}
 
 {{- define "strapUsers" -}}
-{{- with .instance.Stats.user_count -}}
+{{- with deref .instance.Stats.user_count -}}
     {{- if eq . 1 -}}
         <span class="count">{{- . -}}</span> user
     {{- else -}}
@@ -36,7 +36,7 @@ Instance Logo
 {{- end -}}
 
 {{- define "strapPosts" -}}
-{{- with .instance.Stats.status_count -}}
+{{- with deref .instance.Stats.status_count -}}
     {{- if eq . 1 -}}
         <span class="count">{{- . -}}</span> post
     {{- else -}}
@@ -46,7 +46,7 @@ Instance Logo
 {{- end -}}
 
 {{- define "strapInstances" -}}
-{{- with .instance.Stats.domain_count -}}
+{{- with deref .instance.Stats.domain_count -}}
     {{- if eq . 1 -}}
         <span class="count">{{- . -}}</span> other instance
     {{- else -}}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

`with` in templates will skip if the `with` being `with`'d is a zero value. But we want zero values when rendering instance stats! So we can get around this by using a pointer instead :)

![image](https://github.com/superseriousbusiness/gotosocial/assets/31960611/26eb75ef-ff25-4869-90f3-859a0fa7a4db)

closes https://github.com/superseriousbusiness/gotosocial/issues/2588

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
