### PR TITLE
[docs] Add database maintenance section; update info message on ANALYZE run (sqlite)

### DIFF
--- a/docs/admin/database_maintenance.md
+++ b/docs/admin/database_maintenance.md
@@ -1,0 +1,35 @@
+# Database Maintenance
+
+Regardless of whether you choose to run GoToSocial with SQLite or Postgres, you may need to occasionally take maintenance steps to keep your database running well.
+
+## SQLite
+
+### Analyze / Optimize
+
+Following [SQLite best practice](https://sqlite.org/lang_analyze.html#recommended_usage_pattern), GoToSocial runs the `optimize` SQLite pragma with `analysis_limit=1000` on closing database connections to keep index information up to date.
+
+After each database migration, GoToSocial will also run `ANALYZE` with `analysis_limit=10000` to ensure that any indexes added or removed by migrations are taken into account.
+
+As such, in normal circumstances, you should not need to run manual `ANALYZE` commands against your SQLite database file.
+
+However, if you interrupted a previous `ANALYZE` command, it could be the case that query optimizer data stored in SQLite's internal tables has been removed, and you notice that queries are running remarkably slowly.
+
+If this is the case, you can try manually running an `ANALYZE` command in the SQLite CLI tool, by entering: `PRAGMA analysis_limit=10000; ANALYZE;`.
+
+It is not necessary to run a full analyze, an approximate analyze will do. [See here](https://sqlite.org/lang_analyze.html#approximate_analyze_for_large_databases) for more info.
+
+### Vacuum
+
+GoToSocial does not currently enable auto-vacuum for SQLite. As such, you may want to periodically (eg., every few months) run a `VACUUM` command on your SQLite database, to repack the database file to an optimal size.
+
+You can see lots of information about the `VACUUM` command [here](https://sqlite.org/lang_vacuum.html).
+
+The basic steps are:
+
+1. Stop GoToSocial.
+2. Run `VACUUM` using the SQLite CLI tool (this may take quite a few minutes depending on the size of your database file).
+3. Start GoToSocial.
+
+## Postgres
+
+TODO: Maintenance recommendations for Postgres. 

--- a/docs/admin/database_maintenance.md
+++ b/docs/admin/database_maintenance.md
@@ -4,7 +4,7 @@ Regardless of whether you choose to run GoToSocial with SQLite or Postgres, you 
 
 !!! tip
     
-    Though the maintenance tips provided here are intended by non-destructive, you should still consider backing up your database before manually intervening to do maintenance. That way if you mistype something or accidentally run a bad command, you can simply restore your backup and try again.
+    Though the maintenance tips provided here are intended to be non-destructive, you should backup your database before manually performing maintenance. That way if you mistype something or accidentally run a bad command, you can restore your backup and try again.
 
 !!! danger
     

--- a/docs/admin/database_maintenance.md
+++ b/docs/admin/database_maintenance.md
@@ -2,32 +2,48 @@
 
 Regardless of whether you choose to run GoToSocial with SQLite or Postgres, you may need to occasionally take maintenance steps to keep your database running well.
 
+!!! tip
+    
+    Though the maintenance tips provided here are intended by non-destructive, you should still consider backing up your database before manually intervening to do maintenance. That way if you mistype something or accidentally run a bad command, you can simply restore your backup and try again.
+
+!!! danger
+    
+    Manually creating, deleting, or updating entries in your GoToSocial database is **heavily discouraged**, and such commands are not provided here. Even if you think you know what you are doing, running `DELETE` statements etc. may introduce issues that are very difficult to debug. The maintenance tips below are designed to help with the smooth running of your instance; they will not save your ass if you have manually gone into your database and hacked at entries, tables, and indexes.
+
 ## SQLite
+
+To do manual SQLite maintenance, you should first install the SQLite command line tool `sqlite3` on the same machine that your GoToSocial sqlite.db file is stored on. See [here](https://sqlite.org/cli.html) for details about `sqlite3`.
 
 ### Analyze / Optimize
 
 Following [SQLite best practice](https://sqlite.org/lang_analyze.html#recommended_usage_pattern), GoToSocial runs the `optimize` SQLite pragma with `analysis_limit=1000` on closing database connections to keep index information up to date.
 
-After each database migration, GoToSocial will also run `ANALYZE` with `analysis_limit=10000` to ensure that any indexes added or removed by migrations are taken into account.
+After each set of database migrations (eg., when starting a newer version of GoToSocial), GoToSocial will run `ANALYZE` to ensure that any indexes added or removed by migrations are taken into account correctly by the query planner.
 
-As such, in normal circumstances, you should not need to run manual `ANALYZE` commands against your SQLite database file.
+The `ANALYZE` command may take ~10 minutes depending on your hardware and the size of your database file.
 
-However, if you interrupted a previous `ANALYZE` command, it could be the case that query optimizer data stored in SQLite's internal tables has been removed, and you notice that queries are running remarkably slowly.
+Because of the above automated steps, in normal circumstances you should not need to run manual `ANALYZE` commands against your SQLite database file.
 
-If this is the case, you can try manually running an `ANALYZE` command in the SQLite CLI tool, by entering: `PRAGMA analysis_limit=10000; ANALYZE;`.
+However, if you interrupted a previous `ANALYZE` command, and you notice that queries are running remarkably slowly, it could be the case that the index metadata stored in SQLite's internal tables has been removed or undesirably altered.
 
-It is not necessary to run a full analyze, an approximate analyze will do. [See here](https://sqlite.org/lang_analyze.html#approximate_analyze_for_large_databases) for more info.
+If this is the case, you can try manually running a full `ANALYZE` command, by doing the following:
+
+1. Stop GoToSocial.
+2. While connected to your GoToSocial database file in the `sqlite3` shell, run `PRAGMA analysis_limit=0; ANALYZE;` (this may take quite a few minutes).
+3. Start GoToSocial.
+
+[See here](https://sqlite.org/lang_analyze.html#approximate_analyze_for_large_databases) for more info.
 
 ### Vacuum
 
-GoToSocial does not currently enable auto-vacuum for SQLite. As such, you may want to periodically (eg., every few months) run a `VACUUM` command on your SQLite database, to repack the database file to an optimal size.
+GoToSocial does not currently enable auto-vacuum for SQLite. To repack the database file to an optimal size you may want to run a `VACUUM` command on your SQLite database periodically (eg., every few months).
 
 You can see lots of information about the `VACUUM` command [here](https://sqlite.org/lang_vacuum.html).
 
 The basic steps are:
 
 1. Stop GoToSocial.
-2. Run `VACUUM` using the SQLite CLI tool (this may take quite a few minutes depending on the size of your database file).
+2. While connected to your GoToSocial database file in the `sqlite3` shell, run `VACUUM;` (this may take quite a few minutes).
 3. Start GoToSocial.
 
 ## Postgres

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -113,8 +113,8 @@ func doMigration(ctx context.Context, db *bun.DB) error {
 
 	if db.Dialect().Name() == dialect.SQLite {
 		log.Info(ctx,
-			"running ANALYZE to update table and index statistics; this may take 10 minutes or "+
-				"longer depending on your hardware and database size, please be patient",
+			"running ANALYZE to update table and index statistics; this will take somewhere between "+
+				"1-10 minutes, or maybe longer depending on your hardware and database size, please be patient",
 		)
 		_, err := db.ExecContext(ctx, "ANALYZE")
 		if err != nil {

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -113,7 +113,7 @@ func doMigration(ctx context.Context, db *bun.DB) error {
 
 	if db.Dialect().Name() == dialect.SQLite {
 		log.Info(ctx, "running ANALYZE to update table and index statistics")
-		_, err := db.ExecContext(ctx, "ANALYZE")
+		_, err := db.ExecContext(ctx, "PRAGMA analysis_limit=10000; ANALYZE")
 		if err != nil {
 			log.Warnf(ctx, "ANALYZE failed, query planner may make poor life choices: %s", err)
 		}

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -112,8 +112,11 @@ func doMigration(ctx context.Context, db *bun.DB) error {
 	log.Infof(ctx, "MIGRATED DATABASE TO %s", group)
 
 	if db.Dialect().Name() == dialect.SQLite {
-		log.Info(ctx, "running ANALYZE to update table and index statistics")
-		_, err := db.ExecContext(ctx, "PRAGMA analysis_limit=10000; ANALYZE")
+		log.Info(ctx,
+			"running ANALYZE to update table and index statistics; this may take 10 minutes or "+
+				"longer depending on your hardware and database size, please be patient",
+		)
+		_, err := db.ExecContext(ctx, "ANALYZE")
 		if err != nil {
 			log.Warnf(ctx, "ANALYZE failed, query planner may make poor life choices: %s", err)
 		}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
       - "admin/backup_and_restore.md"
       - "admin/media_caching.md"
       - "admin/spam.md"
+      - "admin/database_maintenance.md"
   - "Federation":
       - "federation/index.md"
       - "federation/glossary.md"


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

~~The full ANAYLZE command we run for SQLite after each DB migration is not really necessary, and takes bloody ages (minutes and minutes on my 1cpu 1gb ram machine). This PR updates the post-migration ANALYZE command to use an analysis limit of 10000, which should be plenty (for comparison, we use 1000 for on-close callbacks).~~

Correction to the above: I've been messing about with running partial and full analyzes, and it turns out that running `PRAGMA anaylsis_limit=10000; ANALYZE;` actually doesn't cut it for the purposes of helping the query optimizer use the correct indexes.

Here's the contents of `sqlite_stat1` for statuses after a full `ANALYZE`:

![image](https://github.com/superseriousbusiness/gotosocial/assets/31960611/eab3781d-b6c6-4314-b0d5-2b37a55b3580)

And here's the same after a partial `ANALYZE`:

![image](https://github.com/superseriousbusiness/gotosocial/assets/31960611/3e1ced51-37f7-4178-a4d2-a202c49cb700)

Huge difference in emphasis across some of the important indexes.

Running the statuses web view query after a full analyze uses the intended index:

![image](https://github.com/superseriousbusiness/gotosocial/assets/31960611/e12f9c2c-27df-4f34-b0ea-73d7bcf09ae0)

Where running the same query after a partial analyze causes the query planner to not use correct indexes:

![image](https://github.com/superseriousbusiness/gotosocial/assets/31960611/b0699fb7-8ad8-4a41-be8d-f85adc7ba24d)

So in other words, we should actually keep that full analyze after all!

Also adds some v. basic docs about db maintenance, for SQLite at least.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
