### PR TITLE
[bugfix] boost and account recursion

### DIFF
--- a/internal/db/account.go
+++ b/internal/db/account.go
@@ -57,6 +57,9 @@ type Account interface {
 	// GetAccountByFollowersURI returns one account with the given followers_uri, or an error if something goes wrong.
 	GetAccountByFollowersURI(ctx context.Context, uri string) (*gtsmodel.Account, error)
 
+	// GetAccountByMovedToURI returns any accounts with given moved_to_uri set.
+	GetAccountsByMovedToURI(ctx context.Context, uri string) ([]*gtsmodel.Account, error)
+
 	// GetAccounts returns accounts
 	// with the given parameters.
 	GetAccounts(

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -259,7 +259,8 @@ func (a *accountDB) GetAccountsByMovedToURI(ctx context.Context, uri string) ([]
 	// given moved_to_uri column.
 	if err := a.db.NewSelect().
 		Table("accounts").
-		Column("id").Where("? = ?", bun.Ident("moved_to_uri"), uri).
+		Column("id").
+		Where("? = ?", bun.Ident("moved_to_uri"), uri).
 		Scan(ctx, &accountIDs); err != nil {
 		return nil, err
 	}

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -252,6 +252,26 @@ func (a *accountDB) GetInstanceAccount(ctx context.Context, domain string) (*gts
 	return a.GetAccountByUsernameDomain(ctx, username, domain)
 }
 
+func (a *accountDB) GetAccountsByMovedToURI(ctx context.Context, uri string) ([]*gtsmodel.Account, error) {
+	var accountIDs []string
+
+	// Find all account IDs with
+	// given moved_to_uri column.
+	if err := a.db.NewSelect().
+		Table("accounts").
+		Column("id").Where("? = ?", bun.Ident("moved_to_uri"), uri).
+		Scan(ctx, &accountIDs); err != nil {
+		return nil, err
+	}
+
+	if len(accountIDs) == 0 {
+		return nil, nil
+	}
+
+	// Return account models for all found IDs.
+	return a.GetAccountsByIDs(ctx, accountIDs)
+}
+
 // GetAccounts selects accounts using the given parameters.
 // Unlike with other functions, the paging for GetAccounts
 // is done not by ID, but by a concatenation of `[domain]/@[username]`,

--- a/internal/processing/account/move_test.go
+++ b/internal/processing/account/move_test.go
@@ -161,7 +161,7 @@ func (suite *MoveTestSuite) TestMoveAccountBadPassword() {
 			MovedToURI: targetAcct.URI,
 		},
 	)
-	suite.EqualError(err, "invalid password provided in account Move request")
+	suite.EqualError(err, "invalid password provided in Move request")
 }
 
 func TestMoveTestSuite(t *testing.T) {

--- a/internal/processing/common/status.go
+++ b/internal/processing/common/status.go
@@ -169,11 +169,19 @@ func (p *Processor) UnwrapIfBoost(
 	if status.BoostOfID == "" {
 		return status, nil
 	}
-	return p.GetVisibleTargetStatus(ctx,
+	status, errWithCode := p.GetVisibleTargetStatus(ctx,
 		requester,
 		status.BoostOfID,
 		nil,
 	)
+	if errWithCode != nil {
+		return nil, errWithCode
+	}
+	if status.BoostOfID != "" {
+		err := gtserror.Newf("unwrapped status %s is still a boost", status.URI)
+		return nil, gtserror.NewErrorInternalError(err)
+	}
+	return status, nil
 }
 
 // GetAPIStatus fetches the appropriate API status model for target.

--- a/internal/processing/common/status.go
+++ b/internal/processing/common/status.go
@@ -169,19 +169,11 @@ func (p *Processor) UnwrapIfBoost(
 	if status.BoostOfID == "" {
 		return status, nil
 	}
-	status, errWithCode := p.GetVisibleTargetStatus(ctx,
+	return p.GetVisibleTargetStatus(ctx,
 		requester,
 		status.BoostOfID,
 		nil,
 	)
-	if errWithCode != nil {
-		return nil, errWithCode
-	}
-	if status.BoostOfID != "" {
-		err := gtserror.Newf("unwrapped status %s is still a boost", status.URI)
-		return nil, gtserror.NewErrorInternalError(err)
-	}
-	return status, nil
 }
 
 // GetAPIStatus fetches the appropriate API status model for target.

--- a/internal/processing/status/boost.go
+++ b/internal/processing/status/boost.go
@@ -59,6 +59,12 @@ func (p *Processor) BoostCreate(
 		return nil, errWithCode
 	}
 
+	// Check is viable target.
+	if target.BoostOfID != "" {
+		err := gtserror.Newf("target status %s is boost wrapper", target.URI)
+		return nil, gtserror.NewErrorInternalError(err)
+	}
+
 	// Ensure valid boost target for requester.
 	boostable, err := p.filter.StatusBoostable(ctx,
 		requester,

--- a/internal/processing/status/boost.go
+++ b/internal/processing/status/boost.go
@@ -62,7 +62,7 @@ func (p *Processor) BoostCreate(
 	// Check is viable target.
 	if target.BoostOfID != "" {
 		err := gtserror.Newf("target status %s is boost wrapper", target.URI)
-		return nil, gtserror.NewErrorInternalError(err)
+		return nil, gtserror.NewErrorUnprocessableEntity(err)
 	}
 
 	// Ensure valid boost target for requester.

--- a/internal/processing/status/boost.go
+++ b/internal/processing/status/boost.go
@@ -49,6 +49,7 @@ func (p *Processor) BoostCreate(
 		return nil, errWithCode
 	}
 
+	// Unwrap target in case it is a boost.
 	target, errWithCode = p.c.UnwrapIfBoost(
 		ctx,
 		requester,
@@ -58,7 +59,7 @@ func (p *Processor) BoostCreate(
 		return nil, errWithCode
 	}
 
-	// Ensure valid boost target.
+	// Ensure valid boost target for requester.
 	boostable, err := p.filter.StatusBoostable(ctx,
 		requester,
 		target,
@@ -69,7 +70,7 @@ func (p *Processor) BoostCreate(
 	}
 
 	if !boostable {
-		err := gtserror.New("status is not boostable")
+		err := errors.New("status is not boostable")
 		return nil, gtserror.NewErrorNotFound(err)
 	}
 

--- a/internal/processing/status/boost.go
+++ b/internal/processing/status/boost.go
@@ -76,7 +76,7 @@ func (p *Processor) BoostCreate(
 	}
 
 	if !boostable {
-		err := errors.New("status is not boostable")
+		err := gtserror.New("status is not boostable")
 		return nil, gtserror.NewErrorNotFound(err)
 	}
 

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -1144,12 +1144,17 @@ func (c *Converter) statusToFrontend(
 	}
 
 	if s.BoostOf != nil {
+		if s.BoostOf.BoostOfID != "" {
+			// impossible situation, we do not allow boost wrappers to be boosted.
+			// this is a defensive check to prevent *possible* recursion issues.
+			return nil, gtserror.New("boost target %s is itself a boost wrapper %s")
+		}
+
 		reblog, err := c.StatusToAPIStatus(ctx, s.BoostOf, requestingAccount, filterContext, filters, mutes)
 		if errors.Is(err, statusfilter.ErrHideStatus) {
 			// If we'd hide the original status, hide the boost.
 			return nil, err
-		}
-		if err != nil {
+		} else if err != nil {
 			return nil, gtserror.Newf("error converting boosted status: %w", err)
 		}
 

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -1144,12 +1144,6 @@ func (c *Converter) statusToFrontend(
 	}
 
 	if s.BoostOf != nil {
-		if s.BoostOf.BoostOfID != "" {
-			// impossible situation, we do not allow boost wrappers to be boosted.
-			// this is a defensive check to prevent *possible* recursion issues.
-			return nil, gtserror.New("boost target %s is itself a boost wrapper %s")
-		}
-
 		reblog, err := c.StatusToAPIStatus(ctx, s.BoostOf, requestingAccount, filterContext, filters, mutes)
 		if errors.Is(err, statusfilter.ErrHideStatus) {
 			// If we'd hide the original status, hide the boost.

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -340,7 +340,8 @@ func (c *Converter) fieldsToAPIFields(f []*gtsmodel.Field) []apimodel.Field {
 		}
 
 		if !field.VerifiedAt.IsZero() {
-			mField.VerifiedAt = func() *string { s := util.FormatISO8601(field.VerifiedAt); return &s }()
+			verified := util.FormatISO8601(field.VerifiedAt)
+			mField.VerifiedAt = util.Ptr(verified)
 		}
 
 		fields[i] = mField
@@ -745,6 +746,10 @@ func (c *Converter) StatusToAPIStatus(
 	var aside string
 	aside, apiStatus.MediaAttachments = placeholdUnknownAttachments(apiStatus.MediaAttachments)
 	apiStatus.Content += aside
+	if apiStatus.Reblog != nil {
+		aside, apiStatus.Reblog.MediaAttachments = placeholdUnknownAttachments(apiStatus.Reblog.MediaAttachments)
+		apiStatus.Reblog.Content += aside
+	}
 
 	return apiStatus, nil
 }
@@ -1041,27 +1046,81 @@ func (c *Converter) StatusToAPIStatusSource(ctx context.Context, s *gtsmodel.Sta
 // Requesting account can be nil.
 func (c *Converter) statusToFrontend(
 	ctx context.Context,
+	status *gtsmodel.Status,
+	requestingAccount *gtsmodel.Account,
+	filterContext statusfilter.FilterContext,
+	filters []*gtsmodel.Filter,
+	mutes *usermute.CompiledUserMuteList,
+) (
+	*apimodel.Status,
+	error,
+) {
+	apiStatus, err := c.baseStatusToFrontend(ctx,
+		status,
+		requestingAccount,
+		filterContext,
+		filters,
+		mutes,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if status.BoostOf != nil {
+		reblog, err := c.baseStatusToFrontend(ctx,
+			status.BoostOf,
+			requestingAccount,
+			filterContext,
+			filters,
+			mutes,
+		)
+		if errors.Is(err, statusfilter.ErrHideStatus) {
+			// If we'd hide the original status, hide the boost.
+			return nil, err
+		} else if err != nil {
+			return nil, gtserror.Newf("error converting boosted status: %w", err)
+		}
+
+		// Set boosted status and set interactions from original.
+		apiStatus.Reblog = &apimodel.StatusReblogged{reblog}
+		apiStatus.Favourited = apiStatus.Reblog.Favourited
+		apiStatus.Bookmarked = apiStatus.Reblog.Bookmarked
+		apiStatus.Muted = apiStatus.Reblog.Muted
+		apiStatus.Reblogged = apiStatus.Reblog.Reblogged
+		apiStatus.Pinned = apiStatus.Reblog.Pinned
+	}
+
+	return apiStatus, nil
+}
+
+// baseStatusToFrontend performs the main logic
+// of statusToFrontend() without handling of boost
+// logic, to prevent *possible* recursion issues.
+func (c *Converter) baseStatusToFrontend(
+	ctx context.Context,
 	s *gtsmodel.Status,
 	requestingAccount *gtsmodel.Account,
 	filterContext statusfilter.FilterContext,
 	filters []*gtsmodel.Filter,
 	mutes *usermute.CompiledUserMuteList,
-) (*apimodel.Status, error) {
+) (
+	*apimodel.Status,
+	error,
+) {
 	// Try to populate status struct pointer fields.
 	// We can continue in many cases of partial failure,
 	// but there are some fields we actually need.
 	if err := c.state.DB.PopulateStatus(ctx, s); err != nil {
-		if s.Account == nil {
-			err = gtserror.Newf("error(s) populating status, cannot continue (status.Account not set): %w", err)
-			return nil, err
-		}
+		switch {
+		case s.Account == nil:
+			return nil, gtserror.Newf("error(s) populating status, required account not set: %w", err)
 
-		if s.BoostOfID != "" && s.BoostOf == nil {
-			err = gtserror.Newf("error(s) populating status, cannot continue (status.BoostOfID set, but status.Boost not set): %w", err)
-			return nil, err
-		}
+		case s.BoostOfID != "" && s.BoostOf == nil:
+			return nil, gtserror.Newf("error(s) populating status, required boost not set: %w", err)
 
-		log.Errorf(ctx, "error(s) populating status, will continue: %v", err)
+		default:
+			log.Errorf(ctx, "error(s) populating status, will continue: %v", err)
+		}
 	}
 
 	apiAuthorAccount, err := c.AccountToAPIAccountPublic(ctx, s.Account)
@@ -1143,18 +1202,6 @@ func (c *Converter) statusToFrontend(
 		apiStatus.Language = util.Ptr(s.Language)
 	}
 
-	if s.BoostOf != nil {
-		reblog, err := c.StatusToAPIStatus(ctx, s.BoostOf, requestingAccount, filterContext, filters, mutes)
-		if errors.Is(err, statusfilter.ErrHideStatus) {
-			// If we'd hide the original status, hide the boost.
-			return nil, err
-		} else if err != nil {
-			return nil, gtserror.Newf("error converting boosted status: %w", err)
-		}
-
-		apiStatus.Reblog = &apimodel.StatusReblogged{reblog}
-	}
-
 	if app := s.CreatedWithApplication; app != nil {
 		apiStatus.Application, err = c.AppToAPIAppPublic(ctx, app)
 		if err != nil {
@@ -1179,14 +1226,9 @@ func (c *Converter) statusToFrontend(
 
 	// Status interactions.
 	//
-	// Take from boosted status if set,
-	// otherwise take from status itself.
-	if apiStatus.Reblog != nil {
-		apiStatus.Favourited = apiStatus.Reblog.Favourited
-		apiStatus.Bookmarked = apiStatus.Reblog.Bookmarked
-		apiStatus.Muted = apiStatus.Reblog.Muted
-		apiStatus.Reblogged = apiStatus.Reblog.Reblogged
-		apiStatus.Pinned = apiStatus.Reblog.Pinned
+	if s.BoostOf != nil { //nolint
+		// populated *outside* this
+		// function to prevent recursion.
 	} else {
 		interacts, err := c.interactionsWithStatusForAccount(ctx, s, requestingAccount)
 		if err != nil {
@@ -1219,6 +1261,7 @@ func (c *Converter) statusToFrontend(
 		}
 		return nil, fmt.Errorf("error applying filters: %w", err)
 	}
+
 	apiStatus.Filtered = filterResults
 
 	return apiStatus, nil


### PR DESCRIPTION
# Description

fixes a possible recursion issue with moved accounts referrring back to the original account. adds a protection for boost wrapping statuses to make we're never allowing processing of boostOf-boostOf's

- fix possible recursion issue setting Moved account in type converter
- fix possible recursion issue setting Reblogged status in type converter
- add protections for accepting boost wrapping statuses as boost targets
- add protections for move account recursion loops (closed move chains)

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
