### PR TITLE
[bugfix/frontend] Small safari + gnome web fixes

### DIFF
--- a/web/source/css/base.css
+++ b/web/source/css/base.css
@@ -178,6 +178,16 @@ input, select, textarea, .input {
 	}
 }
 
+select {
+	/*
+		By default this looks awful on Gnome
+		Web so restyle a bit to try to make
+		it consistent with firefox + chrome.
+	*/
+	appearance: none;
+	line-height: 1.5rem;
+}
+
 /*
 	Squeeze emojis so they fit inline in text.
 */

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -308,6 +308,10 @@ main {
 						"eye sensitive ."
 						".   sensitive  .";
 
+					&::-webkit-details-marker {
+						display: none; /* Safari */
+					}
+
 					.eye.button {
 						grid-area: eye;
 						align-self: start;

--- a/web/source/settings/components/form/inputs.tsx
+++ b/web/source/settings/components/form/inputs.tsx
@@ -170,19 +170,21 @@ export function Select({
 			<label>
 				{label}
 				{children}
-				<select
-					onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
-						onChange(e);
-						if (onChangeCallback !== undefined) {
-							onChangeCallback(e.target.value);
-						}
-					}}
-					value={value}
-					ref={ref as RefObject<HTMLSelectElement>}
-					{...props}
-				>
-					{options}
-				</select>
+				<div className="select-wrapper">
+					<select
+						onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+							onChange(e);
+							if (onChangeCallback !== undefined) {
+								onChangeCallback(e.target.value);
+							}
+						}}
+						value={value}
+						ref={ref as RefObject<HTMLSelectElement>}
+						{...props}
+					>
+						{options}
+					</select>
+				</div>
 			</label>
 		</div>
 	);

--- a/web/source/settings/style.css
+++ b/web/source/settings/style.css
@@ -374,6 +374,18 @@ section.with-sidebar > form {
 		flex-wrap: wrap;
 		gap: 0.4rem;
 	}
+
+	.select-wrapper {
+		position: relative;
+
+		&::after {
+			content: "▼";
+			font-size: 0.8rem;
+			top: 0.3rem;
+			right: 1rem;
+			position: absolute;
+		  }
+	}
 }
 
 .form-flex {

--- a/web/source/settings/style.css
+++ b/web/source/settings/style.css
@@ -376,15 +376,18 @@ section.with-sidebar > form {
 	}
 
 	.select-wrapper {
+		/*
+			Selects are normalized in base.css to not have a down arrow on the side.
+			Overcome this on settings panel forms by replacing the down arrow.
+		*/
 		position: relative;
-
 		&::after {
 			content: "▼";
 			font-size: 0.8rem;
 			top: 0.3rem;
 			right: 1rem;
 			position: absolute;
-		  }
+		}
 	}
 }
 


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request fixes `<select>` appearance on Gnome Web aka Epiphany, which was rendering them as white blobs before, and also closes https://github.com/superseriousbusiness/gotosocial/issues/3170

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.

