### PR TITLE
[bugfix] Don't error when populating MovedTo if account not found

### DIFF
--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -316,12 +316,13 @@ func (a *accountDB) PopulateAccount(ctx context.Context, account *gtsmodel.Accou
 	}
 
 	if account.MovedTo == nil && account.MovedToURI != "" {
-		// Account movedTo is not set, fetch from database.
+		// Account movedTo is not set, try to fetch from database,
+		// but only error on real errors since this field is optional.
 		account.MovedTo, err = a.state.DB.GetAccountByURI(
 			gtscontext.SetBarebones(ctx),
 			account.MovedToURI,
 		)
-		if err != nil {
+		if err != nil && !errors.Is(err, db.ErrNoEntries) {
 			errs.Appendf("error populating moved to account: %w", err)
 		}
 	}

--- a/internal/db/bundb/account_test.go
+++ b/internal/db/bundb/account_test.go
@@ -482,6 +482,17 @@ func (suite *AccountTestSuite) TestCountAccountPinnedNothingPinned() {
 	suite.Equal(pinned, 0) // This account has nothing pinned.
 }
 
+func (suite *AccountTestSuite) TestPopulateAccountWithUnknownMovedToURI() {
+	testAccount := &gtsmodel.Account{}
+	*testAccount = *suite.testAccounts["local_account_1"]
+
+	// Set test account MovedToURI to something we don't have in the database.
+	// We should not get an error when populating.
+	testAccount.MovedToURI = "https://unknown-instance.example.org/users/someone_we_dont_know"
+	err := suite.db.PopulateAccount(context.Background(), testAccount)
+	suite.NoError(err)
+}
+
 func TestAccountTestSuite(t *testing.T) {
 	suite.Run(t, new(AccountTestSuite))
 }


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

We may not always have the MovedTo account stored in the database when an account's `MovedToURI` is set. It's nice if we do have it, since we can then convey that via the API too, but it's fine if we don't, and we don't need to error for it.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
