### PR TITLE
[bugfix] take into account rotation when generating thumbnail

### DIFF
--- a/internal/media/ffmpeg.go
+++ b/internal/media/ffmpeg.go
@@ -535,7 +535,6 @@ type ffprobePacketOrFrame struct {
 
 type ffprobeSideData struct {
 	Rotation float64 `json:"rotation"`
-	// + unused fields.
 }
 
 type ffprobeStream struct {

--- a/internal/media/ffmpeg.go
+++ b/internal/media/ffmpeg.go
@@ -239,9 +239,9 @@ func ffprobe(ctx context.Context, filepath string) (*result, error) {
 				// Show specifically stream codec names, types, frame rate, duration and dimens.
 				"stream=codec_name,codec_type,r_frame_rate,duration_ts,width,height" + ":" +
 
-				// Show all
-				// side data.
-				"side_data",
+				// Show any rotation
+				// side data stored.
+				"side_data=rotation",
 
 			// Input file.
 			"-i", filepath,

--- a/internal/media/manager_test.go
+++ b/internal/media/manager_test.go
@@ -483,7 +483,7 @@ func (suite *ManagerTestSuite) TestLongerMp4Process() {
 	suite.EqualValues(float32(10), *attachment.FileMeta.Original.Framerate)
 	suite.EqualValues(0xce3a, *attachment.FileMeta.Original.Bitrate)
 	suite.EqualValues(gtsmodel.Small{
-		Width: 512, Height: 281, Size: 143872, Aspect: 1.822064,
+		Width: 512, Height: 281, Size: 143872, Aspect: 1.8181819,
 	}, attachment.FileMeta.Small)
 	suite.Equal("video/mp4", attachment.File.ContentType)
 	suite.Equal("image/webp", attachment.Thumbnail.ContentType)
@@ -543,7 +543,7 @@ func (suite *ManagerTestSuite) TestBirdnestMp4Process() {
 	suite.EqualValues(float32(30), *attachment.FileMeta.Original.Framerate)
 	suite.EqualValues(0x11844c, *attachment.FileMeta.Original.Bitrate)
 	suite.EqualValues(gtsmodel.Small{
-		Width: 287, Height: 512, Size: 146944, Aspect: 0.5605469,
+		Width: 287, Height: 512, Size: 146944, Aspect: 0.5611111,
 	}, attachment.FileMeta.Small)
 	suite.Equal("video/mp4", attachment.File.ContentType)
 	suite.Equal("image/webp", attachment.Thumbnail.ContentType)

--- a/internal/media/processingmedia.go
+++ b/internal/media/processingmedia.go
@@ -224,8 +224,6 @@ func (p *ProcessingMedia) store(ctx context.Context) error {
 		p.media.FileMeta.Small.Height = thumbHeight
 		p.media.FileMeta.Small.Size = (thumbWidth * thumbHeight)
 		p.media.FileMeta.Small.Aspect = aspect
-		log.Infof(ctx, "%dx%d", width, height)
-		log.Infof(ctx, "%dx%d", thumbWidth, thumbHeight)
 
 		// Generate a thumbnail image from input image path.
 		thumbpath, err = ffmpegGenerateThumb(ctx, temppath,

--- a/internal/media/processingmedia.go
+++ b/internal/media/processingmedia.go
@@ -176,10 +176,11 @@ func (p *ProcessingMedia) store(ctx context.Context) error {
 	// This will always be used regardless of type,
 	// as even audio files may contain embedded album art.
 	width, height, framerate := result.ImageMeta()
+	aspect := util.Div(float32(width), float32(height))
 	p.media.FileMeta.Original.Width = width
 	p.media.FileMeta.Original.Height = height
 	p.media.FileMeta.Original.Size = (width * height)
-	p.media.FileMeta.Original.Aspect = util.Div(float32(width), float32(height))
+	p.media.FileMeta.Original.Aspect = aspect
 	p.media.FileMeta.Original.Framerate = util.PtrIf(framerate)
 	p.media.FileMeta.Original.Duration = util.PtrIf(float32(result.duration))
 	p.media.FileMeta.Original.Bitrate = util.PtrIf(result.bitrate)
@@ -218,11 +219,13 @@ func (p *ProcessingMedia) store(ctx context.Context) error {
 
 	if width > 0 && height > 0 {
 		// Determine thumbnail dimensions to use.
-		thumbWidth, thumbHeight := thumbSize(width, height)
+		thumbWidth, thumbHeight := thumbSize(width, height, aspect, result.rotation)
 		p.media.FileMeta.Small.Width = thumbWidth
 		p.media.FileMeta.Small.Height = thumbHeight
 		p.media.FileMeta.Small.Size = (thumbWidth * thumbHeight)
-		p.media.FileMeta.Small.Aspect = float32(thumbWidth) / float32(thumbHeight)
+		p.media.FileMeta.Small.Aspect = aspect
+		log.Infof(ctx, "%dx%d", width, height)
+		log.Infof(ctx, "%dx%d", thumbWidth, thumbHeight)
 
 		// Generate a thumbnail image from input image path.
 		thumbpath, err = ffmpegGenerateThumb(ctx, temppath,

--- a/internal/media/util.go
+++ b/internal/media/util.go
@@ -62,13 +62,13 @@ func thumbSize(width, height int, aspect float32, rotation int) (int, int) {
 
 	// Width is larger side.
 	case width > height:
-		// i.e. height = widthDiff * (height / width)
+		// i.e. height = newWidth * (height / width)
 		height = int(float32(maxThumbWidth) / aspect)
 		return maxThumbWidth, height
 
 	// Height is larger side.
 	case height > width:
-		// i.e. width = heightDiff * (width / height)
+		// i.e. width = newHeight * (width / height)
 		width = int(float32(maxThumbHeight) * aspect)
 		return width, maxThumbHeight
 

--- a/internal/media/util.go
+++ b/internal/media/util.go
@@ -37,12 +37,23 @@ import (
 
 // thumbSize returns the dimensions to use for an input
 // image of given width / height, for its outgoing thumbnail.
-// This maintains the original image aspect ratio.
-func thumbSize(width, height int) (int, int) {
+// This attempts to maintains the original image aspect ratio.
+func thumbSize(width, height int, aspect float32, rotation int) (int, int) {
 	const (
 		maxThumbWidth  = 512
 		maxThumbHeight = 512
 	)
+
+	// If image is rotated by
+	// any odd multiples of 90,
+	// flip width / height to
+	// get the correct scale.
+	switch rotation {
+	case -90, 90, -270, 270:
+		width, height = height, width
+		aspect = 1 / aspect
+	}
+
 	switch {
 	// Simplest case, within bounds!
 	case width < maxThumbWidth &&
@@ -51,13 +62,15 @@ func thumbSize(width, height int) (int, int) {
 
 	// Width is larger side.
 	case width > height:
-		p := float32(width) / float32(maxThumbWidth)
-		return maxThumbWidth, int(float32(height) / p)
+		// i.e. height = widthDiff * (height / width)
+		height = int(float32(maxThumbWidth) / aspect)
+		return maxThumbWidth, height
 
 	// Height is larger side.
 	case height > width:
-		p := float32(height) / float32(maxThumbHeight)
-		return int(float32(width) / p), maxThumbHeight
+		// i.e. width = heightDiff * (width / height)
+		width = int(float32(maxThumbHeight) * aspect)
+		return width, maxThumbHeight
 
 	// Square.
 	default:


### PR DESCRIPTION
# Description

- takes into account rotation data when generating output thumbnail
- simplifies ffprobe output to only show the fields we actually need

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
