### PR TITLE
[chore] seperate snapshot from release in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,7 +60,7 @@ dockers:
     image_templates:
     - "superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-amd64"
     - "superseriousbusiness/{{ .ProjectName }}:latest-amd64"
-    - "superseriousbusiness/{{ .ProjectName }}:snapshot-amd64"
+    - "{{ if .IsSnapshot }}superseriousbusiness/{{ .ProjectName }}:snapshot-amd64{{ end }}"
     build_flag_templates:
     - "--platform=linux/amd64"
     - "--label=org.opencontainers.image.created={{.Date}}"
@@ -80,7 +80,7 @@ dockers:
     image_templates:
     - "superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-arm64v8"
     - "superseriousbusiness/{{ .ProjectName }}:latest-arm64v8"
-    - "superseriousbusiness/{{ .ProjectName }}:snapshot-arm64v8"
+    - "{{ if .IsSnapshot }}superseriousbusiness/{{ .ProjectName }}:snapshot-arm64v8{{ end }}"
     build_flag_templates:
     - "--platform=linux/arm64/v8"
     - "--label=org.opencontainers.image.created={{.Date}}"
@@ -101,7 +101,7 @@ dockers:
     image_templates:
     - "superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-armv6"
     - "superseriousbusiness/{{ .ProjectName }}:latest-armv6"
-    - "superseriousbusiness/{{ .ProjectName }}:snapshot-armv6"
+    - "{{ if .IsSnapshot }}superseriousbusiness/{{ .ProjectName }}:snapshot-armv6{{ end }}"
     build_flag_templates:
     - "--platform=linux/arm/v6"
     - "--label=org.opencontainers.image.created={{.Date}}"
@@ -122,7 +122,7 @@ dockers:
     image_templates:
     - "superseriousbusiness/{{ .ProjectName }}:{{ .Version }}-armv7"
     - "superseriousbusiness/{{ .ProjectName }}:latest-armv7"
-    - "superseriousbusiness/{{ .ProjectName }}:snapshot-armv7"
+    - "{{ if .IsSnapshot }}superseriousbusiness/{{ .ProjectName }}:snapshot-armv7{{ end }}"
     build_flag_templates:
     - "--platform=linux/arm/v7"
     - "--label=org.opencontainers.image.created={{.Date}}"
@@ -148,7 +148,7 @@ docker_manifests:
     - superseriousbusiness/{{ .ProjectName }}:latest-arm64v8
     - superseriousbusiness/{{ .ProjectName }}:latest-armv6
     - superseriousbusiness/{{ .ProjectName }}:latest-armv7
-  - name_template: superseriousbusiness/{{ .ProjectName }}:snapshot
+  - name_template: "{{ if .IsSnapshot }}superseriousbusiness/{{ .ProjectName }}:snapshot{{ end }}"
     image_templates:
     - superseriousbusiness/{{ .ProjectName }}:snapshot-amd64
     - superseriousbusiness/{{ .ProjectName }}:snapshot-arm64v8


### PR DESCRIPTION
# Description

This pull request adds `{{ if .IsSnapshot }}` check to all snapshot tags and manifests in `.goreleaser.yml`.
With this change docker images with `snapshot` tag will not be produced unless `--snapshot` argument is explicitly set. So the `release` job in Drone CI will not overwrite `snapshot` tag.

closes #2737 
closes #2609 

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
