### PR TITLE
[docs] Update how to enable http2 on nginx

### DIFF
--- a/docs/getting_started/reverse_proxy/nginx.md
+++ b/docs/getting_started/reverse_proxy/nginx.md
@@ -3,7 +3,7 @@
 In order to use NGINX as a reverse proxy for GoToSocial you'll need to have it installed on your server. If you intend for the NGINX instance to also handle TLS, you'll need to [provision TLS certificates](../../advanced/certificates.md) too.
 
 !!! tip
-    Enable HTTP/2 in nginx by including `http2` in the `listen` directives. This can speed up the experience for clients. Browsers do not support HTTP/2 over plain text, so this should only be added to `listen` directives for port `443` that also include the `ssl` directive.
+    Enable HTTP/2 in nginx by including `http2 on;` in the `server` block. This can speed up the experience for clients. See the [ngx_http_v2_module documentation](https://nginx.org/en/docs/http/ngx_http_v2_module.html#example).
 
 NGINX is [packaged for many distributions](https://repology.org/project/nginx/versions). It's very likely you can install it with your distribution's package manager. You can also run NGINX using a container runtime with the [official NGINX image](https://hub.docker.com/_/nginx) that's published to the Docker Hub.
 
@@ -162,8 +162,9 @@ server {
   }
   client_max_body_size 40M;
 
-  listen [::]:443 ssl ipv6only=on http2; # managed by Certbot
-  listen 443 ssl http2; # managed by Certbot
+  listen [::]:443 ssl; # managed by Certbot
+  listen 443 ssl; # managed by Certbot
+  http2 on; # managed by Certbot
   ssl_certificate /etc/letsencrypt/live/example.org/fullchain.pem; # managed by Certbot
   ssl_certificate_key /etc/letsencrypt/live/example.org/privkey.pem; # managed by Certbot
   include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot


### PR DESCRIPTION
# Description

Since 1.25.1 the newer 'http2 on;' syntax should be used. The previous syntax still works, but throws warnings when testing the configuration with 'nginx -t'.

This also updates the certbot template to match what's currently generated. It removes ipv6only=on as that's the default on a listen directive binding on a wildcard IPv6 address.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
