### PR TITLE
[bugfix] Let prometheus client do its own compression handling

### DIFF
--- a/internal/api/metrics/metrics.go
+++ b/internal/api/metrics/metrics.go
@@ -30,9 +30,13 @@ type Module struct {
 }
 
 func New() *Module {
-	// Use our own gzip handler.
+	// Let prometheus use "identity", ie., no compression,
+	// or "gzip", to match our own gzip compression middleware.
 	opts := promhttp.HandlerOpts{
-		DisableCompression: true,
+		OfferedCompressions: []promhttp.Compression{
+			promhttp.Identity,
+			promhttp.Gzip,
+		},
 	}
 
 	// Instrument handler itself.

--- a/testrig/config.go
+++ b/testrig/config.go
@@ -154,7 +154,7 @@ func testDefaults() config.Configuration {
 		TracingTransport:         "grpc",
 		TracingInsecureTransport: true,
 
-		MetricsEnabled:     false,
+		MetricsEnabled:     true,
 		MetricsAuthEnabled: false,
 
 		SyslogEnabled:  false,


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Update routing to *not* pass our gzip middleware to prometheus http endpoint, but let it do its own compression handling. Because of [this change](https://github.com/superseriousbusiness/gotosocial/pull/3210/files#diff-9b0fbb4e734fd51a74793baf89de863a2d1b56f02a713dd6e145a9a0b9eb79ceR438) in [this PR](https://github.com/superseriousbusiness/gotosocial/pull/3210), prometheus overwrites the `content-encoding` header to `identity` (ie., no compression) even if our gzip middleware compresses the body, which was confusing http clients (understandably). Rather than fighting prometheus and trying to hack around this by setting another content-encoding later or something, it's easier to just let prometheus win this round and do its own compression.

Tested this on the testrig and it fixes the issue.

closes https://github.com/superseriousbusiness/gotosocial/issues/3216

![image](https://github.com/user-attachments/assets/3e1459b5-04c3-49d2-8621-b2a79cd124fa)

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
