### PR TITLE
[feature] Stub conversations endpoint

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -818,6 +818,30 @@ definitions:
         type: object
         x-go-name: Card
         x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
+    conversation:
+        description: |-
+            Conversation represents a conversation
+            with "direct message" visibility.
+        properties:
+            accounts:
+                description: Participants in the conversation.
+                items:
+                    $ref: '#/definitions/account'
+                type: array
+                x-go-name: Accounts
+            id:
+                description: Local database ID of the conversation.
+                type: string
+                x-go-name: ID
+            last_status:
+                $ref: '#/definitions/status'
+            unread:
+                description: Is the conversation currently marked as unread?
+                type: boolean
+                x-go-name: Unread
+        type: object
+        x-go-name: Conversation
+        x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
     debugAPUrlResponse:
         description: |-
             DebugAPUrlResponse provides detailed debug
@@ -5595,6 +5619,67 @@ paths:
                     - read:bookmarks
             tags:
                 - bookmarks
+    /api/v1/conversations:
+        get:
+            description: |-
+                NOT IMPLEMENTED YET: Will currently always return an array of length 0.
+
+                The next and previous queries can be parsed from the returned Link header.
+                Example:
+
+                ```
+                <https://example.org/api/v1/conversations?limit=80&max_id=01FC0SKA48HNSVR6YKZCQGS2V8>; rel="next", <https://example.org/api/v1/conversations?limit=80&min_id=01FC0SKW5JK2Q4EVAV2B462YY0>; rel="prev"
+                ````
+            operationId: conversationsGet
+            parameters:
+                - description: 'Return only conversations *OLDER* than the given max ID. The conversation with the specified ID will not be included in the response. NOTE: the ID is of the internal conversation, use the Link header for pagination.'
+                  in: query
+                  name: max_id
+                  type: string
+                - description: 'Return only conversations *NEWER* than the given since ID. The conversation with the specified ID will not be included in the response. NOTE: the ID is of the internal conversation, use the Link header for pagination.'
+                  in: query
+                  name: since_id
+                  type: string
+                - description: 'Return only conversations *IMMEDIATELY NEWER* than the given min ID. The conversation with the specified ID will not be included in the response. NOTE: the ID is of the internal conversation, use the Link header for pagination.'
+                  in: query
+                  name: min_id
+                  type: string
+                - default: 40
+                  description: Number of conversations to return.
+                  in: query
+                  maximum: 80
+                  minimum: 1
+                  name: limit
+                  type: integer
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: ""
+                    headers:
+                        Link:
+                            description: Links to the next and previous queries.
+                            type: string
+                    schema:
+                        items:
+                            $ref: '#/definitions/conversation'
+                        type: array
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:statuses
+            summary: Get an array of (direct message) conversations that requesting account is involved in.
+            tags:
+                - conversations
     /api/v1/custom_emojis:
         get:
             operationId: customEmojisGet

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -26,6 +26,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/apps"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/blocks"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/bookmarks"
+	"github.com/superseriousbusiness/gotosocial/internal/api/client/conversations"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/customemojis"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/favourites"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/featuredtags"
@@ -60,6 +61,7 @@ type Client struct {
 	apps           *apps.Module           // api/v1/apps
 	blocks         *blocks.Module         // api/v1/blocks
 	bookmarks      *bookmarks.Module      // api/v1/bookmarks
+	conversations  *conversations.Module  // api/v1/conversations
 	customEmojis   *customemojis.Module   // api/v1/custom_emojis
 	favourites     *favourites.Module     // api/v1/favourites
 	featuredTags   *featuredtags.Module   // api/v1/featured_tags
@@ -103,6 +105,7 @@ func (c *Client) Route(r *router.Router, m ...gin.HandlerFunc) {
 	c.apps.Route(h)
 	c.blocks.Route(h)
 	c.bookmarks.Route(h)
+	c.conversations.Route(h)
 	c.customEmojis.Route(h)
 	c.favourites.Route(h)
 	c.featuredTags.Route(h)
@@ -134,6 +137,7 @@ func NewClient(db db.DB, p *processing.Processor) *Client {
 		apps:           apps.New(p),
 		blocks:         blocks.New(p),
 		bookmarks:      bookmarks.New(p),
+		conversations:  conversations.New(p),
 		customEmojis:   customemojis.New(p),
 		favourites:     favourites.New(p),
 		featuredTags:   featuredtags.New(p),

--- a/internal/api/client/conversations/conversations.go
+++ b/internal/api/client/conversations/conversations.go
@@ -15,19 +15,31 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package model
+package conversations
 
-// Conversation represents a conversation
-// with "direct message" visibility.
-//
-// swagger:model conversation
-type Conversation struct {
-	// Local database ID of the conversation.
-	ID string `json:"id"`
-	// Is the conversation currently marked as unread?
-	Unread bool `json:"unread"`
-	// Participants in the conversation.
-	Accounts []Account `json:"accounts"`
-	// The last status in the conversation. May be `null`.
-	LastStatus *Status `json:"last_status"`
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/processing"
+)
+
+const (
+	// BasePath is the base URI path for serving
+	// conversations, minus the api prefix.
+	BasePath = "/v1/conversations"
+)
+
+type Module struct {
+	processor *processing.Processor
+}
+
+func New(processor *processing.Processor) *Module {
+	return &Module{
+		processor: processor,
+	}
+}
+
+func (m *Module) Route(attachHandler func(method string, path string, f ...gin.HandlerFunc) gin.IRoutes) {
+	attachHandler(http.MethodGet, BasePath, m.ConversationsGETHandler)
 }

--- a/internal/api/client/conversations/conversationsget.go
+++ b/internal/api/client/conversations/conversationsget.go
@@ -1,0 +1,122 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package conversations
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+	"github.com/superseriousbusiness/gotosocial/internal/oauth"
+)
+
+// ConversationsGETHandler swagger:operation GET /api/v1/conversations conversationsGet
+//
+// Get an array of (direct message) conversations that requesting account is involved in.
+//
+// NOT IMPLEMENTED YET: Will currently always return an array of length 0.
+//
+// The next and previous queries can be parsed from the returned Link header.
+// Example:
+//
+// ```
+// <https://example.org/api/v1/conversations?limit=80&max_id=01FC0SKA48HNSVR6YKZCQGS2V8>; rel="next", <https://example.org/api/v1/conversations?limit=80&min_id=01FC0SKW5JK2Q4EVAV2B462YY0>; rel="prev"
+// ````
+//
+//	---
+//	tags:
+//	- conversations
+//
+//	produces:
+//	- application/json
+//
+//	parameters:
+//	-
+//		name: max_id
+//		type: string
+//		description: >-
+//			Return only conversations *OLDER* than the given max ID.
+//			The conversation with the specified ID will not be included in the response.
+//			NOTE: the ID is of the internal conversation, use the Link header for pagination.
+//		in: query
+//		required: false
+//	-
+//		name: since_id
+//		type: string
+//		description: >-
+//			Return only conversations *NEWER* than the given since ID.
+//			The conversation with the specified ID will not be included in the response.
+//			NOTE: the ID is of the internal conversation, use the Link header for pagination.
+//		in: query
+//	-
+//		name: min_id
+//		type: string
+//		description: >-
+//			Return only conversations *IMMEDIATELY NEWER* than the given min ID.
+//			The conversation with the specified ID will not be included in the response.
+//			NOTE: the ID is of the internal conversation, use the Link header for pagination.
+//		in: query
+//		required: false
+//	-
+//		name: limit
+//		type: integer
+//		description: Number of conversations to return.
+//		default: 40
+//		minimum: 1
+//		maximum: 80
+//		in: query
+//		required: false
+//
+//	security:
+//	- OAuth2 Bearer:
+//		- read:statuses
+//
+//	responses:
+//		'200':
+//			headers:
+//				Link:
+//					type: string
+//					description: Links to the next and previous queries.
+//			schema:
+//				type: array
+//				items:
+//					"$ref": "#/definitions/conversation"
+//		'400':
+//			description: bad request
+//		'401':
+//			description: unauthorized
+//		'404':
+//			description: not found
+//		'406':
+//			description: not acceptable
+//		'500':
+//			description: internal server error
+func (m *Module) ConversationsGETHandler(c *gin.Context) {
+	if _, err := oauth.Authed(c, true, true, true, true); err != nil {
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
+		return
+	}
+
+	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
+		return
+	}
+
+	apiutil.Data(c, http.StatusOK, apiutil.AppJSON, apiutil.EmptyJSONArray)
+}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request stubs the /api/v1/conversations endpoint to always return an empty array (until we implement it properly).

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
