### PR TITLE
[chore] make wasm sqlite3 available to goreleaser via env var

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,8 @@ builds:
       - timetzdata
       - >-
         {{ if and (index .Env "DEBUG") (.Env.DEBUG) }}debugenv{{ end }}
+      - >-
+        {{ if and (index .Env "WASMSQLITE3") (.Env.WASMSQLITE3) }}wasmsqlite3{{ end }}
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
This PR makes wasmsqlite3 available to goreleaser, invoked as follows:

`WASMSQLITE3=1 goreleaser --clean --snapshot`
