### PR TITLE
[chore] log delivery worker stop/start at debug level

### DIFF
--- a/internal/transport/delivery/worker.go
+++ b/internal/transport/delivery/worker.go
@@ -143,8 +143,8 @@ func (w *Worker) run(ctx context.Context) {
 	if w.Client == nil || w.Queue == nil {
 		panic("not yet initialized")
 	}
-	log.Infof(ctx, "%p: starting worker", w)
-	defer log.Infof(ctx, "%p: stopped worker", w)
+	log.Debugf(ctx, "%p: starting worker", w)
+	defer log.Debugf(ctx, "%p: stopped worker", w)
 	util.Must(func() { w.process(ctx) })
 }
 


### PR DESCRIPTION
Just brings worker start logging in line with how we log worker starts elsewhere (at debug level).