### PR TITLE
[bugfix] moves file rename to earlier in media pipeline so ffmpeg calls ALWAYS have a file extension

### DIFF
--- a/internal/media/processingemoji.go
+++ b/internal/media/processingemoji.go
@@ -19,6 +19,7 @@ package media
 
 import (
 	"context"
+	"os"
 
 	errorsv2 "codeberg.org/gruf/go-errors/v2"
 	"codeberg.org/gruf/go-runners"
@@ -168,6 +169,18 @@ func (p *ProcessingEmoji) store(ctx context.Context) error {
 	if fileType != gtsmodel.FileTypeImage {
 		return gtserror.Newf("unsupported emoji filetype: %s (%s)", fileType, ext)
 	}
+
+	// Add file extension to path.
+	newpath := temppath + "." + ext
+
+	// Before ffmpeg processing, rename to set file ext.
+	if err := os.Rename(temppath, newpath); err != nil {
+		return gtserror.Newf("error renaming to %s - >%s: %w", temppath, newpath, err)
+	}
+
+	// Update path var
+	// AFTER successful.
+	temppath = newpath
 
 	// Generate a static image from input emoji path.
 	staticpath, err = ffmpegGenerateStatic(ctx, temppath)


### PR DESCRIPTION
# Description

Stops some weird issues with thumbnail generation losing orientation and color data, so far only seen with iPhone-taken images.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
