### PR TITLE
[chore] update go-structr and go-mangler to no longer rely on modern-go/reflect2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/superseriousbusiness/gotosocial
 
 go 1.22.2
 
+replace codeberg.org/gruf/go-structr => ../go-structr
+
 replace modernc.org/sqlite => gitlab.com/NyaaaWhatsUpDoc/sqlite v1.29.9-concurrency-workaround
 
 require (
@@ -88,7 +90,7 @@ require (
 	codeberg.org/gruf/go-atomics v1.1.0 // indirect
 	codeberg.org/gruf/go-bitutil v1.1.0 // indirect
 	codeberg.org/gruf/go-fastpath/v2 v2.0.0 // indirect
-	codeberg.org/gruf/go-mangler v1.3.0 // indirect
+	codeberg.org/gruf/go-mangler v1.4.0 // indirect
 	codeberg.org/gruf/go-maps v1.0.3 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	codeberg.org/gruf/go-runners v1.6.2
 	codeberg.org/gruf/go-sched v1.2.3
 	codeberg.org/gruf/go-storage v0.1.1
-	codeberg.org/gruf/go-structr v0.8.6
+	codeberg.org/gruf/go-structr v0.8.7
 	codeberg.org/superseriousbusiness/exif-terminator v0.7.0
 	github.com/DmitriyVTitov/size v1.5.0
 	github.com/KimMachineGun/automemlimit v0.6.1

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/superseriousbusiness/gotosocial
 
 go 1.22.2
 
-replace codeberg.org/gruf/go-structr => ../go-structr
-
 replace modernc.org/sqlite => gitlab.com/NyaaaWhatsUpDoc/sqlite v1.29.9-concurrency-workaround
 
 require (
@@ -23,7 +21,7 @@ require (
 	codeberg.org/gruf/go-runners v1.6.2
 	codeberg.org/gruf/go-sched v1.2.3
 	codeberg.org/gruf/go-storage v0.1.1
-	codeberg.org/gruf/go-structr v0.8.5
+	codeberg.org/gruf/go-structr v0.8.6
 	codeberg.org/superseriousbusiness/exif-terminator v0.7.0
 	github.com/DmitriyVTitov/size v1.5.0
 	github.com/KimMachineGun/automemlimit v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ codeberg.org/gruf/go-logger/v2 v2.2.1 h1:RP2u059EQKTBFV3cN8X6xDxNk2RkzqdgXGKflKq
 codeberg.org/gruf/go-logger/v2 v2.2.1/go.mod h1:m/vBfG5jNUmYXI8Hg9aVSk7Pn8YgEBITQB/B/CzdRss=
 codeberg.org/gruf/go-loosy v0.0.0-20231007123304-bb910d1ab5c4 h1:IXwfoU7f2whT6+JKIKskNl/hBlmWmnF1vZd84Eb3cyA=
 codeberg.org/gruf/go-loosy v0.0.0-20231007123304-bb910d1ab5c4/go.mod h1:fiO8HE1wjZCephcYmRRsVnNI/i0+mhy44Z5dQalS0rM=
-codeberg.org/gruf/go-mangler v1.3.0 h1:cf0vuuLJuEhoIukPHj+MUBIQSWxZcfEYt2Eo/r7Rstk=
-codeberg.org/gruf/go-mangler v1.3.0/go.mod h1:jnOA76AQoaO2kTHi0DlTTVaFYfRM+9fzs8f4XO6MsOk=
+codeberg.org/gruf/go-mangler v1.4.0 h1:yOQMygLgCnU0ERt1JDAtv/LsjDwJtAdRpwhm648rA/E=
+codeberg.org/gruf/go-mangler v1.4.0/go.mod h1:TVbrburPF+UjuRSwxH1tHP3pZZXzdyJJO8+PToTEiKg=
 codeberg.org/gruf/go-maps v1.0.3 h1:VDwhnnaVNUIy5O93CvkcE2IZXnMB1+IJjzfop9V12es=
 codeberg.org/gruf/go-maps v1.0.3/go.mod h1:D5LNDxlC9rsDuVQVM6JObaVGAdHB6g2dTdOdkh1aXWA=
 codeberg.org/gruf/go-mempool v0.0.0-20240507125005-cef10d64a760 h1:m2/UCRXhjDwAg4vyji6iKCpomKw6P4PmBOUi5DvAMH4=
@@ -76,8 +76,6 @@ codeberg.org/gruf/go-sched v1.2.3 h1:H5ViDxxzOBR3uIyGBCf0eH8b1L8wMybOXcdtUUTXZHk
 codeberg.org/gruf/go-sched v1.2.3/go.mod h1:vT9uB6KWFIIwnG9vcPY2a0alYNoqdL1mSzRM8I+PK7A=
 codeberg.org/gruf/go-storage v0.1.1 h1:CSX1PMMg/7vqqK8aCFtq94xCrOB3xhj7eWIvzILdLpY=
 codeberg.org/gruf/go-storage v0.1.1/go.mod h1:145IWMUOc6YpIiZIiCIEwkkNZZPiSbwMnZxRjSc5q6c=
-codeberg.org/gruf/go-structr v0.8.5 h1:WQuvLSQFyFwMjdU7dCWvgcjuhk07oWdSl9guShekzGQ=
-codeberg.org/gruf/go-structr v0.8.5/go.mod h1:c5UvVDSA3lZ1kv05V+7pXkO8u8Jea+VRWFDRFBCOxSA=
 codeberg.org/superseriousbusiness/exif-terminator v0.7.0 h1:Y6VApSXhKqExG0H2hZ2JelRK4xmWdjDQjn13CpEfzko=
 codeberg.org/superseriousbusiness/exif-terminator v0.7.0/go.mod h1:gCWKduudUWFzsnixoMzu0FYVdxHWG+AbXnZ50DqxsUE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ codeberg.org/gruf/go-sched v1.2.3 h1:H5ViDxxzOBR3uIyGBCf0eH8b1L8wMybOXcdtUUTXZHk
 codeberg.org/gruf/go-sched v1.2.3/go.mod h1:vT9uB6KWFIIwnG9vcPY2a0alYNoqdL1mSzRM8I+PK7A=
 codeberg.org/gruf/go-storage v0.1.1 h1:CSX1PMMg/7vqqK8aCFtq94xCrOB3xhj7eWIvzILdLpY=
 codeberg.org/gruf/go-storage v0.1.1/go.mod h1:145IWMUOc6YpIiZIiCIEwkkNZZPiSbwMnZxRjSc5q6c=
-codeberg.org/gruf/go-structr v0.8.6 h1:grj5sC+9VhXlMON/nmnQcsT3Qw/P6J64/OvH4oZqN8A=
-codeberg.org/gruf/go-structr v0.8.6/go.mod h1:O0FTNgzUnUKwWey4dEW99QD8rPezKPi5sxCVxYOJ1Fg=
+codeberg.org/gruf/go-structr v0.8.7 h1:agYCI6tSXU4JHVYPwZk3Og5rrBePNVv5iPWsDu7ZJIw=
+codeberg.org/gruf/go-structr v0.8.7/go.mod h1:O0FTNgzUnUKwWey4dEW99QD8rPezKPi5sxCVxYOJ1Fg=
 codeberg.org/superseriousbusiness/exif-terminator v0.7.0 h1:Y6VApSXhKqExG0H2hZ2JelRK4xmWdjDQjn13CpEfzko=
 codeberg.org/superseriousbusiness/exif-terminator v0.7.0/go.mod h1:gCWKduudUWFzsnixoMzu0FYVdxHWG+AbXnZ50DqxsUE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ codeberg.org/gruf/go-sched v1.2.3 h1:H5ViDxxzOBR3uIyGBCf0eH8b1L8wMybOXcdtUUTXZHk
 codeberg.org/gruf/go-sched v1.2.3/go.mod h1:vT9uB6KWFIIwnG9vcPY2a0alYNoqdL1mSzRM8I+PK7A=
 codeberg.org/gruf/go-storage v0.1.1 h1:CSX1PMMg/7vqqK8aCFtq94xCrOB3xhj7eWIvzILdLpY=
 codeberg.org/gruf/go-storage v0.1.1/go.mod h1:145IWMUOc6YpIiZIiCIEwkkNZZPiSbwMnZxRjSc5q6c=
+codeberg.org/gruf/go-structr v0.8.6 h1:grj5sC+9VhXlMON/nmnQcsT3Qw/P6J64/OvH4oZqN8A=
+codeberg.org/gruf/go-structr v0.8.6/go.mod h1:O0FTNgzUnUKwWey4dEW99QD8rPezKPi5sxCVxYOJ1Fg=
 codeberg.org/superseriousbusiness/exif-terminator v0.7.0 h1:Y6VApSXhKqExG0H2hZ2JelRK4xmWdjDQjn13CpEfzko=
 codeberg.org/superseriousbusiness/exif-terminator v0.7.0/go.mod h1:gCWKduudUWFzsnixoMzu0FYVdxHWG+AbXnZ50DqxsUE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=

--- a/vendor/codeberg.org/gruf/go-mangler/README.md
+++ b/vendor/codeberg.org/gruf/go-mangler/README.md
@@ -2,13 +2,13 @@
 
 [Documentation](https://pkg.go.dev/codeberg.org/gruf/go-mangler).
 
-To put it simply is a bit of an odd library. It aims to provide incredibly fast, unique string outputs for all default supported input data types during a given runtime instance.
+To put it simply is a bit of an odd library. It aims to provide incredibly fast, unique string outputs for all default supported input data types during a given runtime instance. See `mangler.String()`for supported types.
 
 It is useful, for example, for use as part of larger abstractions involving hashmaps. That was my particular usecase anyways...
 
 This package does make liberal use of the "unsafe" package.
 
-Benchmarks are below. Those with missing values panicked during our set of benchmarks, usually a case of not handling nil values elegantly. Please note the more important thing to notice here is the relative difference in benchmark scores, the actual `ns/op`,`B/op`,`allocs/op` accounts for running through over 80 possible test cases, including some not-ideal situations.
+Benchmarks are below. Please note the more important thing to notice here is the relative difference in benchmark scores, the actual `ns/op`,`B/op`,`allocs/op` accounts for running through ~80 possible test cases, including some not-ideal situations.
 
 The choice of libraries in the benchmark are just a selection of libraries that could be used in a similar manner to this one, i.e. serializing in some manner.
 
@@ -18,24 +18,14 @@ goos: linux
 goarch: amd64
 pkg: codeberg.org/gruf/go-mangler
 cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
-BenchmarkMangle
-BenchmarkMangle-8                         877761              1323 ns/op               0 B/op          0 allocs/op
-BenchmarkMangleKnown
-BenchmarkMangleKnown-8                   1462954               814.5 ns/op             0 B/op          0 allocs/op
-BenchmarkJSON
-BenchmarkJSON-8                           199930              5910 ns/op            2698 B/op        119 allocs/op
-BenchmarkLoosy
-BenchmarkLoosy-8                          307575              3718 ns/op             664 B/op         53 allocs/op
-BenchmarkBinary
-BenchmarkBinary-8                         413216              2640 ns/op            3824 B/op        116 allocs/op
-BenchmarkFmt
-BenchmarkFmt-8                            133429              8568 ns/op            3010 B/op        207 allocs/op
-BenchmarkFxmackerCbor
-BenchmarkFxmackerCbor-8                   258562              4268 ns/op            2118 B/op        134 allocs/op
-BenchmarkMitchellhHashStructure
-BenchmarkMitchellhHashStructure-8          88941             13049 ns/op           10269 B/op       1096 allocs/op
-BenchmarkCnfStructhash
-BenchmarkCnfStructhash-8                    5586            179537 ns/op          290373 B/op       5863 allocs/op
+BenchmarkMangle-8                        1278526               966.0 ns/op             0 B/op          0 allocs/op
+BenchmarkMangleKnown-8                   3443587               345.9 ns/op             0 B/op          0 allocs/op
+BenchmarkJSON-8                           228962              4717 ns/op            1849 B/op         99 allocs/op
+BenchmarkLoosy-8                          307194              3447 ns/op             776 B/op         65 allocs/op
+BenchmarkFmt-8                            150254              7405 ns/op            1377 B/op        143 allocs/op
+BenchmarkFxmackerCbor-8                   364411              3037 ns/op            1224 B/op        105 allocs/op
+BenchmarkMitchellhHashStructure-8         102272             11268 ns/op            8996 B/op       1000 allocs/op
+BenchmarkCnfStructhash-8                    6789            168703 ns/op          288301 B/op       5779 allocs/op
 PASS
-ok      codeberg.org/gruf/go-mangler    12.469s
+ok      codeberg.org/gruf/go-mangler    11.715s
 ```

--- a/vendor/codeberg.org/gruf/go-mangler/mangle.go
+++ b/vendor/codeberg.org/gruf/go-mangler/mangle.go
@@ -10,15 +10,11 @@ import (
 // type ptrs => Mangler functions.
 var manglers sync.Map
 
-// Mangled is an interface that allows any type to implement a custom
-// Mangler function to improve performance when mangling this type.
-type Mangled interface{ Mangle(buf []byte) []byte }
-
 // Mangler is a function that will take an input interface value of known
 // type, and append it in mangled serialized form to the given byte buffer.
 // While the value type is an interface, the Mangler functions are accessed
 // by the value's runtime type pointer, allowing the input value type to be known.
-type Mangler func(buf []byte, value any) []byte
+type Mangler func(buf []byte, ptr unsafe.Pointer) []byte
 
 // Get will fetch the Mangler function for given runtime type.
 // Note that the returned mangler will be a no-op in the case
@@ -34,27 +30,19 @@ func Get(t reflect.Type) Mangler {
 
 	if !ok {
 		// Load mangler function
-		mng = loadMangler(nil, t)
+		mng = loadMangler(t)
 	} else {
 		// cast cached value
 		mng = v.(Mangler)
 	}
 
-	// Get platform int mangler func.
-	mangle_int := mangle_platform_int()
-
-	return func(buf []byte, value any) []byte {
-		// Type check passed against original type.
-		if vt := reflect.TypeOf(value); vt != t {
-			return buf
-		}
-
+	return func(buf []byte, ptr unsafe.Pointer) []byte {
 		// First write the type ptr (this adds
 		// a unique prefix for each runtime type).
-		buf = mangle_int(buf, uptr)
+		buf = append_uint64(buf, uint64(uptr))
 
 		// Finally, mangle value
-		return mng(buf, value)
+		return mng(buf, ptr)
 	}
 }
 
@@ -94,23 +82,21 @@ func Append(b []byte, a any) []byte {
 	v, ok := manglers.Load(uptr)
 
 	if !ok {
-		// Load mangler into cache
-		mng = loadMangler(nil, t)
+		// Load into cache
+		mng = loadMangler(t)
 		manglers.Store(uptr, mng)
 	} else {
 		// cast cached value
 		mng = v.(Mangler)
 	}
 
-	// Get platform int mangler func.
-	mangle_int := mangle_platform_int()
-
 	// First write the type ptr (this adds
 	// a unique prefix for each runtime type).
-	b = mangle_int(b, uptr)
+	b = append_uint64(b, uint64(uptr))
 
 	// Finally, mangle value
-	return mng(b, a)
+	ptr := eface_data(a)
+	return mng(b, ptr)
 }
 
 // String will return the mangled format of input value 'a'. This
@@ -136,18 +122,8 @@ func Append(b []byte, a any) []byte {
 // - complex64,complex128
 // - arbitrary structs
 // - all type aliases of above
-// - time.Time{}
-// - url.URL{}
-// - net.IPAddr{}
-// - netip.Addr{}, netip.AddrPort{}
-// - mangler.Mangled{}
-// - fmt.Stringer{}
-// - json.Marshaler{}
-// - encoding.BinaryMarshaler{}
-// - encoding.TextMarshaler{}
 // - all pointers to the above
 // - all slices / arrays of the above
-// - all map keys / values of the above
 func String(a any) string {
 	b := Append(make([]byte, 0, 32), a)
 	return *(*string)(unsafe.Pointer(&b))

--- a/vendor/codeberg.org/gruf/go-structr/cache.go
+++ b/vendor/codeberg.org/gruf/go-structr/cache.go
@@ -509,6 +509,11 @@ func (c *Cache[T]) Trim(perc float64) {
 		c.delete(item)
 	}
 
+	// Compact index data stores.
+	for i := range c.indices {
+		c.indices[i].data.Compact()
+	}
+
 	// Done with lock.
 	c.mutex.Unlock()
 }

--- a/vendor/codeberg.org/gruf/go-structr/map.go
+++ b/vendor/codeberg.org/gruf/go-structr/map.go
@@ -15,11 +15,24 @@ func (m *hashmap) Get(key string) (*list, bool) {
 	return list, ok
 }
 
-func (m *hashmap) Put(key string, list *list) { m.m[key] = list }
+func (m *hashmap) Put(key string, list *list) {
+	m.m[key] = list
+	if n := len(m.m); n > m.n {
+		m.n = n
+	}
+}
 
-func (m *hashmap) Delete(key string) { delete(m.m, key) }
+func (m *hashmap) Delete(key string) {
+	delete(m.m, key)
+}
 
 func (m *hashmap) Compact() {
+	// Noop when hashmap size
+	// is too small to matter.
+	if m.n < 2048 {
+		return
+	}
+
 	// Difference between maximum map
 	// size and the current map size.
 	diff := m.n - len(m.m)
@@ -31,7 +44,7 @@ func (m *hashmap) Compact() {
 	// So we apply the inverse/2, once
 	// $maxLoad/2 % of hmap is empty we
 	// compact the map to drop buckets.
-	if diff > (m.n*13)/(16*2) {
+	if 2*16*diff > m.n*13 {
 
 		// Create new map only big as required.
 		m2 := make(map[string]*list, len(m.m))

--- a/vendor/codeberg.org/gruf/go-structr/map.go
+++ b/vendor/codeberg.org/gruf/go-structr/map.go
@@ -1,0 +1,46 @@
+package structr
+
+type hashmap struct {
+	m map[string]*list
+	n int
+}
+
+func (m *hashmap) init(cap int) {
+	m.m = make(map[string]*list, cap)
+	m.n = cap
+}
+
+func (m *hashmap) Get(key string) (*list, bool) {
+	list, ok := m.m[key]
+	return list, ok
+}
+
+func (m *hashmap) Put(key string, list *list) { m.m[key] = list }
+
+func (m *hashmap) Delete(key string) { delete(m.m, key) }
+
+func (m *hashmap) Compact() {
+	// Difference between maximum map
+	// size and the current map size.
+	diff := m.n - len(m.m)
+
+	// Maximum load factor before
+	// runtime allocates new hmap:
+	// maxLoad = 13 / 16
+	//
+	// So we apply the inverse/2, once
+	// $maxLoad/2 % of hmap is empty we
+	// compact the map to drop buckets.
+	if diff > (m.n*13)/(16*2) {
+
+		// Create new map only big as required.
+		m2 := make(map[string]*list, len(m.m))
+		for k, v := range m.m {
+			m2[k] = v
+		}
+
+		// Set new.
+		m.m = m2
+		m.n = len(m2)
+	}
+}

--- a/vendor/codeberg.org/gruf/go-structr/queue.go
+++ b/vendor/codeberg.org/gruf/go-structr/queue.go
@@ -214,10 +214,9 @@ func (q *Queue[T]) Debug() map[string]any {
 	m["indices"] = indices
 	for i := range q.indices {
 		var n uint64
-		q.indices[i].data.Iter(func(_ string, l *list) (stop bool) {
+		for _, l := range q.indices[i].data.m {
 			n += uint64(l.len)
-			return
-		})
+		}
 		indices[q.indices[i].name] = n
 	}
 	q.mutex.Unlock()
@@ -331,8 +330,8 @@ func (q *Queue[T]) delete(item *indexed_item) {
 		// Drop this index_entry.
 		index.delete_entry(entry)
 
-		// Check compact.
-		index.compact()
+		// Check compact map.
+		index.data.Compact()
 	}
 
 	// Drop entry from queue list.

--- a/vendor/codeberg.org/gruf/go-structr/queue_ctx.go
+++ b/vendor/codeberg.org/gruf/go-structr/queue_ctx.go
@@ -73,10 +73,9 @@ func (q *QueueCtx[T]) Debug() map[string]any {
 	m["indices"] = indices
 	for i := range q.indices {
 		var n uint64
-		q.indices[i].data.Iter(func(_ string, l *list) (stop bool) {
+		for _, l := range q.indices[i].data.m {
 			n += uint64(l.len)
-			return
-		})
+		}
 		indices[q.indices[i].name] = n
 	}
 	q.mutex.Unlock()

--- a/vendor/codeberg.org/gruf/go-structr/runtime.go
+++ b/vendor/codeberg.org/gruf/go-structr/runtime.go
@@ -8,18 +8,13 @@ import (
 	"unsafe"
 
 	"codeberg.org/gruf/go-mangler"
-	"github.com/modern-go/reflect2"
 )
 
 // struct_field contains pre-prepared type
 // information about a struct's field member,
 // including memory offset and hash function.
 type struct_field struct {
-
-	// type2 contains the reflect2
-	// type information for this field,
-	// used in repacking it as eface.
-	type2 reflect2.Type
+	rtype reflect.Type
 
 	// offsets defines whereabouts in
 	// memory this field is located.
@@ -109,25 +104,27 @@ func find_field(t reflect.Type, names []string) (sfield struct_field) {
 		t = field.Type
 	}
 
-	// Get field type as reflect2.
-	sfield.type2 = reflect2.Type2(t)
+	// Set final type.
+	sfield.rtype = t
 
 	// Find mangler for field type.
 	sfield.mangle = mangler.Get(t)
 
-	// Set possible zero value and its string.
-	sfield.zero = sfield.type2.UnsafeNew()
-	i := sfield.type2.UnsafeIndirect(sfield.zero)
-	sfield.zerostr = string(sfield.mangle(nil, i))
+	// Get new zero value data ptr.
+	v := reflect.New(t).Elem()
+	zptr := eface_data(v.Interface())
+	zstr := sfield.mangle(nil, zptr)
+	sfield.zerostr = string(zstr)
+	sfield.zero = zptr
 
 	return
 }
 
 // extract_fields extracts given structfields from the provided value type,
 // this is done using predetermined struct field memory offset locations.
-func extract_fields(ptr unsafe.Pointer, fields []struct_field) []any {
-	// Prepare slice of field ifaces.
-	ifaces := make([]any, len(fields))
+func extract_fields(ptr unsafe.Pointer, fields []struct_field) []unsafe.Pointer {
+	// Prepare slice of field value pointers.
+	ptrs := make([]unsafe.Pointer, len(fields))
 	for i, field := range fields {
 
 		// loop scope.
@@ -136,10 +133,7 @@ func extract_fields(ptr unsafe.Pointer, fields []struct_field) []any {
 		for _, offset := range field.offsets {
 			// Dereference any ptrs to offset.
 			fptr = deref(fptr, offset.derefs)
-
 			if fptr == nil {
-				// Use zero value.
-				fptr = field.zero
 				break
 			}
 
@@ -148,11 +142,31 @@ func extract_fields(ptr unsafe.Pointer, fields []struct_field) []any {
 				offset.offset)
 		}
 
-		// Repack value data ptr as empty interface.
-		ifaces[i] = field.type2.UnsafeIndirect(fptr)
-	}
+		if like_ptr(field.rtype) && fptr != nil {
+			// Further dereference value ptr.
+			fptr = *(*unsafe.Pointer)(fptr)
+		}
 
-	return ifaces
+		if fptr == nil {
+			// Use zero value.
+			fptr = field.zero
+		}
+
+		ptrs[i] = fptr
+	}
+	return ptrs
+}
+
+// like_ptr returns whether type's kind is ptr-like.
+func like_ptr(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Pointer,
+		reflect.Map,
+		reflect.Chan,
+		reflect.Func:
+		return true
+	}
+	return false
 }
 
 // deref will dereference ptr 'n' times (or until nil).

--- a/vendor/codeberg.org/gruf/go-structr/util.go
+++ b/vendor/codeberg.org/gruf/go-structr/util.go
@@ -1,5 +1,7 @@
 package structr
 
+import "unsafe"
+
 // once only executes 'fn' once.
 func once(fn func()) func() {
 	var once int32
@@ -10,4 +12,10 @@ func once(fn func()) func() {
 		once = 1
 		fn()
 	}
+}
+
+// eface_data returns the data ptr from an empty interface.
+func eface_data(a any) unsafe.Pointer {
+	type eface struct{ _, data unsafe.Pointer }
+	return (*eface)(unsafe.Pointer(&a)).data
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -43,7 +43,7 @@ codeberg.org/gruf/go-list
 # codeberg.org/gruf/go-logger/v2 v2.2.1
 ## explicit; go 1.19
 codeberg.org/gruf/go-logger/v2/level
-# codeberg.org/gruf/go-mangler v1.3.0
+# codeberg.org/gruf/go-mangler v1.4.0
 ## explicit; go 1.19
 codeberg.org/gruf/go-mangler
 # codeberg.org/gruf/go-maps v1.0.3
@@ -68,7 +68,7 @@ codeberg.org/gruf/go-storage/disk
 codeberg.org/gruf/go-storage/internal
 codeberg.org/gruf/go-storage/memory
 codeberg.org/gruf/go-storage/s3
-# codeberg.org/gruf/go-structr v0.8.5
+# codeberg.org/gruf/go-structr v0.8.5 => ../go-structr
 ## explicit; go 1.21
 codeberg.org/gruf/go-structr
 # codeberg.org/superseriousbusiness/exif-terminator v0.7.0
@@ -1336,4 +1336,5 @@ modernc.org/token
 # mvdan.cc/xurls/v2 v2.5.0
 ## explicit; go 1.19
 mvdan.cc/xurls/v2
+# codeberg.org/gruf/go-structr => ../go-structr
 # modernc.org/sqlite => gitlab.com/NyaaaWhatsUpDoc/sqlite v1.29.9-concurrency-workaround

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -68,7 +68,7 @@ codeberg.org/gruf/go-storage/disk
 codeberg.org/gruf/go-storage/internal
 codeberg.org/gruf/go-storage/memory
 codeberg.org/gruf/go-storage/s3
-# codeberg.org/gruf/go-structr v0.8.6
+# codeberg.org/gruf/go-structr v0.8.7
 ## explicit; go 1.21
 codeberg.org/gruf/go-structr
 # codeberg.org/superseriousbusiness/exif-terminator v0.7.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -68,7 +68,7 @@ codeberg.org/gruf/go-storage/disk
 codeberg.org/gruf/go-storage/internal
 codeberg.org/gruf/go-storage/memory
 codeberg.org/gruf/go-storage/s3
-# codeberg.org/gruf/go-structr v0.8.5 => ../go-structr
+# codeberg.org/gruf/go-structr v0.8.6
 ## explicit; go 1.21
 codeberg.org/gruf/go-structr
 # codeberg.org/superseriousbusiness/exif-terminator v0.7.0
@@ -1336,5 +1336,4 @@ modernc.org/token
 # mvdan.cc/xurls/v2 v2.5.0
 ## explicit; go 1.19
 mvdan.cc/xurls/v2
-# codeberg.org/gruf/go-structr => ../go-structr
 # modernc.org/sqlite => gitlab.com/NyaaaWhatsUpDoc/sqlite v1.29.9-concurrency-workaround


### PR DESCRIPTION
# Description

Updates [go-structr](https://codeberg.org/gruf/go-structr) and [go-mangler](https://codeberg.org/gruf/go-mangler) to no longer rely on [modern-go/reflect2](https://github.com/modern-go/reflect2), which come release of Go 1.23 with changes to how linkname works (now requires both sides of a linkage to confirm it), means we will no longer be reliant on weird build tags to revert to old linkname behaviour.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
