### PR TITLE
[bugfix] Sort follows chronologically

### DIFF
--- a/internal/db/bundb/relationship.go
+++ b/internal/db/bundb/relationship.go
@@ -331,7 +331,7 @@ func newSelectFollows(db *bun.DB, accountID string) *bun.SelectQuery {
 		Table("follows").
 		Column("id").
 		Where("? = ?", bun.Ident("account_id"), accountID).
-		OrderExpr("? DESC", bun.Ident("id"))
+		OrderExpr("? DESC", bun.Ident("created_at"))
 }
 
 // newSelectLocalFollows returns a new select query for all rows in the follows table with
@@ -349,7 +349,7 @@ func newSelectLocalFollows(db *bun.DB, accountID string) *bun.SelectQuery {
 				Column("id").
 				Where("? IS NULL", bun.Ident("domain")),
 		).
-		OrderExpr("? DESC", bun.Ident("id"))
+		OrderExpr("? DESC", bun.Ident("created_at"))
 }
 
 // newSelectFollowers returns a new select query for all rows in the follows table with target_account_id = accountID.
@@ -358,7 +358,7 @@ func newSelectFollowers(db *bun.DB, accountID string) *bun.SelectQuery {
 		Table("follows").
 		Column("id").
 		Where("? = ?", bun.Ident("target_account_id"), accountID).
-		OrderExpr("? DESC", bun.Ident("id"))
+		OrderExpr("? DESC", bun.Ident("created_at"))
 }
 
 // newSelectLocalFollowers returns a new select query for all rows in the follows table with
@@ -376,7 +376,7 @@ func newSelectLocalFollowers(db *bun.DB, accountID string) *bun.SelectQuery {
 				Column("id").
 				Where("? IS NULL", bun.Ident("domain")),
 		).
-		OrderExpr("? DESC", bun.Ident("id"))
+		OrderExpr("? DESC", bun.Ident("created_at"))
 }
 
 // newSelectBlocks returns a new select query for all rows in the blocks table with account_id = accountID.

--- a/internal/federation/federatingdb/following_test.go
+++ b/internal/federation/federatingdb/following_test.go
@@ -47,8 +47,8 @@ func (suite *FollowingTestSuite) TestGetFollowing() {
 	suite.Equal(`{
   "@context": "https://www.w3.org/ns/activitystreams",
   "items": [
-    "http://localhost:8080/users/1happyturtle",
-    "http://localhost:8080/users/admin"
+    "http://localhost:8080/users/admin",
+    "http://localhost:8080/users/1happyturtle"
   ],
   "type": "Collection"
 }`, string(fJson))


### PR DESCRIPTION
# Description

The id on the follows table is not a ULID, but a random ID. Sorting on them results in a completely random order. Instead, sort on created_at, which sould result in a stable and intended sort order.

Fixes: #2769

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
