### PR TITLE
Serialize empty conversation account list as empty list, not null

### DIFF
--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -1752,8 +1752,9 @@ func (c *Converter) ConversationToAPIConversation(
 	mutes *usermute.CompiledUserMuteList,
 ) (*apimodel.Conversation, error) {
 	apiConversation := &apimodel.Conversation{
-		ID:     conversation.ID,
-		Unread: !*conversation.Read,
+		ID:       conversation.ID,
+		Unread:   !*conversation.Read,
+		Accounts: []apimodel.Account{},
 	}
 	for _, account := range conversation.OtherAccounts {
 		var apiAccount *apimodel.Account


### PR DESCRIPTION
# Description

This pull request fixes a type error when serializing a conversation's account list. This is only about the millionth time I've run into this problem; golang/go#63397 when?

Followup to #3013

## Impact

Only affects DMs to yourself *and* clients that are strict about types. Semaphore and Phanpy apparently don't care.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
