### PR TITLE
[feature] Add `requested_by` to relationship model

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -345,6 +345,10 @@ definitions:
                 description: You have requested to follow this account, and the request is pending.
                 type: boolean
                 x-go-name: Requested
+            requested_by:
+                description: This account has requested to follow you, and the request is pending.
+                type: boolean
+                x-go-name: RequestedBy
             showing_reblogs:
                 description: You are seeing reblogs/boosts from this account in your home timeline.
                 type: boolean
@@ -1487,7 +1491,10 @@ definitions:
                 additionalProperties:
                     format: int64
                     type: integer
-                description: 'Statistics about the instance: number of posts, accounts, etc.'
+                description: |-
+                    Statistics about the instance: number of posts, accounts, etc.
+                    Values are pointers because we don't want to skip 0 values when
+                    rendering stats via web templates.
                 type: object
                 x-go-name: Stats
             terms:
@@ -3648,6 +3655,7 @@ paths:
         post:
             consumes:
                 - multipart/form-data
+            description: NOT IMPLEMENTED YET!
             operationId: accountMove
             parameters:
                 - description: Password of the account user, for confirmation.

--- a/internal/api/client/followrequests/authorize_test.go
+++ b/internal/api/client/followrequests/authorize_test.go
@@ -92,6 +92,7 @@ func (suite *AuthorizeTestSuite) TestAuthorize() {
   "muting": false,
   "muting_notifications": false,
   "requested": false,
+  "requested_by": false,
   "domain_blocking": false,
   "endorsed": false,
   "note": ""

--- a/internal/api/client/followrequests/reject_test.go
+++ b/internal/api/client/followrequests/reject_test.go
@@ -92,6 +92,7 @@ func (suite *RejectTestSuite) TestReject() {
   "muting": false,
   "muting_notifications": false,
   "requested": false,
+  "requested_by": false,
   "domain_blocking": false,
   "endorsed": false,
   "note": ""

--- a/internal/api/model/relationship.go
+++ b/internal/api/model/relationship.go
@@ -42,6 +42,8 @@ type Relationship struct {
 	MutingNotifications bool `json:"muting_notifications"`
 	// You have requested to follow this account, and the request is pending.
 	Requested bool `json:"requested"`
+	// This account has requested to follow you, and the request is pending.
+	RequestedBy bool `json:"requested_by"`
 	// You are blocking this account's domain.
 	DomainBlocking bool `json:"domain_blocking"`
 	// You are featuring this account on your profile.

--- a/internal/db/bundb/relationship.go
+++ b/internal/db/bundb/relationship.go
@@ -74,6 +74,15 @@ func (r *relationshipDB) GetRelationship(ctx context.Context, requestingAccount 
 		return nil, gtserror.Newf("error checking requested: %w", err)
 	}
 
+	// check if target has follow requested requesting
+	rel.RequestedBy, err = r.IsFollowRequested(ctx,
+		targetAccount,
+		requestingAccount,
+	)
+	if err != nil {
+		return nil, gtserror.Newf("error checking requestedBy: %w", err)
+	}
+
 	// check if the requesting account is blocking the target account
 	rel.Blocking, err = r.IsBlocked(ctx, requestingAccount, targetAccount)
 	if err != nil {

--- a/internal/db/bundb/relationship_test.go
+++ b/internal/db/bundb/relationship_test.go
@@ -596,6 +596,14 @@ func (suite *RelationshipTestSuite) TestAcceptFollowRequestOK() {
 	suite.False(relationship.Following)
 	suite.True(relationship.Requested)
 
+	// Check the other way around too; local_account_2
+	// should have requested_by true for admin now.
+	inverse, err := suite.db.GetRelationship(ctx, targetAccount.ID, account.ID)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+	suite.True(inverse.RequestedBy)
+
 	followRequestNotification := &gtsmodel.Notification{
 		ID:               "01GV8MY1Q9KX2ZSWN4FAQ3V1PB",
 		OriginAccountID:  account.ID,

--- a/internal/gtsmodel/account.go
+++ b/internal/gtsmodel/account.go
@@ -200,7 +200,8 @@ type Relationship struct {
 	BlockedBy           bool   // Is this user blocking you?
 	Muting              bool   // Are you muting this user?
 	MutingNotifications bool   // Are you muting notifications from this user?
-	Requested           bool   // Do you have a pending follow request for this user?
+	Requested           bool   // Do you have a pending follow request targeting this user?
+	RequestedBy         bool   // Does the user have a pending follow request targeting you?
 	DomainBlocking      bool   // Are you blocking this user's domain?
 	Endorsed            bool   // Are you featuring this user on your profile?
 	Note                string // Your note on this account.

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -1194,6 +1194,7 @@ func (c *Converter) RelationshipToAPIRelationship(ctx context.Context, r *gtsmod
 		Muting:              r.Muting,
 		MutingNotifications: r.MutingNotifications,
 		Requested:           r.Requested,
+		RequestedBy:         r.RequestedBy,
 		DomainBlocking:      r.DomainBlocking,
 		Endorsed:            r.Endorsed,
 		Note:                r.Note,


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request adds the `requested_by` field to relationships, showing if the target account has requested to follow you.

See: https://docs.joinmastodon.org/entities/Relationship/

closes https://github.com/superseriousbusiness/gotosocial/issues/2487
closes https://github.com/superseriousbusiness/gotosocial/issues/871

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
