### PR TITLE
[docs]: Document build tag for WASM SQLite

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,6 +22,7 @@ GO_GCFLAGS=${GO_GCFLAGS-}
 # - noerrcaller: disables caller function prefix in errors                   (slightly better performance, at cost of err readability)
 # - debug:       enables /debug/pprof endpoint                               (adds debug, at performance cost)
 # - debugenv:    enables /debug/pprof endpoint if DEBUG=1 env during runtime (adds debug, at performance cost)
+# - wasmsqlite3: uses SQLite through WASM instead of the C-to-Go transpilation (experimental)
 log_exec env CGO_ENABLED=0 go build -trimpath -v \
                        -tags "${GO_BUILDTAGS}" \
                        -ldflags="${GO_LDFLAGS}" \


### PR DESCRIPTION
# Description

Follow-up for #2863.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
