### PR TITLE
[security] harden account update logic

### DIFF
--- a/internal/federation/dereferencing/account.go
+++ b/internal/federation/dereferencing/account.go
@@ -341,7 +341,7 @@ func (d *Dereferencer) RefreshAccount(
 	)
 	if err != nil {
 		log.Errorf(ctx, "error enriching remote account: %v", err)
-		return nil, nil, gtserror.Newf("error enriching remote account: %w", err)
+		return nil, nil, gtserror.Newf("%w", err)
 	}
 
 	if accountable != nil {
@@ -747,7 +747,7 @@ func (d *Dereferencer) enrichAccount(
 
 	// Before expending any further serious compute, we need
 	// to ensure account keys haven't unexpectedly been changed.
-	if verifyAccountKeysOnUpdate(account, latestAcc, now) {
+	if !verifyAccountKeysOnUpdate(account, latestAcc, now) {
 		return nil, nil, gtserror.Newf("account %s pubkey has changed (key rotation required?)", uri)
 	}
 

--- a/internal/federation/dereferencing/account.go
+++ b/internal/federation/dereferencing/account.go
@@ -600,7 +600,9 @@ func (d *Dereferencer) enrichAccount(
 	d.startHandshake(requestUser, uri)
 	defer d.stopHandshake(requestUser, uri)
 
-	if apubAcc == nil {
+	var resolve bool
+
+	if resolve = (apubAcc == nil); resolve {
 		// We were not given any (partial) ActivityPub
 		// version of this account as a parameter.
 		// Dereference latest version of the account.
@@ -747,7 +749,7 @@ func (d *Dereferencer) enrichAccount(
 
 	// Before expending any further serious compute, we need
 	// to ensure account keys haven't unexpectedly been changed.
-	if !verifyAccountKeysOnUpdate(account, latestAcc, now) {
+	if !verifyAccountKeysOnUpdate(account, latestAcc, now, !resolve) {
 		return nil, nil, gtserror.Newf("account %s pubkey has changed (key rotation required?)", uri)
 	}
 

--- a/internal/federation/dereferencing/account.go
+++ b/internal/federation/dereferencing/account.go
@@ -732,14 +732,22 @@ func (d *Dereferencer) enrichAccount(
 		)...,
 	); err != nil {
 		return nil, nil, gtserror.Newf(
-			"error checking dereferenced account uri %s: %w",
+			"error checking account uri %s: %w",
 			latestAcc.URI, err,
 		)
 	} else if !matches {
 		return nil, nil, gtserror.Newf(
-			"dereferenced account uri %s does not match %s",
+			"account uri %s does not match %s",
 			latestAcc.URI, uri.String(),
 		)
+	}
+
+	// Before we expend any further serious compute on
+	// enriching this account model, we need to check
+	// that the account signing key has remained the same.
+	if account.PublicKey != nil &&
+		!account.PublicKey.Equal(latestAcc.PublicKey) {
+		return nil, nil, gtserror.Newf("account %s pubkey has changed (key rotation required?)", uri)
 	}
 
 	/*

--- a/internal/federation/dereferencing/account_test.go
+++ b/internal/federation/dereferencing/account_test.go
@@ -226,7 +226,7 @@ func (suite *AccountTestSuite) TestDereferenceRemoteAccountWithNonMatchingURI() 
 		fetchingAccount.Username,
 		testrig.URLMustParse(remoteAltURI),
 	)
-	suite.Equal(err.Error(), fmt.Sprintf("enrichAccount: dereferenced account uri %s does not match %s", remoteURI, remoteAltURI))
+	suite.Equal(err.Error(), fmt.Sprintf("enrichAccount: account uri %s does not match %s", remoteURI, remoteAltURI))
 	suite.Nil(fetchedAccount)
 }
 

--- a/internal/federation/dereferencing/account_test.go
+++ b/internal/federation/dereferencing/account_test.go
@@ -19,11 +19,17 @@ package dereferencing_test
 
 import (
 	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/activity/streams"
+	"github.com/superseriousbusiness/activity/streams/vocab"
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
@@ -230,6 +236,172 @@ func (suite *AccountTestSuite) TestDereferenceRemoteAccountWithNonMatchingURI() 
 	suite.Nil(fetchedAccount)
 }
 
+func (suite *AccountTestSuite) TestDereferenceRemoteAccountWithUnexpectedKeyChange() {
+	ctx, cncl := context.WithCancel(context.Background())
+	defer cncl()
+
+	fetchingAcc := suite.testAccounts["local_account_1"]
+	remoteURI := "https://turnip.farm/users/turniplover6969"
+
+	// Fetch the remote account to load into the database.
+	remoteAcc, _, err := suite.dereferencer.GetAccountByURI(ctx,
+		fetchingAcc.Username,
+		testrig.URLMustParse(remoteURI),
+	)
+	suite.NoError(err)
+	suite.NotNil(remoteAcc)
+
+	// Mark account as requiring a refetch.
+	remoteAcc.FetchedAt = time.Time{}
+	err = suite.state.DB.UpdateAccount(ctx, remoteAcc, "fetched_at")
+	suite.NoError(err)
+
+	// Update remote to have an unexpected different key.
+	remotePerson := suite.client.TestRemotePeople[remoteURI]
+	setPublicKey(remotePerson,
+		remoteURI,
+		fetchingAcc.PublicKeyURI+".unique",
+		fetchingAcc.PublicKey,
+	)
+
+	// Force refresh account expecting key change error.
+	_, _, err = suite.dereferencer.RefreshAccount(ctx,
+		fetchingAcc.Username,
+		remoteAcc,
+		nil,
+		nil,
+	)
+	suite.Equal(err.Error(), fmt.Sprintf("RefreshAccount: enrichAccount: account %s pubkey has changed (key rotation required?)", remoteURI))
+}
+
+func (suite *AccountTestSuite) TestDereferenceRemoteAccountWithExpectedKeyChange() {
+	ctx, cncl := context.WithCancel(context.Background())
+	defer cncl()
+
+	fetchingAcc := suite.testAccounts["local_account_1"]
+	remoteURI := "https://turnip.farm/users/turniplover6969"
+
+	// Fetch the remote account to load into the database.
+	remoteAcc, _, err := suite.dereferencer.GetAccountByURI(ctx,
+		fetchingAcc.Username,
+		testrig.URLMustParse(remoteURI),
+	)
+	suite.NoError(err)
+	suite.NotNil(remoteAcc)
+
+	// Expire the remote account's public key.
+	remoteAcc.PublicKeyExpiresAt = time.Now()
+	remoteAcc.FetchedAt = time.Time{} // force fetch
+	err = suite.state.DB.UpdateAccount(ctx, remoteAcc, "fetched_at", "public_key_expires_at")
+	suite.NoError(err)
+
+	// Update remote to have a different stored public key.
+	remotePerson := suite.client.TestRemotePeople[remoteURI]
+	setPublicKey(remotePerson,
+		remoteURI,
+		fetchingAcc.PublicKeyURI+".unique",
+		fetchingAcc.PublicKey,
+	)
+
+	// Refresh account expecting a succesful refresh with changed keys!
+	updatedAcc, apAcc, err := suite.dereferencer.RefreshAccount(ctx,
+		fetchingAcc.Username,
+		remoteAcc,
+		nil,
+		nil,
+	)
+	suite.NoError(err)
+	suite.NotNil(apAcc)
+	suite.True(updatedAcc.PublicKey.Equal(fetchingAcc.PublicKey))
+}
+
+func (suite *AccountTestSuite) TestRefreshRemoteAccountWithExpectedKeyChange() {
+	ctx, cncl := context.WithCancel(context.Background())
+	defer cncl()
+
+	fetchingAcc := suite.testAccounts["local_account_1"]
+	remoteURI := "https://turnip.farm/users/turniplover6969"
+
+	// Fetch the remote account to load into the database.
+	remoteAcc, _, err := suite.dereferencer.GetAccountByURI(ctx,
+		fetchingAcc.Username,
+		testrig.URLMustParse(remoteURI),
+	)
+	suite.NoError(err)
+	suite.NotNil(remoteAcc)
+
+	// Expire the remote account's public key.
+	remoteAcc.PublicKeyExpiresAt = time.Now()
+	remoteAcc.FetchedAt = time.Time{} // force fetch
+	err = suite.state.DB.UpdateAccount(ctx, remoteAcc, "fetched_at", "public_key_expires_at")
+	suite.NoError(err)
+
+	// Update remote to have a different stored public key.
+	remotePerson := suite.client.TestRemotePeople[remoteURI]
+	setPublicKey(remotePerson,
+		remoteURI,
+		fetchingAcc.PublicKeyURI+".unique",
+		fetchingAcc.PublicKey,
+	)
+
+	// Refresh account expecting a succesful refresh with changed keys!
+	updatedAcc, apAcc, err := suite.dereferencer.RefreshAccount(ctx,
+		fetchingAcc.Username,
+		remoteAcc,
+		remotePerson, // pass in the model so no dereference occurs
+		nil,
+	)
+	suite.NoError(err)
+	suite.NotNil(apAcc)
+	suite.True(updatedAcc.PublicKey.Equal(fetchingAcc.PublicKey))
+}
+
 func TestAccountTestSuite(t *testing.T) {
 	suite.Run(t, new(AccountTestSuite))
+}
+
+func setPublicKey(person vocab.ActivityStreamsPerson, ownerURI, keyURI string, key *rsa.PublicKey) {
+	profileIDURI, err := url.Parse(ownerURI)
+	if err != nil {
+		panic(err)
+	}
+
+	publicKeyURI, err := url.Parse(keyURI)
+	if err != nil {
+		panic(err)
+	}
+
+	publicKeyProp := streams.NewW3IDSecurityV1PublicKeyProperty()
+
+	// create the public key
+	publicKey := streams.NewW3IDSecurityV1PublicKey()
+
+	// set ID for the public key
+	publicKeyIDProp := streams.NewJSONLDIdProperty()
+	publicKeyIDProp.SetIRI(publicKeyURI)
+	publicKey.SetJSONLDId(publicKeyIDProp)
+
+	// set owner for the public key
+	publicKeyOwnerProp := streams.NewW3IDSecurityV1OwnerProperty()
+	publicKeyOwnerProp.SetIRI(profileIDURI)
+	publicKey.SetW3IDSecurityV1Owner(publicKeyOwnerProp)
+
+	// set the pem key itself
+	encodedPublicKey, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		panic(err)
+	}
+	publicKeyBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: encodedPublicKey,
+	})
+	publicKeyPEMProp := streams.NewW3IDSecurityV1PublicKeyPemProperty()
+	publicKeyPEMProp.Set(string(publicKeyBytes))
+	publicKey.SetW3IDSecurityV1PublicKeyPem(publicKeyPEMProp)
+
+	// append the public key to the public key property
+	publicKeyProp.AppendW3IDSecurityV1PublicKey(publicKey)
+
+	// set the public key property on the Person
+	person.SetW3IDSecurityV1PublicKey(publicKeyProp)
 }

--- a/internal/federation/dereferencing/authenticate.go
+++ b/internal/federation/dereferencing/authenticate.go
@@ -25,7 +25,15 @@ import (
 
 // verifyAccountKeysOnUpdate verifies that account's public key hasn't changed on update from
 // our existing stored representation, UNLESS the key has been explicitly expired (i.e. key rotation).
-func verifyAccountKeysOnUpdate(existing, latest *gtsmodel.Account, now time.Time) bool {
+func verifyAccountKeysOnUpdate(existing, latest *gtsmodel.Account, now time.Time, federated bool) bool {
+	if federated {
+		// If this data was federated
+		// to us then we implicitly trust
+		// it on the grounds that it
+		// passed any signature checks.
+		return true
+	}
+
 	if existing.PublicKey == nil {
 		// New account which has been
 		// passed as a placeholder.

--- a/internal/federation/dereferencing/authenticate.go
+++ b/internal/federation/dereferencing/authenticate.go
@@ -1,0 +1,45 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package dereferencing
+
+import (
+	"time"
+
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+)
+
+// verifyAccountKeysOnUpdate verifies that account's public key hasn't changed on update from
+// our existing stored representation, UNLESS the key has been explicitly expired (i.e. key rotation).
+func verifyAccountKeysOnUpdate(existing, latest *gtsmodel.Account, now time.Time) bool {
+	if existing.PublicKey == nil {
+		// New account which has been
+		// passed as a placeholder.
+		// This is always permitted.
+		return true
+	}
+
+	// Ensure that public keys have not changed.
+	if existing.PublicKey.Equal(latest.PublicKey) {
+		return true
+	}
+
+	// The only time that an account key change is
+	// permitted is when it is marked as expired.
+	return !existing.PublicKeyExpiresAt.IsZero() &&
+		existing.PublicKeyExpiresAt.Before(now)
+}

--- a/internal/federation/dereferencing/authenticate.go
+++ b/internal/federation/dereferencing/authenticate.go
@@ -34,7 +34,8 @@ func verifyAccountKeysOnUpdate(existing, latest *gtsmodel.Account, now time.Time
 	}
 
 	// Ensure that public keys have not changed.
-	if existing.PublicKey.Equal(latest.PublicKey) {
+	if existing.PublicKey.Equal(latest.PublicKey) &&
+		existing.PublicKeyURI == latest.PublicKeyURI {
 		return true
 	}
 

--- a/internal/processing/workers/fromfediapi.go
+++ b/internal/processing/workers/fromfediapi.go
@@ -674,8 +674,13 @@ func (p *fediAPI) UpdateAccount(ctx context.Context, fMsg *messages.FromFediAPI)
 		fMsg.Receiving.Username,
 		account,
 		apubAcc,
-		// Force refresh within 5min window.
-		dereferencing.Fresh,
+
+		// Force refresh within 10s window.
+		//
+		// Missing account updates could be
+		// detrimental to federation if they
+		// include public key changes.
+		dereferencing.Freshest,
 	)
 	if err != nil {
 		log.Errorf(ctx, "error refreshing account: %v", err)


### PR DESCRIPTION
# Description

A very quick change. It just ensures that on account refresh that the public keys do not change. It ensures that we don't accidentally end up changing the account's public key outside of `AuthenticateFederatedRequest()`.

Though exploring this in more detail, and filling my head once more with the intricasies of AP + http signatures has reminded me how the current implementation only protects against unauthorized GET requests. If a server doesn't sever ties before it goes dark, the domain lapses and someone else sets up a server on that domain, if they set-up a dummy account model that mirrors exactly what we expect (which is possible since there's no signature attached to an account model to verify that the GET request was *responded to* by the expected party), then we may end up sending them followers-only posts, DMs etc without knowing that its actually a compromised server. Though they won't be able to successfully fetch anything, since they won't be able to correctly sign an HTTP signature header.

All of the above, while unfortunate, does make sense given it's called "authorized fetch".

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
