### PR TITLE
[bugfix] send back Sec-Websocket-Protocol header for streaming WebSocket

### DIFF
--- a/internal/api/client/streaming/stream.go
+++ b/internal/api/client/streaming/stream.go
@@ -19,6 +19,7 @@ package streaming
 
 import (
 	"context"
+	"net/http"
 	"slices"
 	"time"
 
@@ -230,7 +231,12 @@ func (m *Module) StreamGETHandler(c *gin.Context) {
 	//
 	// If the upgrade fails, then Upgrade replies to the client
 	// with an HTTP error response.
-	wsConn, err := m.wsUpgrade.Upgrade(c.Writer, c.Request, nil)
+	h := http.Header{}
+	if c.GetHeader(AccessTokenHeader) != "" {
+		// Send it back, else Chrome fails to connect
+		h.Set(AccessTokenHeader, token)
+	}
+	wsConn, err := m.wsUpgrade.Upgrade(c.Writer, c.Request, h)
 	if err != nil {
 		l.Errorf("error upgrading websocket connection: %v", err)
 		stream.Close()

--- a/internal/api/client/streaming/stream.go
+++ b/internal/api/client/streaming/stream.go
@@ -163,8 +163,11 @@ func (m *Module) StreamGETHandler(c *gin.Context) {
 		// query param, no problem.
 		token = t
 	} else if t := c.GetHeader(AccessTokenHeader); t != "" {
-		// Token was provided as
-		// header, no problem.
+		// Token was provided in "Sec-Websocket-Protocol" header.
+		//
+		// This is hacky and not technically correct but some
+		// clients do it since Mastodon allows it, so we must
+		// also allow it to avoid breaking expectations.
 		token = t
 		tokenInHeader = true
 	}
@@ -241,6 +244,8 @@ func (m *Module) StreamGETHandler(c *gin.Context) {
 	if tokenInHeader {
 		// Return the token in the response,
 		// else Chrome fails to connect.
+		//
+		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism#sec-websocket-protocol
 		responseHeader = http.Header{AccessTokenHeader: {token}}
 	}
 

--- a/internal/api/client/streaming/streaming_test.go
+++ b/internal/api/client/streaming/streaming_test.go
@@ -22,7 +22,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -236,7 +236,7 @@ func (suite *StreamingTestSuite) TestSecurityHeader() {
 
 	result := recorder.Result()
 	defer result.Body.Close()
-	b, err := ioutil.ReadAll(result.Body)
+	b, err := io.ReadAll(result.Body)
 	suite.NoError(err)
 
 	// check response


### PR DESCRIPTION
# Description

Chrome expects the selected Sec-Websocket-Protocol to be sent back on the WebSocket upgrade request (RFC6455 1.9).

This makes GTS live update on e.g. elk.zone with a Chrome-based browser.

Solution adapted from https://stackoverflow.com/questions/58417479/sec-websocket-protocol-issues

Fixes #2427.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
