### PR TITLE
[chore] Upgrade our Go version to 1.22

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,7 +28,7 @@ steps:
           - pull_request
 
   - name: test
-    image: golang:1.21-alpine
+    image: golang:1.22-alpine
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -80,7 +80,7 @@ steps:
       - yarn --cwd ./web/source build
 
   - name: snapshot
-    image: superseriousbusiness/gotosocial-drone-build:0.4.0 # https://github.com/superseriousbusiness/gotosocial-drone-build
+    image: superseriousbusiness/gotosocial-drone-build:0.5.0 # https://github.com/superseriousbusiness/gotosocial-drone-build
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -121,7 +121,7 @@ steps:
           - main
 
   - name: release
-    image: superseriousbusiness/gotosocial-drone-build:0.4.0 # https://github.com/superseriousbusiness/gotosocial-drone-build
+    image: superseriousbusiness/gotosocial-drone-build:0.5.0 # https://github.com/superseriousbusiness/gotosocial-drone-build
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -180,7 +180,7 @@ clone:
 
 steps:
   - name: mirror
-    image: superseriousbusiness/gotosocial-drone-build:0.4.0
+    image: superseriousbusiness/gotosocial-drone-build:0.5.0
     environment:
       ORIGIN_REPO: https://github.com/superseriousbusiness/gotosocial
       TARGET_REPO: https://codeberg.org/superseriousbusiness/gotosocial

--- a/.drone.yml
+++ b/.drone.yml
@@ -193,6 +193,6 @@ steps:
 
 ---
 kind: signature
-hmac: 4789cebf9156b2c3cb0f097311ea7620e709e4332f130dcae51a938515dc952e
+hmac: f7ef1e0d3d4fe0a55d43ba0ab5ed6cb5f5c8bf00791464ce7b251a3cdbfd954a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ steps:
   # We use golangci-lint for linting.
   # See: https://golangci-lint.run/
   - name: lint
-    image: golangci/golangci-lint:v1.55.0
+    image: golangci/golangci-lint:v1.57.2
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN yarn --cwd ./web/source install && \
     rm -rf ./web/source
 
 # stage 3: build the executor container
-FROM --platform=${TARGETPLATFORM} alpine:3.17.2 as executor
+FROM --platform=${TARGETPLATFORM} alpine:3.19.1 as executor
 
 # switch to non-root user:group for GtS
 USER 1000:1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile reference: https://docs.docker.com/engine/reference/builder/
 
 # stage 1: generate up-to-date swagger.yaml to put in the final container
-FROM --platform=${BUILDPLATFORM} golang:1.21-alpine AS swagger
+FROM --platform=${BUILDPLATFORM} golang:1.22-alpine AS swagger
 
 RUN \
     ### Installs goswagger for building swagger definitions inside this container

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/superseriousbusiness/gotosocial
 
-go 1.21
+go 1.22
 
 replace modernc.org/sqlite => gitlab.com/NyaaaWhatsUpDoc/sqlite v1.29.8-concurrency-workaround
 
-toolchain go1.21.3
+toolchain go1.22.2
 
 require (
 	codeberg.org/gruf/go-bytes v1.0.2

--- a/internal/oauth/util.go
+++ b/internal/oauth/util.go
@@ -1,3 +1,20 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package oauth
 
 import (


### PR DESCRIPTION
# Description

With Go 1.22 having been released at the start of February, it's now been a few months. No major issues have shown up, and the two point release since then have primarily been security fixes plus some general bug fixing.

This sets the required Go version to 1.22, as there's nothing in 1.22.1 or 1.22.2 that we would explicitly require. It sets the toolchain to the latest point release, to ensure we pick up any fixes from there when building releases etc.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
