### PR TITLE
[bugfix] Ensure side effects for local -> local follows get processed

### DIFF
--- a/internal/processing/account/follow.go
+++ b/internal/processing/account/follow.go
@@ -114,7 +114,7 @@ func (p *Processor) FollowCreate(ctx context.Context, requestingAccount *gtsmode
 			err = gtserror.Newf("error accepting follow request for local unlocked account: %w", err)
 			return nil, gtserror.NewErrorInternalError(err)
 		}
-	} else if targetAccount.IsRemote() {
+	} else {
 		// Otherwise we leave the follow request as it is,
 		// and we handle the rest of the process async.
 		p.state.Workers.EnqueueClientAPI(ctx, messages.FromClientAPI{


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

We weren't passing local -> local follow (requests) back to the workers for side effect processing, which led to notifs not being created for local -> local follows. Fixes that!

Closes https://github.com/superseriousbusiness/gotosocial/issues/2813

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
