### PR TITLE
ensure testrig package only compiled-in (including init) when debug e…

### DIFF
--- a/cmd/gotosocial/action/testrig/no_testrig.go
+++ b/cmd/gotosocial/action/testrig/no_testrig.go
@@ -15,30 +15,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package main
+//go:build !debug && !debugenv
 
-import (
-	"github.com/spf13/cobra"
-	"github.com/superseriousbusiness/gotosocial/cmd/gotosocial/action/testrig"
-)
+package testrig
 
-func testrigCommands() *cobra.Command {
-	if testrig.Start != nil {
-		testrigCmd := &cobra.Command{
-			Use:   "testrig",
-			Short: "gotosocial testrig-related tasks",
-		}
+import "github.com/superseriousbusiness/gotosocial/cmd/gotosocial/action"
 
-		testrigStartCmd := &cobra.Command{
-			Use:   "start",
-			Short: "start the gotosocial testrig server",
-			RunE: func(cmd *cobra.Command, args []string) error {
-				return run(cmd.Context(), testrig.Start)
-			},
-		}
-
-		testrigCmd.AddCommand(testrigStartCmd)
-		return testrigCmd
-	}
-	return nil
-}
+// Start creates and starts a gotosocial testrig server.
+// This is only enabled in debug builds, else is nil.
+var Start action.GTSAction

--- a/cmd/gotosocial/action/testrig/testrig.go
+++ b/cmd/gotosocial/action/testrig/testrig.go
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+//go:build debug || debugenv
+
 package testrig
 
 import (
@@ -52,7 +54,8 @@ import (
 	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
-// Start creates and starts a gotosocial testrig server
+// Start creates and starts a gotosocial testrig server.
+// This is only enabled in debug builds, else is nil.
 var Start action.GTSAction = func(ctx context.Context) error {
 	testrig.InitTestConfig()
 	testrig.InitTestLog()

--- a/cmd/gotosocial/main.go
+++ b/cmd/gotosocial/main.go
@@ -23,7 +23,6 @@ import (
 	godebug "runtime/debug"
 	"strings"
 
-	"codeberg.org/gruf/go-debug"
 	"github.com/spf13/cobra"
 
 	_ "github.com/superseriousbusiness/gotosocial/docs"
@@ -63,11 +62,12 @@ func main() {
 	rootCmd.AddCommand(serverCommands())
 	rootCmd.AddCommand(debugCommands())
 	rootCmd.AddCommand(adminCommands())
-	if debug.DEBUG {
-		// only add testrig if debug enabled.
-		rootCmd.AddCommand(testrigCommands())
+
+	// Testrigcmd will only be set when debug is enabled.
+	if testrigCmd := testrigCommands(); testrigCmd != nil {
+		rootCmd.AddCommand(testrigCmd)
 	} else if len(os.Args) > 1 && os.Args[1] == "testrig" {
-		log.Fatalln("gotosocial must be built and run with the DEBUG enviroment variable set to enable and access testrig")
+		log.Fatal("gotosocial must be built and run with the DEBUG enviroment variable set to enable and access testrig")
 	}
 
 	// run


### PR DESCRIPTION
# Description

The testrig precompiles webassembly during the package init function, which is useful for test running. But in the case of production builds the testrig package was still being compiled-in, even if largely stripped out, which ended up calling the `testrig.init()` function and making the smallest actions always rely on precompiling web assembly...

This ensures testrig package is only included in the build using the debug build flags. In time we should still find a way to move the precompilation stage for the testrig out of the init function, so debug builds don't hang during initialization.

closes #3122

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
