### PR TITLE
[security] Implement `allowFiles` fs for better isolation of ffmpeg / ffprobe

### DIFF
--- a/internal/media/util.go
+++ b/internal/media/util.go
@@ -31,21 +31,21 @@ import (
 	"codeberg.org/gruf/go-mimetypes"
 )
 
-// openFile represents one file in an
-// openFiles with the given flag and perms.
-type openFile struct {
+// file represents one file
+// with the given flag and perms.
+type file struct {
 	abs  string
 	flag int
 	perm os.FileMode
 }
 
-// openFiles implements fs.FS to allow
+// allowFiles implements fs.FS to allow
 // access to a specified slice of files.
-type openFiles []openFile
+type allowFiles []file
 
 // Open implements fs.FS.
-func (of openFiles) Open(name string) (fs.File, error) {
-	for _, file := range of {
+func (af allowFiles) Open(name string) (fs.File, error) {
+	for _, file := range af {
 		var (
 			abs  = file.abs
 			flag = file.flag

--- a/internal/media/util.go
+++ b/internal/media/util.go
@@ -45,8 +45,6 @@ type openFiles []openFile
 
 // Open implements fs.FS.
 func (of openFiles) Open(name string) (fs.File, error) {
-	fmt.Println(name)
-
 	for _, file := range of {
 		var (
 			abs  = file.abs


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request wraps access to files by ffmpeg and ffprobe in `allowFiles`, which implements `fs.FS` to allow only select permissions on in and out files.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
