### PR TITLE
[bugfix] Mitigate empty public/local timeline query pages

### DIFF
--- a/internal/api/client/timelines/public.go
+++ b/internal/api/client/timelines/public.go
@@ -150,7 +150,7 @@ func (m *Module) PublicTimelineGETHandler(c *gin.Context) {
 
 	resp, errWithCode := m.processor.Timeline().PublicTimelineGet(
 		c.Request.Context(),
-		authed,
+		authed.Account,
 		c.Query(apiutil.MaxIDKey),
 		c.Query(apiutil.SinceIDKey),
 		c.Query(apiutil.MinIDKey),

--- a/internal/processing/timeline/public_test.go
+++ b/internal/processing/timeline/public_test.go
@@ -1,0 +1,96 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package timeline_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type PublicTestSuite struct {
+	TimelineStandardTestSuite
+}
+
+func (suite *PublicTestSuite) TestPublicTimelineGet() {
+	var (
+		ctx       = context.Background()
+		requester = suite.testAccounts["local_account_1"]
+		maxID     = ""
+		sinceID   = ""
+		minID     = ""
+		limit     = 10
+		local     = false
+	)
+
+	resp, errWithCode := suite.timeline.PublicTimelineGet(
+		ctx,
+		requester,
+		maxID,
+		sinceID,
+		minID,
+		limit,
+		local,
+	)
+
+	// We should have some statuses,
+	// and paging headers should be set.
+	suite.NoError(errWithCode)
+	suite.NotEmpty(resp.Items)
+	suite.NotEmpty(resp.LinkHeader)
+	suite.NotEmpty(resp.NextLink)
+	suite.NotEmpty(resp.PrevLink)
+}
+
+func (suite *PublicTestSuite) TestPublicTimelineGetNotEmpty() {
+	var (
+		ctx       = context.Background()
+		requester = suite.testAccounts["local_account_1"]
+		// Select 1 *just above* a status we know should
+		// not be in the public timeline -- a public
+		// reply to one of admin's statuses.
+		maxID   = "01HE7XJ1CG84TBKH5V9XKBVGF6"
+		sinceID = ""
+		minID   = ""
+		limit   = 1
+		local   = false
+	)
+
+	resp, errWithCode := suite.timeline.PublicTimelineGet(
+		ctx,
+		requester,
+		maxID,
+		sinceID,
+		minID,
+		limit,
+		local,
+	)
+
+	// We should have a status even though
+	// some other statuses were filtered out.
+	suite.NoError(errWithCode)
+	suite.Len(resp.Items, 1)
+	suite.Equal(`<http://localhost:8080/api/v1/timelines/public?limit=1&max_id=01F8MHCP5P2NWYQ416SBA0XSEV&local=false>; rel="next", <http://localhost:8080/api/v1/timelines/public?limit=1&min_id=01HE7XJ1CG84TBKH5V9XKBVGF5&local=false>; rel="prev"`, resp.LinkHeader)
+	suite.Equal(`http://localhost:8080/api/v1/timelines/public?limit=1&max_id=01F8MHCP5P2NWYQ416SBA0XSEV&local=false`, resp.NextLink)
+	suite.Equal(`http://localhost:8080/api/v1/timelines/public?limit=1&min_id=01HE7XJ1CG84TBKH5V9XKBVGF5&local=false`, resp.PrevLink)
+}
+
+func TestPublicTestSuite(t *testing.T) {
+	suite.Run(t, new(PublicTestSuite))
+}

--- a/internal/processing/timeline/timeline_test.go
+++ b/internal/processing/timeline/timeline_test.go
@@ -1,0 +1,69 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package timeline_test
+
+import (
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/internal/filter/visibility"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/processing/timeline"
+	"github.com/superseriousbusiness/gotosocial/internal/state"
+	"github.com/superseriousbusiness/gotosocial/internal/typeutils"
+	"github.com/superseriousbusiness/gotosocial/testrig"
+)
+
+type TimelineStandardTestSuite struct {
+	suite.Suite
+	db    db.DB
+	state state.State
+
+	// standard suite models
+	testAccounts map[string]*gtsmodel.Account
+
+	// module being tested
+	timeline timeline.Processor
+}
+
+func (suite *TimelineStandardTestSuite) SetupSuite() {
+	suite.testAccounts = testrig.NewTestAccounts()
+}
+
+func (suite *TimelineStandardTestSuite) SetupTest() {
+	suite.state.Caches.Init()
+	testrig.StartNoopWorkers(&suite.state)
+
+	testrig.InitTestConfig()
+	testrig.InitTestLog()
+
+	suite.db = testrig.NewTestDB(&suite.state)
+	suite.state.DB = suite.db
+
+	suite.timeline = timeline.New(
+		&suite.state,
+		typeutils.NewConverter(&suite.state),
+		visibility.NewFilter(&suite.state),
+	)
+
+	testrig.StandardDBSetup(suite.db, suite.testAccounts)
+}
+
+func (suite *TimelineStandardTestSuite) TearDownTest() {
+	testrig.StandardDBTeardown(suite.db)
+	testrig.StopWorkers(&suite.state)
+}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates our public timeline querying to try to avoid the situation where all items from a db query get filtered out, which causes issues like https://github.com/superseriousbusiness/gotosocial/issues/2410 and https://github.com/superseriousbusiness/gotosocial/issues/2273.

Now:

- Always select a bit more than `limit` from the db when doing public timeline queries.
- Reattempt select (paging up or down) to try to get appropriate statuses if previous query resulted in all selected statuses being filtered out (limit 3 queries total).

This won't *completely* fix the problem (it can still happen in edge cases) but it will make it much, much less likely to occur at the expense of doing more/wider db queries.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
