### PR TITLE
[chore] Increase default max image description to 1500 chars, collapse cw char count into status

### DIFF
--- a/docs/configuration/media.md
+++ b/docs/configuration/media.md
@@ -25,9 +25,9 @@ media-video-max-size: 41943040
 media-description-min-chars: 0
 
 # Int. Maximum amount of characters permitted in an image or video description.
-# Examples: [500, 1000, 1500]
-# Default: 500
-media-description-max-chars: 500
+# Examples: [1000, 1500, 3000]
+# Default: 1500
+media-description-max-chars: 1500
 
 # Int. Max size in bytes of emojis uploaded to this instance via the admin API.
 # The default is the same as the Mastodon size limit for emojis (50kb), which allows

--- a/docs/configuration/statuses.md
+++ b/docs/configuration/statuses.md
@@ -9,17 +9,14 @@
 
 # Config pertaining to the creation of statuses/posts, and permitted limits.
 
-# Int. Maximum amount of characters permitted for a new status.
+# Int. Maximum amount of characters permitted for a new status,
+# including the content warning (if set).
+#
 # Note that going way higher than the default might break federation.
+#
 # Examples: [140, 500, 5000]
 # Default: 5000
 statuses-max-chars: 5000
-
-# Int. Maximum amount of characters allowed in the CW/subject header of a status.
-# Note that going way higher than the default might break federation.
-# Examples: [100, 200]
-# Default: 100
-statuses-cw-max-chars: 100
 
 # Int. Maximum amount of options to permit when creating a new poll.
 # Note that going way higher than the default might break federation.

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -429,9 +429,9 @@ media-video-max-size: 41943040
 media-description-min-chars: 0
 
 # Int. Maximum amount of characters permitted in an image or video description.
-# Examples: [500, 1000, 1500]
-# Default: 500
-media-description-max-chars: 500
+# Examples: [1000, 1500, 3000]
+# Default: 1500
+media-description-max-chars: 1500
 
 # Int. Max size in bytes of emojis uploaded to this instance via the admin API.
 # The default is the same as the Mastodon size limit for emojis (50kb), which allows
@@ -551,17 +551,14 @@ storage-s3-bucket: ""
 
 # Config pertaining to the creation of statuses/posts, and permitted limits.
 
-# Int. Maximum amount of characters permitted for a new status.
+# Int. Maximum amount of characters permitted for a new status,
+# including the content warning (if set).
+#
 # Note that going way higher than the default might break federation.
+#
 # Examples: [140, 500, 5000]
 # Default: 5000
 statuses-max-chars: 5000
-
-# Int. Maximum amount of characters allowed in the CW/subject header of a status.
-# Note that going way higher than the default might break federation.
-# Examples: [100, 200]
-# Default: 100
-statuses-cw-max-chars: 100
 
 # Int. Maximum amount of options to permit when creating a new poll.
 # Note that going way higher than the default might break federation.

--- a/internal/api/client/statuses/statuscreate.go
+++ b/internal/api/client/statuses/statuscreate.go
@@ -137,15 +137,11 @@ func validateNormalizeCreateStatus(form *apimodel.AdvancedStatusCreateForm) erro
 	}
 
 	maxChars := config.GetStatusesMaxChars()
