### PR TITLE
[bugfix] Account timeline: exclude self-replies that mention other accounts

### DIFF
--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -604,13 +604,16 @@ func (a *accountDB) GetAccountStatuses(ctx context.Context, accountID string, li
 		Where("? = ?", bun.Ident("status.account_id"), accountID)
 
 	if excludeReplies {
-		q = q.WhereGroup(" AND ", func(*bun.SelectQuery) *bun.SelectQuery {
+		q = q.WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
 			return q.
 				// Do include self replies (threads), but
 				// don't include replies to other people.
 				Where("? = ?", bun.Ident("status.in_reply_to_account_id"), accountID).
 				WhereOr("? IS NULL", bun.Ident("status.in_reply_to_uri"))
 		})
+		// Don't include replies that mention other people:
+		// for example, an account's reply to its own reply to someone else.
+		q = whereArrayIsNullOrEmpty(q, bun.Ident("status.mentions"))
 	}
 
 	if excludeReblogs {

--- a/internal/db/bundb/migrations/20240220204526_add_statuses_mentions_is_null_or_empty_idx.go
+++ b/internal/db/bundb/migrations/20240220204526_add_statuses_mentions_is_null_or_empty_idx.go
@@ -38,10 +38,22 @@ func init() {
 		}
 
 		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			// Remove previous index for viewing
+			// statuses created by account.
+			if _, err := tx.
+				NewDropIndex().
+				Index("statuses_account_id_id_idx").
+				IfExists().
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			// Add new index for viewing statuses created
+			// by account, which includes mentions in the index.
 			if _, err := tx.
 				NewCreateIndex().
 				Model((*gtsmodel.Status)(nil)).
-				Index("statuses_mentions_is_null_or_empty_idx").
+				Index("statuses_account_view_idx").
 				Column(
 					"account_id",
 					"in_reply_to_account_id",

--- a/internal/db/bundb/migrations/20240220204526_add_statuses_mentions_is_null_or_empty_idx.go
+++ b/internal/db/bundb/migrations/20240220204526_add_statuses_mentions_is_null_or_empty_idx.go
@@ -1,0 +1,70 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+
+	gtsmodel "github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		var expression string
+		switch db.Dialect().Name() {
+		case dialect.PG:
+			expression = "(mentions IS NULL OR CARDINALITY(mentions) = 0)"
+		case dialect.SQLite:
+			expression = "(mentions IS NULL OR json_array_length(mentions) = 0)"
+		default:
+			panic("db conn was neither pg not sqlite")
+		}
+
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			if _, err := tx.
+				NewCreateIndex().
+				Model((*gtsmodel.Status)(nil)).
+				Index("statuses_mentions_is_null_or_empty_idx").
+				Column(
+					"account_id",
+					"in_reply_to_account_id",
+					"in_reply_to_uri",
+				).
+				ColumnExpr(expression).
+				ColumnExpr("id DESC").
+				IfNotExists().
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
# Description

This pull request excludes self-replies that mention other accounts when fetching an account's timeline with replies excluded. Normally, self-replies should be included, but it's possible to reply to one of your own replies to somebody else, and thus create a reply that mentions someone else but is included anyway, which looks weird. (I thought this was a Feditext client bug when I first noticed it.)

It doesn't specially handle the case where an account explicitly mentions themselves. (Most clients only include mentions for *other* accounts when replying to an account's own post.) Such posts will now be excluded from an account's timeline when replies are excluded. I could see a case for doing that either way (we could check that `mentions` contains a single entry that is the timeline account's ID), but this is the simpler option.

## Impact

Cosmetic. The bug doesn't expose any statuses that wouldn't be visible anyway. But it is widespread, potentially affecting any account timeline viewed through a GtS instance.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
