### PR TITLE
Swagger: add Link header to all endpoints that use it for paging

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -2907,6 +2907,10 @@ paths:
             responses:
                 "200":
                     description: Array of accounts that follow this account.
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
                     schema:
                         items:
                             $ref: '#/definitions/account'
@@ -2967,6 +2971,14 @@ paths:
             responses:
                 "200":
                     description: Array of accounts that are followed by this account.
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
+                    schema:
+                        items:
+                            $ref: '#/definitions/account'
+                        type: array
                 "400":
                     description: bad request
                 "401":
@@ -3109,6 +3121,10 @@ paths:
             responses:
                 "200":
                     description: Array of statuses.
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
                     schema:
                         items:
                             $ref: '#/definitions/status'
@@ -4875,6 +4891,10 @@ paths:
             responses:
                 "200":
                     description: Array of reports.
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
                     schema:
                         items:
                             $ref: '#/definitions/adminReport'
@@ -6614,6 +6634,10 @@ paths:
             responses:
                 "200":
                     description: Array of reports.
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
                     schema:
                         items:
                             $ref: '#/definitions/report'

--- a/internal/api/client/accounts/followers.go
+++ b/internal/api/client/accounts/followers.go
@@ -102,6 +102,10 @@ import (
 //				type: array
 //				items:
 //					"$ref": "#/definitions/account"
+//			headers:
+//				Link:
+//					type: string
+//					description: Links to the next and previous queries.
 //		'400':
 //			description: bad request
 //		'401':

--- a/internal/api/client/accounts/following.go
+++ b/internal/api/client/accounts/following.go
@@ -99,9 +99,13 @@ import (
 //			name: accounts
 //			description: Array of accounts that are followed by this account.
 //			schema:
-//			type: array
-//			items:
-//				"$ref": "#/definitions/account"
+//				type: array
+//				items:
+//					"$ref": "#/definitions/account"
+//			headers:
+//				Link:
+//					type: string
+//					description: Links to the next and previous queries.
 //		'400':
 //			description: bad request
 //		'401':

--- a/internal/api/client/accounts/statuses.go
+++ b/internal/api/client/accounts/statuses.go
@@ -119,6 +119,10 @@ import (
 //				type: array
 //				items:
 //					"$ref": "#/definitions/status"
+//			headers:
+//				Link:
+//					type: string
+//					description: Links to the next and previous queries.
 //		'400':
 //			description: bad request
 //		'401':

--- a/internal/api/client/admin/reportsget.go
+++ b/internal/api/client/admin/reportsget.go
@@ -112,6 +112,10 @@ import (
 //				type: array
 //				items:
 //					"$ref": "#/definitions/adminReport"
+//			headers:
+//				Link:
+//					type: string
+//					description: Links to the next and previous queries.
 //		'400':
 //			description: bad request
 //		'401':

--- a/internal/api/client/reports/reportsget.go
+++ b/internal/api/client/reports/reportsget.go
@@ -108,6 +108,10 @@ import (
 //				type: array
 //				items:
 //					"$ref": "#/definitions/report"
+//			headers:
+//				Link:
+//					type: string
+//					description: Links to the next and previous queries.
 //		'400':
 //			description: bad request
 //		'401':


### PR DESCRIPTION
# Description

Adds description of the `Link` header to Swagger docs for 5 endpoints that use it but which didn't already have that header in the response description. Also fixes a typo preventing correct docs generation for 1 of those endpoints.

Allows use of `Link` paging with Swagger clients. No code changes.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
