### PR TITLE
[bugfix] Disable the test for long syslog messages over Unix datagram sockets on macOS

### DIFF
--- a/internal/log/sysloglongunixgram_test.go
+++ b/internal/log/sysloglongunixgram_test.go
@@ -1,0 +1,69 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !darwin
+
+package log_test
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+
+	"github.com/google/uuid"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/superseriousbusiness/gotosocial/testrig"
+)
+
+// TestSyslogLongMessageUnixgram is known to hang on macOS for messages longer than about 1500 bytes.
+func (suite *SyslogTestSuite) TestSyslogLongMessageUnixgram() {
+	socketPath := path.Join(os.TempDir(), uuid.NewString())
+	defer func() {
+		if err := os.Remove(socketPath); err != nil {
+			panic(err)
+		}
+	}()
+
+	server, channel, err := testrig.InitTestSyslogUnixgram(socketPath)
+	if err != nil {
+		panic(err)
+	}
+	syslogServer := server
+	syslogChannel := channel
+
+	config.SetSyslogEnabled(true)
+	config.SetSyslogProtocol("unixgram")
+	config.SetSyslogAddress(socketPath)
+
+	testrig.InitTestLog()
+
+	log.Warn(nil, longMessage)
+
+	funcName := log.Caller(2)
+	prefix := fmt.Sprintf(`timestamp="02/01/2006 15:04:05.000" func=%s level=WARN msg="`, funcName)
+
+	entry := <-syslogChannel
+	regex := fmt.Sprintf(`timestamp=.* func=.* level=WARN msg="%s`, longMessage[:2048-len(prefix)])
+
+	suite.Regexp(regexp.MustCompile(regex), entry["content"])
+
+	if err := syslogServer.Kill(); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
# Description

This pull request disables the test for long syslog messages over Unix datagram sockets on macOS, where it's known to hang the test runner. I suspect this is an implementation limit for macOS sockets. Given #493, which seems to cap the message size, I'm not sure this is an issue anything's going to hit in production. Also, we don't support macOS for production deployments anyway.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
