### PR TITLE
[bugfix] Fix typo in instance cache copyF

### DIFF
--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -723,7 +723,7 @@ func (c *Caches) initInstance() {
 		i2.DomainBlock = nil
 		i2.ContactAccount = nil
 
-		return i1
+		return i2
 	}
 
 	c.GTS.Instance.Init(structr.CacheConfig[*gtsmodel.Instance]{


### PR DESCRIPTION
Fix a little typo in the instance cache copy function, which would cause already-populated instances to be returned.