### PR TITLE
[feature] Add from: search operator and account_id query param

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -2872,6 +2872,9 @@ paths:
                     - `https://example.org/some/arbitrary/url` -- search for an account OR a status with the given URL. Will only ever return 1 result at most.
                     - `#[hashtag_name]` -- search for a hashtag with the given hashtag name, or starting with the given hashtag name. Case insensitive. Can return multiple results.
                     - any arbitrary string -- search for accounts or statuses containing the given string. Can return multiple results.
+
+                    Arbitrary string queries may include the following operators:
+                    - `from:localuser`, `from:remoteuser@instance.tld`: restrict results to statuses created by the specified account.
                   in: query
                   name: q
                   required: true
@@ -2902,6 +2905,10 @@ paths:
                   in: query
                   name: exclude_unreviewed
                   type: boolean
+                - description: Restrict results to statuses created by the specified account.
+                  in: query
+                  name: account_id
+                  type: string
             produces:
                 - application/json
             responses:

--- a/docs/user_guide/search.md
+++ b/docs/user_guide/search.md
@@ -1,0 +1,20 @@
+# Search
+
+## Query formats
+
+GotoSocial accepts several kinds of search query:
+
+- `@username`: search for an account with the given username on any domain. Can return multiple results.
+- `@username@domain`: search for a remote account with exact username and domain. Will only ever return 1 result at most.
+- `https://example.org/some/arbitrary/url`: search for an account or post with the given URL. If the account or post hasn't already federated to GotoSocial, it will try to retrieve it. Will only ever return 1 result at most.
+- `#hashtag_name`: search for a hashtag with the given hashtag name, or starting with the given hashtag name. Case insensitive. Can return multiple results.
+- `any arbitrary text`: search for posts containing the text, hashtags containing the text, and accounts with usernames, display names, or bios containing the text, exactly as written. Can return multiple results. Bios will only be searched for accounts that you follow.
+
+## Search operators
+
+Arbitrary text queries may include the following search operators:
+
+- `from:username`: restrict results to statuses created by the specified *local* account.
+- `from:username@domain`: restrict results to statuses created by the specified remote account.
+
+For example, you can search for `sloth from:yourusername` to find your own posts about sloths.

--- a/docs/user_guide/search.md
+++ b/docs/user_guide/search.md
@@ -8,7 +8,7 @@ GotoSocial accepts several kinds of search query:
 - `@username@domain`: search for a remote account with exact username and domain. Will only ever return 1 result at most.
 - `https://example.org/some/arbitrary/url`: search for an account or post with the given URL. If the account or post hasn't already federated to GotoSocial, it will try to retrieve it. Will only ever return 1 result at most.
 - `#hashtag_name`: search for a hashtag with the given hashtag name, or starting with the given hashtag name. Case insensitive. Can return multiple results.
-- `any arbitrary text`: search for posts containing the text, hashtags containing the text, and accounts with usernames, display names, or bios containing the text, exactly as written. Can return multiple results. Bios will only be searched for accounts that you follow.
+- `any arbitrary text`: search for posts containing the text, hashtags containing the text, and accounts with usernames, display names, or bios containing the text, exactly as written. Both posts you've written as well as posts replying to you will be searched. Account bios will only be searched for accounts that you follow. Can return multiple results.
 
 ## Search operators
 

