### PR TITLE
[bugfix] Set domain for empty-domain Friendica accounts

### DIFF
--- a/internal/db/bundb/migrations/20240402113305_nil_domain_fix.go
+++ b/internal/db/bundb/migrations/20240402113305_nil_domain_fix.go
@@ -1,0 +1,86 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			// Select URI of each friendica account
+			// with an empty domain that doesn't have
+			// a corresponding user (ie., not local).
+			// Query looks like:
+			//
+			//	SELECT "uri" FROM "accounts"
+			//	WHERE ("username" = 'friendica')
+			//	AND ("actor_type" = 'Application')
+			//	AND ("domain" IS NULL)
+			//	AND ("id" NOT IN (SELECT "account_id" FROM "users"))
+			URIStrs := []string{}
+			if err := tx.
+				NewSelect().
+				Table("accounts").
+				Column("uri").
+				Where("? = ?", bun.Ident("username"), "friendica").
+				Where("? = ?", bun.Ident("actor_type"), "Application").
+				Where("? IS NULL", bun.Ident("domain")).
+				Where("? NOT IN (?)", bun.Ident("id"), tx.NewSelect().Table("users").Column("account_id")).
+				Scan(ctx, &URIStrs); err != nil {
+				return err
+			}
+
+			// For each URI found this way, parse
+			// out the Host part and update the
+			// domain of the domain-less account.
+			for _, uriStr := range URIStrs {
+				uri, err := url.Parse(uriStr)
+				if err != nil {
+					return err
+				}
+
+				domain := uri.Host
+				if _, err := tx.
+					NewUpdate().
+					Table("accounts").
+					Set("? = ?", bun.Ident("domain"), domain).
+					Where("? = ?", bun.Ident("uri"), uriStr).
+					Exec(ctx); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Adds a migration to update the domain of friendica service accounts that were inadvertently stored with a nil domain. 

closes https://github.com/superseriousbusiness/gotosocial/issues/2515
closes https://github.com/superseriousbusiness/gotosocial/issues/2474

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
