### PR TITLE
[bugfix] Don't throw error when parent statuses are missing (#2011)

### DIFF
--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -561,14 +561,13 @@ func (s *statusDB) GetStatusParents(ctx context.Context, status *gtsmodel.Status
 
 	for id := status.InReplyToID; id != ""; {
 		parent, err := s.GetStatusByID(ctx, id)
-		if err != nil {
-			if errors.Is(err, db.ErrNoEntries) {
-				// This can be caused by a few cases: user has been blocked,
-				// status has been deleted, federation issues...
-				log.Debug(ctx, "status parent not found, returning up to this point")
-				break
-			}
+		if err != nil && !errors.Is(err, db.ErrNoEntries) {
 			return nil, err
+		}
+
+		if parent == nil {
+			// Parent status not found (e.g. deleted)
+			break
 		}
 
 		// Append parent status to slice


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request allows retrieving posts that reply to a parent status that isn't in the database, by ending the traversal below the missing parent. A missing parent post can happen for a few reasons: the calling user being blocked, a deleted post, or federation/remote server issues come to mind.

closes #2011

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [X] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [X] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [X] I/we have not leveraged AI to create the proposed changes.
- [X] I/we have performed a self-review of added code.
- [X] I/we have written code that is legible and maintainable by others.
- [X] I/we have commented the added code, particularly in hard-to-understand areas.
- [X] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [X] I/we have run tests and they pass locally with the changes.
- [X] I/we have run `go fmt ./...` and `golangci-lint run`.
