### PR TITLE
[bugfix] incorrect AP serialize function used serializing worker data

### DIFF
--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -230,7 +230,7 @@ func (msg *FromFediAPI) Serialize() ([]byte, error) {
 
 	// Set serialized AP object data if set.
 	if t, ok := msg.APObject.(vocab.Type); ok {
-		obj, err := t.Serialize()
+		obj, err := streams.Serialize(t)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Description

Updates to use `streams.Serialize()` instead of `interface{ Serialize() (...) }`, the latter of which doesn't include the `@context` field

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
