### PR TITLE
[chore] Rename frontend.tmpl to settings.tmpl, remove unused "lightgray" class

### DIFF
--- a/internal/web/settings-panel.go
+++ b/internal/web/settings-panel.go
@@ -46,7 +46,7 @@ func (m *Module) SettingsPanelHandler(c *gin.Context) {
 	}
 
 	page := apiutil.WebPage{
-		Template: "frontend.tmpl",
+		Template: "settings.tmpl",
 		Instance: instance,
 		Stylesheets: []string{
 			cssFA,

--- a/web/template/settings.tmpl
+++ b/web/template/settings.tmpl
@@ -18,7 +18,7 @@
 */ -}}
 
 {{- with . }}
-<main class="lightgray">
+<main class="settings">
     <div id="root"></div>
 </main>
 {{- end }}


### PR DESCRIPTION
Tidies up a bit of cruft that I didn't catch in the previous big HTML template refactor. Now the template for the settings panel is actually called settings!