### PR TITLE
[chore] Take account of rotation data when calculating full size image dimensions

### DIFF
--- a/internal/media/processingmedia.go
+++ b/internal/media/processingmedia.go
@@ -223,7 +223,6 @@ func (p *ProcessingMedia) store(ctx context.Context) error {
 			width,
 			height,
 			aspect,
-			result.rotation,
 		)
 		p.media.FileMeta.Small.Width = thumbWidth
 		p.media.FileMeta.Small.Height = thumbHeight

--- a/internal/media/util.go
+++ b/internal/media/util.go
@@ -35,15 +35,19 @@ import (
 	"github.com/disintegration/imaging"
 )
 
-// thumbSize returns the dimensions to use for an input
-// image of given width / height, for its outgoing thumbnail.
-// This attempts to maintains the original image aspect ratio.
-func thumbSize(width, height int, aspect float32, rotation int) (int, int) {
-	const (
-		maxThumbWidth  = 512
-		maxThumbHeight = 512
-	)
+type dimensions struct {
+	width  int
+	height int
+	aspect float32
+}
 
+// displayDimensions takes account of the
+// given rotation data to return width and
+// height values as the image will be displayed.
+func displayDimensions(
+	width, height int,
+	rotation int,
+) (int, int) {
 	// If image is rotated by
 	// any odd multiples of 90,
 	// flip width / height to
@@ -51,8 +55,19 @@ func thumbSize(width, height int, aspect float32, rotation int) (int, int) {
 	switch rotation {
 	case -90, 90, -270, 270:
 		width, height = height, width
-		aspect = 1 / aspect
 	}
+
+	return width, height
+}
+
+// thumbSize returns the dimensions to use for an input
+// image of given width / height, for its outgoing thumbnail.
+// This attempts to maintains the original image aspect ratio.
+func thumbSize(width, height int, aspect float32) (int, int) {
+	const (
+		maxThumbWidth  = 512
+		maxThumbHeight = 512
+	)
 
 	switch {
 	// Simplest case, within bounds!

--- a/internal/media/util.go
+++ b/internal/media/util.go
@@ -35,12 +35,6 @@ import (
 	"github.com/disintegration/imaging"
 )
 
-type dimensions struct {
-	width  int
-	height int
-	aspect float32
-}
-
 // displayDimensions takes account of the
 // given rotation data to return width and
 // height values as the image will be displayed.


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates the code that determines height + width, to take account of rotation data *before* doing any aspect ration calculations etc. 

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
