### PR TITLE
[feature] Beef up our AI opt-outs

### DIFF
--- a/internal/middleware/extraheaders.go
+++ b/internal/middleware/extraheaders.go
@@ -44,5 +44,12 @@ func ExtraHeaders() gin.HandlerFunc {
 		//
 		// See: https://github.com/patcg-individual-drafts/topics
 		c.Header("Permissions-Policy", "browsing-topics=()")
+
+		// Some AI scrapers respect the following tags to opt-out
+		// of their crawling and datasets.
+		c.Header("X-Robots-Tag", "noimageai")
+		// c.Header calls .Set(), but we want to emit the header
+		// twice, not override it.
+		c.Writer.Header().Add("X-Robots-Tag", "noai")
 	}
 }

--- a/internal/web/robots.go
+++ b/internal/web/robots.go
@@ -43,15 +43,24 @@ User-agent: Claude-Web
 User-agent: cohere-ai
 User-agent: Diffbot
 User-agent: FacebookBot
+User-agent: facebookexternalhit
 User-agent: FriendlyCrawler
 User-agent: Google-Extended
 User-agent: GoogleOther
+User-agent: GoogleOther-Image
+User-agent: GoogleOther-Video
 User-agent: GPTBot
 User-agent: ImagesiftBot
 User-agent: img2dataset
+User-agent: Meta-ExternalAgent
+User-agent: OAI-SearchBot
 User-agent: omgili
 User-agent: omgilibot
 User-agent: PerplexityBot
+User-agent: PetalBot
+User-agent: Scrapy
+User-agent: Timpibot
+User-agent: VelenPublicWebCrawler
 User-agent: YouBot
 Disallow: /
 


### PR DESCRIPTION
# Description

* Updates our robots.txt with upstream
* Add two headers that a number of AI crawlers respect as an opt-out of their crap

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
