### PR TITLE
[feature] Stub status history endpoint

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -2214,6 +2214,52 @@ definitions:
         type: object
         x-go-name: Context
         x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    statusEdit:
+        description: |-
+            StatusEdit represents one historical revision of a status, containing
+            partial information about the state of the status at that revision.
+        properties:
+            account:
+                $ref: '#/definitions/account'
+            content:
+                description: |-
+                    The content of this status at this revision.
+                    Should be HTML, but might also be plaintext in some cases.
+                example: <p>Hey this is a status!</p>
+                type: string
+                x-go-name: Content
+            created_at:
+                description: The date when this revision was created (ISO 8601 Datetime).
+                example: "2021-07-30T09:20:25+00:00"
+                type: string
+                x-go-name: CreatedAt
+            emojis:
+                description: Custom emoji to be used when rendering status content.
+                items:
+                    $ref: '#/definitions/emoji'
+                type: array
+                x-go-name: Emojis
+            media_attachments:
+                description: Media that is attached to this status.
+                items:
+                    $ref: '#/definitions/attachment'
+                type: array
+                x-go-name: MediaAttachments
+            poll:
+                $ref: '#/definitions/poll'
+            sensitive:
+                description: Status marked sensitive at this revision.
+                example: false
+                type: boolean
+                x-go-name: Sensitive
+            spoiler_text:
+                description: Subject, summary, or content warning for the status at this revision.
+                example: warning nsfw
+                type: string
+                x-go-name: SpoilerText
+        type: object
+        x-go-name: StatusEdit
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
     statusReblogged:
         properties:
             account:
@@ -7462,6 +7508,43 @@ paths:
                 - OAuth2 Bearer:
                     - read:accounts
             summary: View accounts that have faved/starred/liked the target status.
+            tags:
+                - statuses
+    /api/v1/statuses/{id}/history:
+        get:
+            description: 'UNIMPLEMENTED: Currently this endpoint will always return an array of length 1, containing only the latest/current version of the status.'
+            operationId: statusHistoryGet
+            parameters:
+                - description: Target status ID.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: ""
+                    schema:
+                        items:
+                            $ref: '#/definitions/statusEdit'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:statuses
+            summary: View edit history of status with the given ID.
             tags:
                 - statuses
     /api/v1/statuses/{id}/mute:

