### PR TITLE
[bugfix] Fix whitespace move_id issue

### DIFF
--- a/internal/db/bundb/migrations/20240310120046_fix_empty_move_id.go
+++ b/internal/db/bundb/migrations/20240310120046_fix_empty_move_id.go
@@ -1,0 +1,53 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		const emptyULID = "                          "
+
+		// Overwrite any 26-char whitespace move_ids.
+		if _, err := db.
+			NewUpdate().
+			Table("accounts").
+			Column("move_id").
+			Set("? = null", bun.Ident("move_id")).
+			Where("? = ?", bun.Ident("move_id"), emptyULID).
+			Exec(ctx); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}

--- a/internal/gtsmodel/account.go
+++ b/internal/gtsmodel/account.go
@@ -57,7 +57,7 @@ type Account struct {
 	AlsoKnownAs             []*Account       `bun:"-"`                              // This account is associated with these accounts (field not stored in the db).
 	MovedToURI              string           `bun:",nullzero"`                      // This account has (or claims to have) moved to this account URI. Even if this field is set the move may not yet have been processed. Check `move` for this.
 	MovedTo                 *Account         `bun:"-"`                              // This account has moved to this account (field not stored in the db).
-	MoveID                  string           `bun:""`                               // ID of a Move in the database for this account. Only set if we received or created a Move activity for which this account URI was the origin.
+	MoveID                  string           `bun:"type:CHAR(26),nullzero"`         // ID of a Move in the database for this account. Only set if we received or created a Move activity for which this account URI was the origin.
 	Move                    *Move            `bun:"-"`                              // Move corresponding to MoveID, if set.
 	Bot                     *bool            `bun:",default:false"`                 // Does this account identify itself as a bot?
 	Reason                  string           `bun:""`                               // What reason was given for signing up when this account was created?


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

I introduced a bug where account `move_id` was being stored as a 26-character long whitespace string when using Postgres.

This PR fixes this by putting nullzero on the move_id field, and also adds a migration to correct the field for anyone who'd run on the latest Postgres snapshot while the issue was still present.

Reproduced the issue and tested the fix on local postgres-backed testrig.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
