### PR TITLE
[bugfix/chore] Tidy up remaining references to workers in cmd

### DIFF
--- a/cmd/gotosocial/action/admin/account/account.go
+++ b/cmd/gotosocial/action/admin/account/account.go
@@ -52,7 +52,6 @@ func initState(ctx context.Context) (*state.State, error) {
 
 func stopState(state *state.State) error {
 	err := state.DB.Close()
-	state.Workers.Stop()
 	state.Caches.Stop()
 	return err
 }

--- a/cmd/gotosocial/action/admin/media/list.go
+++ b/cmd/gotosocial/action/admin/media/list.go
@@ -127,8 +127,6 @@ func setupList(ctx context.Context) (*list, error) {
 	state.Caches.Init()
 	state.Caches.Start()
 
-	state.Workers.Start()
-
 	dbService, err := bundb.NewBunDBService(ctx, &state)
 	if err != nil {
 		return nil, fmt.Errorf("error creating dbservice: %w", err)
@@ -148,7 +146,6 @@ func setupList(ctx context.Context) (*list, error) {
 func (l *list) shutdown() error {
 	l.out.Flush()
 	err := l.dbService.Close()
-	l.state.Workers.Stop()
 	l.state.Caches.Stop()
 	return err
 }

--- a/cmd/gotosocial/action/admin/media/prune/common.go
+++ b/cmd/gotosocial/action/admin/media/prune/common.go
@@ -88,7 +88,7 @@ func (p *prune) shutdown() error {
 		errs.Appendf("error stopping database: %w", err)
 	}
 
-	p.state.Workers.Stop()
+	p.state.Workers.Scheduler.Stop()
 	p.state.Caches.Stop()
 
 	return errs.Combine()


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Along with https://github.com/superseriousbusiness/gotosocial/pull/2865, this should close https://github.com/superseriousbusiness/gotosocial/issues/2843 by removing remaining references to unused workers in CLI setup/teardown.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
