### PR TITLE
[bugfix] Parse links that contain non-ascii characters

### DIFF
--- a/internal/text/markdown.go
+++ b/internal/text/markdown.go
@@ -24,6 +24,7 @@ import (
 	"codeberg.org/gruf/go-byteutil"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/superseriousbusiness/gotosocial/internal/regexes"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/renderer/html"
@@ -61,7 +62,10 @@ func (f *Formatter) FromMarkdown(
 				false, // emojiOnly = false.
 				result,
 			},
-			extension.Linkify, // Turns URLs into links.
+			// Turns URLs into links.
+			extension.NewLinkify(
+				extension.WithLinkifyURLRegexp(regexes.LinkScheme),
+			),
 			extension.Strikethrough,
 		),
 	)

--- a/internal/text/plain.go
+++ b/internal/text/plain.go
@@ -24,6 +24,7 @@ import (
 	"codeberg.org/gruf/go-byteutil"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/superseriousbusiness/gotosocial/internal/regexes"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
@@ -158,7 +159,10 @@ func (f *Formatter) fromPlain(
 				emojiOnly,
 				result,
 			},
-			extension.Linkify, // Turns URLs into links.
+			// Turns URLs into links.
+			extension.NewLinkify(
+				extension.WithLinkifyURLRegexp(regexes.LinkScheme),
+			),
 		),
 	)
 

--- a/internal/text/plain_test.go
+++ b/internal/text/plain_test.go
@@ -34,6 +34,8 @@ const (
 	withHTMLExpected           = "<p>&lt;div>blah this should just be html escaped blah&lt;/div></p>"
 	moreComplex                = "Another test @foss_satan@fossbros-anonymous.io\n\n#Hashtag\n\nText\n\n:rainbow:"
 	moreComplexExpected        = "<p>Another test <span class=\"h-card\"><a href=\"http://fossbros-anonymous.io/@foss_satan\" class=\"u-url mention\" rel=\"nofollow noreferrer noopener\" target=\"_blank\">@<span>foss_satan</span></a></span><br><br><a href=\"http://localhost:8080/tags/hashtag\" class=\"mention hashtag\" rel=\"tag nofollow noreferrer noopener\" target=\"_blank\">#<span>Hashtag</span></a><br><br>Text<br><br>:rainbow:</p>"
+	withUTF8Link               = "here's a link with utf-8 characters in it: https://example.org/söme_url"
+	withUTF8LinkExpected       = "<p>here's a link with utf-8 characters in it: <a href=\"https://example.org/s%C3%B6me_url\" rel=\"nofollow noreferrer noopener\" target=\"_blank\">https://example.org/söme_url</a></p>"
 )
 
 type PlainTestSuite struct {
@@ -68,6 +70,11 @@ func (suite *PlainTestSuite) TestParseWithHTML() {
 func (suite *PlainTestSuite) TestParseMoreComplex() {
 	formatted := suite.FromPlain(moreComplex)
 	suite.Equal(moreComplexExpected, formatted.HTML)
+}
+
+func (suite *PlainTestSuite) TestWithUTF8Link() {
+	formatted := suite.FromPlain(withUTF8Link)
+	suite.Equal(withUTF8LinkExpected, formatted.HTML)
 }
 
 func (suite *PlainTestSuite) TestLinkNoMention() {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Update the goldmark link parser to use the regex we already had lying around :)

Closes https://github.com/superseriousbusiness/gotosocial/issues/2755

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