--- a/internal/api/client/statuses/status.go
+++ b/internal/api/client/statuses/status.go
@@ -64,6 +64,9 @@ const (
 
 	// ContextPath is used for fetching context of posts
 	ContextPath = BasePathWithID + "/context"
+
+	// HistoryPath is used for fetching history of posts.
+	HistoryPath = BasePathWithID + "/history"
 )
 
 type Module struct {
@@ -104,4 +107,7 @@ func (m *Module) Route(attachHandler func(method string, path string, f ...gin.H
 
 	// context / status thread
 	attachHandler(http.MethodGet, ContextPath, m.StatusContextGETHandler)
+
+	// history/edit stuff
+	attachHandler(http.MethodGet, HistoryPath, m.StatusHistoryGETHandler)
 }

--- a/internal/api/client/statuses/statushistory.go
+++ b/internal/api/client/statuses/statushistory.go
@@ -1,0 +1,97 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package statuses
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+	"github.com/superseriousbusiness/gotosocial/internal/oauth"
+)
+
+// StatusHistoryGETHandler swagger:operation GET /api/v1/statuses/{id}/history statusHistoryGet
+//
+// View edit history of status with the given ID.
+//
+// UNIMPLEMENTED: Currently this endpoint will always return an array of length 1, containing only the latest/current version of the status.
+//
+//	---
+//	tags:
+//	- statuses
+//
+//	produces:
+//	- application/json
+//
+//	parameters:
+//	-
+//		name: id
+//		type: string
+//		description: Target status ID.
+//		in: path
+//		required: true
+//
+//	security:
+//	- OAuth2 Bearer:
+//		- read:statuses
+//
+//	responses:
+//		'200':
+//			schema:
+//				type: array
+//				items:
+//					"$ref": "#/definitions/statusEdit"
+//		'400':
+//			description: bad request
+//		'401':
+//			description: unauthorized
+//		'403':
+//			description: forbidden
+//		'404':
+//			description: not found
+//		'406':
+//			description: not acceptable
+//		'500':
+//			description: internal server error
+func (m *Module) StatusHistoryGETHandler(c *gin.Context) {
+	authed, err := oauth.Authed(c, true, true, true, true)
+	if err != nil {
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
+		return
+	}
+
+	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
+		return
+	}
+
+	targetStatusID, errWithCode := apiutil.ParseID(c.Param(IDKey))
+	if errWithCode != nil {
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
+		return
+	}
+
+	resp, errWithCode := m.processor.Status().HistoryGet(c.Request.Context(), authed.Account, targetStatusID)
+	if errWithCode != nil {
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+}

--- a/internal/api/client/statuses/statushistory_test.go
+++ b/internal/api/client/statuses/statushistory_test.go
@@ -1,0 +1,133 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package statuses_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/api/client/statuses"
+	"github.com/superseriousbusiness/gotosocial/internal/oauth"
+	"github.com/superseriousbusiness/gotosocial/testrig"
+)
+
+type StatusHistoryTestSuite struct {
+	StatusStandardTestSuite
+}
+
+func (suite *StatusHistoryTestSuite) TestGetHistory() {
+	var (
+		testApplication = suite.testApplications["application_1"]
+		testAccount     = suite.testAccounts["local_account_1"]
+		testUser        = suite.testUsers["local_account_1"]
+		testToken       = oauth.DBTokenToToken(suite.testTokens["local_account_1"])
+		targetStatusID  = suite.testStatuses["local_account_1_status_1"].ID
+		target          = fmt.Sprintf("http://localhost:8080%s", strings.ReplaceAll(statuses.HistoryPath, ":id", targetStatusID))
+	)
+
+	// Setup request.
+	recorder := httptest.NewRecorder()
+	request :=  httptest.NewRequest(http.MethodGet, target, nil)
+	request.Header.Set("accept", "application/json")
+	ctx, _ := testrig.CreateGinTestContext(recorder, request)
+	
+	// Set auth + path params.
+	ctx.Set(oauth.SessionAuthorizedApplication, testApplication)
+	ctx.Set(oauth.SessionAuthorizedToken, testToken)
+	ctx.Set(oauth.SessionAuthorizedUser, testUser)
+	ctx.Set(oauth.SessionAuthorizedAccount, testAccount)
+	ctx.Params = gin.Params{
+		gin.Param{
+			Key:   statuses.IDKey,
+			Value: targetStatusID,
+		},
+	}
+
+	// Call the handler.
+	suite.statusModule.StatusHistoryGETHandler(ctx)
+
+	// Check code.
+	if code := recorder.Code; code != http.StatusOK {
+		suite.FailNow("", "unexpected http code: %d", code)
+	}
+
+	// Read body.
+	result := recorder.Result()
+	defer result.Body.Close()
+
+	b, err := io.ReadAll(result.Body)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// Indent nicely.
+	dst := new(bytes.Buffer)
+	if err := json.Indent(dst, b, "", "  "); err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Equal(`[
+  {
+    "content": "hello everyone!",
+    "spoiler_text": "introduction post",
+    "sensitive": true,
+    "created_at": "2021-10-20T10:40:37.000Z",
+    "account": {
+      "id": "01F8MH1H7YV1Z7D2C8K2730QBF",
+      "username": "the_mighty_zork",
+      "acct": "the_mighty_zork",
+      "display_name": "original zork (he/they)",
+      "locked": false,
+      "discoverable": true,
+      "bot": false,
+      "created_at": "2022-05-20T11:09:18.000Z",
+      "note": "\u003cp\u003ehey yo this is my profile!\u003c/p\u003e",
+      "url": "http://localhost:8080/@the_mighty_zork",
+      "avatar": "http://localhost:8080/fileserver/01F8MH1H7YV1Z7D2C8K2730QBF/avatar/original/01F8MH58A357CV5K7R7TJMSH6S.jpg",
+      "avatar_static": "http://localhost:8080/fileserver/01F8MH1H7YV1Z7D2C8K2730QBF/avatar/small/01F8MH58A357CV5K7R7TJMSH6S.jpg",
+      "header": "http://localhost:8080/fileserver/01F8MH1H7YV1Z7D2C8K2730QBF/header/original/01PFPMWK2FF0D9WMHEJHR07C3Q.jpg",
+      "header_static": "http://localhost:8080/fileserver/01F8MH1H7YV1Z7D2C8K2730QBF/header/small/01PFPMWK2FF0D9WMHEJHR07C3Q.jpg",
+      "followers_count": 2,
+      "following_count": 2,
+      "statuses_count": 7,
+      "last_status_at": "2023-12-10T09:24:00.000Z",
+      "emojis": [],
+      "fields": [],
+      "enable_rss": true,
+      "role": {
+        "name": "user"
+      }
+    },
+    "poll": null,
+    "media_attachments": [],
+    "emojis": []
+  }
+]`, dst.String())
+}
+
+func TestStatusHistoryTestSuite(t *testing.T) {
+	suite.Run(t, new(StatusHistoryTestSuite))
+}

