### PR TITLE
[docs/chore] Swagger fixes for filters

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -5296,7 +5296,9 @@ paths:
                 "200":
                     description: Requested filters.
                     schema:
-                        $ref: '#/definitions/filterV1'
+                        items:
+                            $ref: '#/definitions/filterV1'
+                        type: array
                 "400":
                     description: bad request
                 "401":

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -5331,7 +5331,8 @@ paths:
                   name: phrase
                   required: true
                   type: string
-                - description: |-
+                - collectionFormat: multi
+                  description: |-
                     The contexts in which the filter should be applied.
 
                     Sample: home, public
@@ -5345,7 +5346,7 @@ paths:
                   items:
                     type: string
                   minItems: 1
-                  name: context
+                  name: context[]
                   required: true
                   type: array
                   uniqueItems: true
@@ -5479,7 +5480,8 @@ paths:
                   name: phrase
                   required: true
                   type: string
-                - description: |-
+                - collectionFormat: multi
+                  description: |-
                     The contexts in which the filter should be applied.
 
                     Sample: home, public
@@ -5493,7 +5495,7 @@ paths:
                   items:
                     type: string
                   minItems: 1
-                  name: context
+                  name: context[]
                   required: true
                   type: array
                   uniqueItems: true

--- a/internal/api/client/filters/v1/filterpost.go
+++ b/internal/api/client/filters/v1/filterpost.go
@@ -55,7 +55,7 @@ import (
 //		maxLength: 40
 //		type: string
 //	-
-//		name: context
+//		name: context[]
 //		in: formData
 //		required: true
 //		description: |-
@@ -72,6 +72,7 @@ import (
 //		items:
 //			type:
 //				string
+//		collectionFormat: multi
 //		minItems: 1
 //		uniqueItems: true
 //	-

--- a/internal/api/client/filters/v1/filterput.go
+++ b/internal/api/client/filters/v1/filterput.go
@@ -61,7 +61,7 @@ import (
 //		maxLength: 40
 //		type: string
 //	-
-//		name: context
+//		name: context[]
 //		in: formData
 //		required: true
 //		description: |-
@@ -78,6 +78,7 @@ import (
 //		items:
 //			type:
 //				string
+//		collectionFormat: multi
 //		minItems: 1
 //		uniqueItems: true
 //	-

--- a/internal/api/client/filters/v1/filtersget.go
+++ b/internal/api/client/filters/v1/filtersget.go
@@ -43,10 +43,12 @@ import (
 //
 //	responses:
 //		'200':
-//			name: filter
+//			name: filters
 //			description: Requested filters.
 //			schema:
-//				"$ref": "#/definitions/filterV1"
+//				type: array
+//				items:
+//					"$ref": "#/definitions/filterV1"
 //		'400':
 //			description: bad request
 //		'401':


### PR DESCRIPTION
# Description

This updates the Swagger spec to fix an incorrect type (getting filters returns an array of filters, not a single filter), and changes the way that filter contexts are serialized when creating or updating a filter (they should be passed as multiple parameters, but the default is apparently a single comma-separated parameter).

There are no code changes, just Swagger.

This is another followup patch to #2594 and #2698, and like #2729, I also found it while working on https://github.com/VyrCossont/slurp. Once this was patched and one bug in go-swagger itself go-swagger/go-swagger#2997 was worked around, `slurp` was able to import and export filters from both GtS and Mastodon instances, using a Swagger client generated from our own Swagger spec.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
