### PR TITLE
[chore] Tiny tweak to ApprovedByURI

### DIFF
--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -523,7 +523,9 @@ func (d *Dereferencer) enrichStatus(
 	//
 	// If a remote has in the meantime retracted its approval,
 	// the next call to 'isPermittedStatus' will catch that.
-	latestStatus.ApprovedByURI = status.ApprovedByURI
+	if latestStatus.ApprovedByURI == "" && status.ApprovedByURI != "" {
+		latestStatus.ApprovedByURI = status.ApprovedByURI
+	}
 
 	// Check if this is a permitted status we should accept.
 	// Function also sets "PendingApproval" bool as necessary.


### PR DESCRIPTION
Further tweak on top of https://github.com/superseriousbusiness/gotosocial/pull/3231 because I realized there are cases where we might not have an `approvedBy` stored, but a remote status has had `approvedBy` added in the meantime, we should use the latter value then.