### PR TITLE
[chore] add log line about lengthy reindex migration

### DIFF
--- a/internal/db/bundb/migrations/20240220204526_add_statuses_mentions_is_null_or_empty_idx.go
+++ b/internal/db/bundb/migrations/20240220204526_add_statuses_mentions_is_null_or_empty_idx.go
@@ -21,6 +21,7 @@ import (
 	"context"
 
 	gtsmodel "github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect"
 )
@@ -38,6 +39,8 @@ func init() {
 		}
 
 		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			log.Info(ctx, "reindexing statuses_account_id_id_idx -> statuses_account_view_idx; this may take a few minutes, please don't interrupt this migration!")
+
 			// Remove previous index for viewing
 			// statuses created by account.
 			if _, err := tx.


### PR DESCRIPTION
Just add a little line about the potentially lengthy statuses index migration. Don't want people pressing ctrl-c thinking their instance has stopped doing anything.