### PR TITLE
Swagger: correct names and formats for several array params

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -3353,11 +3353,12 @@ paths:
         get:
             operationId: accountRelationships
             parameters:
-                - description: Account IDs.
+                - collectionFormat: multi
+                  description: Account IDs.
                   in: query
                   items:
                     type: string
-                  name: id
+                  name: id[]
                   required: true
                   type: array
             produces:
@@ -6067,11 +6068,12 @@ paths:
                   name: id
                   required: true
                   type: string
-                - description: Array of accountIDs to modify. Each accountID must correspond to an account that the requesting account follows.
+                - collectionFormat: multi
+                  description: Array of accountIDs to modify. Each accountID must correspond to an account that the requesting account follows.
                   in: formData
                   items:
                     type: string
-                  name: account_ids
+                  name: account_ids[]
                   required: true
                   type: array
             produces:
@@ -6171,11 +6173,12 @@ paths:
                   name: id
                   required: true
                   type: string
-                - description: Array of accountIDs to modify. Each accountID must correspond to an account that the requesting account follows.
+                - collectionFormat: multi
+                  description: Array of accountIDs to modify. Each accountID must correspond to an account that the requesting account follows.
                   in: formData
                   items:
                     type: string
-                  name: account_ids
+                  name: account_ids[]
                   required: true
                   type: array
             produces:

--- a/internal/api/client/accounts/relationships.go
+++ b/internal/api/client/accounts/relationships.go
@@ -41,12 +41,13 @@ import (
 //
 //	parameters:
 //	-
-//		name: id
+//		name: id[]
 //		type: array
 //		items:
 //			type: string
 //		description: Account IDs.
 //		in: query
+//		collectionFormat: multi
 //		required: true
 //
 //	security:

--- a/internal/api/client/lists/listaccountsadd.go
+++ b/internal/api/client/lists/listaccountsadd.go
@@ -52,7 +52,7 @@ import (
 //		in: path
 //		required: true
 //	-
-//		name: account_ids
+//		name: account_ids[]
 //		type: array
 //		items:
 //			type: string
@@ -61,6 +61,7 @@ import (
 //			Each accountID must correspond to an account
 //			that the requesting account follows.
 //		in: formData
+//		collectionFormat: multi
 //		required: true
 //
 //	security:

--- a/internal/api/client/lists/listaccountsremove.go
+++ b/internal/api/client/lists/listaccountsremove.go
@@ -52,7 +52,7 @@ import (
 //		in: path
 //		required: true
 //	-
-//		name: account_ids
+//		name: account_ids[]
 //		type: array
 //		items:
 //			type: string
@@ -61,6 +61,7 @@ import (
 //			Each accountID must correspond to an account
 //			that the requesting account follows.
 //		in: formData
+//		collectionFormat: multi
 //		required: true
 //
 //	security:


### PR DESCRIPTION
# Description

These parameters should have names ending in `[]` and use `collectionFormat: multi` (pass multiple elements by repeating the param in the form data).

No code changes.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
