### PR TITLE
Swagger: add missing paging params to bookmarks list

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -5176,6 +5176,20 @@ paths:
         get:
             description: Get an array of statuses bookmarked in the instance
             operationId: bookmarksGet
+            parameters:
+                - default: 30
+                  description: Number of statuses to return.
+                  in: query
+                  name: limit
+                  type: integer
+                - description: Return only bookmarked statuses *OLDER* than the given bookmark ID. The status with the corresponding bookmark ID will not be included in the response.
+                  in: query
+                  name: max_id
+                  type: string
+                - description: Return only bookmarked statuses *NEWER* than the given bookmark ID. The status with the corresponding bookmark ID will not be included in the response.
+                  in: query
+                  name: min_id
+                  type: string
             produces:
                 - application/json
             responses:

--- a/internal/api/client/bookmarks/bookmarksget.go
+++ b/internal/api/client/bookmarks/bookmarksget.go
@@ -53,6 +53,28 @@ const (
 //	- OAuth2 Bearer:
 //		- read:bookmarks
 //
+//	parameters:
+//	-
+//		name: limit
+//		type: integer
+//		description: Number of statuses to return.
+//		default: 30
+//		in: query
+//	-
+//		name: max_id
+//		type: string
+//		description: >-
+//			Return only bookmarked statuses *OLDER* than the given bookmark ID.
+//			The status with the corresponding bookmark ID will not be included in the response.
+//		in: query
+//	-
+//		name: min_id
+//		type: string
+//		description: >-
+//			Return only bookmarked statuses *NEWER* than the given bookmark ID.
+//			The status with the corresponding bookmark ID will not be included in the response.
+//		in: query
+//
 //	responses:
 //		'200':
 //			description: Array of bookmarked statuses


### PR DESCRIPTION
# Description

Add paging params for the `bookmarksGet` API method to Swagger.

No code changes.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
