### PR TITLE
[chore/frontend] Update namerole rendering on skinny devices

### DIFF
--- a/web/source/css/profile.css
+++ b/web/source/css/profile.css
@@ -122,7 +122,7 @@
 			display: grid;
 			gap: 0 1rem;
 			box-sizing: border-box;
-			grid-template-columns: auto 1fr;
+			grid-template-columns: 1fr auto;
 			grid-template-rows: $name-size auto;
 			grid-template-areas:
 				"displayname displayname"
@@ -207,6 +207,9 @@
 	}
 }
 
+/*
+	Tablet-ish-kinda size.
+*/
 @media screen and (max-width: 750px) {
 	.profile .profile-header {
 		.basic-info {
@@ -217,17 +220,52 @@
 				"namerole namerole"
 				"namerole namerole";
 			
+			/*
+				Make display name a bit smaller
+				so there's more chance of being
+				able to read everything.
+			*/
 			.namerole {
-				grid-template-columns: 1fr;
-				grid-template-rows: $name-size auto;
-				grid-template-areas:
-					"displayname displayname"
-					"username role";
-				
 				.displayname {
-					font-size: 1.4rem;
+					font-size: 1.2rem;
+					line-height: 2rem;
+					margin-top: 0.5rem;
 				}
 			}
+		}
+	}
+}
+
+/*
+	Phone-ish-kinda size.
+*/
+@media screen and (max-width: 500px) {
+	.profile
+	.profile-header
+	.basic-info
+	.namerole {
+		/*
+			Line up in smallest possible
+			horizontal space to avoid overflow.
+		*/
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+
+		/*
+			Don't hug the right anymore
+			(good life advice in general).
+		*/
+		.role {
+			align-self: flex-start;
+		}
+
+		/*
+			Allow this to wrap in case
+			of a really skinny screen.
+		*/
+		.bot-username-wrapper {
+			flex-wrap: wrap;
 		}
 	}
 }


### PR DESCRIPTION
Noticed that it was fairly easy on a profile page with a reasonably long username + domain for the role badge to get lost in x-overflow cutoff. This PR updates our CSS for namerole to become even more compact on smaller screens, giving a higher chance of being able to read everything.

Normal width:

![Screenshot from 2024-08-03 13-02-17](https://github.com/user-attachments/assets/864cbbc3-0274-44c3-8cd7-59755b4a4dbc)

Tablet-ish width:

![Screenshot from 2024-08-03 13-02-09](https://github.com/user-attachments/assets/69c8a0f0-dc80-439b-96e1-f41a1b673d20)

Phone-ish width:

![Screenshot from 2024-08-03 13-02-34](https://github.com/user-attachments/assets/59df0ce9-43a1-423d-a1f6-aa8009462c6c)

Really skinny phone-ish width:

![Screenshot from 2024-08-03 13-05-11](https://github.com/user-attachments/assets/054cb619-dd69-4828-a6b8-64b420513bbf)
