### PR TITLE
[bugfix] Carry-over `ApprovedByURI` to avoid marking already-approved remote statuses as pending approval

### DIFF
--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -520,6 +520,9 @@ func (d *Dereferencer) enrichStatus(
 	// based on the author's inclusion in a followers/following
 	// collection. By carrying over previously-set values we
 	// can avoid marking such statuses as "pending" again.
+	//
+	// If a remote has in the meantime retracted its approval,
+	// the next call to 'isPermittedStatus' will catch that.
 	latestStatus.ApprovedByURI = status.ApprovedByURI
 
 	// Check if this is a permitted status we should accept.

--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -520,7 +520,6 @@ func (d *Dereferencer) enrichStatus(
 	// based on the author's inclusion in a followers/following
 	// collection. By carrying over previously-set values we
 	// can avoid marking such statuses as "pending" again.
-	latestStatus.PendingApproval = status.PendingApproval
 	latestStatus.ApprovedByURI = status.ApprovedByURI
 
 	// Check if this is a permitted status we should accept.

--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -514,6 +514,15 @@ func (d *Dereferencer) enrichStatus(
 	latestStatus.FetchedAt = time.Now()
 	latestStatus.Local = status.Local
 
+	// Carry-over approvals. Remote instances might not yet
+	// serve statuses with the `approved_by` field, but we
+	// might have marked a status as pre-approved on our side
+	// based on the author's inclusion in a followers/following
+	// collection. By carrying over previously-set values we
+	// can avoid marking such statuses as "pending" again.
+	latestStatus.PendingApproval = status.PendingApproval
+	latestStatus.ApprovedByURI = status.ApprovedByURI
+
 	// Check if this is a permitted status we should accept.
 	// Function also sets "PendingApproval" bool as necessary.
 	permit, err := d.isPermittedStatus(ctx, requestUser, status, latestStatus)


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Lil bugfix for a case where a remote status could be marked as pending approval even after being previously pre-approved.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
