### PR TITLE
[bugfix/frontend] Use re2 syntax for regex validation

### DIFF
--- a/web/source/package.json
+++ b/web/source/package.json
@@ -27,6 +27,7 @@
     "photoswipe-dynamic-caption-plugin": "^1.2.7",
     "plyr": "^3.7.8",
     "psl": "^1.9.0",
+    "re2js": "^0.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.3",

--- a/web/source/settings/views/admin/http-header-permissions/create.tsx
+++ b/web/source/settings/views/admin/http-header-permissions/create.tsx
@@ -24,6 +24,7 @@ import useFormSubmit from "../../../lib/form/submit";
 import { TextInput } from "../../../components/form/inputs";
 import MutationButton from "../../../components/form/mutation-button";
 import { PermType } from "../../../lib/types/perm";
+import { RE2JS } from "re2js";
 
 export default function HeaderPermCreateForm({ permType }: { permType: PermType }) {
 	const form = {
@@ -56,7 +57,7 @@ export default function HeaderPermCreateForm({ permType }: { permType: PermType 
 
 				// Ensure regex compiles.
 				try {
-					new RegExp(val);
+					RE2JS.compile(val);
 				} catch (e) {
 					return e;
 				}
@@ -116,14 +117,14 @@ export default function HeaderPermCreateForm({ permType }: { permType: PermType 
 				field={form.regex}
 				label={
 					<>
-						HTTP Header Value Regex&nbsp;
+						HTTP Header Value RE2 Regex&nbsp;
 						<a
-							href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions"
+							href="https://github.com/google/re2/wiki/Syntax"
 							target="_blank"
 							className="docslink"
 							rel="noreferrer"
 						>
-							Learn more about regular expressions (opens in a new tab)
+							Learn more about RE2 regular expressions (opens in a new tab)
 						</a>
 					</>
 				}

--- a/web/source/settings/views/admin/http-header-permissions/detail.tsx
+++ b/web/source/settings/views/admin/http-header-permissions/detail.tsx
@@ -154,7 +154,7 @@ function PermDeets({
 	// with this regular expression prepopulated.
 	const testParams = new URLSearchParams();
 	testParams.set("regex", perm.regex);
-	testParams.set("flags", "g");
+	testParams.set("flags", "gm");
 	testParams.set("testString", testString);
 	const regexLink = `https://regex101.com/?${testParams.toString()}`;	
 

--- a/web/source/yarn.lock
+++ b/web/source/yarn.lock
@@ -5513,6 +5513,11 @@ raw-body@~1.1.0:
     bytes "1"
     string_decoder "0.10"
 
+re2js@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/re2js/-/re2js-0.4.1.tgz#74a87a90b79ab5dc1effed818151354c8faccb3d"
+  integrity sha512-Kxb+OKXrEPowP4bXAF07NDXtgYX07S8HeVGgadx5/D/R41LzWg1kgTD2szIv2iHJM3vrAPnDKaBzfUE/7QWX9w==
+
 react-dom@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Use RE2 syntax on frontend for validation of header permissions regexes.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
