### PR TITLE
[performance] limit ffprobe read time to at most 1s after start of file

### DIFF
--- a/internal/media/ffmpeg.go
+++ b/internal/media/ffmpeg.go
@@ -243,6 +243,11 @@ func ffprobe(ctx context.Context, filepath string) (*result, error) {
 				// side data stored.
 				"side_data=rotation",
 
+			// Limit to reading the first
+			// 1s of data looking for "rotation"
+			// side_data tags (expensive part).
+			"-read_intervals", "%+1",
+
 			// Input file.
 			"-i", filepath,
 		},


### PR DESCRIPTION
i would link to the ffprobe option for it but there isn't a specific link for `-read_interval` :p 