### PR TITLE
[chore] Different error message for email validation from net/mail parsing on go 1.21.8 and above

### DIFF
--- a/internal/validate/formvalidation_test.go
+++ b/internal/validate/formvalidation_test.go
@@ -144,7 +144,10 @@ func (suite *ValidationTestSuite) TestValidateEmail() {
 
 	err = validate.Email(almostAnEmailAddress)
 	if suite.Error(err) {
-		suite.Equal(errors.New("mail: no angle-addr"), err)
+		suite.True("mail: no angle-addr" == err.Error() ||
+			// golang 1.21.8 fixed some inconsistencies in net/mail which leads
+			// to different error messages.
+			"mail: missing word in phrase: mail: invalid string" == err.Error())
 	}
 
 	err = validate.Email(aWebsite)


### PR DESCRIPTION
go 1.21.8 fixed some minor issues in net/mail that causes the test suite to fail for some mail validation cases. Although we're not on go 1.21.8 yet, make the test forward and backwards compatible.

See: https://github.com/golang/go/commit/263c059b09fdd40d9dd945f2ecb20c89ea28efe5

Running the test suite with go 1.21.8 leads to test failures like:

```
-- FAIL: TestValidationTestSuite (0.00s)
    --- FAIL: TestValidationTestSuite/TestValidateEmail (0.00s)
        formvalidation_test.go:147:
                Error Trace:    /home/blake/src/gotosocial/internal/validate/formvalidation_test.go:147
                Error:          Not equal:
                                expected: &errors.errorString{s:"mail: no angle-addr"}
                                actual  : &errors.errorString{s:"mail: missing word in phrase: mail: invalid string"}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,3 +1,3 @@
                                 (*errors.errorString)({
                                - s: (string) (len=19) "mail: no angle-addr"
                                + s: (string) (len=50) "mail: missing word in phrase: mail: invalid string"
                                 })
                Test:           TestValidationTestSuite/TestValidateEmail
FAIL
FAIL    github.com/superseriousbusiness/gotosocial/internal/validate    0.006s
```

This cropped up when trying to update the gotosocial nix package to 0.14.2, while at the same time nix updated its go release to 1.21.8. https://github.com/NixOS/nixpkgs/pull/295584

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
