### PR TITLE
[chore] Make worker run startup messages debug output

### DIFF
--- a/internal/transport/delivery/delivery.go
+++ b/internal/transport/delivery/delivery.go
@@ -181,8 +181,8 @@ func (w *Worker) run(ctx context.Context) {
 	if w.Client == nil || w.Queue == nil {
 		panic("not yet initialized")
 	}
-	log.Infof(ctx, "%p: starting worker", w)
-	defer log.Infof(ctx, "%p: stopped worker", w)
+	log.Debugf(ctx, "%p: starting worker", w)
+	defer log.Debugf(ctx, "%p: stopped worker", w)
 	util.Must(func() { w.process(ctx) })
 }
 

--- a/internal/workers/worker_fn.go
+++ b/internal/workers/worker_fn.go
@@ -114,8 +114,8 @@ func (w *FnWorker) run(ctx context.Context) {
 	if w.Queue == nil {
 		panic("not yet initialized")
 	}
-	log.Infof(ctx, "%p: starting worker", w)
-	defer log.Infof(ctx, "%p: stopped worker", w)
+	log.Debugf(ctx, "%p: starting worker", w)
+	defer log.Debugf(ctx, "%p: stopped worker", w)
 	util.Must(func() { w.process(ctx) })
 }
 

--- a/internal/workers/worker_msg.go
+++ b/internal/workers/worker_msg.go
@@ -127,8 +127,8 @@ func (w *MsgWorker[T]) run(ctx context.Context) {
 	if w.Process == nil || w.Queue == nil {
 		panic("not yet initialized")
 	}
-	log.Infof(ctx, "%p: starting worker", w)
-	defer log.Infof(ctx, "%p: stopped worker", w)
+	log.Debugf(ctx, "%p: starting worker", w)
+	defer log.Debugf(ctx, "%p: stopped worker", w)
 	util.Must(func() { w.process(ctx) })
 }
 


### PR DESCRIPTION
# Description

On startup and shutdown of a worker, we log a message of the worker being started together with a textual representation of a memory address. Though this can be handy for developers to debug startup/shutdown sequencing issues of the workers, it's typically not very useful or informative for an admin. We can also output a lot of these (on my system I get 265 lines of these during startup).

This changes the messages from Info to Debug, to not print them under normal circumstances.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
