### PR TITLE
[bugfix] defer rows.Close() when using QueryContext

### DIFF
--- a/internal/db/bundb/drivers.go
+++ b/internal/db/bundb/drivers.go
@@ -218,6 +218,7 @@ func (c *SQLiteConn) Query(query string, args []driver.Value) (driver.Rows, erro
 func (c *SQLiteConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (rows driver.Rows, err error) {
 	err = retryOnBusy(ctx, func() error {
 		rows, err = c.conn.QueryContext(ctx, query, args)
+		defer rows.Close()
 		err = processSQLiteError(err)
 		return err
 	})
@@ -276,6 +277,7 @@ func (stmt *SQLiteStmt) Query(args []driver.Value) (driver.Rows, error) {
 func (stmt *SQLiteStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (rows driver.Rows, err error) {
 	err = retryOnBusy(ctx, func() error {
 		rows, err = stmt.stmt.QueryContext(ctx, args)
+		defer rows.Close()
 		err = processSQLiteError(err)
 		return err
 	})


### PR DESCRIPTION
Update our SQLite OnBusy handler to close rows when using QueryContext, ensuring that the connection gets returned properly to the pool.