### PR TITLE
Use http for webfinger if protocol="http"

### DIFF
--- a/internal/transport/finger.go
+++ b/internal/transport/finger.go
@@ -27,6 +27,7 @@ import (
 
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 )
 
@@ -34,7 +35,9 @@ import (
 // well as if the URL was retrieved from cache. When the URL is retrieved
 // from cache we don't have to try and do host-meta discovery
 func (t *transport) webfingerURLFor(targetDomain string) (string, bool) {
-	url := "https://" + targetDomain + "/.well-known/webfinger"
+	protocol := config.GetProtocol()
+
+	url := protocol + "://" + targetDomain + "/.well-known/webfinger"
 
 	wc := t.controller.state.Caches.GTS.Webfinger
 


### PR DESCRIPTION
When testing locally, all my services use http. So I also need the webfinger requests to use it.

If there is a reason to mix http & https, one could add a second configuration variable for this.


## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [ ] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
