### PR TITLE
[chore] Add some log lines to recent migrations warning not to interrupt

### DIFF
--- a/internal/db/bundb/migrations/20240613091853_drop_unused_media_columns.go
+++ b/internal/db/bundb/migrations/20240613091853_drop_unused_media_columns.go
@@ -20,11 +20,17 @@ package migrations
 import (
 	"context"
 
+	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/uptrace/bun"
 )
 
 func init() {
 	up := func(ctx context.Context, db *bun.DB) error {
+		log.Info(
+			ctx,
+			"dropping unused media attachments columns, please wait; "+
+				"this may take a long time if your database has lots of media attachments, don't interrupt it!",
+		)
 		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 
 			for _, dropcase := range []struct {

--- a/internal/db/bundb/migrations/20240715204203_media_pipeline_improvements.go
+++ b/internal/db/bundb/migrations/20240715204203_media_pipeline_improvements.go
@@ -22,12 +22,18 @@ import (
 
 	old_gtsmodel "github.com/superseriousbusiness/gotosocial/internal/db/bundb/migrations/20240715204203_media_pipeline_improvements"
 	new_gtsmodel "github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
 
 	"github.com/uptrace/bun"
 )
 
 func init() {
 	up := func(ctx context.Context, db *bun.DB) error {
+		log.Info(
+			ctx,
+			"doing media pipeline improvements; "+
+				"this may take a while if your database has lots of media attachments, don't interrupt it!",
+		)
 		if err := db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 			if _, err := tx.NewAddColumn().
 				Table("media_attachments").

--- a/internal/db/bundb/migrations/20240722222556_remove_boost_content.go
+++ b/internal/db/bundb/migrations/20240722222556_remove_boost_content.go
@@ -21,6 +21,7 @@ import (
 	"context"
 
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/uptrace/bun"
 )
 
@@ -29,6 +30,11 @@ import (
 // Admins may want to vacuum after running this migration.
 func init() {
 	up := func(ctx context.Context, db *bun.DB) error {
+		log.Info(
+			ctx,
+			"dropping duplicated status boost data, please wait; "+
+				"this may take a long time if your database has lots of statuses, don't interrupt it!",
+		)
 		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 			_, err := tx.NewUpdate().
 				Model((*gtsmodel.Status)(nil)).

--- a/internal/typeutils/internaltofrontend_test.go
+++ b/internal/typeutils/internaltofrontend_test.go
@@ -780,10 +780,10 @@ func (suite *InternalToFrontendTestSuite) TestWarnFilteredBoostToFrontend() {
   "created_at": "2021-10-20T10:41:37.000Z",
   "in_reply_to_id": null,
   "in_reply_to_account_id": null,
-  "sensitive": true,
-  "spoiler_text": "introduction post",
+  "sensitive": false,
+  "spoiler_text": "",
   "visibility": "public",
-  "language": "en",
+  "language": null,
   "uri": "http://localhost:8080/users/admin/statuses/01G36SF3V6Y6V5BF9P4R7PQG7G",
   "url": "http://localhost:8080/@admin/statuses/01G36SF3V6Y6V5BF9P4R7PQG7G",
   "replies_count": 0,
@@ -794,7 +794,7 @@ func (suite *InternalToFrontendTestSuite) TestWarnFilteredBoostToFrontend() {
   "muted": false,
   "bookmarked": true,
   "pinned": false,
-  "content": "hello everyone!",
+  "content": "",
   "reblog": {
     "id": "01F8MH75CBF9JFX4ZAD54N0W0R",
     "created_at": "2021-10-20T11:36:45.000Z",
@@ -981,7 +981,6 @@ func (suite *InternalToFrontendTestSuite) TestWarnFilteredBoostToFrontend() {
   "emojis": [],
   "card": null,
   "poll": null,
-  "text": "hello everyone!",
   "filtered": [
     {
       "filter": {


### PR DESCRIPTION
Just a chore PR to add some logging to some of the lengthy recent migrations, so admins know that stuff is actually happening and won't be tempted to press ctrl-c.