### PR TITLE
[bugfix] permit unspecified orientation data

### DIFF
--- a/internal/media/ffmpeg.go
+++ b/internal/media/ffmpeg.go
@@ -484,7 +484,7 @@ func (res *ffprobeResult) Process() (*result, error) {
 
 		// Parse as integer value.
 		i, _ := strconv.Atoi(str)
-		if i <= 0 || i >= 9 {
+		if i < 0 || i >= 9 {
 			return nil, errors.New("invalid orientation data")
 		}
 


### PR DESCRIPTION
# Description

Fixes `invalid orientation data` being returned if the image doesn't actually specify it (which is totally valid to do).

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
