### PR TITLE
SMTPEncryption config option to support SMTPS email transport

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,6 +153,7 @@ type Configuration struct {
 	SMTPUsername           string `name:"smtp-username" usage:"Username to authenticate with the smtp server as. Eg., 'postmaster@mail.example.org'"`
 	SMTPPassword           string `name:"smtp-password" usage:"Password to pass to the smtp server."`
 	SMTPFrom               string `name:"smtp-from" usage:"Address to use as the 'from' field of the email. Eg., 'gotosocial@example.org'"`
+	SMTPEncryption         string `name:"smtp-encryption" usage:"'SMTPS' (typically port 465, SMTP inside TLS) or 'STARTTLS' (typically port 587, TLS inside SMTP).  Defaults to 'STARTTLS'."`
 	SMTPDiscloseRecipients bool   `name:"smtp-disclose-recipients" usage:"If true, email notifications sent to multiple recipients will be To'd to every recipient at once. If false, recipients will not be disclosed"`
 
 	SyslogEnabled  bool   `name:"syslog-enabled" usage:"Enable the syslog logging hook. Logs will be mirrored to the configured destination."`

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -115,6 +115,7 @@ var Defaults = Configuration{
 	SMTPUsername:           "",
 	SMTPPassword:           "",
 	SMTPFrom:               "",
+	SMTPEncryption:         "STARTTLS",
 	SMTPDiscloseRecipients: false,
 
 	TracingEnabled:           false,

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -142,6 +142,7 @@ func (s *ConfigState) AddServerFlags(cmd *cobra.Command) {
 		cmd.Flags().String(SMTPUsernameFlag(), cfg.SMTPUsername, fieldtag("SMTPUsername", "usage"))
 		cmd.Flags().String(SMTPPasswordFlag(), cfg.SMTPPassword, fieldtag("SMTPPassword", "usage"))
 		cmd.Flags().String(SMTPFromFlag(), cfg.SMTPFrom, fieldtag("SMTPFrom", "usage"))
+		cmd.Flags().String(SMTPEncryptionFlag(), cfg.SMTPEncryption, fieldtag("SMTPEncryption", "usage"))
 		cmd.Flags().Bool(SMTPDiscloseRecipientsFlag(), cfg.SMTPDiscloseRecipients, fieldtag("SMTPDiscloseRecipients", "usage"))
 
 		// Syslog

--- a/internal/config/gen/gen.go
+++ b/internal/config/gen/gen.go
@@ -52,16 +52,17 @@ func main() {
 	var out string
 
 	// Load runtime config flags
-	flag.StringVar(&out, "out", "", "Generated file output path")
+	flag.StringVar(&out, "out", "./internal/config/helpers.gen.go", "Generated file output path")
 	flag.Parse()
 
 	// Open output file path
 	output, err := os.OpenFile(out, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("%+v. Try running this from the repository root or recreating that file if it got deleted.", err))
 	}
 
 	fmt.Fprint(output, "// THIS IS A GENERATED FILE, DO NOT EDIT BY HAND\n")
+	fmt.Fprint(output, "// edit internal/config/gen/gen.go instead.\n")
 	fmt.Fprint(output, license)
 	fmt.Fprint(output, "package config\n\n")
 	fmt.Fprint(output, "import (\n")

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -1,8 +1,9 @@
 // THIS IS A GENERATED FILE, DO NOT EDIT BY HAND
+// edit internal/config/gen/gen.go instead.
 // GoToSocial
 // Copyright (C) GoToSocial Authors admin@gotosocial.org
 // SPDX-License-Identifier: AGPL-3.0-or-later
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -2400,6 +2401,31 @@ func GetSMTPFrom() string { return global.GetSMTPFrom() }
 // SetSMTPFrom safely sets the value for global configuration 'SMTPFrom' field
 func SetSMTPFrom(v string) { global.SetSMTPFrom(v) }
 
+// GetSMTPEncryption safely fetches the Configuration value for state's 'SMTPEncryption' field
+func (st *ConfigState) GetSMTPEncryption() (v string) {
+	st.mutex.RLock()
+	v = st.config.SMTPEncryption
+	st.mutex.RUnlock()
+	return
+}
+
+// SetSMTPEncryption safely sets the Configuration value for state's 'SMTPEncryption' field
+func (st *ConfigState) SetSMTPEncryption(v string) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.SMTPEncryption = v
+	st.reloadToViper()
+}
+
+// SMTPEncryptionFlag returns the flag name for the 'SMTPEncryption' field
+func SMTPEncryptionFlag() string { return "smtp-encryption" }
+
+// GetSMTPEncryption safely fetches the value for global configuration 'SMTPEncryption' field
+func GetSMTPEncryption() string { return global.GetSMTPEncryption() }
+
+// SetSMTPEncryption safely sets the value for global configuration 'SMTPEncryption' field
+func SetSMTPEncryption(v string) { global.SetSMTPEncryption(v) }
+
 // GetSMTPDiscloseRecipients safely fetches the Configuration value for state's 'SMTPDiscloseRecipients' field
 func (st *ConfigState) GetSMTPDiscloseRecipients() (v bool) {
 	st.mutex.RLock()
@@ -2867,19 +2893,13 @@ func (st *ConfigState) SetCacheAccountIDsFollowingTagMemRatio(v float64) {
 }
 
 // CacheAccountIDsFollowingTagMemRatioFlag returns the flag name for the 'Cache.AccountIDsFollowingTagMemRatio' field
-func CacheAccountIDsFollowingTagMemRatioFlag() string {
-	return "cache-account-ids-following-tag-mem-ratio"
-}
+func CacheAccountIDsFollowingTagMemRatioFlag() string { return "cache-account-ids-following-tag-mem-ratio" }
 
 // GetCacheAccountIDsFollowingTagMemRatio safely fetches the value for global configuration 'Cache.AccountIDsFollowingTagMemRatio' field
-func GetCacheAccountIDsFollowingTagMemRatio() float64 {
-	return global.GetCacheAccountIDsFollowingTagMemRatio()
-}
+func GetCacheAccountIDsFollowingTagMemRatio() float64 { return global.GetCacheAccountIDsFollowingTagMemRatio() }
 
 // SetCacheAccountIDsFollowingTagMemRatio safely sets the value for global configuration 'Cache.AccountIDsFollowingTagMemRatio' field
-func SetCacheAccountIDsFollowingTagMemRatio(v float64) {
-	global.SetCacheAccountIDsFollowingTagMemRatio(v)
-}
+func SetCacheAccountIDsFollowingTagMemRatio(v float64) { global.SetCacheAccountIDsFollowingTagMemRatio(v) }
 
 // GetCacheAccountNoteMemRatio safely fetches the Configuration value for state's 'Cache.AccountNoteMemRatio' field
 func (st *ConfigState) GetCacheAccountNoteMemRatio() (v float64) {
@@ -3123,19 +3143,13 @@ func (st *ConfigState) SetCacheConversationLastStatusIDsMemRatio(v float64) {
 }
 
 // CacheConversationLastStatusIDsMemRatioFlag returns the flag name for the 'Cache.ConversationLastStatusIDsMemRatio' field
-func CacheConversationLastStatusIDsMemRatioFlag() string {
-	return "cache-conversation-last-status-ids-mem-ratio"
-}
+func CacheConversationLastStatusIDsMemRatioFlag() string { return "cache-conversation-last-status-ids-mem-ratio" }
 
 // GetCacheConversationLastStatusIDsMemRatio safely fetches the value for global configuration 'Cache.ConversationLastStatusIDsMemRatio' field
-func GetCacheConversationLastStatusIDsMemRatio() float64 {
-	return global.GetCacheConversationLastStatusIDsMemRatio()
-}
+func GetCacheConversationLastStatusIDsMemRatio() float64 { return global.GetCacheConversationLastStatusIDsMemRatio() }
 
 // SetCacheConversationLastStatusIDsMemRatio safely sets the value for global configuration 'Cache.ConversationLastStatusIDsMemRatio' field
-func SetCacheConversationLastStatusIDsMemRatio(v float64) {
-	global.SetCacheConversationLastStatusIDsMemRatio(v)
-}
+func SetCacheConversationLastStatusIDsMemRatio(v float64) { global.SetCacheConversationLastStatusIDsMemRatio(v) }
 
 // GetCacheEmojiMemRatio safely fetches the Configuration value for state's 'Cache.EmojiMemRatio' field
 func (st *ConfigState) GetCacheEmojiMemRatio() (v float64) {
@@ -3879,19 +3893,13 @@ func (st *ConfigState) SetCacheTagIDsFollowedByAccountMemRatio(v float64) {
 }
 
 // CacheTagIDsFollowedByAccountMemRatioFlag returns the flag name for the 'Cache.TagIDsFollowedByAccountMemRatio' field
-func CacheTagIDsFollowedByAccountMemRatioFlag() string {
-	return "cache-tag-ids-followed-by-account-mem-ratio"
-}
+func CacheTagIDsFollowedByAccountMemRatioFlag() string { return "cache-tag-ids-followed-by-account-mem-ratio" }
 
 // GetCacheTagIDsFollowedByAccountMemRatio safely fetches the value for global configuration 'Cache.TagIDsFollowedByAccountMemRatio' field
-func GetCacheTagIDsFollowedByAccountMemRatio() float64 {
-	return global.GetCacheTagIDsFollowedByAccountMemRatio()
-}
+func GetCacheTagIDsFollowedByAccountMemRatio() float64 { return global.GetCacheTagIDsFollowedByAccountMemRatio() }
 
 // SetCacheTagIDsFollowedByAccountMemRatio safely sets the value for global configuration 'Cache.TagIDsFollowedByAccountMemRatio' field
-func SetCacheTagIDsFollowedByAccountMemRatio(v float64) {
-	global.SetCacheTagIDsFollowedByAccountMemRatio(v)
-}
+func SetCacheTagIDsFollowedByAccountMemRatio(v float64) { global.SetCacheTagIDsFollowedByAccountMemRatio(v) }
 
 // GetCacheThreadMuteMemRatio safely fetches the Configuration value for state's 'Cache.ThreadMuteMemRatio' field
 func (st *ConfigState) GetCacheThreadMuteMemRatio() (v float64) {
@@ -4292,3 +4300,4 @@ func GetRequestIDHeader() string { return global.GetRequestIDHeader() }
 
 // SetRequestIDHeader safely sets the value for global configuration 'RequestIDHeader' field
 func SetRequestIDHeader(v string) { global.SetRequestIDHeader(v) }
+

--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -18,7 +18,6 @@
 package email
 
 import (
-	"fmt"
 	"net/smtp"
 	"text/template"
 
@@ -76,21 +75,26 @@ func NewSender() (Sender, error) {
 	host := config.GetSMTPHost()
 	port := config.GetSMTPPort()
 	from := config.GetSMTPFrom()
+	encryptionMode := config.GetSMTPEncryption()
 	msgIDHost := config.GetHost()
 
 	return &sender{
-		hostAddress: fmt.Sprintf("%s:%d", host, port),
-		from:        from,
-		auth:        smtp.PlainAuth("", username, password, host),
-		msgIDHost:   msgIDHost,
-		template:    t,
+		hostname:       host,
+		port:           port,
+		from:           from,
+		encryptionMode: encryptionMode,
+		auth:           smtp.PlainAuth("", username, password, host),
+		msgIDHost:      msgIDHost,
+		template:       t,
 	}, nil
 }
 
 type sender struct {
-	hostAddress string
-	from        string
-	auth        smtp.Auth
-	msgIDHost   string
-	template    *template.Template
+	hostname       string
+	port           int
+	from           string
+	encryptionMode string
+	auth           smtp.Auth
+	msgIDHost      string
+	template       *template.Template
 }


### PR DESCRIPTION
# Description

Support email servers that only support SMTPS (smtp inside TLS). 

STARTTLS  (TLS inside SMTP) is considered by  some to be deprecated and shouldn't be required IMO.

Here are the configs I tested and the corresponding email server logs:



```
      GTS_SMTP_HOST: 'smtp.nullhex.com'
      GTS_SMTP_PORT: '587'
      GTS_SMTP_USERNAME: 'forest@sequentialread.com'
      GTS_SMTP_PASSWORD: '${NULLHEX_PASSWORD}'
      GTS_SMTP_FROM: 'forest@sequentialread.com'
```


```
Aug 26 06:16:18 domechild mail.info smtpd[16098]: 0d672a6feb14295b smtp connected address=198.74.6.203 host=198-74-6-203.fttp.usinternet.com
Aug 26 06:16:18 domechild mail.info smtpd[16098]: 0d672a6feb14295b smtp tls ciphers=TLSv1.3:TLS_AES_256_GCM_SHA384:256
Aug 26 06:16:19 domechild mail.info smtpd[16098]: 0d672a6feb14295b smtp authentication user=forest@sequentialread.com result=ok
Aug 26 06:16:19 domechild mail.info smtpd[16098]: 0d672a6feb14295b smtp message msgid=de188435 size=1701 nrcpt=1 proto=ESMTP
Aug 26 06:16:19 domechild mail.info smtpd[16098]: 0d672a6feb14295b smtp envelope evpid=de1884357e21d03b from=<forest@sequentialread.com> to=<test4@nullhex.com>
Aug 26 06:16:19 domechild mail.info dovecot: lmtp(16120): Connect from local
Aug 26 06:16:19 domechild mail.info smtpd[16098]: 0d672a6feb14295b smtp disconnected reason=quit
Aug 26 06:16:19 domechild mail.info dovecot: lmtp(test4@nullhex.com)<16120><jeFCFrMdzGb4PgAAEh31eQ>: msgid=<59f6fe49-a2e0-4c56-b1cd-ce55c2185748@gotosocial.sequentialread.com>: saved mail to INBOX
Aug 26 06:16:19 domechild mail.info smtpd[16098]: 0d672a70179aef0d mda delivery evpid=de1884357e21d03b from=<forest@sequentialread.com> to=<test4@nullhex.com> rcpt=<test4@nullhex.com> user=vmail delay=0s result=Ok stat=Delivered

```




```
      GTS_SMTP_HOST: 'smtp.nullhex.com'
      GTS_SMTP_PORT: '465'
      GTS_SMTP_ENCRYPTION: 'SMTPS'
      GTS_SMTP_USERNAME: 'forest@sequentialread.com'
      GTS_SMTP_PASSWORD: '${NULLHEX_PASSWORD}'
      GTS_SMTP_FROM: 'forest@sequentialread.com'
```


```
Aug 26 06:08:28 domechild mail.info smtpd[15931]: 9567b6bf3b10535d smtp connected address=198.74.6.203 host=198-74-6-203.fttp.usinternet.com
Aug 26 06:08:28 domechild mail.info smtpd[15931]: 9567b6bf3b10535d smtp tls ciphers=TLSv1.3:TLS_AES_256_GCM_SHA384:256
Aug 26 06:08:28 domechild mail.info smtpd[15931]: 9567b6bf3b10535d smtp authentication user=forest@sequentialread.com result=ok
Aug 26 06:08:28 domechild mail.info smtpd[15931]: 9567b6bf3b10535d smtp message msgid=12b645e9 size=1701 nrcpt=1 proto=ESMTP
Aug 26 06:08:28 domechild mail.info smtpd[15931]: 9567b6bf3b10535d smtp envelope evpid=12b645e9ed22b4cb from=<forest@sequentialread.com> to=<test3@nullhex.com>
Aug 26 06:08:28 domechild mail.info dovecot: lmtp(15955): Connect from local
Aug 26 06:08:28 domechild mail.info smtpd[15931]: 9567b6bf3b10535d smtp disconnected reason=quit
Aug 26 06:08:28 domechild mail.info dovecot: lmtp(test3@nullhex.com)<15955><gwe4I9wbzGZTPgAAEh31eQ>: msgid=<e3e0d659-716e-4cd8-a885-b233d4bb75ac@gotosocial.sequentialread.com>: saved mail to INBOX
Aug 26 06:08:28 domechild mail.info smtpd[15931]: 9567b6c01d7c2c33 mda delivery evpid=12b645e9ed22b4cb from=<forest@sequentialread.com> to=<test3@nullhex.com> rcpt=<test3@nullhex.com> user=vmail delay=0s result=Ok stat=Delivered
```



```
      GTS_SMTP_PORT: '587'
      GTS_SMTP_ENCRYPTION: 'SMTPS'
```

```
Aug 26 05:58:36 domechild mail.info smtpd[15617]: b848de53739f113f smtp connected address=198.74.6.203 host=198-74-6-203.fttp.usinternet.com
Aug 26 05:58:36 domechild mail.info smtpd[15617]: b848de53739f113f smtp bad-input result="500 5.5.1 Invalid command: Pipelining not supported"
Aug 26 05:58:36 domechild mail.info smtpd[15617]: b848de53739f113f smtp disconnected reason=quit
```


## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [X] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [X] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [X] I/we have not leveraged AI to create the proposed changes.
- [X] I/we have performed a self-review of added code.
- [X] I/we have written code that is legible and maintainable by others.
- [X] I/we have commented the added code, particularly in hard-to-understand areas.
- [Not Yet] I/we have made any necessary changes to documentation.
- [No] I/we have added tests that cover new code.
- [Nope] I/we have run tests and they pass locally with the changes.
- [Nope] I/we have run `go fmt ./...` and `golangci-lint run`.





