### PR TITLE
[bugfix] Sanitize incoming PropertyValue fields

### DIFF
--- a/internal/ap/interfaces.go
+++ b/internal/ap/interfaces.go
@@ -387,6 +387,12 @@ type WithName interface {
 	SetActivityStreamsName(vocab.ActivityStreamsNameProperty)
 }
 
+// WithValue represents an activity with SchemaValueProperty
+type WithValue interface {
+	GetSchemaValue() vocab.SchemaValueProperty
+	SetSchemaValue(vocab.SchemaValueProperty)
+}
+
 // WithImage represents an activity with ActivityStreamsImageProperty
 type WithImage interface {
 	GetActivityStreamsImage() vocab.ActivityStreamsImageProperty


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Normalize/sanitize incoming PropertyValue fields on profiles. This wasn't an immediate vulnerability or anything like that, since we never display those fields from remotes on our web pages (and we have our own xss stuff in our content-security-policy headers), but you never know if it might cause some issue in a client that doesn't do its own sanitization.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
