### PR TITLE
[bugfix] Lock when checking/creating notifs to avoid race

### DIFF
--- a/internal/processing/account/move.go
+++ b/internal/processing/account/move.go
@@ -113,7 +113,7 @@ func (p *Processor) MoveSelf(
 	// in quick succession, so get a lock on
 	// this account.
 	lockKey := originAcct.URI
-	unlock := p.state.AccountLocks.Lock(lockKey)
+	unlock := p.state.ProcessingLocks.Lock(lockKey)
 	defer unlock()
 
 	// Ensure we have a valid, up-to-date representation of the target account.

--- a/internal/processing/admin/accountapprove.go
+++ b/internal/processing/admin/accountapprove.go
@@ -49,7 +49,7 @@ func (p *Processor) AccountApprove(
 	// Get a lock on the account URI,
 	// to ensure it's not also being
 	// rejected at the same time!
-	unlock := p.state.AccountLocks.Lock(user.Account.URI)
+	unlock := p.state.ProcessingLocks.Lock(user.Account.URI)
 	defer unlock()
 
 	if !*user.Approved {

--- a/internal/processing/admin/accountreject.go
+++ b/internal/processing/admin/accountreject.go
@@ -52,7 +52,7 @@ func (p *Processor) AccountReject(
 	// Get a lock on the account URI,
 	// since we're going to be deleting
 	// it and its associated user.
-	unlock := p.state.AccountLocks.Lock(user.Account.URI)
+	unlock := p.state.ProcessingLocks.Lock(user.Account.URI)
 	defer unlock()
 
 	// Can't reject an account with a

--- a/internal/processing/status/pin.go
+++ b/internal/processing/status/pin.go
@@ -83,7 +83,7 @@ func (p *Processor) PinCreate(ctx context.Context, requestingAccount *gtsmodel.A
 	}
 
 	// Get a lock on this account.
-	unlock := p.state.AccountLocks.Lock(requestingAccount.URI)
+	unlock := p.state.ProcessingLocks.Lock(requestingAccount.URI)
 	defer unlock()
 
 	if !targetStatus.PinnedAt.IsZero() {
@@ -148,7 +148,7 @@ func (p *Processor) PinRemove(ctx context.Context, requestingAccount *gtsmodel.A
 	}
 
 	// Get a lock on this account.
-	unlock := p.state.AccountLocks.Lock(requestingAccount.URI)
+	unlock := p.state.ProcessingLocks.Lock(requestingAccount.URI)
 	defer unlock()
 
 	if targetStatus.PinnedAt.IsZero() {

--- a/internal/processing/workers/fromclientapi.go
+++ b/internal/processing/workers/fromclientapi.go
@@ -41,7 +41,7 @@ import (
 type clientAPI struct {
 	state     *state.State
 	converter *typeutils.Converter
-	surface   *surface
+	surface   *Surface
 	federate  *federate
 	account   *account.Processor
 	utils     *utils

--- a/internal/processing/workers/fromfediapi.go
+++ b/internal/processing/workers/fromfediapi.go
@@ -41,7 +41,7 @@ import (
 // from the federation/ActivityPub API.
 type fediAPI struct {
 	state    *state.State
-	surface  *surface
+	surface  *Surface
 	federate *federate
 	account  *account.Processor
 	utils    *utils

--- a/internal/processing/workers/surface.go
+++ b/internal/processing/workers/surface.go
@@ -25,16 +25,16 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/typeutils"
 )
 
-// surface wraps functions for 'surfacing' the result
+// Surface wraps functions for 'surfacing' the result
 // of processing a message, eg:
 //   - timelining a status
 //   - removing a status from timelines
 //   - sending a notification to a user
 //   - sending an email
-type surface struct {
-	state       *state.State
-	converter   *typeutils.Converter
-	stream      *stream.Processor
-	filter      *visibility.Filter
-	emailSender email.Sender
+type Surface struct {
+	State       *state.State
+	Converter   *typeutils.Converter
+	Stream      *stream.Processor
+	Filter      *visibility.Filter
+	EmailSender email.Sender
 }

--- a/internal/processing/workers/surfacenotify.go
+++ b/internal/processing/workers/surfacenotify.go
@@ -33,7 +33,7 @@ import (
 // notifyMentions iterates through mentions on the
 // given status, and notifies each mentioned account
 // that they have a new mention.
-func (s *surface) notifyMentions(
+func (s *Surface) notifyMentions(
 	ctx context.Context,
 	status *gtsmodel.Status,
 ) error {
@@ -45,7 +45,7 @@ func (s *surface) notifyMentions(
 		mention.Status = status
 
 		// Beforehand, ensure the passed mention is fully populated.
-		if err := s.state.DB.PopulateMention(ctx, mention); err != nil {
+		if err := s.State.DB.PopulateMention(ctx, mention); err != nil {
 			errs.Appendf("error populating mention %s: %w", mention.ID, err)
 			continue
 		}
@@ -58,7 +58,7 @@ func (s *surface) notifyMentions(
 
 		// Ensure thread not muted
 		// by mentioned account.
-		muted, err := s.state.DB.IsThreadMutedByAccount(
+		muted, err := s.State.DB.IsThreadMutedByAccount(
 			ctx,
 			status.ThreadID,
 			mention.TargetAccountID,
@@ -77,7 +77,7 @@ func (s *surface) notifyMentions(
 
 		// notify mentioned
 		// by status author.
-		if err := s.notify(ctx,
+		if err := s.Notify(ctx,
 			gtsmodel.NotificationMention,
 			mention.TargetAccount,
 			mention.OriginAccount,
@@ -93,12 +93,12 @@ func (s *surface) notifyMentions(
 
 // notifyFollowRequest notifies the target of the given
 // follow request that they have a new follow request.
-func (s *surface) notifyFollowRequest(
+func (s *Surface) notifyFollowRequest(
 	ctx context.Context,
 	followReq *gtsmodel.FollowRequest,
 ) error {
 	// Beforehand, ensure the passed follow request is fully populated.
-	if err := s.state.DB.PopulateFollowRequest(ctx, followReq); err != nil {
+	if err := s.State.DB.PopulateFollowRequest(ctx, followReq); err != nil {
 		return gtserror.Newf("error populating follow request %s: %w", followReq.ID, err)
 	}
 
@@ -109,7 +109,7 @@ func (s *surface) notifyFollowRequest(
 	}
 
 	// Now notify the follow request itself.
-	if err := s.notify(ctx,
+	if err := s.Notify(ctx,
 		gtsmodel.NotificationFollowRequest,
 		followReq.TargetAccount,
 		followReq.Account,
@@ -125,12 +125,12 @@ func (s *surface) notifyFollowRequest(
 // they have a new follow. It will also remove any previous
 // notification of a follow request, essentially replacing
 // that notification.
-func (s *surface) notifyFollow(
+func (s *Surface) notifyFollow(
 	ctx context.Context,
 	follow *gtsmodel.Follow,
 ) error {
 	// Beforehand, ensure the passed follow is fully populated.
-	if err := s.state.DB.PopulateFollow(ctx, follow); err != nil {
+	if err := s.State.DB.PopulateFollow(ctx, follow); err != nil {
 		return gtserror.Newf("error populating follow %s: %w", follow.ID, err)
 	}
 
@@ -141,7 +141,7 @@ func (s *surface) notifyFollow(
 	}
 
 	// Check if previous follow req notif exists.
-	prevNotif, err := s.state.DB.GetNotification(
+	prevNotif, err := s.State.DB.GetNotification(
 		gtscontext.SetBarebones(ctx),
 		gtsmodel.NotificationFollowRequest,
 		follow.TargetAccountID,
@@ -154,14 +154,14 @@ func (s *surface) notifyFollow(
 
 	if prevNotif != nil {
 		// Previous follow request notif existed, delete it before creating new.
-		if err := s.state.DB.DeleteNotificationByID(ctx, prevNotif.ID); // nocollapse
+		if err := s.State.DB.DeleteNotificationByID(ctx, prevNotif.ID); // nocollapse
 		err != nil && !errors.Is(err, db.ErrNoEntries) {
 			return gtserror.Newf("error deleting notification %s: %w", prevNotif.ID, err)
 		}
 	}
 
 	// Now notify the follow itself.
-	if err := s.notify(ctx,
+	if err := s.Notify(ctx,
 		gtsmodel.NotificationFollow,
 		follow.TargetAccount,
 		follow.Account,
@@ -175,7 +175,7 @@ func (s *surface) notifyFollow(
 
 // notifyFave notifies the target of the given
 // fave that their status has been liked/faved.
-func (s *surface) notifyFave(
+func (s *Surface) notifyFave(
 	ctx context.Context,
 	fave *gtsmodel.StatusFave,
 ) error {
@@ -185,7 +185,7 @@ func (s *surface) notifyFave(
 	}
 
 	// Beforehand, ensure the passed status fave is fully populated.
-	if err := s.state.DB.PopulateStatusFave(ctx, fave); err != nil {
+	if err := s.State.DB.PopulateStatusFave(ctx, fave); err != nil {
 		return gtserror.Newf("error populating fave %s: %w", fave.ID, err)
 	}
 
@@ -197,7 +197,7 @@ func (s *surface) notifyFave(
 
 	// Ensure favee hasn't
 	// muted the thread.
-	muted, err := s.state.DB.IsThreadMutedByAccount(
+	muted, err := s.State.DB.IsThreadMutedByAccount(
 		ctx,
 		fave.Status.ThreadID,
 		fave.TargetAccountID,
@@ -214,7 +214,7 @@ func (s *surface) notifyFave(
 
 	// notify status author
 	// of fave by account.
-	if err := s.notify(ctx,
+	if err := s.Notify(ctx,
 		gtsmodel.NotificationFave,
 		fave.TargetAccount,
 		fave.Account,
@@ -228,7 +228,7 @@ func (s *surface) notifyFave(
 
 // notifyAnnounce notifies the status boost target
 // account that their status has been boosted.
-func (s *surface) notifyAnnounce(
+func (s *Surface) notifyAnnounce(
 	ctx context.Context,
 	status *gtsmodel.Status,
 ) error {
@@ -243,7 +243,7 @@ func (s *surface) notifyAnnounce(
 	}
 
 	// Beforehand, ensure the passed status is fully populated.
-	if err := s.state.DB.PopulateStatus(ctx, status); err != nil {
+	if err := s.State.DB.PopulateStatus(ctx, status); err != nil {
 		return gtserror.Newf("error populating status %s: %w", status.ID, err)
 	}
 
@@ -255,7 +255,7 @@ func (s *surface) notifyAnnounce(
 
 	// Ensure boostee hasn't
 	// muted the thread.
-	muted, err := s.state.DB.IsThreadMutedByAccount(
+	muted, err := s.State.DB.IsThreadMutedByAccount(
 		ctx,
 		status.BoostOf.ThreadID,
 		status.BoostOfAccountID,
@@ -273,7 +273,7 @@ func (s *surface) notifyAnnounce(
 
 	// notify status author
 	// of boost by account.
-	if err := s.notify(ctx,
+	if err := s.Notify(ctx,
 		gtsmodel.NotificationReblog,
 		status.BoostOfAccount,
 		status.Account,
@@ -285,14 +285,14 @@ func (s *surface) notifyAnnounce(
 	return nil
 }
 
-func (s *surface) notifyPollClose(ctx context.Context, status *gtsmodel.Status) error {
+func (s *Surface) notifyPollClose(ctx context.Context, status *gtsmodel.Status) error {
 	// Beforehand, ensure the passed status is fully populated.
-	if err := s.state.DB.PopulateStatus(ctx, status); err != nil {
+	if err := s.State.DB.PopulateStatus(ctx, status); err != nil {
 		return gtserror.Newf("error populating status %s: %w", status.ID, err)
 	}
 
 	// Fetch all votes in the attached status poll.
-	votes, err := s.state.DB.GetPollVotes(ctx, status.PollID)
+	votes, err := s.State.DB.GetPollVotes(ctx, status.PollID)
 	if err != nil {
 		return gtserror.Newf("error getting poll %s votes: %w", status.PollID, err)
 	}
@@ -302,7 +302,7 @@ func (s *surface) notifyPollClose(ctx context.Context, status *gtsmodel.Status) 
 	if status.Account.IsLocal() {
 		// Send a notification to the status
 		// author that their poll has closed!
-		if err := s.notify(ctx,
+		if err := s.Notify(ctx,
 			gtsmodel.NotificationPoll,
 			status.Account,
 			status.Account,
@@ -321,7 +321,7 @@ func (s *surface) notifyPollClose(ctx context.Context, status *gtsmodel.Status) 
 
 		// notify voter that
 		// poll has been closed.
-		if err := s.notify(ctx,
+		if err := s.Notify(ctx,
 			gtsmodel.NotificationPoll,
 			vote.Account,
 			status.Account,
@@ -335,8 +335,8 @@ func (s *surface) notifyPollClose(ctx context.Context, status *gtsmodel.Status) 
 	return errs.Combine()
 }
 
-func (s *surface) notifySignup(ctx context.Context, newUser *gtsmodel.User) error {
-	modAccounts, err := s.state.DB.GetInstanceModerators(ctx)
+func (s *Surface) notifySignup(ctx context.Context, newUser *gtsmodel.User) error {
+	modAccounts, err := s.State.DB.GetInstanceModerators(ctx)
 	if err != nil {
 		if errors.Is(err, db.ErrNoEntries) {
 			// No registered
@@ -349,18 +349,18 @@ func (s *surface) notifySignup(ctx context.Context, newUser *gtsmodel.User) erro
 	}
 
 	// Ensure user + account populated.
-	if err := s.state.DB.PopulateUser(ctx, newUser); err != nil {
+	if err := s.State.DB.PopulateUser(ctx, newUser); err != nil {
 		return gtserror.Newf("db error populating new user: %w", err)
 	}
 
-	if err := s.state.DB.PopulateAccount(ctx, newUser.Account); err != nil {
+	if err := s.State.DB.PopulateAccount(ctx, newUser.Account); err != nil {
 		return gtserror.Newf("db error populating new user's account: %w", err)
 	}
 
 	// Notify each moderator.
 	var errs gtserror.MultiError
 	for _, mod := range modAccounts {
-		if err := s.notify(ctx,
+		if err := s.Notify(ctx,
 			gtsmodel.NotificationSignup,
 			mod,
 			newUser.Account,
@@ -391,7 +391,7 @@ func getNotifyLockURI(
 	return builder.String()
 }
 
-// notify creates, inserts, and streams a new
+// Notify creates, inserts, and streams a new
 // notification to the target account if it
 // doesn't yet exist with the given parameters.
 //
@@ -402,7 +402,7 @@ func getNotifyLockURI(
 //
 // targetAccount and originAccount must be
 // set, but statusID can be an empty string.
-func (s *surface) notify(
+func (s *Surface) Notify(
 	ctx context.Context,
 	notificationType gtsmodel.NotificationType,
 	targetAccount *gtsmodel.Account,
@@ -422,7 +422,7 @@ func (s *surface) notify(
 		originAccount,
 		statusID,
 	)
-	unlock := s.state.ProcessingLocks.Lock(lockURI)
+	unlock := s.State.ProcessingLocks.Lock(lockURI)
 
 	// Wrap the unlock so we
 	// can do granular unlocking.
@@ -431,7 +431,7 @@ func (s *surface) notify(
 
 	// Make sure a notification doesn't
 	// already exist with these params.
-	if _, err := s.state.DB.GetNotification(
+	if _, err := s.State.DB.GetNotification(
 		gtscontext.SetBarebones(ctx),
 		notificationType,
 		targetAccount.ID,
@@ -458,7 +458,7 @@ func (s *surface) notify(
 		StatusID:         statusID,
 	}
 
-	if err := s.state.DB.PutNotification(ctx, notif); err != nil {
+	if err := s.State.DB.PutNotification(ctx, notif); err != nil {
 		return gtserror.Newf("error putting notification in database: %w", err)
 	}
 
@@ -467,11 +467,11 @@ func (s *surface) notify(
 	unlock()
 
 	// Stream notification to the user.
-	apiNotif, err := s.converter.NotificationToAPINotification(ctx, notif)
+	apiNotif, err := s.Converter.NotificationToAPINotification(ctx, notif)
 	if err != nil {
 		return gtserror.Newf("error converting notification to api representation: %w", err)
 	}
-	s.stream.Notify(ctx, targetAccount, apiNotif)
+	s.Stream.Notify(ctx, targetAccount, apiNotif)
 
 	return nil
 }

--- a/internal/processing/workers/surfacetimeline.go
+++ b/internal/processing/workers/surfacetimeline.go
@@ -36,14 +36,14 @@ import (
 // It will also handle notifications for any mentions attached to
 // the account, and notifications for any local accounts that want
 // to know when this account posts.
-func (s *surface) timelineAndNotifyStatus(ctx context.Context, status *gtsmodel.Status) error {
+func (s *Surface) timelineAndNotifyStatus(ctx context.Context, status *gtsmodel.Status) error {
 	// Ensure status fully populated; including account, mentions, etc.
-	if err := s.state.DB.PopulateStatus(ctx, status); err != nil {
+	if err := s.State.DB.PopulateStatus(ctx, status); err != nil {
 		return gtserror.Newf("error populating status with id %s: %w", status.ID, err)
 	}
 
 	// Get all local followers of the account that posted the status.
-	follows, err := s.state.DB.GetAccountLocalFollowers(ctx, status.AccountID)
+	follows, err := s.State.DB.GetAccountLocalFollowers(ctx, status.AccountID)
 	if err != nil {
 		return gtserror.Newf("error getting local followers of account %s: %w", status.AccountID, err)
 	}
@@ -79,7 +79,7 @@ func (s *surface) timelineAndNotifyStatus(ctx context.Context, status *gtsmodel.
 // adding the status to list timelines + home timelines of each
 // follower, as appropriate, and notifying each follower of the
 // new status, if the status is eligible for notification.
-func (s *surface) timelineAndNotifyStatusForFollowers(
+func (s *Surface) timelineAndNotifyStatusForFollowers(
 	ctx context.Context,
 	status *gtsmodel.Status,
 	follows []*gtsmodel.Follow,
@@ -98,7 +98,7 @@ func (s *surface) timelineAndNotifyStatusForFollowers(
 		// If it's not timelineable, we can just stop early, since lists
 		// are prettymuch subsets of the home timeline, so if it shouldn't
 		// appear there, it shouldn't appear in lists either.
-		timelineable, err := s.filter.StatusHomeTimelineable(
+		timelineable, err := s.Filter.StatusHomeTimelineable(
 			ctx, follow.Account, status,
 		)
 		if err != nil {
@@ -124,7 +124,7 @@ func (s *surface) timelineAndNotifyStatusForFollowers(
 		// of this follow, if applicable.
 		homeTimelined, err := s.timelineStatus(
 			ctx,
-			s.state.Timelines.Home.IngestOne,
+			s.State.Timelines.Home.IngestOne,
 			follow.AccountID, // home timelines are keyed by account ID
 			follow.Account,
 			status,
@@ -160,7 +160,7 @@ func (s *surface) timelineAndNotifyStatusForFollowers(
 		//   - This is a top-level post (not a reply or boost).
 		//
 		// That means we can officially notify this one.
-		if err := s.notify(ctx,
+		if err := s.Notify(ctx,
 			gtsmodel.NotificationStatus,
 			follow.Account,
 			status.Account,
@@ -175,7 +175,7 @@ func (s *surface) timelineAndNotifyStatusForFollowers(
 
 // listTimelineStatusForFollow puts the given status
 // in any eligible lists owned by the given follower.
-func (s *surface) listTimelineStatusForFollow(
+func (s *Surface) listTimelineStatusForFollow(
 	ctx context.Context,
 	status *gtsmodel.Status,
 	follow *gtsmodel.Follow,
@@ -189,7 +189,7 @@ func (s *surface) listTimelineStatusForFollow(
 	// inclusion in the list.
 
 	// Get every list entry that targets this follow's ID.
-	listEntries, err := s.state.DB.GetListEntriesForFollowID(
+	listEntries, err := s.State.DB.GetListEntriesForFollowID(
 		// We only need the list IDs.
 		gtscontext.SetBarebones(ctx),
 		follow.ID,
@@ -217,7 +217,7 @@ func (s *surface) listTimelineStatusForFollow(
 		// list that this list entry belongs to.
 		if _, err := s.timelineStatus(
 			ctx,
-			s.state.Timelines.List.IngestOne,
+			s.State.Timelines.List.IngestOne,
 			listEntry.ListID, // list timelines are keyed by list ID
 			follow.Account,
 			status,
@@ -232,7 +232,7 @@ func (s *surface) listTimelineStatusForFollow(
 // listEligible checks if the given status is eligible
 // for inclusion in the list that that the given listEntry
 // belongs to, based on the replies policy of the list.
-func (s *surface) listEligible(
+func (s *Surface) listEligible(
 	ctx context.Context,
 	listEntry *gtsmodel.ListEntry,
 	status *gtsmodel.Status,
@@ -253,7 +253,7 @@ func (s *surface) listEligible(
 	// We need to fetch the list that this
 	// entry belongs to, in order to check
 	// the list's replies policy.
-	list, err := s.state.DB.GetListByID(
+	list, err := s.State.DB.GetListByID(
 		ctx, listEntry.ListID,
 	)
 	if err != nil {
@@ -273,7 +273,7 @@ func (s *surface) listEligible(
 		//
 		// Check if replied-to account is
 		// also included in this list.
-		includes, err := s.state.DB.ListIncludesAccount(
+		includes, err := s.State.DB.ListIncludesAccount(
 			ctx,
 			list.ID,
 			status.InReplyToAccountID,
@@ -295,7 +295,7 @@ func (s *surface) listEligible(
 		//
 		// Check if replied-to account is
 		// followed by list owner account.
-		follows, err := s.state.DB.IsFollowing(
+		follows, err := s.State.DB.IsFollowing(
 			ctx,
 			list.AccountID,
 			status.InReplyToAccountID,
@@ -325,7 +325,7 @@ func (s *surface) listEligible(
 //
 // If the status was inserted into the timeline, true will be returned
 // + it will also be streamed to the user using the given streamType.
-func (s *surface) timelineStatus(
+func (s *Surface) timelineStatus(
 	ctx context.Context,
 	ingest func(context.Context, string, timeline.Timelineable) (bool, error),
 	timelineID string,
@@ -343,26 +343,26 @@ func (s *surface) timelineStatus(
 	}
 
 	// The status was inserted so stream it to the user.
-	apiStatus, err := s.converter.StatusToAPIStatus(ctx, status, account)
+	apiStatus, err := s.Converter.StatusToAPIStatus(ctx, status, account)
 	if err != nil {
 		err = gtserror.Newf("error converting status %s to frontend representation: %w", status.ID, err)
 		return true, err
 	}
-	s.stream.Update(ctx, account, apiStatus, streamType)
+	s.Stream.Update(ctx, account, apiStatus, streamType)
 
 	return true, nil
 }
 
 // deleteStatusFromTimelines completely removes the given status from all timelines.
 // It will also stream deletion of the status to all open streams.
-func (s *surface) deleteStatusFromTimelines(ctx context.Context, statusID string) error {
-	if err := s.state.Timelines.Home.WipeItemFromAllTimelines(ctx, statusID); err != nil {
+func (s *Surface) deleteStatusFromTimelines(ctx context.Context, statusID string) error {
+	if err := s.State.Timelines.Home.WipeItemFromAllTimelines(ctx, statusID); err != nil {
 		return err
 	}
-	if err := s.state.Timelines.List.WipeItemFromAllTimelines(ctx, statusID); err != nil {
+	if err := s.State.Timelines.List.WipeItemFromAllTimelines(ctx, statusID); err != nil {
 		return err
 	}
-	s.stream.Delete(ctx, statusID)
+	s.Stream.Delete(ctx, statusID)
 	return nil
 }
 
@@ -370,15 +370,15 @@ func (s *surface) deleteStatusFromTimelines(ctx context.Context, statusID string
 // unpreparing it from all timelines, forcing it to be prepared again (with updated
 // stats, boost counts, etc) next time it's fetched by the timeline owner. This goes
 // both for the status itself, and for any boosts of the status.
-func (s *surface) invalidateStatusFromTimelines(ctx context.Context, statusID string) {
-	if err := s.state.Timelines.Home.UnprepareItemFromAllTimelines(ctx, statusID); err != nil {
+func (s *Surface) invalidateStatusFromTimelines(ctx context.Context, statusID string) {
+	if err := s.State.Timelines.Home.UnprepareItemFromAllTimelines(ctx, statusID); err != nil {
 		log.
 			WithContext(ctx).
 			WithField("statusID", statusID).
 			Errorf("error unpreparing status from home timelines: %v", err)
 	}
 
-	if err := s.state.Timelines.List.UnprepareItemFromAllTimelines(ctx, statusID); err != nil {
+	if err := s.State.Timelines.List.UnprepareItemFromAllTimelines(ctx, statusID); err != nil {
 		log.
 			WithContext(ctx).
 			WithField("statusID", statusID).
@@ -392,14 +392,14 @@ func (s *surface) invalidateStatusFromTimelines(ctx context.Context, statusID st
 // Note that calling invalidateStatusFromTimelines takes care of the
 // state in general, we just need to do this for any streams that are
 // open right now.
-func (s *surface) timelineStatusUpdate(ctx context.Context, status *gtsmodel.Status) error {
+func (s *Surface) timelineStatusUpdate(ctx context.Context, status *gtsmodel.Status) error {
 	// Ensure status fully populated; including account, mentions, etc.
-	if err := s.state.DB.PopulateStatus(ctx, status); err != nil {
+	if err := s.State.DB.PopulateStatus(ctx, status); err != nil {
 		return gtserror.Newf("error populating status with id %s: %w", status.ID, err)
 	}
 
 	// Get all local followers of the account that posted the status.
-	follows, err := s.state.DB.GetAccountLocalFollowers(ctx, status.AccountID)
+	follows, err := s.State.DB.GetAccountLocalFollowers(ctx, status.AccountID)
 	if err != nil {
 		return gtserror.Newf("error getting local followers of account %s: %w", status.AccountID, err)
 	}
@@ -427,7 +427,7 @@ func (s *surface) timelineStatusUpdate(ctx context.Context, status *gtsmodel.Sta
 // slice of followers of the account that posted the given status,
 // pushing update messages into open list/home streams of each
 // follower.
-func (s *surface) timelineStatusUpdateForFollowers(
+func (s *Surface) timelineStatusUpdateForFollowers(
 	ctx context.Context,
 	status *gtsmodel.Status,
 	follows []*gtsmodel.Follow,
@@ -444,7 +444,7 @@ func (s *surface) timelineStatusUpdateForFollowers(
 		// If it's not timelineable, we can just stop early, since lists
 		// are prettymuch subsets of the home timeline, so if it shouldn't
 		// appear there, it shouldn't appear in lists either.
-		timelineable, err := s.filter.StatusHomeTimelineable(
+		timelineable, err := s.Filter.StatusHomeTimelineable(
 			ctx, follow.Account, status,
 		)
 		if err != nil {
@@ -485,7 +485,7 @@ func (s *surface) timelineStatusUpdateForFollowers(
 
 // listTimelineStatusUpdateForFollow pushes edits of the given status
 // into any eligible lists streams opened by the given follower.
-func (s *surface) listTimelineStatusUpdateForFollow(
+func (s *Surface) listTimelineStatusUpdateForFollow(
 	ctx context.Context,
 	status *gtsmodel.Status,
 	follow *gtsmodel.Follow,
@@ -499,7 +499,7 @@ func (s *surface) listTimelineStatusUpdateForFollow(
 	// inclusion in the list.
 
 	// Get every list entry that targets this follow's ID.
-	listEntries, err := s.state.DB.GetListEntriesForFollowID(
+	listEntries, err := s.State.DB.GetListEntriesForFollowID(
 		// We only need the list IDs.
 		gtscontext.SetBarebones(ctx),
 		follow.ID,
@@ -539,17 +539,17 @@ func (s *surface) listTimelineStatusUpdateForFollow(
 
 // timelineStatusUpdate streams the edited status to the user using the
 // given streamType.
-func (s *surface) timelineStreamStatusUpdate(
+func (s *Surface) timelineStreamStatusUpdate(
 	ctx context.Context,
 	account *gtsmodel.Account,
 	status *gtsmodel.Status,
 	streamType string,
 ) error {
-	apiStatus, err := s.converter.StatusToAPIStatus(ctx, status, account)
+	apiStatus, err := s.Converter.StatusToAPIStatus(ctx, status, account)
 	if err != nil {
 		err = gtserror.Newf("error converting status %s to frontend representation: %w", status.ID, err)
 		return err
 	}
-	s.stream.StatusUpdate(ctx, account, apiStatus, streamType)
+	s.Stream.StatusUpdate(ctx, account, apiStatus, streamType)
 	return nil
 }

--- a/internal/processing/workers/util.go
+++ b/internal/processing/workers/util.go
@@ -245,7 +245,7 @@ func (u *utils) incrementStatusesCount(
 	status *gtsmodel.Status,
 ) error {
 	// Lock on this account since we're changing stats.
-	unlock := u.state.AccountLocks.Lock(account.URI)
+	unlock := u.state.ProcessingLocks.Lock(account.URI)
 	defer unlock()
 
 	// Populate stats.
@@ -276,7 +276,7 @@ func (u *utils) decrementStatusesCount(
 	account *gtsmodel.Account,
 ) error {
 	// Lock on this account since we're changing stats.
-	unlock := u.state.AccountLocks.Lock(account.URI)
+	unlock := u.state.ProcessingLocks.Lock(account.URI)
 	defer unlock()
 
 	// Populate stats.
@@ -310,7 +310,7 @@ func (u *utils) incrementFollowersCount(
 	account *gtsmodel.Account,
 ) error {
 	// Lock on this account since we're changing stats.
-	unlock := u.state.AccountLocks.Lock(account.URI)
+	unlock := u.state.ProcessingLocks.Lock(account.URI)
 	defer unlock()
 
 	// Populate stats.
@@ -339,7 +339,7 @@ func (u *utils) decrementFollowersCount(
 	account *gtsmodel.Account,
 ) error {
 	// Lock on this account since we're changing stats.
-	unlock := u.state.AccountLocks.Lock(account.URI)
+	unlock := u.state.ProcessingLocks.Lock(account.URI)
 	defer unlock()
 
 	// Populate stats.
@@ -373,7 +373,7 @@ func (u *utils) incrementFollowingCount(
 	account *gtsmodel.Account,
 ) error {
 	// Lock on this account since we're changing stats.
-	unlock := u.state.AccountLocks.Lock(account.URI)
+	unlock := u.state.ProcessingLocks.Lock(account.URI)
 	defer unlock()
 
 	// Populate stats.
@@ -402,7 +402,7 @@ func (u *utils) decrementFollowingCount(
 	account *gtsmodel.Account,
 ) error {
 	// Lock on this account since we're changing stats.
-	unlock := u.state.AccountLocks.Lock(account.URI)
+	unlock := u.state.ProcessingLocks.Lock(account.URI)
 	defer unlock()
 
 	// Populate stats.
@@ -436,7 +436,7 @@ func (u *utils) incrementFollowRequestsCount(
 	account *gtsmodel.Account,
 ) error {
 	// Lock on this account since we're changing stats.
-	unlock := u.state.AccountLocks.Lock(account.URI)
+	unlock := u.state.ProcessingLocks.Lock(account.URI)
 	defer unlock()
 
 	// Populate stats.
@@ -465,7 +465,7 @@ func (u *utils) decrementFollowRequestsCount(
 	account *gtsmodel.Account,
 ) error {
 	// Lock on this account since we're changing stats.
-	unlock := u.state.AccountLocks.Lock(account.URI)
+	unlock := u.state.ProcessingLocks.Lock(account.URI)
 	defer unlock()
 
 	// Populate stats.

--- a/internal/processing/workers/util.go
+++ b/internal/processing/workers/util.go
@@ -38,7 +38,7 @@ type utils struct {
 	state   *state.State
 	media   *media.Processor
 	account *account.Processor
-	surface *surface
+	surface *Surface
 }
 
 // wipeStatus encapsulates common logic

--- a/internal/processing/workers/workers.go
+++ b/internal/processing/workers/workers.go
@@ -55,12 +55,12 @@ func New(
 
 	// Init surface logic
 	// wrapper struct.
-	surface := &surface{
-		state:       state,
-		converter:   converter,
-		stream:      stream,
-		filter:      filter,
-		emailSender: emailSender,
+	surface := &Surface{
+		State:       state,
+		Converter:   converter,
+		Stream:      stream,
+		Filter:      filter,
+		EmailSender: emailSender,
 	}
 
 	// Init shared util funcs.

--- a/internal/processing/workers/workers_test.go
+++ b/internal/processing/workers/workers_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/superseriousbusiness/gotosocial/internal/cleaner"
+	"github.com/superseriousbusiness/gotosocial/internal/email"
 	"github.com/superseriousbusiness/gotosocial/internal/filter/visibility"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/oauth"
@@ -68,6 +69,7 @@ type TestStructs struct {
 	Processor     *processing.Processor
 	HTTPClient    *testrig.MockHTTPClient
 	TypeConverter *typeutils.Converter
+	EmailSender   email.Sender
 }
 
 func (suite *WorkersTestSuite) SetupSuite() {
@@ -168,6 +170,7 @@ func (suite *WorkersTestSuite) SetupTestStructs() *TestStructs {
 		Processor:     processor,
 		HTTPClient:    httpClient,
 		TypeConverter: typeconverter,
+		EmailSender:   emailSender,
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -42,20 +42,21 @@ type State struct {
 	// DB provides access to the database.
 	DB db.DB
 
-	// FedLocks provides access to this state's
-	// mutex map of per URI federation locks.
+	// FedLocks provides access to this state's mutex
+	// map of per URI federation locks, intended for
+	// use in internal/federation functions.
 	//
 	// Used during account and status dereferencing,
-	// message processing in the FromFediAPI worker
-	// functions, and by the go-fed/activity library.
+	// and by the go-fed/activity library.
 	FedLocks mutexes.MutexMap
 
-	// AccountLocks provides access to this state's
+	// ProcessingLocks provides access to this state's
 	// mutex map of per URI locks, intended for use
+	// in internal/processing functions, for example
 	// when updating accounts, migrating, approving
-	// or rejecting an account, changing stats,
-	// pinned statuses, etc.
-	AccountLocks mutexes.MutexMap
+	// or rejecting an account, changing stats or
+	// pinned statuses, creating notifs, etc.
+	ProcessingLocks mutexes.MutexMap
 
 	// Storage provides access to the storage driver.
 	Storage *storage.Driver


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request adds some locks in the surfaceNotify functionality to ensure that multiple notifications aren't created for the same status. Previously it was possible to create multiple notifs if the function was called in parallel (see added tests, which fail without the fix).

Should close https://github.com/superseriousbusiness/gotosocial/issues/2858

Note: to test this in isolation I had to expose a few things in the surface package, and I renamed the AccountLocks thing to ProcessingLocks too. The actual fix itself is very small.

Here's how it looks now when you spam `surface.Notify` 20 times, in the format `[timestamp] - [goroutine nr.] [message]`

```text
1714652500976969 - 19 starting
1714652500977045 - 17 starting
1714652500977084 - 19 got lock
1714652500977087 - 10 starting
1714652500977104 - 2 starting
1714652500977113 - 9 starting
1714652500977120 - 7 starting
1714652500977122 - 13 starting
1714652500977124 - 5 starting
1714652500977132 - 0 starting
1714652500977139 - 1 starting
1714652500977145 - 3 starting
1714652500977147 - 16 starting
1714652500977180 - 14 starting
1714652500977182 - 11 starting
1714652500977182 - 8 starting
1714652500977183 - 6 starting
1714652500977184 - 12 starting
1714652500977186 - 4 starting
1714652500977187 - 15 starting
1714652500977190 - 18 starting
1714652500977690 - 19 creating notif
1714652500978183 - 19 created notif
1714652500978203 - 1 got lock
1714652500978221 - 1 notif exists
1714652500978227 - 1 leaving
1714652500978235 - 17 got lock
1714652500978240 - 17 notif exists
1714652500978246 - 17 leaving
1714652500978248 - 3 got lock
1714652500978271 - 3 notif exists
1714652500978278 - 3 leaving
1714652500978284 - 7 got lock
1714652500978288 - 7 notif exists
1714652500978294 - 7 leaving
1714652500978297 - 16 got lock
1714652500978301 - 16 notif exists
1714652500978304 - 16 leaving
1714652500978308 - 10 got lock
1714652500978312 - 10 notif exists
1714652500978314 - 10 leaving
1714652500978317 - 6 got lock
1714652500978321 - 6 notif exists
1714652500978327 - 6 leaving
1714652500978330 - 14 got lock
1714652500978354 - 14 notif exists
1714652500978360 - 14 leaving
1714652500978366 - 2 got lock
1714652500978374 - 2 notif exists
1714652500978378 - 2 leaving
1714652500978383 - 18 got lock
1714652500978390 - 18 notif exists
1714652500978396 - 18 leaving
1714652500978404 - 8 got lock
1714652500978421 - 8 notif exists
1714652500978429 - 8 leaving
1714652500978435 - 5 got lock
1714652500978443 - 5 notif exists
1714652500978449 - 5 leaving
1714652500978454 - 4 got lock
1714652500978463 - 4 notif exists
1714652500978469 - 4 leaving
1714652500978474 - 9 got lock
1714652500978481 - 9 notif exists
1714652500978485 - 9 leaving
1714652500978490 - 15 got lock
1714652500978496 - 15 notif exists
1714652500978499 - 15 leaving
1714652500978517 - 0 got lock
1714652500978538 - 0 notif exists
1714652500978546 - 0 leaving
1714652500978557 - 12 got lock
1714652500978567 - 12 notif exists
1714652500978573 - 12 leaving
1714652500978580 - 13 got lock
1714652500978589 - 13 notif exists
1714652500978594 - 13 leaving
1714652500978600 - 11 got lock
1714652500978609 - 11 notif exists
1714652500978614 - 11 leaving
1714652500980147 - 19 leaving
```

In this scenario, goroutine 19 is the one that actually creates the notif, and the rest just see if it exists and leave.

Here's the same but without the lock fix:

```text
1714652735305421 - 7 starting
1714652735305493 - 2 starting
1714652735305564 - 1 starting
1714652735305569 - 7 got lock
1714652735305573 - 0 starting
1714652735305599 - 0 got lock
1714652735305626 - 1 got lock
1714652735305646 - 19 starting
1714652735305674 - 15 starting
1714652735305674 - 19 got lock
1714652735305731 - 15 got lock
1714652735305878 - 10 starting
1714652735305885 - 17 starting
1714652735306002 - 16 starting
1714652735306005 - 11 starting
1714652735306005 - 8 starting
1714652735306013 - 9 starting
1714652735306019 - 14 starting
1714652735306026 - 18 starting
1714652735306031 - 12 starting
1714652735306032 - 13 starting
1714652735306039 - 3 starting
1714652735306040 - 4 starting
1714652735306045 - 5 starting
1714652735306047 - 6 starting
1714652735306223 - 10 got lock
1714652735306394 - 8 got lock
1714652735306602 - 14 got lock
1714652735307089 - 17 got lock
1714652735307325 - 2 got lock
1714652735307586 - 3 got lock
1714652735307609 - 4 got lock
1714652735307973 - 18 got lock
1714652735307987 - 16 got lock
1714652735308428 - 13 got lock
1714652735308808 - 6 got lock
1714652735308830 - 0 creating notif
1714652735308832 - 6 creating notif
1714652735308836 - 13 creating notif
1714652735308847 - 11 got lock
1714652735308852 - 11 creating notif
1714652735309107 - 5 got lock
1714652735309111 - 5 creating notif
1714652735309293 - 12 got lock
1714652735309300 - 12 creating notif
1714652735309358 - 9 got lock
1714652735309366 - 9 creating notif
1714652735309830 - 16 creating notif
1714652735311209 - 18 creating notif
1714652735311708 - 9 created notif
1714652735312210 - 4 creating notif
1714652735312714 - 1 creating notif
1714652735313181 - 1 created notif
1714652735315102 - 1 leaving
1714652735317221 - 15 creating notif
1714652735318178 - 15 created notif
1714652735318431 - 19 creating notif
1714652735318588 - 18 created notif
1714652735318826 - 14 creating notif
1714652735319220 - 8 creating notif
1714652735319716 - 8 created notif
1714652735320420 - 14 created notif
1714652735320749 - 14 leaving
1714652735322387 - 17 creating notif
1714652735322878 - 17 created notif
1714652735323694 - 3 creating notif
1714652735324316 - 15 leaving
1714652735324958 - 10 creating notif
1714652735325857 - 2 creating notif
1714652735326396 - 3 created notif
1714652735326655 - 4 created notif
1714652735327345 - 0 created notif
1714652735329193 - 5 created notif
1714652735329862 - 7 creating notif
1714652735331383 - 13 created notif
1714652735333996 - 6 created notif
1714652735334493 - 5 leaving
1714652735334621 - 11 created notif
1714652735335090 - 0 leaving
1714652735335786 - 16 created notif
1714652735335865 - 8 leaving
1714652735336551 - 13 leaving
1714652735336560 - 19 created notif
1714652735338076 - 3 leaving
1714652735341546 - 6 leaving
1714652735343863 - 2 created notif
1714652735344138 - 16 leaving
1714652735344219 - 17 leaving
1714652735345601 - 7 created notif
1714652735345667 - 2 leaving
1714652735346329 - 10 created notif
1714652735346394 - 19 leaving
1714652735347209 - 4 leaving
1714652735348056 - 11 leaving
1714652735348724 - 12 created notif
1714652735348789 - 18 leaving
1714652735349258 - 10 leaving
1714652735350037 - 9 leaving
1714652735350226 - 7 leaving
1714652735350284 - 12 leaving
```

So in this scenario the notif gets created a bunch of times.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