--- a/internal/api/client/search/searchget.go
+++ b/internal/api/client/search/searchget.go
@@ -99,6 +99,9 @@ import (
 //			- `https://example.org/some/arbitrary/url` -- search for an account OR a status with the given URL. Will only ever return 1 result at most.
 //			- `#[hashtag_name]` -- search for a hashtag with the given hashtag name, or starting with the given hashtag name. Case insensitive. Can return multiple results.
 //			- any arbitrary string -- search for accounts or statuses containing the given string. Can return multiple results.
+//
+//			Arbitrary string queries may include the following operators:
+//			- `from:localuser`, `from:remoteuser@instance.tld`: restrict results to statuses created by the specified account.
 //		in: query
 //		required: true
 //	-
@@ -137,6 +140,12 @@ import (
 //			If searching for hashtags, exclude those not yet approved by instance admin.
 //			Currently this parameter is unused.
 //		default: false
+//		in: query
+// -
+//		name: account_id
+//		type: string
+//		description: >-
+//			Restrict results to statuses created by the specified account.
 //		in: query
 //
 //	security:
@@ -238,6 +247,7 @@ func (m *Module) SearchGETHandler(c *gin.Context) {
 		Resolve:           resolve,
 		Following:         following,
 		ExcludeUnreviewed: excludeUnreviewed,
+		AccountID:         c.Query(apiutil.SearchAccountIDKey),
 		APIv1:             apiVersion == apiutil.APIv1,
 	}
 

--- a/internal/api/client/search/searchget.go
+++ b/internal/api/client/search/searchget.go
@@ -141,7 +141,7 @@ import (
 //			Currently this parameter is unused.
 //		default: false
 //		in: query
-// -
+//	-
 //		name: account_id
 //		type: string
 //		description: >-

--- a/internal/api/client/search/searchget_test.go
+++ b/internal/api/client/search/searchget_test.go
@@ -60,6 +60,7 @@ func (suite *SearchGetTestSuite) getSearch(
 	queryType *string,
 	resolve *bool,
 	following *bool,
+	fromAccountID *string,
 	expectedHTTPStatus int,
 	expectedBody string,
 ) (*apimodel.SearchResult, error) {
@@ -101,6 +102,10 @@ func (suite *SearchGetTestSuite) getSearch(
 
 	if following != nil {
 		queryParts = append(queryParts, apiutil.SearchFollowingKey+"="+strconv.FormatBool(*following))
+	}
+
+	if fromAccountID != nil {
+		queryParts = append(queryParts, apiutil.SearchAccountIDKey+"="+url.QueryEscape(*fromAccountID))
 	}
 
 	requestURL.RawQuery = strings.Join(queryParts, "&")
@@ -174,6 +179,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteAccountByURI() {
 		query                      = "https://unknown-instance.com/users/brand_new_person"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -191,6 +197,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteAccountByURI() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -218,6 +225,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteAccountByNamestring() {
 		query                      = "@brand_new_person@unknown-instance.com"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -235,6 +243,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteAccountByNamestring() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -262,6 +271,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteAccountByNamestringUppercase() 
 		query                      = "@Some_User@example.org"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -279,6 +289,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteAccountByNamestringUppercase() 
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -306,6 +317,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteAccountByNamestringNoLeadingAt(
 		query                      = "brand_new_person@unknown-instance.com"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -323,6 +335,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteAccountByNamestringNoLeadingAt(
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -350,6 +363,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteAccountByNamestringNoResolve() 
 		query                      = "@brand_new_person@unknown-instance.com"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -367,6 +381,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteAccountByNamestringNoResolve() 
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -389,6 +404,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteAccountByNamestringSpecialChars
 		query                      = "@üser@ëxample.org"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -406,6 +422,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteAccountByNamestringSpecialChars
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -431,6 +448,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteAccountByNamestringSpecialChars
 		query                      = "@üser@xn--xample-ova.org"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -448,6 +466,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteAccountByNamestringSpecialChars
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -473,6 +492,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalAccountByNamestring() {
 		query                      = "@the_mighty_zork"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -490,6 +510,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalAccountByNamestring() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -517,6 +538,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalAccountByNamestringWithDomain() 
 		query                      = "@the_mighty_zork@localhost:8080"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -534,6 +556,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalAccountByNamestringWithDomain() 
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -561,6 +584,7 @@ func (suite *SearchGetTestSuite) TestSearchNonexistingLocalAccountByNamestringRe
 		query                      = "@somone_made_up@localhost:8080"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -578,6 +602,7 @@ func (suite *SearchGetTestSuite) TestSearchNonexistingLocalAccountByNamestringRe
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -600,6 +625,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalAccountByURI() {
 		query                      = "http://localhost:8080/users/the_mighty_zork"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -617,6 +643,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalAccountByURI() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -644,6 +671,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalAccountByURL() {
 		query                      = "http://localhost:8080/@the_mighty_zork"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -661,6 +689,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalAccountByURL() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -688,6 +717,7 @@ func (suite *SearchGetTestSuite) TestSearchNonexistingLocalAccountByURL() {
 		query                      = "http://localhost:8080/@the_shmighty_shmork"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -705,6 +735,7 @@ func (suite *SearchGetTestSuite) TestSearchNonexistingLocalAccountByURL() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -727,6 +758,7 @@ func (suite *SearchGetTestSuite) TestSearchStatusByURL() {
 		query                      = "https://turnip.farm/users/turniplover6969/statuses/70c53e54-3146-42d5-a630-83c8b6c7c042"
 		queryType          *string = func() *string { i := "statuses"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -744,6 +776,7 @@ func (suite *SearchGetTestSuite) TestSearchStatusByURL() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -771,6 +804,7 @@ func (suite *SearchGetTestSuite) TestSearchBlockedDomainURL() {
 		query                      = "https://replyguys.com/@someone"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -788,6 +822,7 @@ func (suite *SearchGetTestSuite) TestSearchBlockedDomainURL() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -812,6 +847,7 @@ func (suite *SearchGetTestSuite) TestSearchBlockedDomainNamestring() {
 		query                      = "@someone@replyguys.com"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -829,6 +865,7 @@ func (suite *SearchGetTestSuite) TestSearchBlockedDomainNamestring() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -853,6 +890,7 @@ func (suite *SearchGetTestSuite) TestSearchAAny() {
 		query                      = "a"
 		queryType          *string = nil // Return anything.
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -870,6 +908,7 @@ func (suite *SearchGetTestSuite) TestSearchAAny() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -894,6 +933,7 @@ func (suite *SearchGetTestSuite) TestSearchAAnyFollowingOnly() {
 		query                      = "a"
 		queryType          *string = nil // Return anything.
 		following          *bool   = func() *bool { i := true; return &i }()
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -911,6 +951,7 @@ func (suite *SearchGetTestSuite) TestSearchAAnyFollowingOnly() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -935,6 +976,7 @@ func (suite *SearchGetTestSuite) TestSearchAStatuses() {
 		query                      = "a"
 		queryType          *string = func() *string { i := "statuses"; return &i }() // Only statuses.
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -952,6 +994,7 @@ func (suite *SearchGetTestSuite) TestSearchAStatuses() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -960,6 +1003,92 @@ func (suite *SearchGetTestSuite) TestSearchAStatuses() {
 
 	suite.Len(searchResult.Accounts, 0)
 	suite.Len(searchResult.Statuses, 6)
+	suite.Len(searchResult.Hashtags, 0)
+}
+
+func (suite *SearchGetTestSuite) TestSearchHiStatusesWithAccountIDInQueryParam() {
+	var (
+		requestingAccount          = suite.testAccounts["local_account_1"]
+		token                      = suite.testTokens["local_account_1"]
+		user                       = suite.testUsers["local_account_1"]
+		maxID              *string = nil
+		minID              *string = nil
+		limit              *int    = nil
+		offset             *int    = nil
+		resolve            *bool   = func() *bool { i := true; return &i }()
+		query                      = "hi"
+		queryType          *string = func() *string { i := "statuses"; return &i }() // Only statuses.
+		following          *bool   = nil
+		fromAccountID      *string = func() *string { i := suite.testAccounts["local_account_2"].ID; return &i }()
+		expectedHTTPStatus         = http.StatusOK
+		expectedBody               = ""
+	)
+
+	searchResult, err := suite.getSearch(
+		requestingAccount,
+		token,
+		apiutil.APIv2,
+		user,
+		maxID,
+		minID,
+		limit,
+		offset,
+		query,
+		queryType,
+		resolve,
+		following,
+		fromAccountID,
+		expectedHTTPStatus,
+		expectedBody)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Len(searchResult.Accounts, 0)
+	suite.Len(searchResult.Statuses, 1)
+	suite.Len(searchResult.Hashtags, 0)
+}
+
+func (suite *SearchGetTestSuite) TestSearchHiStatusesWithAccountIDInQueryText() {
+	var (
+		requestingAccount          = suite.testAccounts["local_account_1"]
+		token                      = suite.testTokens["local_account_1"]
+		user                       = suite.testUsers["local_account_1"]
+		maxID              *string = nil
+		minID              *string = nil
+		limit              *int    = nil
+		offset             *int    = nil
+		resolve            *bool   = func() *bool { i := true; return &i }()
+		query                      = "hi from:1happyturtle"
+		queryType          *string = func() *string { i := "statuses"; return &i }() // Only statuses.
+		following          *bool   = nil
+		fromAccountID      *string = nil
+		expectedHTTPStatus         = http.StatusOK
+		expectedBody               = ""
+	)
+
+	searchResult, err := suite.getSearch(
+		requestingAccount,
+		token,
+		apiutil.APIv2,
+		user,
+		maxID,
+		minID,
+		limit,
+		offset,
+		query,
+		queryType,
+		resolve,
+		following,
+		fromAccountID,
+		expectedHTTPStatus,
+		expectedBody)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Len(searchResult.Accounts, 0)
+	suite.Len(searchResult.Statuses, 1)
 	suite.Len(searchResult.Hashtags, 0)
 }
 
@@ -976,6 +1105,7 @@ func (suite *SearchGetTestSuite) TestSearchAAccounts() {
 		query                      = "a"
 		queryType          *string = func() *string { i := "accounts"; return &i }() // Only accounts.
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -993,6 +1123,7 @@ func (suite *SearchGetTestSuite) TestSearchAAccounts() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1017,6 +1148,7 @@ func (suite *SearchGetTestSuite) TestSearchAccountsLimit1() {
 		query                      = "a"
 		queryType          *string = func() *string { i := "accounts"; return &i }() // Only accounts.
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -1034,6 +1166,7 @@ func (suite *SearchGetTestSuite) TestSearchAccountsLimit1() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1058,6 +1191,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalInstanceAccountByURI() {
 		query                      = "http://localhost:8080/users/localhost:8080"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -1075,6 +1209,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalInstanceAccountByURI() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1107,6 +1242,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalInstanceAccountFull() {
 		query                      = "@" + newDomain + "@" + newDomain
 		queryType          *string = nil
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -1124,6 +1260,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalInstanceAccountFull() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1156,6 +1293,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalInstanceAccountPartial() {
 		query                      = "@" + newDomain
 		queryType          *string = nil
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -1173,6 +1311,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalInstanceAccountPartial() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1206,6 +1345,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalInstanceAccountEvenMorePartial()
 		query                      = newDomain
 		queryType          *string = nil
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -1223,6 +1363,7 @@ func (suite *SearchGetTestSuite) TestSearchLocalInstanceAccountEvenMorePartial()
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1280,6 +1421,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteInstanceAccountPartial() {
 		query                      = "@" + theirDomain
 		queryType          *string = nil
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -1297,6 +1439,7 @@ func (suite *SearchGetTestSuite) TestSearchRemoteInstanceAccountPartial() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1323,6 +1466,7 @@ func (suite *SearchGetTestSuite) TestSearchBadQueryType() {
 		query                      = "whatever"
 		queryType          *string = func() *string { i := "aaaaaaaaaaa"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusBadRequest
 		expectedBody               = `{"error":"Bad Request: search query type aaaaaaaaaaa was not recognized, valid options are ['', 'accounts', 'statuses', 'hashtags']"}`
 	)
@@ -1340,6 +1484,7 @@ func (suite *SearchGetTestSuite) TestSearchBadQueryType() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1360,6 +1505,7 @@ func (suite *SearchGetTestSuite) TestSearchEmptyQuery() {
 		query                      = ""
 		queryType          *string = func() *string { i := "aaaaaaaaaaa"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusBadRequest
 		expectedBody               = `{"error":"Bad Request: required key q was not set or had empty value"}`
 	)
@@ -1377,6 +1523,7 @@ func (suite *SearchGetTestSuite) TestSearchEmptyQuery() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1397,6 +1544,7 @@ func (suite *SearchGetTestSuite) TestSearchHashtagV1() {
 		query                      = "#welcome"
 		queryType          *string = func() *string { i := "hashtags"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = `{"accounts":[],"statuses":[],"hashtags":[{"name":"welcome","url":"http://localhost:8080/tags/welcome","history":[]}]}`
 	)
@@ -1414,6 +1562,7 @@ func (suite *SearchGetTestSuite) TestSearchHashtagV1() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1438,6 +1587,7 @@ func (suite *SearchGetTestSuite) TestSearchHashtagV2() {
 		query                      = "#welcome"
 		queryType          *string = func() *string { i := "hashtags"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = `{"accounts":[],"statuses":[],"hashtags":["welcome"]}`
 	)
@@ -1455,6 +1605,7 @@ func (suite *SearchGetTestSuite) TestSearchHashtagV2() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1479,6 +1630,7 @@ func (suite *SearchGetTestSuite) TestSearchHashtagButWithAccountSearch() {
 		query                      = "#welcome"
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ``
 	)
@@ -1496,6 +1648,7 @@ func (suite *SearchGetTestSuite) TestSearchHashtagButWithAccountSearch() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1520,6 +1673,7 @@ func (suite *SearchGetTestSuite) TestSearchNotHashtagButWithTypeHashtag() {
 		query                      = "welco"
 		queryType          *string = func() *string { i := "hashtags"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ``
 	)
@@ -1537,6 +1691,7 @@ func (suite *SearchGetTestSuite) TestSearchNotHashtagButWithTypeHashtag() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1562,6 +1717,7 @@ func (suite *SearchGetTestSuite) TestSearchBlockedAccountFullNamestring() {
 		query                      = "@" + targetAccount.Username + "@" + targetAccount.Domain
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -1593,6 +1749,7 @@ func (suite *SearchGetTestSuite) TestSearchBlockedAccountFullNamestring() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1624,6 +1781,7 @@ func (suite *SearchGetTestSuite) TestSearchBlockedAccountPartialNamestring() {
 		query                      = "@" + targetAccount.Username
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -1655,6 +1813,7 @@ func (suite *SearchGetTestSuite) TestSearchBlockedAccountPartialNamestring() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {
@@ -1683,6 +1842,7 @@ func (suite *SearchGetTestSuite) TestSearchBlockedAccountURI() {
 		query                      = targetAccount.URI
 		queryType          *string = func() *string { i := "accounts"; return &i }()
 		following          *bool   = nil
+		fromAccountID      *string = nil
 		expectedHTTPStatus         = http.StatusOK
 		expectedBody               = ""
 	)
@@ -1714,6 +1874,7 @@ func (suite *SearchGetTestSuite) TestSearchBlockedAccountURI() {
 		queryType,
 		resolve,
 		following,
+		fromAccountID,
 		expectedHTTPStatus,
 		expectedBody)
 	if err != nil {

--- a/internal/api/model/search.go
+++ b/internal/api/model/search.go
@@ -28,6 +28,7 @@ type SearchRequest struct {
 	Resolve           bool
 	Following         bool
 	ExcludeUnreviewed bool
+	AccountID         string
 	APIv1             bool // Set to 'true' if using version 1 of the search API.
 }
 

--- a/internal/api/util/parsequery.go
+++ b/internal/api/util/parsequery.go
@@ -55,6 +55,7 @@ const (
 	SearchQueryKey             = "q"
 	SearchResolveKey           = "resolve"
 	SearchTypeKey              = "type"
+	SearchAccountIDKey         = "account_id"
 
 	/* Tag keys */
 

--- a/internal/db/bundb/search.go
+++ b/internal/db/bundb/search.go
@@ -266,8 +266,9 @@ func (s *searchDB) accountText(following bool) *bun.SelectQuery {
 //	ORDER BY "status"."id" DESC LIMIT 10
 func (s *searchDB) SearchForStatuses(
 	ctx context.Context,
-	accountID string,
+	requestingAccountID string,
 	query string,
+	fromAccountID string,
 	maxID string,
 	minID string,
 	limit int,
@@ -295,9 +296,12 @@ func (s *searchDB) SearchForStatuses(
 		// accountID or replying to accountID.
 		WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
 			return q.
-				Where("? = ?", bun.Ident("status.account_id"), accountID).
-				WhereOr("? = ?", bun.Ident("status.in_reply_to_account_id"), accountID)
+				Where("? = ?", bun.Ident("status.account_id"), requestingAccountID).
+				WhereOr("? = ?", bun.Ident("status.in_reply_to_account_id"), requestingAccountID)
 		})
+	if fromAccountID != "" {
+		q = q.Where("? = ?", bun.Ident("status.account_id"), fromAccountID)
+	}
 
 	// Return only items with a LOWER id than maxID.
 	if maxID == "" {

--- a/internal/db/bundb/search_test.go
+++ b/internal/db/bundb/search_test.go
@@ -107,9 +107,20 @@ func (suite *SearchTestSuite) TestSearchAccountsFossAny() {
 func (suite *SearchTestSuite) TestSearchStatuses() {
 	testAccount := suite.testAccounts["local_account_1"]
 
-	statuses, err := suite.db.SearchForStatuses(context.Background(), testAccount.ID, "hello", "", "", 10, 0)
+	statuses, err := suite.db.SearchForStatuses(context.Background(), testAccount.ID, "hello", "", "", "", 10, 0)
 	suite.NoError(err)
 	suite.Len(statuses, 1)
+}
+
+func (suite *SearchTestSuite) TestSearchStatusesFromAccount() {
+	testAccount := suite.testAccounts["local_account_1"]
+	fromAccount := suite.testAccounts["local_account_2"]
+
+	statuses, err := suite.db.SearchForStatuses(context.Background(), testAccount.ID, "hi", fromAccount.ID, "", "", 10, 0)
+	suite.NoError(err)
+	if suite.Len(statuses, 1) {
+		suite.Equal(fromAccount.ID, statuses[0].AccountID)
+	}
 }
 
 func (suite *SearchTestSuite) TestSearchTags() {

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -27,8 +27,9 @@ type Search interface {
 	// SearchForAccounts uses the given query text to search for accounts that accountID follows.
 	SearchForAccounts(ctx context.Context, accountID string, query string, maxID string, minID string, limit int, following bool, offset int) ([]*gtsmodel.Account, error)
 
-	// SearchForStatuses uses the given query text to search for statuses created by accountID, or in reply to accountID.
-	SearchForStatuses(ctx context.Context, accountID string, query string, maxID string, minID string, limit int, offset int) ([]*gtsmodel.Status, error)
+	// SearchForStatuses uses the given query text to search for statuses created by requestingAccountID, or in reply to requestingAccountID.
+	// If fromAccountID is used, the results are restricted to statuses created by fromAccountID.
+	SearchForStatuses(ctx context.Context, requestingAccountID string, query string, fromAccountID string, maxID string, minID string, limit int, offset int) ([]*gtsmodel.Status, error)
 
 	// SearchForTags searches for tags that start with the given query text (case insensitive).
 	SearchForTags(ctx context.Context, query string, maxID string, minID string, limit int, offset int) ([]*gtsmodel.Tag, error)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
   - "User Guide":
       - "user_guide/posts.md"
       - "user_guide/settings.md"
+      - "user_guide/search.md"
       - "user_guide/custom_css.md"
       - "user_guide/password_management.md"
       - "user_guide/rss.md"


### PR DESCRIPTION
# Description

This pull request implements Mastodon-compatible functionality for restricting a search to statuses authored by a specific account:

- [`account_id` parameter to search API](https://docs.joinmastodon.org/methods/search/#query-parameters)
- `from:localuser` or `from:remoteuser@domain` as an additional (or only) term in search query text, useful for the majority of clients which don't support `account_id` (also implemented in Mastodon, documented only in online help)

There are two main use cases:

- Find your most recent conversations with somebody else
- Find your own posts

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
