### PR TITLE
[bugfix] Don't nil emojis + fields on blocked accounts

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -223,7 +223,9 @@ definitions:
                 type: string
                 x-go-name: DisplayName
             emojis:
-                description: Array of custom emojis used in this account's note or display name.
+                description: |-
+                    Array of custom emojis used in this account's note or display name.
+                    Empty for blocked accounts.
                 items:
                     $ref: '#/definitions/emoji'
                 type: array
@@ -235,7 +237,9 @@ definitions:
                 type: boolean
                 x-go-name: EnableRSS
             fields:
-                description: Additional metadata attached to this account's profile.
+                description: |-
+                    Additional metadata attached to this account's profile.
+                    Empty for blocked accounts.
                 items:
                     $ref: '#/definitions/field'
                 type: array

--- a/internal/api/model/account.go
+++ b/internal/api/model/account.go
@@ -79,8 +79,10 @@ type Account struct {
 	// example: 2021-07-30T09:20:25+00:00
 	LastStatusAt *string `json:"last_status_at"`
 	// Array of custom emojis used in this account's note or display name.
+	// Empty for blocked accounts.
 	Emojis []Emoji `json:"emojis"`
 	// Additional metadata attached to this account's profile.
+	// Empty for blocked accounts.
 	Fields []Field `json:"fields"`
 	// Account has been suspended by our instance.
 	Suspended bool `json:"suspended,omitempty"`

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -368,6 +368,8 @@ func (c *Converter) AccountToAPIAccountBlocked(ctx context.Context, a *gtsmodel.
 		Bot:       *a.Bot,
 		CreatedAt: util.FormatISO8601(a.CreatedAt),
 		URL:       a.URL,
+		Emojis:    make([]apimodel.Emoji, 0),
+		Fields:    make([]apimodel.Field, 0),
 		Suspended: !a.SuspendedAt.IsZero(),
 		Role:      role,
 	}

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -368,7 +368,9 @@ func (c *Converter) AccountToAPIAccountBlocked(ctx context.Context, a *gtsmodel.
 		Bot:       *a.Bot,
 		CreatedAt: util.FormatISO8601(a.CreatedAt),
 		URL:       a.URL,
-		Emojis:    make([]apimodel.Emoji, 0),
+		// Empty array (not nillable).
+		Emojis: make([]apimodel.Emoji, 0),
+		// Empty array (not nillable).
 		Fields:    make([]apimodel.Field, 0),
 		Suspended: !a.SuspendedAt.IsZero(),
 		Role:      role,

--- a/internal/typeutils/internaltofrontend_test.go
+++ b/internal/typeutils/internaltofrontend_test.go
@@ -420,8 +420,8 @@ func (suite *InternalToFrontendTestSuite) TestLocalInstanceAccountToFrontendBloc
   "following_count": 0,
   "statuses_count": 0,
   "last_status_at": null,
-  "emojis": null,
-  "fields": null
+  "emojis": [],
+  "fields": []
 }`, string(b))
 }
 


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Don't nil emojis + fields on blocked accounts, use empty array instead as these fields are nillable (https://docs.joinmastodon.org/entities/Account/#fields).

Fixes an issue where some clients would fail on showing a blocked account.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
