### PR TITLE
[bugfix] Fix minor API issue w/ boosted statuses

### DIFF
--- a/internal/api/client/statuses/statusboost_test.go
+++ b/internal/api/client/statuses/statusboost_test.go
@@ -100,6 +100,8 @@ func (suite *StatusBoostTestSuite) TestPostBoost() {
 	suite.Len(statusReply.Reblog.MediaAttachments, 1)
 	suite.Len(statusReply.Reblog.Tags, 1)
 	suite.Len(statusReply.Reblog.Emojis, 1)
+	suite.True(statusReply.Reblogged)
+	suite.True(statusReply.Reblog.Reblogged)
 	suite.Equal("superseriousbusiness", statusReply.Reblog.Application.Name)
 }
 
@@ -165,6 +167,8 @@ func (suite *StatusBoostTestSuite) TestPostBoostOwnFollowersOnly() {
 	suite.Empty(responseStatus.Reblog.MediaAttachments)
 	suite.Empty(responseStatus.Reblog.Tags)
 	suite.Empty(responseStatus.Reblog.Emojis)
+	suite.True(responseStatus.Reblogged)
+	suite.True(responseStatus.Reblog.Reblogged)
 	suite.Equal("really cool gts application", responseStatus.Reblog.Application.Name)
 }
 

--- a/internal/typeutils/util.go
+++ b/internal/typeutils/util.go
@@ -36,7 +36,7 @@ import (
 )
 
 type statusInteractions struct {
-	Faved      bool
+	Favourited bool
 	Muted      bool
 	Bookmarked bool
 	Reblogged  bool
@@ -51,7 +51,7 @@ func (c *Converter) interactionsWithStatusForAccount(ctx context.Context, s *gts
 		if err != nil {
 			return nil, fmt.Errorf("error checking if requesting account has faved status: %s", err)
 		}
-		si.Faved = faved
+		si.Favourited = faved
 
 		reblogged, err := c.state.DB.IsStatusBoostedBy(ctx, s.ID, requestingAccount.ID)
 		if err != nil {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Following the Mastodon API we should be taking interaction counts from the boosted status, rather than generating them separately on the boost wrapper status, when serializing via the API.

This PR fixes that by serializing the wrapped reblogged status first, then just taking the interactions from that.

This also means fewer DB calls in total when serializing a boosted status, which is a nice bonus :)

MIGHT be a fix for https://github.com/superseriousbusiness/gotosocial/issues/2844 but i'm not sure.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
