### PR TITLE
[chore] Fix a Swagger warning that only manifests during Go client code generation

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -1018,7 +1018,7 @@ definitions:
                     - public
                 items:
                     $ref: '#/definitions/filterContext'
-                minLength: 1
+                minItems: 1
                 type: array
                 uniqueItems: true
                 x-go-name: Context

--- a/internal/api/model/filterv1.go
+++ b/internal/api/model/filterv1.go
@@ -40,7 +40,7 @@ type FilterV1 struct {
 	Phrase string `json:"phrase"`
 	// The contexts in which the filter should be applied.
 	//
-	// Minimum length: 1
+	// Minimum items: 1
 	// Unique: true
 	// Enum:
 	//	- home


### PR DESCRIPTION
# Description

Followup to #2698. Found while updating generated code in https://github.com/VyrCossont/slurp:

```
2024/03/06 09:24:23 validating spec https://raw.githubusercontent.com/superseriousbusiness/gotosocial/main/docs/api/swagger.yaml
2024/03/06 09:24:27 preprocessing spec with option:  minimal flattening
2024/03/06 09:24:27 building a plan for generation
2024/03/06 09:24:27 generation target ./
2024/03/06 09:24:27 planning definitions (found: 67)
2024/03/06 09:24:27 warning: validation minLength (value: 1) not compatible with type [array]. Skipped
2024/03/06 09:24:27 planning operations (found: 126)
2024/03/06 09:24:31 grouping operations into packages (packages: 27)
2024/03/06 09:24:31 operations for package packages "favourites" (found: 1)
2024/03/06 09:24:31 operations for package packages "federation" (found: 3)
2024/03/06 09:24:31 …
```

I'm not yet sure why go-swagger's validator only catches this while generating Go client code, but meanwhile, this one property should definitely be `minItems` instead of `minLength`.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
