### PR TITLE
[feature] Stub account mutes endpoint

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -6745,6 +6745,67 @@ paths:
             summary: Update a media attachment.
             tags:
                 - media
+    /api/v1/mutes:
+        get:
+            description: |-
+                NOT IMPLEMENTED YET: Will currently always return an array of length 0.
+
+                The next and previous queries can be parsed from the returned Link header.
+                Example:
+
+                ```
+                <https://example.org/api/v1/mutes?limit=80&max_id=01FC0SKA48HNSVR6YKZCQGS2V8>; rel="next", <https://example.org/api/v1/mutes?limit=80&min_id=01FC0SKW5JK2Q4EVAV2B462YY0>; rel="prev"
+                ````
+            operationId: mutesGet
+            parameters:
+                - description: 'Return only muted accounts *OLDER* than the given max ID. The muted account with the specified ID will not be included in the response. NOTE: the ID is of the internal mute, NOT any of the returned accounts.'
+                  in: query
+                  name: max_id
+                  type: string
+                - description: 'Return only muted accounts *NEWER* than the given since ID. The muted account with the specified ID will not be included in the response. NOTE: the ID is of the internal mute, NOT any of the returned accounts.'
+                  in: query
+                  name: since_id
+                  type: string
+                - description: 'Return only muted accounts *IMMEDIATELY NEWER* than the given min ID. The muted account with the specified ID will not be included in the response. NOTE: the ID is of the internal mute, NOT any of the returned accounts.'
+                  in: query
+                  name: min_id
+                  type: string
+                - default: 40
+                  description: Number of muted accounts to return.
+                  in: query
+                  maximum: 80
+                  minimum: 1
+                  name: limit
+                  type: integer
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: ""
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
+                    schema:
+                        items:
+                            $ref: '#/definitions/account'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:mutes
+            summary: Get an array of accounts that requesting account has muted.
+            tags:
+                - mutes
     /api/v1/notification/{id}:
         get:
             operationId: notification

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -35,6 +35,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/lists"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/markers"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/media"
+	"github.com/superseriousbusiness/gotosocial/internal/api/client/mutes"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/notifications"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/polls"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/preferences"
@@ -68,6 +69,7 @@ type Client struct {
 	lists          *lists.Module          // api/v1/lists
 	markers        *markers.Module        // api/v1/markers
 	media          *media.Module          // api/v1/media, api/v2/media
+	mutes          *mutes.Module          // api/v1/mutes
 	notifications  *notifications.Module  // api/v1/notifications
 	polls          *polls.Module          // api/v1/polls
 	preferences    *preferences.Module    // api/v1/preferences
@@ -110,6 +112,7 @@ func (c *Client) Route(r *router.Router, m ...gin.HandlerFunc) {
 	c.lists.Route(h)
 	c.markers.Route(h)
 	c.media.Route(h)
+	c.mutes.Route(h)
 	c.notifications.Route(h)
 	c.polls.Route(h)
 	c.preferences.Route(h)
@@ -140,6 +143,7 @@ func NewClient(db db.DB, p *processing.Processor) *Client {
 		lists:          lists.New(p),
 		markers:        markers.New(p),
 		media:          media.New(p),
+		mutes:          mutes.New(p),
 		notifications:  notifications.New(p),
 		polls:          polls.New(p),
 		preferences:    preferences.New(p),

--- a/internal/api/client/mutes/mutes.go
+++ b/internal/api/client/mutes/mutes.go
@@ -1,0 +1,44 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package mutes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/processing"
+)
+
+const (
+	// BasePath is the base URI path for serving mutes, minus the api prefix.
+	BasePath = "/v1/mutes"
+)
+
+type Module struct {
+	processor *processing.Processor
+}
+
+func New(processor *processing.Processor) *Module {
+	return &Module{
+		processor: processor,
+	}
+}
+
+func (m *Module) Route(attachHandler func(method string, path string, f ...gin.HandlerFunc) gin.IRoutes) {
+	attachHandler(http.MethodGet, BasePath, m.MutesGETHandler)
+}

--- a/internal/api/client/mutes/mutesget.go
+++ b/internal/api/client/mutes/mutesget.go
@@ -1,0 +1,122 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package mutes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+	"github.com/superseriousbusiness/gotosocial/internal/oauth"
+)
+
+// MutesGETHandler swagger:operation GET /api/v1/mutes mutesGet
+//
+// Get an array of accounts that requesting account has muted.
+//
+// NOT IMPLEMENTED YET: Will currently always return an array of length 0.
+//
+// The next and previous queries can be parsed from the returned Link header.
+// Example:
+//
+// ```
+// <https://example.org/api/v1/mutes?limit=80&max_id=01FC0SKA48HNSVR6YKZCQGS2V8>; rel="next", <https://example.org/api/v1/mutes?limit=80&min_id=01FC0SKW5JK2Q4EVAV2B462YY0>; rel="prev"
+// ````
+//
+//	---
+//	tags:
+//	- mutes
+//
+//	produces:
+//	- application/json
+//
+//	parameters:
+//	-
+//		name: max_id
+//		type: string
+//		description: >-
+//			Return only muted accounts *OLDER* than the given max ID.
+//			The muted account with the specified ID will not be included in the response.
+//			NOTE: the ID is of the internal mute, NOT any of the returned accounts.
+//		in: query
+//		required: false
+//	-
+//		name: since_id
+//		type: string
+//		description: >-
+//			Return only muted accounts *NEWER* than the given since ID.
+//			The muted account with the specified ID will not be included in the response.
+//			NOTE: the ID is of the internal mute, NOT any of the returned accounts.
+//		in: query
+//	-
+//		name: min_id
+//		type: string
+//		description: >-
+//			Return only muted accounts *IMMEDIATELY NEWER* than the given min ID.
+//			The muted account with the specified ID will not be included in the response.
+//			NOTE: the ID is of the internal mute, NOT any of the returned accounts.
+//		in: query
+//		required: false
+//	-
+//		name: limit
+//		type: integer
+//		description: Number of muted accounts to return.
+//		default: 40
+//		minimum: 1
+//		maximum: 80
+//		in: query
+//		required: false
+//
+//	security:
+//	- OAuth2 Bearer:
+//		- read:mutes
+//
+//	responses:
+//		'200':
+//			headers:
+//				Link:
+//					type: string
+//					description: Links to the next and previous queries.
+//			schema:
+//				type: array
+//				items:
+//					"$ref": "#/definitions/account"
+//		'400':
+//			description: bad request
+//		'401':
+//			description: unauthorized
+//		'404':
+//			description: not found
+//		'406':
+//			description: not acceptable
+//		'500':
+//			description: internal server error
+func (m *Module) MutesGETHandler(c *gin.Context) {
+	if _, err := oauth.Authed(c, true, true, true, true); err != nil {
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
+		return
+	}
+
+	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
+		return
+	}
+
+	apiutil.Data(c, http.StatusOK, apiutil.AppJSON, apiutil.EmptyJSONArray)
+}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request just stubs out the mutes endpoint to always return an empty array. Not being able to fetch mutes was causing issues for some clients, and we'll eventually implement it anyway so stubbing it now makes sense.

Should help with https://github.com/superseriousbusiness/gotosocial/issues/2845

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
