### PR TITLE
[chore] Turn `accounts-registration-open` false by default

### DIFF
--- a/docs/configuration/accounts.md
+++ b/docs/configuration/accounts.md
@@ -9,10 +9,11 @@
 
 # Config pertaining to creation and maintenance of accounts on the server, as well as defaults for new accounts.
 
-# Bool. Do we want people to be able to just submit sign up requests, or do we want invite only?
+# Bool. Allow people to submit new sign-up / registration requests via the form at /signup.
+#
 # Options: [true, false]
-# Default: true
-accounts-registration-open: true
+# Default: false
+accounts-registration-open: false
 
 # Bool. Are sign up requests required to submit a reason for the request (eg., an explanation of why they want to join the instance)?
 # Options: [true, false]

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -406,10 +406,11 @@ instance-inject-mastodon-version: false
 
 # Config pertaining to creation and maintenance of accounts on the server, as well as defaults for new accounts.
 
-# Bool. Do we want people to be able to just submit sign up requests, or do we want invite only?
+# Bool. Allow people to submit new sign-up / registration requests via the form at /signup.
+#
 # Options: [true, false]
-# Default: true
-accounts-registration-open: true
+# Default: false
+accounts-registration-open: false
 
 # Bool. Are sign up requests required to submit a reason for the request (eg., an explanation of why they want to join the instance)?
 # Options: [true, false]

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -66,7 +66,7 @@ var Defaults = Configuration{
 	InstanceDeliverToSharedInboxes: true,
 	InstanceLanguages:              make(language.Languages, 0),
 
-	AccountsRegistrationOpen: true,
+	AccountsRegistrationOpen: false,
 	AccountsReasonRequired:   true,
 	AccountsAllowCustomCSS:   false,
 	AccountsCustomCSSLength:  10000,


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

I actually thought we already had this `false` by default but it was `true`, so this PR just fixes that!

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
