### PR TITLE
[chore] Silence memlimit package

### DIFF
--- a/cmd/gotosocial/action/server/server.go
+++ b/cmd/gotosocial/action/server/server.go
@@ -24,9 +24,11 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
+	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/gin-gonic/gin"
 	"github.com/superseriousbusiness/gotosocial/cmd/gotosocial/action"
 	"github.com/superseriousbusiness/gotosocial/internal/api"
@@ -60,15 +62,18 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/transport"
 	"github.com/superseriousbusiness/gotosocial/internal/typeutils"
 	"github.com/superseriousbusiness/gotosocial/internal/web"
-
-	// Inherit memory limit if set from cgroup
-	_ "github.com/KimMachineGun/automemlimit"
 )
 
 // Start creates and starts a gotosocial server
 var Start action.GTSAction = func(ctx context.Context) error {
 	if _, err := maxprocs.Set(maxprocs.Logger(nil)); err != nil {
 		log.Warnf(ctx, "could not set CPU limits from cgroup: %s", err)
+	}
+
+	if _, err := memlimit.SetGoMemLimitWithOpts(); err != nil {
+		if !strings.Contains(err.Error(), "cgroup mountpoint does not exist") {
+			log.Warnf(ctx, "could not set Memory limits from cgroup: %s", err)
+		}
 	}
 
 	var (


### PR DESCRIPTION
# Description

The memlimit package started to log any error returned by automemlimit. This updates our implementation to call SetGoMemLimitWithOpts() instead which uses the same defaults as automemlimit except for being initialised with a noop logger.

We check the returned error for a particular substring, as when cgroups isn't available even when running on a Linux system that's not a problem. If it's anything but that error, we log it at the warning level so that admins can still diagnose other cgroup related issues.

Fixes #2983

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
