### PR TITLE
[feature] log worker startup counts

### DIFF
--- a/internal/transport/delivery/delivery.go
+++ b/internal/transport/delivery/delivery.go
@@ -26,7 +26,6 @@ import (
 	"codeberg.org/gruf/go-structr"
 	"github.com/superseriousbusiness/gotosocial/internal/gtscontext"
 	"github.com/superseriousbusiness/gotosocial/internal/httpclient"
-	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/queue"
 	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
@@ -181,8 +180,6 @@ func (w *Worker) run(ctx context.Context) {
 	if w.Client == nil || w.Queue == nil {
 		panic("not yet initialized")
 	}
-	log.Debugf(ctx, "%p: starting worker", w)
-	defer log.Debugf(ctx, "%p: stopped worker", w)
 	util.Must(func() { w.process(ctx) })
 }
 

--- a/internal/workers/worker_msg.go
+++ b/internal/workers/worker_msg.go
@@ -127,8 +127,6 @@ func (w *MsgWorker[T]) run(ctx context.Context) {
 	if w.Process == nil || w.Queue == nil {
 		panic("not yet initialized")
 	}
-	log.Debugf(ctx, "%p: starting worker", w)
-	defer log.Debugf(ctx, "%p: stopped worker", w)
 	util.Must(func() { w.process(ctx) })
 }
 

--- a/internal/workers/workers.go
+++ b/internal/workers/workers.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 
 	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/messages"
 	"github.com/superseriousbusiness/gotosocial/internal/scheduler"
 	"github.com/superseriousbusiness/gotosocial/internal/transport/delivery"
@@ -59,26 +60,54 @@ type Workers struct {
 // StartScheduler starts the job scheduler.
 func (w *Workers) StartScheduler() {
 	_ = w.Scheduler.Start() // false = already running
+	log.Info(nil, "started scheduler")
 }
 
 // Start will start contained worker pools.
 func (w *Workers) Start() {
+	var n int
+
 	maxprocs := runtime.GOMAXPROCS(0)
-	w.Delivery.Start(deliveryWorkers(maxprocs))
-	w.Client.Start(4 * maxprocs)
-	w.Federator.Start(4 * maxprocs)
-	w.Dereference.Start(4 * maxprocs)
-	w.Media.Start(8 * maxprocs)
+
+	n = deliveryWorkers(maxprocs)
+	w.Delivery.Start(n)
+	log.Infof(nil, "started %d delivery workers", n)
+
+	n = 4 * maxprocs
+	w.Client.Start(n)
+	log.Infof(nil, "started %d client workers", n)
+
+	n = 4 * maxprocs
+	w.Federator.Start(n)
+	log.Infof(nil, "started %d federator workers", n)
+
+	n = 4 * maxprocs
+	w.Dereference.Start(n)
+	log.Infof(nil, "started %d dereference workers", n)
+
+	n = 4 * maxprocs
+	w.Media.Start(n)
+	log.Infof(nil, "started %d media workers", n)
 }
 
 // Stop will stop all of the contained worker pools (and global scheduler).
 func (w *Workers) Stop() {
 	_ = w.Scheduler.Stop() // false = not running
+
 	w.Delivery.Stop()
+	log.Info(nil, "stopped delivery workers")
+
 	w.Client.Stop()
+	log.Info(nil, "stopped client workers")
+
 	w.Federator.Stop()
+	log.Info(nil, "stopped federator workers")
+
 	w.Dereference.Stop()
+	log.Info(nil, "stopped dereference workers")
+
 	w.Media.Stop()
+	log.Info(nil, "stopped media workers")
 }
 
 // nocopy when embedded will signal linter to

--- a/internal/workers/workers.go
+++ b/internal/workers/workers.go
@@ -85,7 +85,7 @@ func (w *Workers) Start() {
 	w.Dereference.Start(n)
 	log.Infof(nil, "started %d dereference workers", n)
 
-	n = 4 * maxprocs
+	n = 8 * maxprocs
 	w.Media.Start(n)
 	log.Infof(nil, "started %d media workers", n)
 }


### PR DESCRIPTION
# Description

Logs the number of each worker kind started during init. As pointed out by @daenney the way we were doing it previously was overly verbose and kinda useless, so moving to debug logging was definitely an improvement, but this removes the per-worker logging and instead just uses simple per-worker-pool-type n-workers-started style logging

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
