### PR TITLE
[chore] Update setting testrig loglevel

### DIFF
--- a/testrig/config.go
+++ b/testrig/config.go
@@ -18,6 +18,7 @@
 package testrig
 
 import (
+	"cmp"
 	"os"
 	"time"
 
@@ -34,16 +35,8 @@ func InitTestConfig() {
 	})
 }
 
-func logLevel() string {
-	level := "error"
-	if lv := os.Getenv("GTS_LOG_LEVEL"); lv != "" {
-		level = lv
-	}
-	return level
-}
-
 var testDefaults = config.Configuration{
-	LogLevel:           logLevel(),
+	LogLevel:           cmp.Or(os.Getenv("GTS_LOG_LEVEL"), "error"),
 	LogTimestampFormat: "02/01/2006 15:04:05.000",
 	LogDbQueries:       true,
 	ApplicationName:    "gotosocial",


### PR DESCRIPTION
# Description

cmp.Or was introduced in Go 1.22 and picks the first value that's not the zero value for the type. For a string, the zero value is the empty string, which is what os.Getenv will return if the environment variable is not set. That then results in "error" being returned instead.

This allows loading an environment variable with a default without having to do the check and write out the conditional.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
