### PR TITLE
[feature] Log OTEL internal logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/gin-contrib/gzip v1.0.1
 	github.com/gin-contrib/sessions v1.0.1
 	github.com/gin-gonic/gin v1.10.0
+	github.com/go-logr/logr v1.4.1
 	github.com/go-playground/form/v4 v4.2.1
 	github.com/go-swagger/go-swagger v0.31.0
 	github.com/google/go-cmp v0.6.0
@@ -122,7 +123,6 @@ require (
 	github.com/go-fed/httpsig v1.1.0 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.2 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -361,9 +361,7 @@ type LogrSink struct {
 // Ensure Logger implements logr.LogSink
 var _ logr.LogSink = &LogrSink{}
 
-func (l LogrSink) Init(_ logr.RuntimeInfo) {
-	return
-}
+func (l LogrSink) Init(_ logr.RuntimeInfo) {}
 
 func (l LogrSink) Enabled(level int) bool {
 	return otelLogLevelToGoLoggerLevel(level) <= loglvl

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,0 +1,69 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package log
+
+import (
+	"testing"
+
+	"codeberg.org/gruf/go-kv"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		keysAndValues  []any
+		expectedFields []kv.Field
+	}{
+		{
+			name:          "Even number of elements",
+			keysAndValues: []any{"count", 2, "total_dropped", 0},
+			expectedFields: []kv.Field{
+				{K: "count", V: 2},
+				{K: "total_dropped", V: 0},
+			},
+		},
+		{
+			name:          "Odd number of elements",
+			keysAndValues: []any{"count", 2, "whatever"},
+			expectedFields: []kv.Field{
+				{K: "count", V: 2},
+				{K: "whatever", V: nil},
+			},
+		},
+		{
+			name:           "Empty input",
+			keysAndValues:  []any{},
+			expectedFields: []kv.Field{},
+		},
+		{
+			name:          "Single element",
+			keysAndValues: []any{"single"},
+			expectedFields: []kv.Field{
+				{K: "single", V: nil},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualFields := toFields(tt.keysAndValues...)
+			assert.Equal(t, tt.expectedFields, actualFields)
+		})
+	}
+}

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -55,6 +55,9 @@ func Initialize() error {
 
 	insecure := config.GetTracingInsecureTransport()
 
+	// Log internal OTEL logs
+	otel.SetLogger(log.NewLogrLogger())
+
 	var tpo trace.TracerProviderOption
 	switch config.GetTracingTransport() {
 	case "grpc":


### PR DESCRIPTION
# Description

Currently the internal logs of the OTEL library aren't logged making it hard to debug situations like #3117

The OTEL library [expects a Logr logger ](https://pkg.go.dev/go.opentelemetry.io/otel#SetLogger) to be passed to it so this pull request implements a [Logr `LogSink`](https://pkg.go.dev/github.com/go-logr/logr#LogSink) that logs through the existing logging mechanism. 

When tracing is enabled this will produce logs like the following for example:
```bash
timestamp="14/08/2024 19:00:18.752" func=trace.(*TracerProvider).Tracer level=INFO name=github.com/uptrace/bun version="" schemaURL="" msg="Tracer created"
timestamp="14/08/2024 19:00:19.173" func=trace.(*TracerProvider).Tracer level=INFO name=github.com/superseriousbusiness/gotosocial/internal/tracing version=0.0.0-testrig schemaURL="" msg="Tracer created"
timestamp="14/08/2024 19:05:23.394" func=trace.(*batchSpanProcessor).exportSpans level=DEBUG count=2 total_dropped=0 msg="exporting spans"
```


## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
