### PR TITLE
[bugfix] improved authenticate post inbox error handling

### DIFF
--- a/internal/api/activitypub/users/inboxpost_test.go
+++ b/internal/api/activitypub/users/inboxpost_test.go
@@ -590,7 +590,7 @@ func (suite *InboxPostTestSuite) TestPostUnauthorized() {
 		requestingAccount,
 		targetAccount,
 		http.StatusUnauthorized,
-		`{"error":"Unauthorized: not authenticated"}`,
+		`{"error":"Unauthorized: http request wasn't signed or http signature was invalid: (verifier)"}`,
 		// Omit signature check middleware.
 	)
 }

--- a/internal/federation/federatingactor.go
+++ b/internal/federation/federatingactor.go
@@ -80,6 +80,14 @@ func (f *federatingActor) PostInboxScheme(ctx context.Context, w http.ResponseWr
 	}
 
 	// Authenticate request by checking http signature.
+	//
+	// NOTE: the behaviour here is a little strange as we have
+	// the competing code styles of the go-fed interface expecting
+	// that any 'err' is fatal, but 'authenticated' bool is intended to
+	// be the main passer of whether failed auth occurred, but we in
+	// the gts codebase use errors to pass-back non-200 status codes,
+	// so we specifically have to check for already wrapped with code.
+	//
 	ctx, authenticated, err := f.sideEffectActor.AuthenticatePostInbox(ctx, w, r)
 	if errors.As(err, new(gtserror.WithCode)) {
 		// If it was already wrapped with an

--- a/internal/federation/federatingprotocol.go
+++ b/internal/federation/federatingprotocol.go
@@ -216,7 +216,6 @@ func (f *Federator) AuthenticatePostInbox(ctx context.Context, w http.ResponseWr
 			// If codes 400, 401, or 403, obey the go-fed
 			// interface by writing the header and bailing.
 			w.WriteHeader(errWithCode.Code())
-			return ctx, false, nil
 		case http.StatusGone:
 			// If the requesting account's key has gone
 			// (410) then likely inbox post was a delete.
@@ -225,11 +224,11 @@ func (f *Federator) AuthenticatePostInbox(ctx context.Context, w http.ResponseWr
 			// know about the account anyway, so we can't
 			// do any further processing.
 			w.WriteHeader(http.StatusAccepted)
-			return ctx, false, nil
-		default:
-			// Proper error.
-			return ctx, false, err
 		}
+
+		// We still return the error
+		// for later request logging.
+		return ctx, false, err
 	}
 
 	if pubKeyAuth.Handshaking {

--- a/internal/federation/federatingprotocol.go
+++ b/internal/federation/federatingprotocol.go
@@ -228,7 +228,7 @@ func (f *Federator) AuthenticatePostInbox(ctx context.Context, w http.ResponseWr
 
 		// We still return the error
 		// for later request logging.
-		return ctx, false, err
+		return ctx, false, errWithCode
 	}
 
 	if pubKeyAuth.Handshaking {

--- a/internal/federation/federatingprotocol_test.go
+++ b/internal/federation/federatingprotocol_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -30,6 +31,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
 	"github.com/superseriousbusiness/gotosocial/internal/gtscontext"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/testrig"
 	"github.com/superseriousbusiness/httpsig"
@@ -99,7 +101,14 @@ func (suite *FederatingProtocolTestSuite) authenticatePostInbox(
 
 	recorder := httptest.NewRecorder()
 	newContext, authed, err := suite.federator.AuthenticatePostInbox(ctx, recorder, request)
-	if err != nil {
+	if withCode := new(gtserror.WithCode); (errors.As(err, withCode) &&
+		(*withCode).Code() >= 500) || (err != nil && (*withCode) == nil) {
+		// NOTE: the behaviour here is a little strange as we have
+		// the competing code styles of the go-fed interface expecting
+		// that any err is a no-go, but authed bool is intended to be
+		// the main passer of whether failed auth occurred, but we in
+		// the gts codebase use errors to pass-back non-200 status codes,
+		// so we specifically have to check for an internal error code.
 		suite.FailNow(err.Error())
 	}
 


### PR DESCRIPTION
# Description

updates the failed auth error handling on the post inbox route to better handle returned errors, previously we were masking a lot with just "not authenticated" which wasn't the most useful in the logs :D 

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