-	maxMediaFiles := config.GetStatusesMediaMaxFiles()
-	maxCwChars := config.GetStatusesCWMaxChars()
-
-	if form.Status != "" {
-		if length := len([]rune(form.Status)); length > maxChars {
-			return fmt.Errorf("status too long, %d characters provided but limit is %d", length, maxChars)
-		}
+	if length := len([]rune(form.Status)) + len([]rune(form.SpoilerText)); length > maxChars {
+		return fmt.Errorf("status too long, %d characters provided (including spoiler/content warning) but limit is %d", length, maxChars)
 	}
 
+	maxMediaFiles := config.GetStatusesMediaMaxFiles()
 	if len(form.MediaIDs) > maxMediaFiles {
 		return fmt.Errorf("too many media files attached to status, %d attached but limit is %d", len(form.MediaIDs), maxMediaFiles)
 	}
@@ -153,12 +149,6 @@ func validateNormalizeCreateStatus(form *apimodel.AdvancedStatusCreateForm) erro
 	if form.Poll != nil {
 		if err := validateNormalizeCreatePoll(form); err != nil {
 			return err
-		}
-	}
-
-	if form.SpoilerText != "" {
-		if length := len([]rune(form.SpoilerText)); length > maxCwChars {
-			return fmt.Errorf("content-warning/spoilertext too long, %d characters provided but limit is %d", length, maxCwChars)
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,8 +111,7 @@ type Configuration struct {
 	StorageS3BucketName  string `name:"storage-s3-bucket" usage:"Place blobs in this bucket"`
 	StorageS3Proxy       bool   `name:"storage-s3-proxy" usage:"Proxy S3 contents through GoToSocial instead of redirecting to a presigned URL"`
 
-	StatusesMaxChars           int `name:"statuses-max-chars" usage:"Max permitted characters for posted statuses"`
-	StatusesCWMaxChars         int `name:"statuses-cw-max-chars" usage:"Max permitted characters for content/spoiler warnings on statuses"`
+	StatusesMaxChars           int `name:"statuses-max-chars" usage:"Max permitted characters for posted statuses, including content warning"`
 	StatusesPollMaxOptions     int `name:"statuses-poll-max-options" usage:"Max amount of options permitted on a poll"`
 	StatusesPollOptionMaxChars int `name:"statuses-poll-option-max-chars" usage:"Max amount of characters for a poll option"`
 	StatusesMediaMaxFiles      int `name:"statuses-media-max-files" usage:"Maximum number of media files/attachments per status"`

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -74,7 +74,7 @@ var Defaults = Configuration{
 	MediaImageMaxSize:        10 * bytesize.MiB,
 	MediaVideoMaxSize:        40 * bytesize.MiB,
 	MediaDescriptionMinChars: 0,
-	MediaDescriptionMaxChars: 500,
+	MediaDescriptionMaxChars: 1500,
 	MediaRemoteCacheDays:     7,
 	MediaEmojiLocalMaxSize:   50 * bytesize.KiB,
 	MediaEmojiRemoteMaxSize:  100 * bytesize.KiB,
@@ -87,7 +87,6 @@ var Defaults = Configuration{
 	StorageS3Proxy:       false,
 
 	StatusesMaxChars:           5000,
-	StatusesCWMaxChars:         100,
 	StatusesPollMaxOptions:     6,
 	StatusesPollOptionMaxChars: 50,
 	StatusesMediaMaxFiles:      6,

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -113,7 +113,6 @@ func (s *ConfigState) AddServerFlags(cmd *cobra.Command) {
 
 		// Statuses
 		cmd.Flags().Int(StatusesMaxCharsFlag(), cfg.StatusesMaxChars, fieldtag("StatusesMaxChars", "usage"))
-		cmd.Flags().Int(StatusesCWMaxCharsFlag(), cfg.StatusesCWMaxChars, fieldtag("StatusesCWMaxChars", "usage"))
 		cmd.Flags().Int(StatusesPollMaxOptionsFlag(), cfg.StatusesPollMaxOptions, fieldtag("StatusesPollMaxOptions", "usage"))
 		cmd.Flags().Int(StatusesPollOptionMaxCharsFlag(), cfg.StatusesPollOptionMaxChars, fieldtag("StatusesPollOptionMaxChars", "usage"))
 		cmd.Flags().Int(StatusesMediaMaxFilesFlag(), cfg.StatusesMediaMaxFiles, fieldtag("StatusesMediaMaxFiles", "usage"))

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -1525,31 +1525,6 @@ func GetStatusesMaxChars() int { return global.GetStatusesMaxChars() }
 // SetStatusesMaxChars safely sets the value for global configuration 'StatusesMaxChars' field
 func SetStatusesMaxChars(v int) { global.SetStatusesMaxChars(v) }
 
-// GetStatusesCWMaxChars safely fetches the Configuration value for state's 'StatusesCWMaxChars' field
-func (st *ConfigState) GetStatusesCWMaxChars() (v int) {
-	st.mutex.RLock()
-	v = st.config.StatusesCWMaxChars
-	st.mutex.RUnlock()
-	return
-}
-
-// SetStatusesCWMaxChars safely sets the Configuration value for state's 'StatusesCWMaxChars' field
-func (st *ConfigState) SetStatusesCWMaxChars(v int) {
-	st.mutex.Lock()
-	defer st.mutex.Unlock()
-	st.config.StatusesCWMaxChars = v
-	st.reloadToViper()
-}
-
-// StatusesCWMaxCharsFlag returns the flag name for the 'StatusesCWMaxChars' field
-func StatusesCWMaxCharsFlag() string { return "statuses-cw-max-chars" }
-
-// GetStatusesCWMaxChars safely fetches the value for global configuration 'StatusesCWMaxChars' field
-func GetStatusesCWMaxChars() int { return global.GetStatusesCWMaxChars() }
-
-// SetStatusesCWMaxChars safely sets the value for global configuration 'StatusesCWMaxChars' field
-func SetStatusesCWMaxChars(v int) { global.SetStatusesCWMaxChars(v) }
-
 // GetStatusesPollMaxOptions safely fetches the Configuration value for state's 'StatusesPollMaxOptions' field
 func (st *ConfigState) GetStatusesPollMaxOptions() (v int) {
 	st.mutex.RLock()

--- a/test/envparsing.sh
+++ b/test/envparsing.sh
@@ -142,7 +142,6 @@ EXPECT=$(cat << "EOF"
     "smtp-port": 4269,
     "smtp-username": "sex-haver",
     "software-version": "",
-    "statuses-cw-max-chars": 420,
     "statuses-max-chars": 69,
     "statuses-media-max-files": 1,
     "statuses-poll-max-options": 1,

--- a/testrig/config.go
+++ b/testrig/config.go
@@ -101,7 +101,6 @@ var testDefaults = config.Configuration{
 	StorageLocalBasePath: "",
 
 	StatusesMaxChars:           5000,
-	StatusesCWMaxChars:         100,
 	StatusesPollMaxOptions:     6,
 	StatusesPollOptionMaxChars: 50,
 	StatusesMediaMaxFiles:      6,


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request removes some of the friction of using Mastodon clients on GtS by bringing some of our character counts more in line with Mastodon:

- Increase default image description char count from 500 => 1500 (the Mastodon default). There's no real reason we had such a limited default in the first place.
- Remove the statuses-cw-max-chars config option, and just add cw and body text together when checking that a status is within character limits. This is also closer to the Mastodon behavior, and so should cause fewer issues in clients (like Tusky, for example) which provide a total character count that includes the cw. Technically this is a reduction in how many characters are permitted by default in a GtS status, but admins can always bump their character count up to 5500 or something if they want to.

Partially addresses https://github.com/superseriousbusiness/gotosocial/issues/2457, but doesn't quite close it since we don't count links as 23 characters etc.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
