### PR TITLE
[chore] Use `(created)` instead of `date` for outgoing HTTP signatures

### DIFF
--- a/docs/federation/federating_with_gotosocial.md
+++ b/docs/federation/federating_with_gotosocial.md
@@ -44,8 +44,8 @@ GoToSocial request signing is implemented in [internal/transport](https://github
 
 When assembling signatures:
 
-- outgoing `GET` requests use `(request-target) host date`
-- outgoing `POST` requests use `(request-target) host date digest` 
+- outgoing `GET` requests use `(request-target) (created) host`
+- outgoing `POST` requests use `(request-target) (created) host digest` 
 
 GoToSocial sets the "algorithm" field in signatures to the value `hs2019`, which essentially means "derive the algorithm from metadata associated with the keyId". The *actual* algorithm used for generating signatures is `RSA_SHA256`, which is in line with other ActivityPub implementations. When validating a GoToSocial HTTP signature, remote servers can safely assume that the signature is generated using `sha256`.
 

--- a/internal/transport/signing.go
+++ b/internal/transport/signing.go
@@ -25,8 +25,8 @@ var (
 	// http signer preferences
 	prefs       = []httpsig.Algorithm{httpsig.RSA_SHA256}
 	digestAlgo  = httpsig.DigestSha256
-	getHeaders  = []string{httpsig.RequestTarget, "host", "date"}
-	postHeaders = []string{httpsig.RequestTarget, "host", "date", "digest"}
+	getHeaders  = []string{httpsig.RequestTarget, "(created)", "host"}
+	postHeaders = []string{httpsig.RequestTarget, "(created)", "host", "digest"}
 )
 
 // NewGETSigner returns a new httpsig.Signer instance initialized with GTS GET preferences.


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Throughout [the spec](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12), `(created)` is used instead of `date` for constructing signatures. This PR switches to using that, which is already supported by the library we use anyway.

Tested with Mastodon, Misskey, Akkoma, Kristec, and other GtS instances, and it seems to work fine with all of those.

closes https://github.com/superseriousbusiness/gotosocial/issues/2857

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
