### PR TITLE
[docs] traefik redirect regex documentation

### DIFF
--- a/docs/advanced/host-account-domain.md
+++ b/docs/advanced/host-account-domain.md
@@ -98,8 +98,8 @@ myservice:
   labels:
     - 'traefik.http.routers.myservice.rule=Host(`example.org`)'                                                                # account-domain
     - 'traefik.http.middlewares.myservice-gts.redirectregex.permanent=true'
-    - 'traefik.http.middlewares.myservice-gts.redirectregex.regex=^https://(.*)/.well-known/(webfinger|nodeinfo|host-meta)$$'  # host
-    - 'traefik.http.middlewares.myservice-gts.redirectregex.replacement=https://social.$${1}/.well-known/$${2}'                # host
+    - 'traefik.http.middlewares.myservice-gts.redirectregex.regex=^https://(.*)/.well-known/(webfinger|nodeinfo|host-meta)(\?.*)?$'  # host
+    - 'traefik.http.middlewares.myservice-gts.redirectregex.replacement=https://social.$${1}/.well-known/$${2}$${3}'                # host
     - 'traefik.http.routers.myservice.middlewares=myservice-gts@docker'
 ```
 


### PR DESCRIPTION
# Description

This pull request fixes the Traefik redirect regex issue in the [split domain documentation](https://docs.gotosocial.org/en/latest/advanced/host-account-domain/). The current regex won't keep the query string, e.g. `?resource=acct:example@example.org`, which would cause federation issues with other instances.

I've met the federation issues on my own instance. After checking Traefik logs (e.g. `GET /.well-known/webfinger?resource=acct:example@example.org 502`), I found out it's due to the redirection. And changed the regex which fixed the problem for me. Maybe some further checking of the regex would be better (I am really bad at regex :(

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
