### PR TITLE
[chore] update go-fastcopy to v1.1.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	codeberg.org/gruf/go-cache/v3 v3.5.7
 	codeberg.org/gruf/go-debug v1.3.0
 	codeberg.org/gruf/go-errors/v2 v2.3.2
-	codeberg.org/gruf/go-fastcopy v1.1.2
+	codeberg.org/gruf/go-fastcopy v1.1.3
 	codeberg.org/gruf/go-ffmpreg v0.2.4
 	codeberg.org/gruf/go-iotools v0.0.0-20240710125620-934ae9c654cf
 	codeberg.org/gruf/go-kv v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ codeberg.org/gruf/go-debug v1.3.0/go.mod h1:N+vSy9uJBQgpQcJUqjctvqFz7tBHJf+S/PIj
 codeberg.org/gruf/go-errors/v2 v2.0.0/go.mod h1:ZRhbdhvgoUA3Yw6e56kd9Ox984RrvbEFC2pOXyHDJP4=
 codeberg.org/gruf/go-errors/v2 v2.3.2 h1:8ItWaOMfhDaqrJK1Pw8MO0Nu+o/tVcQtR5cJ58Vc4zo=
 codeberg.org/gruf/go-errors/v2 v2.3.2/go.mod h1:LfzD9nkAAJpEDbkUqOZQ2jdaQ8VrK0pnR36zLOMFq6Y=
-codeberg.org/gruf/go-fastcopy v1.1.2 h1:YwmYXPsyOcRBxKEE2+w1bGAZfclHVaPijFsOVOcnNcw=
-codeberg.org/gruf/go-fastcopy v1.1.2/go.mod h1:GDDYR0Cnb3U/AIfGM3983V/L+GN+vuwVMvrmVABo21s=
+codeberg.org/gruf/go-fastcopy v1.1.3 h1:Jo9VTQjI6KYimlw25PPc7YLA3Xm+XMQhaHwKnM7xD1g=
+codeberg.org/gruf/go-fastcopy v1.1.3/go.mod h1:GDDYR0Cnb3U/AIfGM3983V/L+GN+vuwVMvrmVABo21s=
 codeberg.org/gruf/go-fastpath/v2 v2.0.0 h1:iAS9GZahFhyWEH0KLhFEJR+txx1ZhMXxYzu2q5Qo9c0=
 codeberg.org/gruf/go-fastpath/v2 v2.0.0/go.mod h1:3pPqu5nZjpbRrOqvLyAK7puS1OfEtQvjd6342Cwz56Q=
 codeberg.org/gruf/go-ffmpreg v0.2.4 h1:9NR0a5a0RjiIpyQgsqmHen6oadABADv04BWt7dr9kuE=

--- a/vendor/codeberg.org/gruf/go-fastcopy/copy.go
+++ b/vendor/codeberg.org/gruf/go-fastcopy/copy.go
@@ -1,6 +1,7 @@
 package fastcopy
 
 import (
+	"errors"
 	"io"
 	"sync"
 	_ "unsafe" // link to io.errInvalidWrite.
@@ -10,8 +11,8 @@ var (
 	// global pool instance.
 	pool = CopyPool{size: 4096}
 
-	//go:linkname errInvalidWrite io.errInvalidWrite
-	errInvalidWrite error
+	// errInvalidWrite means that a write returned an impossible count.
+	errInvalidWrite = errors.New("invalid write result")
 )
 
 // CopyPool provides a memory pool of byte

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -24,7 +24,7 @@ codeberg.org/gruf/go-debug
 # codeberg.org/gruf/go-errors/v2 v2.3.2
 ## explicit; go 1.19
 codeberg.org/gruf/go-errors/v2
-# codeberg.org/gruf/go-fastcopy v1.1.2
+# codeberg.org/gruf/go-fastcopy v1.1.3
 ## explicit; go 1.17
 codeberg.org/gruf/go-fastcopy
 # codeberg.org/gruf/go-fastpath/v2 v2.0.0


### PR DESCRIPTION
# Description

Updates go-fastcopy to v1.1.3 which removes reliance on go:linkname

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
