### PR TITLE
[frontend] Do optimistic update when approving/rejecting/suspending account

### DIFF
--- a/web/source/settings/lib/types/account.ts
+++ b/web/source/settings/lib/types/account.ts
@@ -63,6 +63,7 @@ export interface Account {
 	fields: [],
 	enable_rss: boolean,
 	role: any,
+	suspended?: boolean,
 }
 
 export interface SearchAccountParams {
@@ -91,4 +92,10 @@ export interface HandleSignupParams {
 	private_comment?: string,
 	message?: string,
 	send_email?: boolean,
+}
+
+export interface ActionAccountParams {
+	id: string;
+	action: "suspend";
+	reason: string;
 }


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Cheeky little PR to do optimistic updates when taking account moderation actions, to provide more immediate feedback to the admin. Now instead of clicking and having to refresh a few times while the backend does its things and marks the account as suspended / approved / rejected or whatever, the change is reflected immediately in the frontend redux cache state.

See: https://redux-toolkit.js.org/rtk-query/usage/manual-cache-updates#optimistic-updates

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).

