### PR TITLE
[chore] Don't render sign-up form when registrations closed

### DIFF
--- a/internal/web/signup.go
+++ b/internal/web/signup.go
@@ -58,7 +58,8 @@ func (m *Module) signupGETHandler(c *gin.Context) {
 		Instance: instance,
 		OGMeta:   apiutil.OGBase(instance),
 		Extra: map[string]any{
-			"reasonRequired": config.GetAccountsReasonRequired(),
+			"reasonRequired":   config.GetAccountsReasonRequired(),
+			"registrationOpen": config.GetAccountsRegistrationOpen(),
 		},
 	}
 

--- a/web/template/sign-up.tmpl
+++ b/web/template/sign-up.tmpl
@@ -21,6 +21,9 @@
 <main>
     <section class="with-form" aria-labelledby="sign-up">
         <h2 id="sign-up">Sign up for an account on {{ .instance.Title -}}</h2>
+        {{- if not .registrationOpen }}
+        <p>This instance is not currently open to new sign-ups.</p>
+        {{- else }}
         <form action="/signup" method="POST">
             <div class="labelinput">
                 <label for="email">Email</label>
@@ -40,6 +43,7 @@
                     name="password"
                     required
                     placeholder="Please enter your desired password"
+                    autocomplete="new-password"
                 >
             </div>
             <div class="labelinput">
@@ -88,6 +92,7 @@
             <input type="hidden" name="locale" value="en">
             <button type="submit" class="btn btn-success">Submit</button>
         </form>
+        {{- end }}
     </section>
 </main>
 {{- end }}


### PR DESCRIPTION
Hide the sign-up form when instance is not open to new registrations, to prevent people thinking they can still submit.