### PR TITLE
[bugfix] Explicitly propagate filter results from statuses to their boosts in API responses

### DIFF
--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -841,6 +841,7 @@ func (c *Converter) statusToAPIFilterResults(
 	if mutes.Matches(s.AccountID, filterContext, now) {
 		return nil, statusfilter.ErrHideStatus
 	}
+
 	// If this status is part of a multi-account discussion,
 	// and all of the accounts replied to or mentioned are invisible to the requesting account
 	// (due to blocks, domain blocks, moderation, etc.),
@@ -1185,13 +1186,14 @@ func (c *Converter) statusToFrontend(
 			return nil, gtserror.Newf("error converting boosted status: %w", err)
 		}
 
-		// Set boosted status and set interactions from original.
+		// Set boosted status and set interactions and filter results from original.
 		apiStatus.Reblog = &apimodel.StatusReblogged{reblog}
 		apiStatus.Favourited = apiStatus.Reblog.Favourited
 		apiStatus.Bookmarked = apiStatus.Reblog.Bookmarked
 		apiStatus.Muted = apiStatus.Reblog.Muted
 		apiStatus.Reblogged = apiStatus.Reblog.Reblogged
 		apiStatus.Pinned = apiStatus.Reblog.Pinned
+		apiStatus.Filtered = apiStatus.Reblog.Filtered
 	}
 
 	return apiStatus, nil


### PR DESCRIPTION
# Description

Explicitly propagate `.Filtered` from an original status to its boosts in the type converter, the same way we explicitly propagate `ErrHideStatus`.

This changes one line of actual code. The tests either ensure that existing filter-matching behavior continues (see #3128) or that `.Filtered` is copied.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
