### PR TITLE
[chore] Update move test

### DIFF
--- a/internal/processing/workers/fromfediapi_test.go
+++ b/internal/processing/workers/fromfediapi_test.go
@@ -627,12 +627,17 @@ func (suite *FromFediAPITestSuite) TestMoveAccount() {
 	})
 	suite.NoError(err)
 
+	// Wait for side effects to trigger:
 	// Zork should now be following admin account.
-	follows, err := testStructs.State.DB.IsFollowing(ctx, receivingAcct.ID, targetAcct.ID)
-	if err != nil {
-		suite.FailNow(err.Error())
+	if !testrig.WaitFor(func() bool {
+		follows, err := testStructs.State.DB.IsFollowing(ctx, receivingAcct.ID, targetAcct.ID)
+		if err != nil {
+			suite.FailNow(err.Error())
+		}
+		return follows
+	}) {
+		suite.FailNow("timed out waiting for zork to follow admin account")
 	}
-	suite.True(follows)
 
 	// Move should be in the DB.
 	move, err := testStructs.State.DB.GetMoveByURI(ctx, "https://fossbros-anonymous.io/users/foss_satan/moves/01HRA064871MR8HGVSAFJ333GM")


### PR DESCRIPTION
In https://github.com/superseriousbusiness/gotosocial/pull/2998 the FollowCreate function was changed to not create the follow immediately but to create the follow asynchronously, which was causing a test to run into a race. This PR fixes that by ensuring that the test waits until side effects are complete.