### PR TITLE
[bugfix] Fix wide images being squished when used as instance avatar

### DIFF
--- a/web/source/css/index.css
+++ b/web/source/css/index.css
@@ -18,12 +18,23 @@
 */
 
 /*
-	Render instance title a
-	bit bigger on index page.
+	Render instance title + image
+	a bit bigger on index page.
+
+	Overrides the css from page.css.
 */
-.page-header a h1 {
-	font-size: 2rem;
-	line-height: 2rem;
+.page-header {
+	& > a {
+		& > h1 {
+			font-size: 2rem;
+			line-height: 2rem;
+		}
+
+		& > img {
+			align-self: center;
+			max-height: 6rem;
+		}
+	}
 }
 
 /*

--- a/web/source/css/page.css
+++ b/web/source/css/page.css
@@ -47,11 +47,20 @@
 		flex-wrap: wrap;
 		gap: 1rem;
 		justify-content: center;
-	
+
 		img {
 			align-self: center;
+			
+			/*
+				Shrink too-wide / too-tall instance
+				icons to sensible proportions. Allow
+				pretty wide images but prevent things
+				getting too out of hand + looking bad.
+			*/
+			max-height: 4rem;
+			max-width: 16rem;
 		}
-	
+
 		h1 {
 			align-self: center;
 			text-align: center;

--- a/web/source/settings/admin/settings/index.tsx
+++ b/web/source/settings/admin/settings/index.tsx
@@ -105,19 +105,18 @@ function AdminSettingsForm({ data: instance }: AdminSettingsFormProps) {
 			/>
 
 			<div className="file-upload" aria-labelledby="avatar">
-				<strong id="avatar">Instance avatar</strong>
-				<div>
+				<strong id="avatar">Instance avatar (1:1 images look best)</strong>
+				<div className="file-upload-with-preview">
 					<img
 						className="preview avatar"
 						src={form.thumbnail.previewValue ?? instance?.thumbnail}
 						alt={form.thumbnailDesc.value ?? (instance?.thumbnail ? `Thumbnail image for the instance` : "No instance thumbnail image set")}
 					/>
-					<div>
+					<div className="file-input-with-image-description">
 						<FileInput
 							field={form.thumbnail}
 							accept="image/png, image/jpeg, image/webp, image/gif"
 						/>
-						<br/>
 						<TextInput
 							field={form.thumbnailDesc}
 							label="Avatar image description"

--- a/web/source/settings/style.css
+++ b/web/source/settings/style.css
@@ -395,21 +395,29 @@ section.with-sidebar > div, section.with-sidebar > form {
 	gap: 1rem;
 }
 
-.file-upload > div {
-	display: flex;
-	gap: 1rem;
-
-	img {
-		height: 8rem;
-		border: 0.2rem solid $border-accent;
+.file-upload {
+	.file-upload-with-preview {
+		display: flex;
+		gap: 1rem;
+	
+		img {
+			height: 8rem;
+			border: 0.2rem solid $border-accent;
+		}
+	
+		img.avatar {
+			width: 8rem;
+		}
+	
+		img.header {
+			width: 24rem;
+		}
 	}
-
-	img.avatar {
-		width: 8rem;
-	}
-
-	img.header {
-		width: 24rem;
+	
+	.file-input-with-image-description {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-around;
 	}
 }
 

--- a/web/template/page_header.tmpl
+++ b/web/template/page_header.tmpl
@@ -61,8 +61,6 @@ Instance Logo
         src="{{- .instance.Thumbnail -}}"
         alt="{{- template "thumbnailDescription" . -}}"
         title="{{- template "thumbnailDescription" . -}}"
-        width="100"
-        height="100"
     />
     <h1>{{- .instance.Title -}}</h1>
 </a>


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request removes the HTML that forces images into a 100px x 100px box, and just uses css to resize the image instead.

I did the html trick in the first place to try to avoid flashes of unstyled content with massive images used as the instance avatar, but it just causes more headaches than it fixes. Rolled this back now to use a rem value that works for a variety of image dimensions. In future if we update the API we can set height/width using dimensions extracted from the avatar media attachment, but for now this is fine.

Also added a note to the settings panel that 1:1 images look best, and tidied up a bit of the css in the settings panel itself.

closes https://github.com/superseriousbusiness/gotosocial/issues/2607

With a square image on the main page (large):

![Screenshot from 2024-02-19 17-52-48](https://github.com/superseriousbusiness/gotosocial/assets/31960611/85bfd720-387c-4f17-91a6-e3a28152569a)

With a square image on not the main page (smaller):

![Screenshot from 2024-02-19 17-52-55](https://github.com/superseriousbusiness/gotosocial/assets/31960611/9a2c9edb-4a39-448b-976b-abfb3c73f5d6)

With a silly wide image on the main page:

![Screenshot from 2024-02-19 17-54-22](https://github.com/superseriousbusiness/gotosocial/assets/31960611/1059e297-4330-4b53-8dcf-3d4c1b06bc57)

With a silly side image not on the main page:

![image](https://github.com/superseriousbusiness/gotosocial/assets/31960611/eaaae427-8ec2-46d3-8aa9-40f7b5d45c0b)

Styling changes on the settings panel:

![image](https://github.com/superseriousbusiness/gotosocial/assets/31960611/449cc019-1432-43be-b813-fcb0bcd98614)

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
