### PR TITLE
[chore] Log less output on failed test

### DIFF
--- a/internal/log/syslog_test.go
+++ b/internal/log/syslog_test.go
@@ -62,10 +62,10 @@ func (suite *SyslogTestSuite) TearDownTest() {
 }
 
 func (suite *SyslogTestSuite) TestSyslog() {
-	log.Info(nil, "this is a test of the emergency broadcast system!")
+	log.Error(nil, "this is a test of the emergency broadcast system!")
 
 	entry := <-suite.syslogChannel
-	suite.Regexp(regexp.MustCompile(`timestamp=.* func=.* level=INFO msg="this is a test of the emergency broadcast system!"`), entry["content"])
+	suite.Regexp(regexp.MustCompile(`timestamp=.* func=.* level=ERROR msg="this is a test of the emergency broadcast system!"`), entry["content"])
 }
 
 func (suite *SyslogTestSuite) TestSyslogDisableTimestamp() {
@@ -78,20 +78,20 @@ func (suite *SyslogTestSuite) TestSyslogDisableTimestamp() {
 	// Set old timestamp on return.
 	defer log.SetTimeFormat(timefmt)
 
-	log.Info(nil, "this is a test of the emergency broadcast system!")
+	log.Error(nil, "this is a test of the emergency broadcast system!")
 
 	entry := <-suite.syslogChannel
-	suite.Regexp(regexp.MustCompile(`func=.* level=INFO msg="this is a test of the emergency broadcast system!"`), entry["content"])
+	suite.Regexp(regexp.MustCompile(`func=.* level=ERROR msg="this is a test of the emergency broadcast system!"`), entry["content"])
 }
 
 func (suite *SyslogTestSuite) TestSyslogLongMessage() {
-	log.Warn(nil, longMessage)
+	log.Error(nil, longMessage)
 
 	funcName := log.Caller(2)
-	prefix := fmt.Sprintf(`timestamp="02/01/2006 15:04:05.000" func=%s level=WARN msg="`, funcName)
+	prefix := fmt.Sprintf(`timestamp="02/01/2006 15:04:05.000" func=%s level=ERROR msg="`, funcName)
 
 	entry := <-suite.syslogChannel
-	regex := fmt.Sprintf(`timestamp=.* func=.* level=WARN msg="%s`, longMessage[:2048-len(prefix)])
+	regex := fmt.Sprintf(`timestamp=.* func=.* level=ERROR msg="%s`, longMessage[:2048-len(prefix)])
 	suite.Regexp(regexp.MustCompile(regex), entry["content"])
 }
 

--- a/internal/log/sysloglongunixgram_test.go
+++ b/internal/log/sysloglongunixgram_test.go
@@ -53,13 +53,13 @@ func (suite *SyslogTestSuite) TestSyslogLongMessageUnixgram() {
 
 	testrig.InitTestLog()
 
-	log.Warn(nil, longMessage)
+	log.Error(nil, longMessage)
 
 	funcName := log.Caller(2)
-	prefix := fmt.Sprintf(`timestamp="02/01/2006 15:04:05.000" func=%s level=WARN msg="`, funcName)
+	prefix := fmt.Sprintf(`timestamp="02/01/2006 15:04:05.000" func=%s level=ERROR msg="`, funcName)
 
 	entry := <-syslogChannel
-	regex := fmt.Sprintf(`timestamp=.* func=.* level=WARN msg="%s`, longMessage[:2048-len(prefix)])
+	regex := fmt.Sprintf(`timestamp=.* func=.* level=ERROR msg="%s`, longMessage[:2048-len(prefix)])
 
 	suite.Regexp(regexp.MustCompile(regex), entry["content"])
 

--- a/testrig/config.go
+++ b/testrig/config.go
@@ -18,6 +18,7 @@
 package testrig
 
 import (
+	"os"
 	"time"
 
 	"codeberg.org/gruf/go-bytesize"
@@ -33,8 +34,16 @@ func InitTestConfig() {
 	})
 }
 
+func logLevel() string {
+	level := "error"
+	if lv := os.Getenv("GTS_TESTRIG_LOG_LEVEL"); lv != "" {
+		level = lv
+	}
+	return level
+}
+
 var testDefaults = config.Configuration{
-	LogLevel:           "info",
+	LogLevel:           logLevel(),
 	LogTimestampFormat: "02/01/2006 15:04:05.000",
 	LogDbQueries:       true,
 	ApplicationName:    "gotosocial",


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This changes the testrig log level to be error by default instead of info. This makes test failures a lot easier to read, as we don't have the parade of info logs for each failure to scroll through.

It speeds up the test suite by a couple of seconds since we need to buffer and flush a lot less messages. On a clean run, so no test failures, it's about a 3s difference on my machine. Depending on the amount of test failures, total time saved can vary.

This also introduces a GTS_TESTRIG_LOG_LEVEL environment variable that we explicitly check for, making it easy to override the log level should we have a need for it. This would be primarily for running locally, and not so much as part of go test.

Lastly, it updates the syslog tests to use log.Error because if the log level is set to error but we call log.Info no message is emitted and we hang indefinitely on the channel read.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
