### PR TITLE
[bugfix] Allow access to TMP directories in example AppArmor config

### DIFF
--- a/example/apparmor/gotosocial
+++ b/example/apparmor/gotosocial
@@ -1,40 +1,53 @@
 #include <tunables/global>
 
 profile gotosocial flags=(attach_disconnected, mediate_deleted) {
-  #include <abstractions/base>
-  #include <abstractions/nameservice>
+  include <abstractions/base>
+  include <abstractions/dbus-session-strict>
+  include <abstractions/gio-open>
+  include <abstractions/nameservice>
+  include <abstractions/user-tmp>
 
   /gotosocial/gotosocial mrix,
-  /usr/bin/gotosocial mrix,
   /usr/local/bin/gotosocial mrix,
+  /usr/bin/gotosocial mrix,
+  /usr/sbin/gotosocial mrix,
 
   owner /gotosocial/{,**} r,
   owner /gotosocial/db/* wk,
   owner /gotosocial/storage/** wk,
 
   # Allow GoToSocial to write logs
-  #
   # NOTE: you only need to allow write permissions to /var/log/syslog if you've
-  # enabled logging to syslog. Otherwise, you can comment out that line.
-  /var/log/gotosocial/* w,
-  owner /var/log/syslog w,
+  # enabled logging to syslog.
+  # owner /var/log/syslog w,
 
   # These directories are not currently used by any of the recommended
   # GoToSocial installation methods, but they may be used in the future and/or
   # for custom installations.
   owner /etc/gotosocial/{,**} r,
-  owner /usr/lib/gotosocial/{,**} r,
-  owner /usr/share/gotosocial/{,**} r,
   owner /usr/local/etc/gotosocial/{,**} r,
-  owner /usr/local/lib/gotosocial/{,**} r,
+  owner /usr/share/gotosocial/{,**} r,
   owner /usr/local/share/gotosocial/{,**} r,
+  owner /usr/lib/gotosocial/{,**} r,
+  owner /usr/lib/gotosocial/db/* wk,
+  owner /usr/lib/gotosocial/storage/** wk,
+  owner /usr/local/lib/gotosocial/{,**} r,
+  owner /usr/local/lib/gotosocial/db/* wk,
+  owner /usr/local/lib/gotosocial/storage/** wk,
   owner /var/lib/gotosocial/{,**} r,
+  owner /var/lib/gotosocial/db/* wk,
+  owner /var/lib/gotosocial/storage/** wk,
   owner /opt/gotosocial/{,**} r,
   owner /run/gotosocial/{,**} r,
 
+  /etc/mime.types r,
+  /etc/services r,
   /proc/sys/net/core/somaxconn r,
+  /sys/fs/cgroup/system.slice/gotosocial.service/{,*} r,
   /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
-  owner @{PROC}/@{pid}/cpuset r,
+  owner /proc/*/cgroup r,
+  owner /proc/*/cpuset r,
+  owner /proc/*/mountinfo r,
 
   # TCP / UDP network access
   network inet stream,
@@ -42,9 +55,9 @@ profile gotosocial flags=(attach_disconnected, mediate_deleted) {
   network inet dgram,
   network inet6 dgram,
 
-  # Allow GoToSocial to send signals to/receive signals from worker processes
   # Allow GoToSocial to receive signals from unconfined processes
   signal (receive) peer=unconfined,
+  # Allow GoToSocial to send signals to/receive signals from worker processes
   signal (send,receive) peer=gotosocial,
 }
 

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -296,7 +296,7 @@ instance-languages: []
 
 # String. Federation mode to use for this instance.
 #
-# "blocklist" -- open federation by default. Only instances that are explicitly 
+# "blocklist" -- open federation by default. Only instances that are explicitly
 #                blocked will be denied (unless they are also explicitly allowed).
 #
 # "allowlist" -- closed federation by default. Only instances that are explicitly
@@ -468,7 +468,7 @@ media-remote-cache-days: 7
 
 # String. 24hr time of day formatted as hh:mm.
 # Examples: ["14:30", "00:00", "04:00"]
-# Default: "00:00" (midnight). 
+# Default: "00:00" (midnight).
 media-cleanup-from: "00:00"
 
 # Duration. Period between media cleanup runs.
@@ -874,7 +874,7 @@ http-client:
   #
   # THIS SETTING SHOULD BE USED FOR TESTING ONLY! IF YOU TURN THIS
   # ON WHILE RUNNING IN PRODUCTION YOU ARE LEAVING YOUR SERVER WIDE
-  # OPEN TO MAN IN THE MIDDLE ATTACKS! DO NOT CHANGE THIS SETTING 
+  # OPEN TO MAN IN THE MIDDLE ATTACKS! DO NOT CHANGE THIS SETTING
   # UNLESS YOU KNOW EXACTLY WHAT YOU'RE DOING AND WHY YOU'RE DOING IT.
   #
   # Default: false
@@ -1029,7 +1029,7 @@ advanced-sender-multiplier: 2
 # generate a correct Content-Security-Policy, you probably won't need
 # to ever touch this setting, but it's included in the 'spirit of more
 # configurable (usually) means more good'.
-# 
+#
 # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
 #
 # Example: ["s3.example.org", "some-bucket-name.s3.example.org"]


### PR DESCRIPTION
# Description

The current example configuration does not allow access to TMP directories, which is needed to process media attachments downloaded from other instances.
Additionally I modified some of the rules in the "not currently used" section to match the rules of the default paths and included some new rules suggested by `aa-logprof`

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
