### PR TITLE
[bugfix] Handle ErrHideStatus when preparing timeline statuses

### DIFF
--- a/internal/processing/timeline/timeline_test.go
+++ b/internal/processing/timeline/timeline_test.go
@@ -35,6 +35,7 @@ type TimelineStandardTestSuite struct {
 
 	// standard suite models
 	testAccounts map[string]*gtsmodel.Account
+	testStatuses map[string]*gtsmodel.Status
 
 	// module being tested
 	timeline timeline.Processor
@@ -42,6 +43,7 @@ type TimelineStandardTestSuite struct {
 
 func (suite *TimelineStandardTestSuite) SetupSuite() {
 	suite.testAccounts = testrig.NewTestAccounts()
+	suite.testStatuses = testrig.NewTestStatuses()
 }
 
 func (suite *TimelineStandardTestSuite) SetupTest() {


### PR DESCRIPTION
# Description

The included tests weren't successful as regression tests for this bug, but describe behavior that works now and should continue to work in the future, so I'm leaving them in.

Reported by @tsmethurst. The symptom is the log message `db error while trying to prepare`, which occurs in three places, one of which already handles `ErrHideStatus`, and the other two of which I've added handling for in this patch.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
