### PR TITLE
[bugfix] Serve correct URI for AP following collection

### DIFF
--- a/internal/processing/fedi/collections.go
+++ b/internal/processing/fedi/collections.go
@@ -279,9 +279,9 @@ func (p *Processor) FollowingGet(ctx context.Context, requestedUser string, page
 
 		// Set the collection item property builder function.
 		pageParams.Append = func(i int, itemsProp ap.ItemsPropertyBuilder) {
-			// Get follower URI at index.
+			// Get followed URI at index.
 			follow := follows[i]
-			accURI := follow.Account.URI
+			accURI := follow.TargetAccount.URI
 
 			// Parse URL object from URI.
 			iri, err := url.Parse(accURI)


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Fix an error in serving the following collection, where we were taking the account of the follow, not the target account.

closes https://github.com/superseriousbusiness/gotosocial/issues/2786

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
