### PR TITLE
[feature] Use gifv type for short soundless mp4 videos

### DIFF
--- a/internal/gtsmodel/mediaattachment.go
+++ b/internal/gtsmodel/mediaattachment.go
@@ -91,6 +91,7 @@ const (
 	FileTypeImage   FileType = 1 // FileTypeImage is for jpegs, pngs, and standard gifs
 	FileTypeAudio   FileType = 2 // FileTypeAudio is for audio-only files (no video)
 	FileTypeVideo   FileType = 3 // FileTypeVideo is for files with audio + visual
+	FileTypeGifv    FileType = 4 // FileTypeGifv is for short video-only files (20s or less, mp4, no audio).
 )
 
 // String returns a stringified, frontend API compatible form of FileType.
@@ -104,6 +105,8 @@ func (t FileType) String() string {
 		return "audio"
 	case FileTypeVideo:
 		return "video"
+	case FileTypeGifv:
+		return "gifv"
 	default:
 		panic("invalid filetype")
 	}

--- a/internal/media/ffmpeg.go
+++ b/internal/media/ffmpeg.go
@@ -305,7 +305,15 @@ func (res *result) GetFileType() (gtsmodel.FileType, string) {
 	case "mov,mp4,m4a,3gp,3g2,mj2":
 		switch {
 		case len(res.video) > 0:
-			return gtsmodel.FileTypeVideo, "mp4"
+			if len(res.audio) == 0 &&
+				res.duration <= 30 {
+				// Short, soundless
+				// video file aka gifv.
+				return gtsmodel.FileTypeGifv, "mp4"
+			} else {
+				// Video file (with or without audio).
+				return gtsmodel.FileTypeVideo, "mp4"
+			}
 		case len(res.audio) > 0 &&
 			res.audio[0].codec == "aac":
 			// m4a only supports [aac] audio.

--- a/internal/media/processingmedia.go
+++ b/internal/media/processingmedia.go
@@ -202,7 +202,8 @@ func (p *ProcessingMedia) store(ctx context.Context) error {
 
 	switch p.media.Type {
 	case gtsmodel.FileTypeImage,
-		gtsmodel.FileTypeVideo:
+		gtsmodel.FileTypeVideo,
+		gtsmodel.FileTypeGifv:
 		// Attempt to clean as metadata from file as possible.
 		if err := clearMetadata(ctx, temppath); err != nil {
 			return gtserror.Newf("error cleaning metadata: %w", err)

--- a/web/template/status_attachments.tmpl
+++ b/web/template/status_attachments.tmpl
@@ -99,7 +99,7 @@ media photoswipe-gallery {{ (len .) | oddOrEven }} {{ if eq (len .) 1 }}single{{
                     <i class="hide fa fa-fw fa-eye-slash" aria-hidden="true"></i>
                     <i class="show fa fa-fw fa-eye" aria-hidden="true"></i>
                 </span>
-                {{- if eq .Type "video" }}
+                {{- if or (eq .Type "video") (eq .Type "gifv") }}
                 {{- include "videoPreview" $media | indent 4 }}
                 {{- else if eq .Type "image" }}
                 {{- include "imagePreview" $media | indent 4 }}
@@ -107,11 +107,17 @@ media photoswipe-gallery {{ (len .) | oddOrEven }} {{ if eq (len .) 1 }}single{{
                 {{- include "audioPreview" $media | indent 4 }}
                 {{- end }}
             </summary>
-            {{- if eq .Type "video" }}
+            {{- if or (eq .Type "video") (eq .Type "gifv") }}
             <video
+                {{- if eq .Type "video" }}
                 preload="none"
-                class="plyr-video photoswipe-slide"
+                {{- else }}
+                preload="auto"
+                muted
+                {{- end }}
+                class="plyr-video photoswipe-slide{{- if eq .Type "gifv" }} gifv{{ end }}"
                 controls
+                playsinline
                 data-pswp-index="{{- $index -}}"
                 poster="{{- .PreviewURL -}}"
                 data-pswp-width="{{- $media.Meta.Small.Width -}}px"
@@ -128,6 +134,7 @@ media photoswipe-gallery {{ (len .) | oddOrEven }} {{ if eq (len .) 1 }}single{{
                 preload="none"
                 class="plyr-video photoswipe-slide"
                 controls
+                playsinline
                 data-pswp-index="{{- $index -}}"
                 {{- if and $media.PreviewURL $media.Meta.Small.Width }}
                 poster="{{- .PreviewURL -}}"


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates some of our media parsing logic to use `gifv` instead of `video` as the type label for short, soundless mp4 videos. This is in line with what Mastodon does, and maybe some others, but I haven't checked. The `gifv` type hints to clients that they should show the video as a looping gif, rather than a traditional video.

Also updates the frontend to autoplay gifvs (if prefers-reduced-motion isn't set to reduce), an example can be seen here: https://goblin.technology/@tobi/statuses/01J4EGXESJ7X0801YNE05CWWA6

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
