### PR TITLE
[bugfix] Deref stats async, serve stub collections if handshaking

### DIFF
--- a/internal/ap/activitystreams_test.go
+++ b/internal/ap/activitystreams_test.go
@@ -211,14 +211,14 @@ func TestASOrderedCollectionNoTotal(t *testing.T) {
 
 	// Create JSON string of expected output.
 	expect := toJSON(map[string]any{
-		"@context":   "https://www.w3.org/ns/activitystreams",
-		"type":       "OrderedCollection",
-		"id":         idURI,
+		"@context": "https://www.w3.org/ns/activitystreams",
+		"type":     "OrderedCollection",
+		"id":       idURI,
 	})
 
 	// Create new collection using builder function.
 	c := ap.NewASOrderedCollection(ap.CollectionParams{
-		ID:    parseURI(idURI),
+		ID: parseURI(idURI),
 	})
 
 	// Serialize collection.

--- a/internal/ap/activitystreams_test.go
+++ b/internal/ap/activitystreams_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/superseriousbusiness/activity/streams/vocab"
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
 	"github.com/superseriousbusiness/gotosocial/internal/paging"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
 
 func TestASCollection(t *testing.T) {
@@ -51,7 +52,7 @@ func TestASCollection(t *testing.T) {
 		ID:    parseURI(idURI),
 		First: new(paging.Page),
 		Query: url.Values{"limit": []string{"40"}},
-		Total: total,
+		Total: util.Ptr(total),
 	})
 
 	// Serialize collection.
@@ -82,7 +83,7 @@ func TestASCollectionTotalOnly(t *testing.T) {
 	// Create new collection using builder function.
 	c := ap.NewASCollection(ap.CollectionParams{
 		ID:    parseURI(idURI),
-		Total: total,
+		Total: util.Ptr(total),
 	})
 
 	// Serialize collection.
@@ -128,7 +129,7 @@ func TestASCollectionPage(t *testing.T) {
 	p := ap.NewASCollectionPage(ap.CollectionPageParams{
 		CollectionParams: ap.CollectionParams{
 			ID:    parseURI(idURI),
-			Total: total,
+			Total: util.Ptr(total),
 		},
 
 		Current: currPg,
@@ -166,7 +167,7 @@ func TestASOrderedCollection(t *testing.T) {
 		ID:    parseURI(idURI),
 		First: new(paging.Page),
 		Query: url.Values{"limit": []string{"40"}},
-		Total: total,
+		Total: util.Ptr(total),
 	})
 
 	// Serialize collection.
@@ -193,7 +194,31 @@ func TestASOrderedCollectionTotalOnly(t *testing.T) {
 	// Create new collection using builder function.
 	c := ap.NewASOrderedCollection(ap.CollectionParams{
 		ID:    parseURI(idURI),
-		Total: total,
+		Total: util.Ptr(total),
+	})
+
+	// Serialize collection.
+	s := toJSON(c)
+
+	// Ensure outputs are equal.
+	assert.Equal(t, expect, s)
+}
+
+func TestASOrderedCollectionNoTotal(t *testing.T) {
+	const (
+		idURI = "https://zorg.flabormagorg.xyz/users/itsa_me_mario"
+	)
+
+	// Create JSON string of expected output.
+	expect := toJSON(map[string]any{
+		"@context":   "https://www.w3.org/ns/activitystreams",
+		"type":       "OrderedCollection",
+		"id":         idURI,
+	})
+
+	// Create new collection using builder function.
+	c := ap.NewASOrderedCollection(ap.CollectionParams{
+		ID:    parseURI(idURI),
 	})
 
 	// Serialize collection.
@@ -239,7 +264,7 @@ func TestASOrderedCollectionPage(t *testing.T) {
 	p := ap.NewASOrderedCollectionPage(ap.CollectionPageParams{
 		CollectionParams: ap.CollectionParams{
 			ID:    parseURI(idURI),
-			Total: total,
+			Total: util.Ptr(total),
 		},
 
 		Current: currPg,

--- a/internal/ap/collections.go
+++ b/internal/ap/collections.go
@@ -321,7 +321,8 @@ type CollectionParams struct {
 	Query url.Values
 
 	// Total no. items.
-	Total int
+	// Omitted if nil.
+	Total *int
 }
 
 type CollectionPageParams struct {
@@ -410,9 +411,11 @@ func buildCollection[C CollectionBuilder](collection C, params CollectionParams)
 	collection.SetJSONLDId(idProp)
 
 	// Add the collection totalItems count property.
-	totalItems := streams.NewActivityStreamsTotalItemsProperty()
-	totalItems.Set(params.Total)
-	collection.SetActivityStreamsTotalItems(totalItems)
+	if params.Total != nil {
+		totalItems := streams.NewActivityStreamsTotalItemsProperty()
+		totalItems.Set(*params.Total)
+		collection.SetActivityStreamsTotalItems(totalItems)
+	}
 
 	// No First page means we're done.
 	if params.First == nil {
@@ -498,9 +501,11 @@ func buildCollectionPage[C CollectionPageBuilder, I ItemsPropertyBuilder](collec
 	}
 
 	// Add the collection totalItems count property.
-	totalItems := streams.NewActivityStreamsTotalItemsProperty()
-	totalItems.Set(params.Total)
-	collectionPage.SetActivityStreamsTotalItems(totalItems)
+	if params.Total != nil {
+		totalItems := streams.NewActivityStreamsTotalItemsProperty()
+		totalItems.Set(*params.Total)
+		collectionPage.SetActivityStreamsTotalItems(totalItems)
+	}
 
 	if params.Append == nil {
 		// nil check outside the for loop.

--- a/internal/ap/collections.go
+++ b/internal/ap/collections.go
@@ -367,6 +367,7 @@ type CollectionPageBuilder interface {
 // vocab.ActivityStreamsOrderedItemsProperty
 type ItemsPropertyBuilder interface {
 	AppendIRI(*url.URL)
+	AppendActivityStreamsCreate(vocab.ActivityStreamsCreate)
 
 	// NOTE: add more of the items-property-like interface
 	// functions here as you require them for building pages.

--- a/internal/api/activitypub/users/outboxget_test.go
+++ b/internal/api/activitypub/users/outboxget_test.go
@@ -80,8 +80,9 @@ func (suite *OutboxGetTestSuite) TestGetOutbox() {
 	suite.NoError(err)
 	suite.Equal(`{
   "@context": "https://www.w3.org/ns/activitystreams",
-  "first": "http://localhost:8080/users/the_mighty_zork/outbox?page=true",
+  "first": "http://localhost:8080/users/the_mighty_zork/outbox?limit=40",
   "id": "http://localhost:8080/users/the_mighty_zork/outbox",
+  "totalItems": 7,
   "type": "OrderedCollection"
 }`, dst.String())
 
@@ -105,7 +106,7 @@ func (suite *OutboxGetTestSuite) TestGetOutboxFirstPage() {
 	// setup request
 	recorder := httptest.NewRecorder()
 	ctx, _ := testrig.CreateGinTestContext(recorder, nil)
-	ctx.Request = httptest.NewRequest(http.MethodGet, targetAccount.OutboxURI+"?page=true", nil) // the endpoint we're hitting
+	ctx.Request = httptest.NewRequest(http.MethodGet, targetAccount.OutboxURI+"?limit=40", nil) // the endpoint we're hitting
 	ctx.Request.Header.Set("accept", "application/activity+json")
 	ctx.Request.Header.Set("Signature", signedRequest.SignatureHeader)
 	ctx.Request.Header.Set("Date", signedRequest.DateHeader)
@@ -138,8 +139,8 @@ func (suite *OutboxGetTestSuite) TestGetOutboxFirstPage() {
 	suite.NoError(err)
 	suite.Equal(`{
   "@context": "https://www.w3.org/ns/activitystreams",
-  "id": "http://localhost:8080/users/the_mighty_zork/outbox?page=true",
-  "next": "http://localhost:8080/users/the_mighty_zork/outbox?page=true\u0026max_id=01F8MHAMCHF6Y650WCRSCP4WMY",
+  "id": "http://localhost:8080/users/the_mighty_zork/outbox?limit=40",
+  "next": "http://localhost:8080/users/the_mighty_zork/outbox?limit=40\u0026max_id=01F8MHAMCHF6Y650WCRSCP4WMY",
   "orderedItems": [
     {
       "actor": "http://localhost:8080/users/the_mighty_zork",
@@ -159,7 +160,8 @@ func (suite *OutboxGetTestSuite) TestGetOutboxFirstPage() {
     }
   ],
   "partOf": "http://localhost:8080/users/the_mighty_zork/outbox",
-  "prev": "http://localhost:8080/users/the_mighty_zork/outbox?page=true\u0026min_id=01HH9KYNQPA416TNJ53NSATP40",
+  "prev": "http://localhost:8080/users/the_mighty_zork/outbox?limit=40\u0026min_id=01HH9KYNQPA416TNJ53NSATP40",
+  "totalItems": 7,
   "type": "OrderedCollectionPage"
 }`, dst.String())
 
@@ -183,7 +185,7 @@ func (suite *OutboxGetTestSuite) TestGetOutboxNextPage() {
 	// setup request
 	recorder := httptest.NewRecorder()
 	ctx, _ := testrig.CreateGinTestContext(recorder, nil)
-	ctx.Request = httptest.NewRequest(http.MethodGet, targetAccount.OutboxURI+"?page=true&max_id=01F8MHAMCHF6Y650WCRSCP4WMY", nil) // the endpoint we're hitting
+	ctx.Request = httptest.NewRequest(http.MethodGet, targetAccount.OutboxURI+"?limit=40&max_id=01F8MHAMCHF6Y650WCRSCP4WMY", nil) // the endpoint we're hitting
 	ctx.Request.Header.Set("accept", "application/activity+json")
 	ctx.Request.Header.Set("Signature", signedRequest.SignatureHeader)
 	ctx.Request.Header.Set("Date", signedRequest.DateHeader)
@@ -219,9 +221,10 @@ func (suite *OutboxGetTestSuite) TestGetOutboxNextPage() {
 	suite.NoError(err)
 	suite.Equal(`{
   "@context": "https://www.w3.org/ns/activitystreams",
-  "id": "http://localhost:8080/users/the_mighty_zork/outbox?page=true&maxID=01F8MHAMCHF6Y650WCRSCP4WMY",
+  "id": "http://localhost:8080/users/the_mighty_zork/outbox?limit=40&max_id=01F8MHAMCHF6Y650WCRSCP4WMY",
   "orderedItems": [],
   "partOf": "http://localhost:8080/users/the_mighty_zork/outbox",
+  "totalItems": 7,
   "type": "OrderedCollectionPage"
 }`, dst.String())
 

--- a/internal/db/account.go
+++ b/internal/db/account.go
@@ -137,9 +137,22 @@ type Account interface {
 	// Update local account settings.
 	UpdateAccountSettings(ctx context.Context, settings *gtsmodel.AccountSettings, columns ...string) error
 
-	// PopulateAccountStats gets (or creates and gets) account stats for
-	// the given account, and attaches them to the account model.
+	// PopulateAccountStats either creates account stats for the given
+	// account by performing COUNT(*) database queries, or retrieves
+	// existing stats from the database, and attaches stats to account.
+	//
+	// If account is local and stats were last regenerated > 48 hours ago,
+	// stats will always be regenerated using COUNT(*) queries, to prevent drift.
 	PopulateAccountStats(ctx context.Context, account *gtsmodel.Account) error
+
+	// StubAccountStats creates zeroed account stats for the given account,
+	// skipping COUNT(*) queries, upserts them in the DB, and attaches them
+	// to the account model.
+	//
+	// Useful following fresh dereference of a remote account, or fresh
+	// creation of a local account, when you know all COUNT(*) queries
+	// would return 0 anyway.
+	StubAccountStats(ctx context.Context, account *gtsmodel.Account) error
 
 	// RegenerateAccountStats creates, upserts, and returns stats
 	// for the given account, and attaches them to the account model.

--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -1196,6 +1196,35 @@ func (a *accountDB) PopulateAccountStats(ctx context.Context, account *gtsmodel.
 	return nil
 }
 
+func (a *accountDB) StubAccountStats(ctx context.Context, account *gtsmodel.Account) error {
+	stats := &gtsmodel.AccountStats{
+		AccountID:           account.ID,
+		RegeneratedAt:       time.Now(),
+		FollowersCount:      util.Ptr(0),
+		FollowingCount:      util.Ptr(0),
+		FollowRequestsCount: util.Ptr(0),
+		StatusesCount:       util.Ptr(0),
+		StatusesPinnedCount: util.Ptr(0),
+	}
+
+	// Upsert this stats in case a race
+	// meant someone else inserted it first.
+	if err := a.state.Caches.GTS.AccountStats.Store(stats, func() error {
+		if _, err := NewUpsert(a.db).
+			Model(stats).
+			Constraint("account_id").
+			Exec(ctx); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	account.Stats = stats
+	return nil
+}
+
 func (a *accountDB) RegenerateAccountStats(ctx context.Context, account *gtsmodel.Account) error {
 	// Initialize a new stats struct.
 	stats := &gtsmodel.AccountStats{

--- a/internal/processing/fedi/collections.go
+++ b/internal/processing/fedi/collections.go
@@ -30,6 +30,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/paging"
 	"github.com/superseriousbusiness/gotosocial/internal/typeutils"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
 
 // InboxPost handles POST requests to a user's inbox for new activitypub messages.
@@ -81,7 +82,6 @@ func (p *Processor) OutboxGet(
 	// Start the AS collection params.
 	var params ap.CollectionParams
 	params.ID = collectionID
-	params.Total = *receivingAcct.Stats.StatusesCount
 
 	switch {
 
@@ -89,13 +89,14 @@ func (p *Processor) OutboxGet(
 		receivingAcct.IsInstance():
 		// If account that hides collections, or instance
 		// account (ie., can't post / have relationships),
-		// just return totalItems.
+		// just return barest stub of collection.
 		obj = ap.NewASOrderedCollection(params)
 
 	case page == nil || auth.handshakingURI != nil:
 		// If paging disabled, or we're currently handshaking
 		// the requester, just return collection that links
 		// to first page (i.e. path below), with no items.
+		params.Total = util.Ptr(*receivingAcct.Stats.StatusesCount)
 		params.First = new(paging.Page)
 		params.Query = make(url.Values, 1)
 		params.Query.Set("limit", "40") // enables paging
@@ -131,6 +132,7 @@ func (p *Processor) OutboxGet(
 		}
 
 		// Start building AS collection page params.
+		params.Total = util.Ptr(*receivingAcct.Stats.StatusesCount)
 		var pageParams ap.CollectionPageParams
 		pageParams.CollectionParams = params
 
@@ -210,7 +212,6 @@ func (p *Processor) FollowersGet(
 	// Start the AS collection params.
 	var params ap.CollectionParams
 	params.ID = collectionID
-	params.Total = *receivingAcct.Stats.FollowersCount
 
 	switch {
 
@@ -218,13 +219,14 @@ func (p *Processor) FollowersGet(
 		*receivingAcct.Settings.HideCollections:
 		// If account that hides collections, or instance
 		// account (ie., can't post / have relationships),
-		// just return totalItems.
+		// just return barest stub of collection.
 		obj = ap.NewASOrderedCollection(params)
 
 	case page == nil || auth.handshakingURI != nil:
 		// If paging disabled, or we're currently handshaking
 		// the requester, just return collection that links
 		// to first page (i.e. path below), with no items.
+		params.Total = util.Ptr(*receivingAcct.Stats.FollowersCount)
 		params.First = new(paging.Page)
 		params.Query = make(url.Values, 1)
 		params.Query.Set("limit", "40") // enables paging
@@ -250,6 +252,7 @@ func (p *Processor) FollowersGet(
 		}
 
 		// Start building AS collection page params.
+		params.Total = util.Ptr(*receivingAcct.Stats.FollowersCount)
 		var pageParams ap.CollectionPageParams
 		pageParams.CollectionParams = params
 
@@ -323,20 +326,20 @@ func (p *Processor) FollowingGet(ctx context.Context, requestedUser string, page
 	// Start AS collection params.
 	var params ap.CollectionParams
 	params.ID = collectionID
-	params.Total = *receivingAcct.Stats.FollowingCount
 
 	switch {
 	case receivingAcct.IsInstance() ||
 		*receivingAcct.Settings.HideCollections:
 		// If account that hides collections, or instance
 		// account (ie., can't post / have relationships),
-		// just return totalItems.
+		// just return barest stub of collection.
 		obj = ap.NewASOrderedCollection(params)
 
 	case page == nil || auth.handshakingURI != nil:
 		// If paging disabled, or we're currently handshaking
 		// the requester, just return collection that links
 		// to first page (i.e. path below), with no items.
+		params.Total = util.Ptr(*receivingAcct.Stats.FollowingCount)
 		params.First = new(paging.Page)
 		params.Query = make(url.Values, 1)
 		params.Query.Set("limit", "40") // enables paging
@@ -362,6 +365,7 @@ func (p *Processor) FollowingGet(ctx context.Context, requestedUser string, page
 		}
 
 		// Start AS collection page params.
+		params.Total = util.Ptr(*receivingAcct.Stats.FollowingCount)
 		var pageParams ap.CollectionPageParams
 		pageParams.CollectionParams = params
 

--- a/internal/processing/fedi/collections.go
+++ b/internal/processing/fedi/collections.go
@@ -108,13 +108,13 @@ func (p *Processor) OutboxGet(
 		statuses, err := p.state.DB.GetAccountStatuses(
 			ctx,
 			receivingAcct.ID,
-			page.Limit,    // limit
-			true,          // excludeReplies
-			true,          // excludeReblogs
-			page.GetMax(), // maxID
-			page.GetMin(), // minID
-			false,         // mediaOnly
-			true,          // publicOnly
+			page.GetLimit(), // limit
+			true,            // excludeReplies
+			true,            // excludeReblogs
+			page.GetMax(),   // maxID
+			page.GetMin(),   // minID
+			false,           // mediaOnly
+			true,            // publicOnly
 		)
 		if err != nil && !errors.Is(err, db.ErrNoEntries) {
 			err := gtserror.Newf("error getting statuses: %w", err)

--- a/internal/processing/fedi/status.go
+++ b/internal/processing/fedi/status.go
@@ -35,18 +35,29 @@ import (
 // StatusGet handles the getting of a fedi/activitypub representation of a local status.
 // It performs appropriate authentication before returning a JSON serializable interface.
 func (p *Processor) StatusGet(ctx context.Context, requestedUser string, statusID string) (interface{}, gtserror.WithCode) {
-	// Authenticate the incoming request, getting related user accounts.
-	requester, receiver, errWithCode := p.authenticate(ctx, requestedUser)
+	// Authenticate incoming request, getting related accounts.
+	auth, errWithCode := p.authenticate(ctx, requestedUser)
 	if errWithCode != nil {
 		return nil, errWithCode
 	}
+
+	if auth.handshakingURI != nil {
+		// We're currently handshaking, which means
+		// we don't know this account yet. This should
+		// be a very rare race condition.
+		err := gtserror.Newf("network race handshaking %s", auth.handshakingURI)
+		return nil, gtserror.NewErrorInternalError(err)
+	}
+
+	receivingAcct := auth.receivingAcct
+	requestingAcct := auth.requestingAcct
 
 	status, err := p.state.DB.GetStatusByID(ctx, statusID)
 	if err != nil {
 		return nil, gtserror.NewErrorNotFound(err)
 	}
 
-	if status.AccountID != receiver.ID {
+	if status.AccountID != receivingAcct.ID {
 		const text = "status does not belong to receiving account"
 		return nil, gtserror.NewErrorNotFound(errors.New(text))
 	}
@@ -56,7 +67,7 @@ func (p *Processor) StatusGet(ctx context.Context, requestedUser string, statusI
 		return nil, gtserror.NewErrorNotFound(errors.New(text))
 	}
 
-	visible, err := p.filter.StatusVisible(ctx, requester, status)
+	visible, err := p.filter.StatusVisible(ctx, requestingAcct, status)
 	if err != nil {
 		return nil, gtserror.NewErrorInternalError(err)
 	}
@@ -90,15 +101,26 @@ func (p *Processor) StatusRepliesGet(
 	page *paging.Page,
 	onlyOtherAccounts bool,
 ) (interface{}, gtserror.WithCode) {
-	// Authenticate the incoming request, getting related user accounts.
-	requester, receiver, errWithCode := p.authenticate(ctx, requestedUser)
+	// Authenticate incoming request, getting related accounts.
+	auth, errWithCode := p.authenticate(ctx, requestedUser)
 	if errWithCode != nil {
 		return nil, errWithCode
 	}
 
+	if auth.handshakingURI != nil {
+		// We're currently handshaking, which means
+		// we don't know this account yet. This should
+		// be a very rare race condition.
+		err := gtserror.Newf("network race handshaking %s", auth.handshakingURI)
+		return nil, gtserror.NewErrorInternalError(err)
+	}
+
+	receivingAcct := auth.receivingAcct
+	requestingAcct := auth.requestingAcct
+
 	// Get target status and ensure visible to requester.
 	status, errWithCode := p.c.GetVisibleTargetStatus(ctx,
-		requester,
+		requestingAcct,
 		statusID,
 		nil, // default freshness
 	)
@@ -107,7 +129,7 @@ func (p *Processor) StatusRepliesGet(
 	}
 
 	// Ensure status is by receiving account.
-	if status.AccountID != receiver.ID {
+	if status.AccountID != receivingAcct.ID {
 		const text = "status does not belong to receiving account"
 		return nil, gtserror.NewErrorNotFound(errors.New(text))
 	}
@@ -140,7 +162,7 @@ func (p *Processor) StatusRepliesGet(
 	}
 
 	// Reslice replies dropping all those invisible to requester.
-	replies, err = p.filter.StatusesVisible(ctx, requester, replies)
+	replies, err = p.filter.StatusesVisible(ctx, requestingAcct, replies)
 	if err != nil {
 		err := gtserror.Newf("error filtering status replies: %w", err)
 		return nil, gtserror.NewErrorInternalError(err)

--- a/internal/processing/fedi/status.go
+++ b/internal/processing/fedi/status.go
@@ -30,6 +30,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/paging"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
 
 // StatusGet handles the getting of a fedi/activitypub representation of a local status.
@@ -173,7 +174,7 @@ func (p *Processor) StatusRepliesGet(
 	// Start AS collection params.
 	var params ap.CollectionParams
 	params.ID = collectionID
-	params.Total = len(replies)
+	params.Total = util.Ptr(len(replies))
 
 	if page == nil {
 		// i.e. paging disabled, return collection

--- a/internal/typeutils/internaltoas.go
+++ b/internal/typeutils/internaltoas.go
@@ -1560,39 +1560,6 @@ func (c *Converter) StatusesToASOutboxPage(ctx context.Context, outboxID string,
 	return page, nil
 }
 
-// OutboxToASCollection returns an ordered collection with appropriate id, next, and last fields.
-// The returned collection won't have any actual entries; just links to where entries can be obtained.
-// we want something that looks like this:
-//
-//	{
-//		"@context": "https://www.w3.org/ns/activitystreams",
-//		"id": "https://example.org/users/whatever/outbox",
-//		"type": "OrderedCollection",
-//		"first": "https://example.org/users/whatever/outbox?page=true"
-//	}
-func (c *Converter) OutboxToASCollection(ctx context.Context, outboxID string) (vocab.ActivityStreamsOrderedCollection, error) {
-	collection := streams.NewActivityStreamsOrderedCollection()
-
-	collectionIDProp := streams.NewJSONLDIdProperty()
-	outboxIDURI, err := url.Parse(outboxID)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing url %s", outboxID)
-	}
-	collectionIDProp.SetIRI(outboxIDURI)
-	collection.SetJSONLDId(collectionIDProp)
-
-	collectionFirstProp := streams.NewActivityStreamsFirstProperty()
-	collectionFirstPropID := fmt.Sprintf("%s?page=true", outboxID)
-	collectionFirstPropIDURI, err := url.Parse(collectionFirstPropID)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing url %s", collectionFirstPropID)
-	}
-	collectionFirstProp.SetIRI(collectionFirstPropIDURI)
-	collection.SetActivityStreamsFirst(collectionFirstProp)
-
-	return collection, nil
-}
-
 // StatusesToASFeaturedCollection converts a slice of statuses into an ordered collection
 // of URIs, suitable for serializing and serving via the activitypub API.
 func (c *Converter) StatusesToASFeaturedCollection(ctx context.Context, featuredCollectionID string, statuses []*gtsmodel.Status) (vocab.ActivityStreamsOrderedCollection, error) {

--- a/internal/typeutils/internaltoas_test.go
+++ b/internal/typeutils/internaltoas_test.go
@@ -366,27 +366,6 @@ func (suite *InternalToASTestSuite) TestAccountToASWithSharedInbox() {
 }`, trimmed)
 }
 
-func (suite *InternalToASTestSuite) TestOutboxToASCollection() {
-	testAccount := suite.testAccounts["admin_account"]
-	ctx := context.Background()
-
-	collection, err := suite.typeconverter.OutboxToASCollection(ctx, testAccount.OutboxURI)
-	suite.NoError(err)
-
-	ser, err := ap.Serialize(collection)
-	suite.NoError(err)
-
-	bytes, err := json.MarshalIndent(ser, "", "  ")
-	suite.NoError(err)
-
-	suite.Equal(`{
-  "@context": "https://www.w3.org/ns/activitystreams",
-  "first": "http://localhost:8080/users/admin/outbox?page=true",
-  "id": "http://localhost:8080/users/admin/outbox",
-  "type": "OrderedCollection"
-}`, string(bytes))
-}
-
 func (suite *InternalToASTestSuite) TestStatusToAS() {
 	testStatus := suite.testStatuses["local_account_1_status_1"]
 	ctx := context.Background()

--- a/testrig/testmodels.go
+++ b/testrig/testmodels.go
@@ -3227,7 +3227,7 @@ func NewTestDereferenceRequests(accounts map[string]*gtsmodel.Account) map[strin
 		DateHeader:      date,
 	}
 
-	target = URLMustParse(accounts["local_account_1"].OutboxURI + "?page=true")
+	target = URLMustParse(accounts["local_account_1"].OutboxURI + "?limit=40")
 	sig, digest, date = GetSignatureForDereference(accounts["remote_account_1"].PublicKeyURI, accounts["remote_account_1"].PrivateKey, target)
 	fossSatanDereferenceZorkOutboxFirst := ActivityWithSignature{
 		SignatureHeader: sig,
@@ -3235,7 +3235,7 @@ func NewTestDereferenceRequests(accounts map[string]*gtsmodel.Account) map[strin
 		DateHeader:      date,
 	}
 
-	target = URLMustParse(accounts["local_account_1"].OutboxURI + "?page=true&max_id=01F8MHAMCHF6Y650WCRSCP4WMY")
+	target = URLMustParse(accounts["local_account_1"].OutboxURI + "?limit=40&max_id=01F8MHAMCHF6Y650WCRSCP4WMY")
 	sig, digest, date = GetSignatureForDereference(accounts["remote_account_1"].PublicKeyURI, accounts["remote_account_1"].PrivateKey, target)
 	fossSatanDereferenceZorkOutboxNext := ActivityWithSignature{
 		SignatureHeader: sig,


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request solves a bug introduced in 0.16.0-rc1 where account stats were fetched during the initial dereference attempt, leading to a potential recursive handshake loop where two GtS instances would fail to dereference each other.

The fix is to:

1. Only fetch stats asynchronously, and during a first dereference just return local stats (ie., 0 followers, 0 following, 0 statuses).
2. Serve bare stub endpoints for an Actor's collections (without even totalItems) if dereference is done during handshaking, just to get things moving along. This part isn't strictly necessary to fix this bug now, but it will ensure that future softwares trying to deref GtS collections, who withhold their collections first, can still get something in response.

The PR also stops serving totalItems in cases where the receiving account has decided to hide their collections. This brings it in line with what Mastodon glitch does.

Oh, and the PR also uses our paging code for `outbox`, in contrast to the sorta freewheeling code we had there before.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