--- a/internal/api/model/status.go
+++ b/internal/api/model/status.go
@@ -249,3 +249,33 @@ const (
 	StatusContentTypeMarkdown StatusContentType = "text/markdown"
 	StatusContentTypeDefault                    = StatusContentTypePlain
 )
+
+// StatusEdit represents one historical revision of a status, containing
+// partial information about the state of the status at that revision.
+//
+// swagger:model statusEdit
+type StatusEdit struct {
+	// The content of this status at this revision.
+	// Should be HTML, but might also be plaintext in some cases.
+	// example: <p>Hey this is a status!</p>
+	Content string `json:"content"`
+	// Subject, summary, or content warning for the status at this revision.
+	// example: warning nsfw
+	SpoilerText string `json:"spoiler_text"`
+	// Status marked sensitive at this revision.
+	// example: false
+	Sensitive bool `json:"sensitive"`
+	// The date when this revision was created (ISO 8601 Datetime).
+	// example: 2021-07-30T09:20:25+00:00
+	CreatedAt string `json:"created_at"`
+	// The account that authored this status.
+	Account *Account `json:"account"`
+	// The poll attached to the status at this revision.
+	// Note that edits changing the poll options will be collapsed together into one edit, since this action resets the poll.
+	// nullable: true
+	Poll *Poll `json:"poll"`
+	// Media that is attached to this status.
+	MediaAttachments []*Attachment `json:"media_attachments"`
+	// Custom emoji to be used when rendering status content.
+	Emojis []Emoji `json:"emojis"`
+}

--- a/internal/processing/status/get.go
+++ b/internal/processing/status/get.go
@@ -25,7 +25,39 @@ import (
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
+
+// HistoryGet gets edit history for the target status, taking account of privacy settings and blocks etc.
+// TODO: currently this just returns the latest version of the status.
+func (p *Processor) HistoryGet(ctx context.Context, requestingAccount *gtsmodel.Account, targetStatusID string) ([]*apimodel.StatusEdit, gtserror.WithCode) {
+	targetStatus, errWithCode := p.c.GetVisibleTargetStatus(ctx,
+		requestingAccount,
+		targetStatusID,
+		nil, // default freshness
+	)
+	if errWithCode != nil {
+		return nil, errWithCode
+	}
+
+	apiStatus, errWithCode := p.c.GetAPIStatus(ctx, requestingAccount, targetStatus)
+	if errWithCode != nil {
+		return nil, errWithCode
+	}
+
+	return []*apimodel.StatusEdit{
+		{
+			Content:          apiStatus.Content,
+			SpoilerText:      apiStatus.SpoilerText,
+			Sensitive:        apiStatus.Sensitive,
+			CreatedAt:        util.FormatISO8601(targetStatus.UpdatedAt),
+			Account:          apiStatus.Account,
+			Poll:             apiStatus.Poll,
+			MediaAttachments: apiStatus.MediaAttachments,
+			Emojis:           apiStatus.Emojis,
+		},
+	}, nil
+}
 
 // Get gets the given status, taking account of privacy settings and blocks etc.
 func (p *Processor) Get(ctx context.Context, requestingAccount *gtsmodel.Account, targetStatusID string) (*apimodel.Status, gtserror.WithCode) {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request implements a stub for the `/api/v1/statuses/{id}/history` endpoint, which just returns a single-length array of status edits with the current/latest revision. See https://docs.joinmastodon.org/entities/StatusEdit/ and https://docs.joinmastodon.org/methods/statuses/#history.

In future when we implement storing revisions/edit history we can flesh this endpoint out.

Should close https://github.com/superseriousbusiness/gotosocial/issues/1681

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
