### PR TITLE
[chore] Try to parse public key as both Actor + bare key

### DIFF
--- a/internal/ap/extractpubkey_test.go
+++ b/internal/ap/extractpubkey_test.go
@@ -1,0 +1,108 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package ap_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/activity/streams"
+	typepublickey "github.com/superseriousbusiness/activity/streams/impl/w3idsecurityv1/type_publickey"
+	"github.com/superseriousbusiness/gotosocial/internal/ap"
+)
+
+const (
+	stubActor = `{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/security/v1"
+  ],
+  "id": "https://gts.superseriousbusiness.org/users/dumpsterqueer",
+  "preferredUsername": "dumpsterqueer",
+  "publicKey": {
+    "id": "https://gts.superseriousbusiness.org/users/dumpsterqueer/main-key",
+    "owner": "https://gts.superseriousbusiness.org/users/dumpsterqueer",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt7cDz2XfTJXbmmmVXZ3o\nQGB1zu1yP+2/QZZFbLCeM0bMm5cfjJ/olli6kpdcGLh1lFpSgyLE0PlAVNYdSke9\nzcxDao6N16wavFx/bOYhh8HJPPXzlFpNeQQ+EBQ1ivzuLQyzIFTMV4TyZzOREoG9\nizuXuuKDaH/ENDE6qlIDuqtICIjnURjpxnBLldPUxfUvuSO3zY+jTidsxhjUjqkK\nC7RtEVi/D6/CzktVevz5bE/gcAYgKmK0dmkJ9HH6LzOlvkM4Wrq5h/hrM+H1z5e5\nPpdJsl3KlRT4wusuM1Z5xqLQ0oIP4mX/Kd3ypCe150i+jaoCsqBk8OPtl/zKMw1a\nYQIDAQAB\n-----END PUBLIC KEY-----\n"
+  },
+  "type": "Person"
+}`
+
+	key = `{
+  "@context": "https://w3id.org/security/v1",
+  "id": "https://gts.superseriousbusiness.org/users/dumpsterqueer/main-key",
+  "owner": "https://gts.superseriousbusiness.org/users/dumpsterqueer",
+  "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt7cDz2XfTJXbmmmVXZ3o\nQGB1zu1yP+2/QZZFbLCeM0bMm5cfjJ/olli6kpdcGLh1lFpSgyLE0PlAVNYdSke9\nzcxDao6N16wavFx/bOYhh8HJPPXzlFpNeQQ+EBQ1ivzuLQyzIFTMV4TyZzOREoG9\nizuXuuKDaH/ENDE6qlIDuqtICIjnURjpxnBLldPUxfUvuSO3zY+jTidsxhjUjqkK\nC7RtEVi/D6/CzktVevz5bE/gcAYgKmK0dmkJ9HH6LzOlvkM4Wrq5h/hrM+H1z5e5\nPpdJsl3KlRT4wusuM1Z5xqLQ0oIP4mX/Kd3ypCe150i+jaoCsqBk8OPtl/zKMw1a\nYQIDAQAB\n-----END PUBLIC KEY-----\n"
+}`
+)
+
+type ExtractPubKeyTestSuite struct {
+	APTestSuite
+}
+
+func (suite *ExtractPubKeyTestSuite) TestExtractPubKeyFromStub() {
+	m := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(stubActor), &m); err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	t, err := streams.ToType(context.Background(), m)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	wpk, ok := t.(ap.WithPublicKey)
+	if !ok {
+		suite.FailNow("", "could not parse %T as WithPublicKey", t)
+	}
+
+	pubKey, pubKeyID, ownerURI, err := ap.ExtractPubKeyFromActor(wpk)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.NotNil(pubKey)
+	suite.Equal("https://gts.superseriousbusiness.org/users/dumpsterqueer/main-key", pubKeyID.String())
+	suite.Equal("https://gts.superseriousbusiness.org/users/dumpsterqueer", ownerURI.String())
+}
+
+func (suite *ExtractPubKeyTestSuite) TestExtractPubKeyFromKey() {
+	m := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(key), &m); err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	pk, err := typepublickey.DeserializePublicKey(m, nil)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	pubKey, pubKeyID, ownerURI, err := ap.ExtractPubKeyFromKey(pk)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.NotNil(pubKey)
+	suite.Equal("https://gts.superseriousbusiness.org/users/dumpsterqueer/main-key", pubKeyID.String())
+	suite.Equal("https://gts.superseriousbusiness.org/users/dumpsterqueer", ownerURI.String())
+}
+
+func TestExtractPubKeyTestSuite(t *testing.T) {
+	suite.Run(t, &ExtractPubKeyTestSuite{})
+}

--- a/internal/timeline/get_test.go
+++ b/internal/timeline/get_test.go
@@ -688,7 +688,7 @@ func (suite *GetTestSuite) TestGetTimelinesAsync() {
 					limit,
 					local,
 				); err != nil {
-					suite.FailNow(err.Error())
+					suite.Fail(err.Error())
 				}
 
 				wg.Done()

--- a/internal/typeutils/astointernal.go
+++ b/internal/typeutils/astointernal.go
@@ -219,7 +219,7 @@ func (c *Converter) ASRepresentationToAccount(ctx context.Context, accountable a
 	}
 
 	// Extract account public key and verify ownership to account.
-	pkey, pkeyURL, pkeyOwnerID, err := ap.ExtractPublicKey(accountable)
+	pkey, pkeyURL, pkeyOwnerID, err := ap.ExtractPubKeyFromActor(accountable)
 	if err != nil {
 		err := gtserror.Newf("error extracting public key for %s: %w", uri, err)
 		return nil, gtserror.SetMalformed(err)


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request is the first part of a fix for https://github.com/superseriousbusiness/gotosocial/issues/1186.

At this point, it *just* adds some logic to try to parse bytes received from a dereference to a public key endpoint as both an Actor, and as a bare Public Key. There are no real logic changes aside from that.

As far as I know, nobody actually serves just the key at the main-key endpoint yet, but it's not a bad idea to get this merged early in the GtS codebase for forwards compatibility reasons. Ie., if we include this change in 0.15.0, and then in 0.16.0 or later change our logic to serve only the key at `/main-key`, then GtS 0.15.0 will be compatible with the new way of doing things introduced in 0.16.0.

~~Draft so we don't squerge this by accident before we release 0.14.0.~~

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
