### PR TITLE
[bugfix] rename `include_types[]` to `types[]`

### DIFF
--- a/internal/api/client/notifications/notifications.go
+++ b/internal/api/client/notifications/notifications.go
@@ -34,8 +34,8 @@ const (
 	BasePathWithID    = BasePath + "/:" + IDKey
 	BasePathWithClear = BasePath + "/clear"
 
-	// IncludeTypesKey names an array param specifying notification types to include.
-	IncludeTypesKey = "include_types[]"
+	// TypesKey names an array param specifying notification types to include.
+	TypesKey = "types[]"
 	// ExcludeTypesKey names an array param specifying notification types to exclude.
 	ExcludeTypesKey = "exclude_types[]"
 	MaxIDKey        = "max_id"

--- a/internal/api/client/notifications/notificationsget.go
+++ b/internal/api/client/notifications/notificationsget.go
@@ -171,7 +171,7 @@ func (m *Module) NotificationsGETHandler(c *gin.Context) {
 		c.Query(SinceIDKey),
 		c.Query(MinIDKey),
 		limit,
-		c.QueryArray(IncludeTypesKey),
+		c.QueryArray(TypesKey),
 		c.QueryArray(ExcludeTypesKey),
 	)
 	if errWithCode != nil {

--- a/internal/api/client/notifications/notificationsget_test.go
+++ b/internal/api/client/notifications/notificationsget_test.go
@@ -45,7 +45,7 @@ func (suite *NotificationsTestSuite) getNotifications(
 	maxID string,
 	minID string,
 	limit int,
-	includeTypes []string,
+	types []string,
 	excludeTypes []string,
 	expectedHTTPStatus int,
 	expectedBody string,
@@ -71,8 +71,8 @@ func (suite *NotificationsTestSuite) getNotifications(
 	if limit != 0 {
 		query.Set(notifications.LimitKey, strconv.Itoa(limit))
 	}
-	if len(includeTypes) > 0 {
-		query[notifications.IncludeTypesKey] = includeTypes
+	if len(types) > 0 {
+		query[notifications.TypesKey] = types
 	}
 	if len(excludeTypes) > 0 {
 		query[notifications.ExcludeTypesKey] = excludeTypes
@@ -123,7 +123,7 @@ func (suite *NotificationsTestSuite) TestGetNotificationsSingle() {
 	maxID := ""
 	minID := ""
 	limit := 10
-	includeTypes := []string(nil)
+	types := []string(nil)
 	excludeTypes := []string(nil)
 	expectedHTTPStatus := http.StatusOK
 	expectedBody := ""
@@ -135,7 +135,7 @@ func (suite *NotificationsTestSuite) TestGetNotificationsSingle() {
 		maxID,
 		minID,
 		limit,
-		includeTypes,
+		types,
 		excludeTypes,
 		expectedHTTPStatus,
 		expectedBody,
@@ -181,7 +181,7 @@ func (suite *NotificationsTestSuite) TestGetNotificationsExcludeOneType() {
 	maxID := ""
 	minID := ""
 	limit := 10
-	includeTypes := []string(nil)
+	types := []string(nil)
 	excludeTypes := []string{"follow_request"}
 	expectedHTTPStatus := http.StatusOK
 	expectedBody := ""
@@ -193,7 +193,7 @@ func (suite *NotificationsTestSuite) TestGetNotificationsExcludeOneType() {
 		maxID,
 		minID,
 		limit,
-		includeTypes,
+		types,
 		excludeTypes,
 		expectedHTTPStatus,
 		expectedBody,
@@ -220,7 +220,7 @@ func (suite *NotificationsTestSuite) TestGetNotificationsIncludeOneType() {
 	maxID := ""
 	minID := ""
 	limit := 10
-	includeTypes := []string{"favourite"}
+	types := []string{"favourite"}
 	excludeTypes := []string(nil)
 	expectedHTTPStatus := http.StatusOK
 	expectedBody := ""
@@ -232,7 +232,7 @@ func (suite *NotificationsTestSuite) TestGetNotificationsIncludeOneType() {
 		maxID,
 		minID,
 		limit,
-		includeTypes,
+		types,
 		excludeTypes,
 		expectedHTTPStatus,
 		expectedBody,

--- a/internal/db/bundb/notification.go
+++ b/internal/db/bundb/notification.go
@@ -200,7 +200,7 @@ func (n *notificationDB) GetAccountNotifications(
 	sinceID string,
 	minID string,
 	limit int,
-	includeTypes []string,
+	types []string,
 	excludeTypes []string,
 ) ([]*gtsmodel.Notification, error) {
 	// Ensure reasonable
@@ -238,9 +238,9 @@ func (n *notificationDB) GetAccountNotifications(
 		frontToBack = false // page up
 	}
 
-	if len(includeTypes) > 0 {
+	if len(types) > 0 {
 		// Include only requested notification types.
-		q = q.Where("? IN (?)", bun.Ident("notification.notification_type"), bun.In(includeTypes))
+		q = q.Where("? IN (?)", bun.Ident("notification.notification_type"), bun.In(types))
 	}
 
 	if len(excludeTypes) > 0 {

--- a/internal/db/notification.go
+++ b/internal/db/notification.go
@@ -28,8 +28,8 @@ type Notification interface {
 	// GetAccountNotifications returns a slice of notifications that pertain to the given accountID.
 	//
 	// Returned notifications will be ordered ID descending (ie., highest/newest to lowest/oldest).
-	// If includeTypes is empty, *all* notification types will be included.
-	GetAccountNotifications(ctx context.Context, accountID string, maxID string, sinceID string, minID string, limit int, includeTypes []string, excludeTypes []string) ([]*gtsmodel.Notification, error)
+	// If types is empty, *all* notification types will be included.
+	GetAccountNotifications(ctx context.Context, accountID string, maxID string, sinceID string, minID string, limit int, types []string, excludeTypes []string) ([]*gtsmodel.Notification, error)
 
 	// GetNotificationByID returns one notification according to its id.
 	GetNotificationByID(ctx context.Context, id string) (*gtsmodel.Notification, error)

--- a/internal/processing/timeline/notification.go
+++ b/internal/processing/timeline/notification.go
@@ -41,7 +41,7 @@ func (p *Processor) NotificationsGet(
 	sinceID string,
 	minID string,
 	limit int,
-	includeTypes []string,
+	types []string,
 	excludeTypes []string,
 ) (*apimodel.PageableResponse, gtserror.WithCode) {
 	notifs, err := p.state.DB.GetAccountNotifications(
@@ -51,7 +51,7 @@ func (p *Processor) NotificationsGet(
 		sinceID,
 		minID,
 		limit,
-		includeTypes,
+		types,
 		excludeTypes,
 	)
 	if err != nil && !errors.Is(err, db.ErrNoEntries) {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

We accidentally named the `types[]` parameter incorrectly in https://github.com/superseriousbusiness/gotosocial/pull/3009, this just fixes that by renaming `include_types[]` to `types[]`.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
