### PR TITLE
[chore] update go-structr to v0.8.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	codeberg.org/gruf/go-runners v1.6.2
 	codeberg.org/gruf/go-sched v1.2.3
 	codeberg.org/gruf/go-storage v0.1.2
-	codeberg.org/gruf/go-structr v0.8.7
+	codeberg.org/gruf/go-structr v0.8.8
 	codeberg.org/superseriousbusiness/exif-terminator v0.9.0
 	github.com/DmitriyVTitov/size v1.5.0
 	github.com/KimMachineGun/automemlimit v0.6.1
@@ -89,7 +89,7 @@ require (
 	codeberg.org/gruf/go-atomics v1.1.0 // indirect
 	codeberg.org/gruf/go-bitutil v1.1.0 // indirect
 	codeberg.org/gruf/go-fastpath/v2 v2.0.0 // indirect
-	codeberg.org/gruf/go-mangler v1.4.0 // indirect
+	codeberg.org/gruf/go-mangler v1.4.1 // indirect
 	codeberg.org/gruf/go-maps v1.0.3 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ codeberg.org/gruf/go-logger/v2 v2.2.1 h1:RP2u059EQKTBFV3cN8X6xDxNk2RkzqdgXGKflKq
 codeberg.org/gruf/go-logger/v2 v2.2.1/go.mod h1:m/vBfG5jNUmYXI8Hg9aVSk7Pn8YgEBITQB/B/CzdRss=
 codeberg.org/gruf/go-loosy v0.0.0-20231007123304-bb910d1ab5c4 h1:IXwfoU7f2whT6+JKIKskNl/hBlmWmnF1vZd84Eb3cyA=
 codeberg.org/gruf/go-loosy v0.0.0-20231007123304-bb910d1ab5c4/go.mod h1:fiO8HE1wjZCephcYmRRsVnNI/i0+mhy44Z5dQalS0rM=
-codeberg.org/gruf/go-mangler v1.4.0 h1:yOQMygLgCnU0ERt1JDAtv/LsjDwJtAdRpwhm648rA/E=
-codeberg.org/gruf/go-mangler v1.4.0/go.mod h1:TVbrburPF+UjuRSwxH1tHP3pZZXzdyJJO8+PToTEiKg=
+codeberg.org/gruf/go-mangler v1.4.1 h1:Dv58jFfy9On49L11ji6tpADUknwoJA46iaiZvnNXecs=
+codeberg.org/gruf/go-mangler v1.4.1/go.mod h1:mDmW8Ia352RvNFaXoP9K60TgcmCZJtX0j6wm3vjAsJE=
 codeberg.org/gruf/go-maps v1.0.3 h1:VDwhnnaVNUIy5O93CvkcE2IZXnMB1+IJjzfop9V12es=
 codeberg.org/gruf/go-maps v1.0.3/go.mod h1:D5LNDxlC9rsDuVQVM6JObaVGAdHB6g2dTdOdkh1aXWA=
 codeberg.org/gruf/go-mempool v0.0.0-20240507125005-cef10d64a760 h1:m2/UCRXhjDwAg4vyji6iKCpomKw6P4PmBOUi5DvAMH4=
@@ -80,8 +80,8 @@ codeberg.org/gruf/go-sched v1.2.3 h1:H5ViDxxzOBR3uIyGBCf0eH8b1L8wMybOXcdtUUTXZHk
 codeberg.org/gruf/go-sched v1.2.3/go.mod h1:vT9uB6KWFIIwnG9vcPY2a0alYNoqdL1mSzRM8I+PK7A=
 codeberg.org/gruf/go-storage v0.1.2 h1:dIOVOKq1CJpRmuhbB8Zok3mmo8V6VV/nX5GLIm6hywA=
 codeberg.org/gruf/go-storage v0.1.2/go.mod h1:LRDpFHqRJi0f+35c3ltBH2e/pGfwY5dGlNlgCJ/R1DA=
-codeberg.org/gruf/go-structr v0.8.7 h1:agYCI6tSXU4JHVYPwZk3Og5rrBePNVv5iPWsDu7ZJIw=
-codeberg.org/gruf/go-structr v0.8.7/go.mod h1:O0FTNgzUnUKwWey4dEW99QD8rPezKPi5sxCVxYOJ1Fg=
+codeberg.org/gruf/go-structr v0.8.8 h1:lRPpyTmLKvQCkkQiSUbOAh6jtL2wncEO8DwksMqQXM8=
+codeberg.org/gruf/go-structr v0.8.8/go.mod h1:zkoXVrAnKosh8VFAsbP/Hhs8FmLBjbVVy5w/Ngm8ApM=
 codeberg.org/superseriousbusiness/exif-terminator v0.9.0 h1:/EfyGI6HIrbkhFwgXGSjZ9o1kr/+k8v4mKdfXTH02Go=
 codeberg.org/superseriousbusiness/exif-terminator v0.9.0/go.mod h1:gCWKduudUWFzsnixoMzu0FYVdxHWG+AbXnZ50DqxsUE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=

--- a/vendor/codeberg.org/gruf/go-mangler/helpers.go
+++ b/vendor/codeberg.org/gruf/go-mangler/helpers.go
@@ -69,7 +69,7 @@ func deref_ptr_mangler(ctx typecontext, mangle Mangler, n uint) Mangler {
 		}
 
 		if ptr == nil {
-			// Check for nil values
+			// Final nil val check
 			buf = append(buf, '0')
 			return buf
 		}
@@ -144,8 +144,8 @@ func iter_struct_mangler(ctx typecontext, manglers []Mangler) Mangler {
 	}
 
 	type field struct {
-		offset uintptr
 		mangle Mangler
+		offset uintptr
 	}
 
 	// Bundle together the fields and manglers.

--- a/vendor/codeberg.org/gruf/go-structr/cache.go
+++ b/vendor/codeberg.org/gruf/go-structr/cache.go
@@ -20,17 +20,6 @@ func DefaultIgnoreErr(err error) bool {
 // for initializing a struct cache.
 type CacheConfig[StructType any] struct {
 
-	// Indices defines indices to create
-	// in the Cache for the receiving
-	// generic struct type parameter.
-	Indices []IndexConfig
-
-	// MaxSize defines the maximum number
-	// of items allowed in the Cache at
-	// one time, before old items start
-	// getting evicted.
-	MaxSize int
-
 	// IgnoreErr defines which errors to
 	// ignore (i.e. not cache) returned
 	// from load function callback calls.
@@ -48,6 +37,17 @@ type CacheConfig[StructType any] struct {
 	// as the values passed to Put() / Store(),
 	// or by the keys by calls to Invalidate().
 	Invalidate func(StructType)
+
+	// Indices defines indices to create
+	// in the Cache for the receiving
+	// generic struct type parameter.
+	Indices []IndexConfig
+
+	// MaxSize defines the maximum number
+	// of items allowed in the Cache at
+	// one time, before old items start
+	// getting evicted.
+	MaxSize int
 }
 
 // Cache provides a structure cache with automated
@@ -56,23 +56,23 @@ type CacheConfig[StructType any] struct {
 // of negative results (errors!) returned by LoadOne().
 type Cache[StructType any] struct {
 
-	// indices used in storing passed struct
-	// types by user defined sets of fields.
-	indices []Index
+	// hook functions.
+	ignore  func(error) bool
+	copy    func(StructType) StructType
+	invalid func(StructType)
 
 	// keeps track of all indexed items,
 	// in order of last recently used (LRU).
 	lru list
 
+	// indices used in storing passed struct
+	// types by user defined sets of fields.
+	indices []Index
+
 	// max cache size, imposes size
 	// limit on the lruList in order
 	// to evict old entries.
 	maxSize int
-
-	// hook functions.
-	ignore  func(error) bool
-	copy    func(StructType) StructType
-	invalid func(StructType)
 
 	// protective mutex, guards:
 	// - Cache{}.lruList

--- a/vendor/codeberg.org/gruf/go-structr/index.go
+++ b/vendor/codeberg.org/gruf/go-structr/index.go
@@ -349,15 +349,15 @@ type index_entry struct {
 	// elem.data is ptr to index_entry.
 	elem list_elem
 
-	// raw cache key
-	// for this entry.
-	key string
-
 	// index this is stored in.
 	index *Index
 
 	// underlying indexed item.
 	item *indexed_item
+
+	// raw cache key
+	// for this entry.
+	key string
 }
 
 var index_entry_pool sync.Pool

--- a/vendor/codeberg.org/gruf/go-structr/item.go
+++ b/vendor/codeberg.org/gruf/go-structr/item.go
@@ -10,12 +10,12 @@ type indexed_item struct {
 	// is stored in a main list.
 	elem list_elem
 
+	// cached data with type.
+	data interface{}
+
 	// indexed stores the indices
 	// this item is stored under.
 	indexed []*index_entry
-
-	// cached data with type.
-	data interface{}
 }
 
 var indexed_item_pool sync.Pool

--- a/vendor/codeberg.org/gruf/go-structr/key.go
+++ b/vendor/codeberg.org/gruf/go-structr/key.go
@@ -10,8 +10,8 @@ import (
 // lookup (potentially) stored
 // entries in an Index.
 type Key struct {
-	raw []any
 	key string
+	raw []any
 }
 
 // Key returns the underlying cache key string.

--- a/vendor/codeberg.org/gruf/go-structr/queue.go
+++ b/vendor/codeberg.org/gruf/go-structr/queue.go
@@ -10,15 +10,15 @@ import (
 // for initializing a struct queue.
 type QueueConfig[StructType any] struct {
 
-	// Indices defines indices to create
-	// in the Queue for the receiving
-	// generic struct parameter type.
-	Indices []IndexConfig
-
 	// Pop is called when queue values
 	// are popped, during calls to any
 	// of the Pop___() series of fns.
 	Pop func(StructType)
+
+	// Indices defines indices to create
+	// in the Queue for the receiving
+	// generic struct parameter type.
+	Indices []IndexConfig
 }
 
 // Queue provides a structure model queue with
@@ -26,17 +26,17 @@ type QueueConfig[StructType any] struct {
 // defined lookups of field combinations.
 type Queue[StructType any] struct {
 
-	// indices used in storing passed struct
-	// types by user defined sets of fields.
-	indices []Index
+	// hook functions.
+	copy func(StructType) StructType
+	pop  func(StructType)
 
 	// main underlying
 	// struct item queue.
 	queue list
 
-	// hook functions.
-	copy func(StructType) StructType
-	pop  func(StructType)
+	// indices used in storing passed struct
+	// types by user defined sets of fields.
+	indices []Index
 
 	// protective mutex, guards:
 	// - Queue{}.queue

--- a/vendor/codeberg.org/gruf/go-structr/queue_ctx.go
+++ b/vendor/codeberg.org/gruf/go-structr/queue_ctx.go
@@ -6,8 +6,8 @@ import (
 
 // QueueCtx is a context-aware form of Queue{}.
 type QueueCtx[StructType any] struct {
-	Queue[StructType]
 	ch chan struct{}
+	Queue[StructType]
 }
 
 // PopFront pops the current value at front of the queue, else blocking on ctx.

--- a/vendor/codeberg.org/gruf/go-structr/runtime.go
+++ b/vendor/codeberg.org/gruf/go-structr/runtime.go
@@ -16,10 +16,6 @@ import (
 type struct_field struct {
 	rtype reflect.Type
 
-	// offsets defines whereabouts in
-	// memory this field is located.
-	offsets []next_offset
-
 	// struct field type mangling
 	// (i.e. fast serializing) fn.
 	mangle mangler.Mangler
@@ -33,6 +29,10 @@ type struct_field struct {
 	// if set this indicates zero
 	// values of field not allowed
 	zerostr string
+
+	// offsets defines whereabouts in
+	// memory this field is located.
+	offsets []next_offset
 }
 
 // next_offset defines a next offset location

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -48,7 +48,7 @@ codeberg.org/gruf/go-list
 # codeberg.org/gruf/go-logger/v2 v2.2.1
 ## explicit; go 1.19
 codeberg.org/gruf/go-logger/v2/level
-# codeberg.org/gruf/go-mangler v1.4.0
+# codeberg.org/gruf/go-mangler v1.4.1
 ## explicit; go 1.19
 codeberg.org/gruf/go-mangler
 # codeberg.org/gruf/go-maps v1.0.3
@@ -76,7 +76,7 @@ codeberg.org/gruf/go-storage/disk
 codeberg.org/gruf/go-storage/internal
 codeberg.org/gruf/go-storage/memory
 codeberg.org/gruf/go-storage/s3
-# codeberg.org/gruf/go-structr v0.8.7
+# codeberg.org/gruf/go-structr v0.8.8
 ## explicit; go 1.21
 codeberg.org/gruf/go-structr
 # codeberg.org/superseriousbusiness/exif-terminator v0.9.0


### PR DESCRIPTION
# Description

Just does some shuffling of the `go-structr` struct fields to optimize memory alignment and minimise memory footprint. May / may not have much of an effect, but hey :p 

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
