### PR TITLE
[chore] Exit on misconfigured journal mode

### DIFF
--- a/docs/configuration/database.md
+++ b/docs/configuration/database.md
@@ -12,6 +12,9 @@ To configure GoToSocial to use SQLite, change `db-type` to `sqlite`. The `addres
 
 Note that the `:memory:` setting will use an *in-memory database* which will be wiped when your GoToSocial instance stops running. This is for testing only and is absolutely not suitable for running a proper instance, so *don't do this*.
 
+!!! warning "WASM SQLite build"
+    When running the experimental WASM SQLite build on anything other than Linux, you have to set `db-sqlite-journal-mode` to `TRUNCATE` instead of `WAL`. You'll experience abysmal performance otherwise.
+
 ## Postgres
 
 Postgres is a heavier database format, which is useful for larger instances where you need to scale performance, or where you need to run your database on a dedicated machine separate from your GoToSocial instance (or do funky stuff like run a database cluster).
@@ -143,6 +146,11 @@ db-max-open-conns-multiplier: 8
 # SQLite only -- unused otherwise.
 # If set to empty string, the sqlite default will be used.
 # See: https://www.sqlite.org/pragma.html#pragma_journal_mode
+#
+# WARNING: when running the experimental WASM SQLite build on
+# anything other than Linux, set this to "TRUNCATE" instead.
+# The server will complain about this on startup.
+#
 # Examples: ["DELETE", "TRUNCATE", "PERSIST", "MEMORY", "WAL", "OFF"]
 # Default: "WAL"
 db-sqlite-journal-mode: "WAL"

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -214,6 +214,11 @@ db-max-open-conns-multiplier: 8
 # SQLite only -- unused otherwise.
 # If set to empty string, the sqlite default will be used.
 # See: https://www.sqlite.org/pragma.html#pragma_journal_mode
+#
+# WARNING: when running the experimental WASM SQLite build on
+# anything other than Linux, set this to "TRUNCATE" instead.
+# The server will complain about this on startup.
+#
 # Examples: ["DELETE", "TRUNCATE", "PERSIST", "MEMORY", "WAL", "OFF"]
 # Default: "WAL"
 db-sqlite-journal-mode: "WAL"


### PR DESCRIPTION
# Description

Adds documentation and a configuration validation check to ensure that when folks run with the WASM SQLite build on anything other than Linux we don't allow them to run with journaling set to WAL. That will result in abysmal performance until ncruces/go-sqlite3#85 is resolved.

Fixes #2962

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
