### PR TITLE
[chore/frontend] Don't use italics for block quotes

### DIFF
--- a/web/source/css/base.css
+++ b/web/source/css/base.css
@@ -239,7 +239,7 @@ blockquote {
 	padding: 0.5rem 0 0.5rem 0.5rem;
 	border-left: 0.2rem solid $border-accent;
 	margin: 0;
-	font-style: italic;
+	font-style: normal;
 }
 
 /*


### PR DESCRIPTION
Just a lil PR to remove the use of italics in block quotes. Italics make longer block quotes arduous to read, and also prevent italics inside the quote itself from appearing correctly.

Before:

![Screenshot from 2024-02-19 16-25-17](https://github.com/superseriousbusiness/gotosocial/assets/31960611/f302c58a-d02b-47a9-a1c6-803b0cf68f94)

With this PR:

![Screenshot from 2024-02-19 16-25-02](https://github.com/superseriousbusiness/gotosocial/assets/31960611/5f4fa1b4-e169-4e65-addf-3a919a7f2846)