### PR TITLE
Compile filter keyword regexps when touched through PutFilter or UpdateFilter

### DIFF
--- a/internal/db/bundb/filter.go
+++ b/internal/db/bundb/filter.go
@@ -154,6 +154,13 @@ func (f *filterDB) populateFilter(ctx context.Context, filter *gtsmodel.Filter) 
 }
 
 func (f *filterDB) PutFilter(ctx context.Context, filter *gtsmodel.Filter) error {
+	// Pre-compile filter keyword regular expressions.
+	for _, filterKeyword := range filter.Keywords {
+		if err := filterKeyword.Compile(); err != nil {
+			return gtserror.Newf("error compiling filter keyword regex: %w", err)
+		}
+	}
+
 	// Update database.
 	if err := f.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 		if _, err := tx.
@@ -222,6 +229,13 @@ func (f *filterDB) UpdateFilter(
 	for i := range filterKeywordColumns {
 		if len(filterKeywordColumns[i]) > 0 {
 			filterKeywordColumns[i] = append(filterKeywordColumns[i], "updated_at")
+		}
+	}
+
+	// Pre-compile filter keyword regular expressions.
+	for _, filterKeyword := range filter.Keywords {
+		if err := filterKeyword.Compile(); err != nil {
+			return gtserror.Newf("error compiling filter keyword regex: %w", err)
 		}
 	}
 


### PR DESCRIPTION
# Description

User reported a bug in chat where their home timeline was crashing while filtering due to a nil `Regexp`:

```
gotosocial_1  | timestamp="01/06/2024 15:19:54.432" func=server.init.func1.Logger.14.1 level=INFO latency="25.915262ms"userAgent="***" method=GET statusCode=200 path=/api/v1/timelines/home clientIP=x.x.x.x errors="Error #01: recovered panic: runtime error: invalid memory addresss or nil pointer dereference
" requestID=4v3p5n4f04001700hav0 msg="OK: wrote 23B"
gotosocial_1  | timestamp="01/06/2024 15:19:54.432" func=server.init.func1.Logger.14.1 level=ERROR stacktrace="()
	/usr/local/go/src/runtime/panic.go:261
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:881
regexp.(*Regexp).doExecute()
	/usr/local/go/src/regexp/exec.go:527
()
	/usr/local/go/src/regexp/exec.go:514
regexp.(*Regexp).MatchString()
	/usr/local/go/src/regexp/regexp.go:531
typeutils.(*Converter).statusToAPIFilterResults()
	/drone/src/internal/typeutils/internaltofrontend.go:750
typeutils.(*Converter).statusToFrontend()
	/drone/src/internal/typeutils/internaltofrontend.go:1124
typeutils.(*Converter).StatusToAPIStatus()
	/drone/src/internal/typeutils/internaltofrontend.go:702
server.init.func1.HomeTimelineStatusPrepare.7()
	/drone/src/internal/processing/timeline/home.go:108
" requestID=4v3p5n4f04001700hav0 msg="recovered panic: runtime error: invalid memory address or nil pointer dereference"
```

This seems likely to be the result of creating or updating a filter through the v1 filter API, which uses `PutFilter` or `UpdateFilter` to create or update a filter and filter keyword at the same time, but doesn't compile the filter keyword's regexp because we missed those paths when compiled regexp caching was added. Will mark this as ready once I repro locally.

Followup to #2903

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
