### PR TITLE
[bugfix] add Date and Message-ID headers for email

### DIFF
--- a/internal/email/common.go
+++ b/internal/email/common.go
@@ -39,7 +39,7 @@ func (s *sender) sendTemplate(template string, subject string, data any, toAddre
 		return err
 	}
 
-	msg, err := assembleMessage(subject, buf.String(), s.from, s.msgIdHost, toAddresses...)
+	msg, err := assembleMessage(subject, buf.String(), s.from, s.msgIDHost, toAddresses...)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func loadTemplates(templateBaseDir string) (*template.Template, error) {
 // assembleMessage assembles a valid email message following:
 //   - https://datatracker.ietf.org/doc/html/rfc2822
 //   - https://pkg.go.dev/net/smtp#SendMail
-func assembleMessage(mailSubject string, mailBody string, mailFrom string, msgIdHost string, mailTo ...string) ([]byte, error) {
+func assembleMessage(mailSubject string, mailBody string, mailFrom string, msgIDHost string, mailTo ...string) ([]byte, error) {
 	if strings.ContainsAny(mailSubject, "\r\n") {
 		return nil, errors.New("email subject must not contain newline characters")
 	}
@@ -107,7 +107,7 @@ func assembleMessage(mailSubject string, mailBody string, mailFrom string, msgId
 	}
 	msg.WriteString("Date: " + time.Now().Format(time.RFC822Z) + CRLF)
 	msg.WriteString("From: " + mailFrom + CRLF)
-	msg.WriteString("Message-ID: <" + uuid.New().String() + "@" + msgIdHost + ">" + CRLF)
+	msg.WriteString("Message-ID: <" + uuid.New().String() + "@" + msgIDHost + ">" + CRLF)
 	msg.WriteString("Subject: " + mailSubject + CRLF)
 	msg.WriteString("MIME-Version: 1.0" + CRLF)
 	msg.WriteString("Content-Transfer-Encoding: 8bit" + CRLF)

--- a/internal/email/common.go
+++ b/internal/email/common.go
@@ -26,7 +26,9 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 )
@@ -37,7 +39,7 @@ func (s *sender) sendTemplate(template string, subject string, data any, toAddre
 		return err
 	}
 
-	msg, err := assembleMessage(subject, buf.String(), s.from, toAddresses...)
+	msg, err := assembleMessage(subject, buf.String(), s.from, s.msgIdHost, toAddresses...)
 	if err != nil {
 		return err
 	}
@@ -65,7 +67,7 @@ func loadTemplates(templateBaseDir string) (*template.Template, error) {
 // assembleMessage assembles a valid email message following:
 //   - https://datatracker.ietf.org/doc/html/rfc2822
 //   - https://pkg.go.dev/net/smtp#SendMail
-func assembleMessage(mailSubject string, mailBody string, mailFrom string, mailTo ...string) ([]byte, error) {
+func assembleMessage(mailSubject string, mailBody string, mailFrom string, msgIdHost string, mailTo ...string) ([]byte, error) {
 	if strings.ContainsAny(mailSubject, "\r\n") {
 		return nil, errors.New("email subject must not contain newline characters")
 	}
@@ -103,7 +105,9 @@ func assembleMessage(mailSubject string, mailBody string, mailFrom string, mailT
 		// msg headers.'
 		msg.WriteString("To: Undisclosed Recipients:;" + CRLF)
 	}
+	msg.WriteString("Date: " + time.Now().Format(time.RFC822Z) + CRLF)
 	msg.WriteString("From: " + mailFrom + CRLF)
+	msg.WriteString("Message-ID: <" + uuid.New().String() + "@" + msgIdHost + ">" + CRLF)
 	msg.WriteString("Subject: " + mailSubject + CRLF)
 	msg.WriteString("MIME-Version: 1.0" + CRLF)
 	msg.WriteString("Content-Transfer-Encoding: 8bit" + CRLF)

--- a/internal/email/noopsender.go
+++ b/internal/email/noopsender.go
@@ -31,7 +31,7 @@ import (
 // Passing a nil function is also acceptable, in which case the send functions will just return nil.
 func NewNoopSender(sendCallback func(toAddress string, message string)) (Sender, error) {
 	templateBaseDir := config.GetWebTemplateBaseDir()
-	msgIdHost := config.GetHost()
+	msgIDHost := config.GetHost()
 
 	t, err := loadTemplates(templateBaseDir)
 	if err != nil {
@@ -40,14 +40,14 @@ func NewNoopSender(sendCallback func(toAddress string, message string)) (Sender,
 
 	return &noopSender{
 		sendCallback: sendCallback,
-		msgIdHost:    msgIdHost,
+		msgIDHost:    msgIDHost,
 		template:     t,
 	}, nil
 }
 
 type noopSender struct {
 	sendCallback func(toAddress string, message string)
-	msgIdHost    string
+	msgIDHost    string
 	template     *template.Template
 }
 
@@ -89,7 +89,7 @@ func (s *noopSender) sendTemplate(template string, subject string, data any, toA
 		return err
 	}
 
-	msg, err := assembleMessage(subject, buf.String(), "test@example.org", s.msgIdHost, toAddresses...)
+	msg, err := assembleMessage(subject, buf.String(), "test@example.org", s.msgIDHost, toAddresses...)
 	if err != nil {
 		return err
 	}

--- a/internal/email/noopsender.go
+++ b/internal/email/noopsender.go
@@ -31,6 +31,7 @@ import (
 // Passing a nil function is also acceptable, in which case the send functions will just return nil.
 func NewNoopSender(sendCallback func(toAddress string, message string)) (Sender, error) {
 	templateBaseDir := config.GetWebTemplateBaseDir()
+	msgIdHost := config.GetHost()
 
 	t, err := loadTemplates(templateBaseDir)
 	if err != nil {
@@ -39,12 +40,14 @@ func NewNoopSender(sendCallback func(toAddress string, message string)) (Sender,
 
 	return &noopSender{
 		sendCallback: sendCallback,
+		msgIdHost:    msgIdHost,
 		template:     t,
 	}, nil
 }
 
 type noopSender struct {
 	sendCallback func(toAddress string, message string)
+	msgIdHost    string
 	template     *template.Template
 }
 
@@ -86,7 +89,7 @@ func (s *noopSender) sendTemplate(template string, subject string, data any, toA
 		return err
 	}
 
-	msg, err := assembleMessage(subject, buf.String(), "test@example.org", toAddresses...)
+	msg, err := assembleMessage(subject, buf.String(), "test@example.org", s.msgIdHost, toAddresses...)
 	if err != nil {
 		return err
 	}

--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -76,11 +76,13 @@ func NewSender() (Sender, error) {
 	host := config.GetSMTPHost()
 	port := config.GetSMTPPort()
 	from := config.GetSMTPFrom()
+	msgIdHost := config.GetHost()
 
 	return &sender{
 		hostAddress: fmt.Sprintf("%s:%d", host, port),
 		from:        from,
 		auth:        smtp.PlainAuth("", username, password, host),
+		msgIdHost:   msgIdHost,
 		template:    t,
 	}, nil
 }
@@ -89,5 +91,6 @@ type sender struct {
 	hostAddress string
 	from        string
 	auth        smtp.Auth
+	msgIdHost   string
 	template    *template.Template
 }

--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -76,13 +76,13 @@ func NewSender() (Sender, error) {
 	host := config.GetSMTPHost()
 	port := config.GetSMTPPort()
 	from := config.GetSMTPFrom()
-	msgIdHost := config.GetHost()
+	msgIDHost := config.GetHost()
 
 	return &sender{
 		hostAddress: fmt.Sprintf("%s:%d", host, port),
 		from:        from,
 		auth:        smtp.PlainAuth("", username, password, host),
-		msgIdHost:   msgIdHost,
+		msgIDHost:   msgIDHost,
 		template:    t,
 	}, nil
 }
@@ -91,6 +91,6 @@ type sender struct {
 	hostAddress string
 	from        string
 	auth        smtp.Auth
-	msgIdHost   string
+	msgIDHost   string
 	template    *template.Template
 }


### PR DESCRIPTION
# Description

This should make spam filters more happy, as most of them grant some negative score for not having those headers. Also the Date is convenient for the user receiving the mail.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
