### PR TITLE
[chore] Roll back use of `(created)` pseudo-header pending #2991

### DIFF
--- a/docs/federation/federating_with_gotosocial.md
+++ b/docs/federation/federating_with_gotosocial.md
@@ -42,10 +42,12 @@ ED25519
 
 GoToSocial request signing is implemented in [internal/transport](https://github.com/superseriousbusiness/gotosocial/blob/main/internal/transport/signing.go).
 
-When assembling signatures:
+Once https://github.com/superseriousbusiness/gotosocial/issues/2991 is resolved, GoToSocial will use the `(created)` pseudo-header instead of `date`.
 
-- outgoing `GET` requests use `(request-target) (created) host`
-- outgoing `POST` requests use `(request-target) (created) host digest` 
+For now however, when assembling signatures:
+
+- outgoing `GET` requests use `(request-target) host date`
+- outgoing `POST` requests use `(request-target) host date digest` 
 
 GoToSocial sets the "algorithm" field in signatures to the value `hs2019`, which essentially means "derive the algorithm from metadata associated with the keyId". The *actual* algorithm used for generating signatures is `RSA_SHA256`, which is in line with other ActivityPub implementations. When validating a GoToSocial HTTP signature, remote servers can safely assume that the signature is generated using `sha256`.
 

--- a/internal/transport/signing.go
+++ b/internal/transport/signing.go
@@ -23,10 +23,12 @@ import (
 
 var (
 	// http signer preferences
-	prefs       = []httpsig.Algorithm{httpsig.RSA_SHA256}
-	digestAlgo  = httpsig.DigestSha256
-	getHeaders  = []string{httpsig.RequestTarget, "(created)", "host"}
-	postHeaders = []string{httpsig.RequestTarget, "(created)", "host", "digest"}
+	prefs      = []httpsig.Algorithm{httpsig.RSA_SHA256}
+	digestAlgo = httpsig.DigestSha256
+
+	// TODO: Update these to use `(created)` pseudo-header instead of `Date`.
+	getHeaders  = []string{httpsig.RequestTarget, "host", "date"}
+	postHeaders = []string{httpsig.RequestTarget, "host", "date", "digest"}
 )
 
 // NewGETSigner returns a new httpsig.Signer instance initialized with GTS GET preferences.


### PR DESCRIPTION
Roll back `(created)`, see: https://github.com/superseriousbusiness/gotosocial/issues/2991