### PR TITLE
[docs] Set the right site_url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: GoToSocial Documentation
-site_url: https://docs.gotosocial.org
+site_url: https://docs.gotosocial.org/en/latest/
 theme:
   name: material
   language: en


### PR DESCRIPTION
# Description

Though the entry point is docs.gotosocial.org, that's redirected by RTD to docs.gotosocial.org/en/latest/ which is where the actual site is served from. However, other URLs like docs.gotosocial.org/admin aren't redirected to docs.gotosocial.org/en/latest/admin. They just 404.

Without us including the /en/latest/ all the generated og:img URLs as well as the link rel=canonical result in URLs that all 404.

This means that currently the social cards aren't working well, but indexing the docs site by search engines is probably also partially broken, since our sitemap.xml is also pointing at things that don't exist.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
