### PR TITLE
[bugfix] Don't return 500 when searching for unpermitted status

### DIFF
--- a/internal/processing/search/get.go
+++ b/internal/processing/search/get.go
@@ -491,7 +491,14 @@ func (p *Processor) byURI(
 		if err != nil {
 			// Check for semi-expected error types.
 			// On one of these, we can continue.
-			if !gtserror.IsUnretrievable(err) && !gtserror.IsWrongType(err) {
+			switch {
+			case gtserror.IsUnretrievable(err),
+				gtserror.IsWrongType(err):
+				log.Debugf(ctx,
+					"semi-expected error type looking up %s as account: %v",
+					uri, err,
+				)
+			default:
 				err = gtserror.Newf("error looking up %s as account: %w", uri, err)
 				return gtserror.NewErrorInternalError(err)
 			}
@@ -509,7 +516,15 @@ func (p *Processor) byURI(
 		if err != nil {
 			// Check for semi-expected error types.
 			// On one of these, we can continue.
-			if !gtserror.IsUnretrievable(err) && !gtserror.IsWrongType(err) {
+			switch {
+			case gtserror.IsUnretrievable(err),
+				gtserror.IsWrongType(err),
+				gtserror.NotPermitted(err):
+				log.Debugf(ctx,
+					"semi-expected error type looking up %s as status: %v",
+					uri, err,
+				)
+			default:
 				err = gtserror.Newf("error looking up %s as status: %w", uri, err)
 				return gtserror.NewErrorInternalError(err)
 			}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

When searching for an unpermitted status, GtS will return 500 if the status is not permitted. This fixes that by including the error in the "semi-expected" error types when searching.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
