### PR TITLE
[chore] Close copied request body in SignDelivery

### DIFF
--- a/internal/transport/deliver.go
+++ b/internal/transport/deliver.go
@@ -175,14 +175,18 @@ func (t *transport) SignDelivery(dlv *delivery.Delivery) error {
 		return gtserror.New("delivery request body not rewindable")
 	}
 
-	// Get a new copy of the request body.
-	body, err := dlv.Request.GetBody()
+	// Fetch a fresh copy of request body.
+	rBody, err := dlv.Request.GetBody()
 	if err != nil {
 		return gtserror.Newf("error getting request body: %w", err)
 	}
 
 	// Read body data into memory.
-	data, err := io.ReadAll(body)
+	data, err := io.ReadAll(rBody)
+
+	// Done with body.
+	_ = rBody.Close()
+
 	if err != nil {
 		return gtserror.Newf("error reading request body: %w", err)
 	}


### PR DESCRIPTION
Tiny chore PR to just close the copy of body used in SignDelivery (which is like 99% sure to be a no-op anyway).