### PR TITLE
[bugfix] Fix temp table deletion causing runaway allocations

### DIFF
--- a/internal/db/bundb/conversation.go
+++ b/internal/db/bundb/conversation.go
@@ -336,10 +336,8 @@ func (c *conversationDB) DeleteConversationsByOwnerAccountID(ctx context.Context
 
 func (c *conversationDB) DeleteStatusFromConversations(ctx context.Context, statusID string) error {
 	var (
-		updatedConversationIDs        = []string{}
-		deletedConversationIDs        = []string{}
-		conversationStatusesTmp       = "conversation_statuses_" + id.NewULID()
-		latestConversationStatusesTmp = "latest_conversation_statuses_" + id.NewULID()
+		updatedConversationIDs = []string{}
+		deletedConversationIDs = []string{}
 
 		// Method of creating + dropping temp
 		// tables differs depending on driver.
@@ -441,6 +439,7 @@ func (c *conversationDB) DeleteStatusFromConversations(ctx context.Context, stat
 	//	        "conversations"."last_status_id" = '01J78T2BQ4TN5S2XSC9VNQ5GBS'
 	//	      )
 	//	  )
+	conversationStatusesTmp := "conversation_statuses_" + id.NewULID()
 	conversationStatusesTmpQ := tx.NewRaw(
 		tmpQ,
 		bun.Ident(conversationStatusesTmp),
@@ -513,7 +512,7 @@ func (c *conversationDB) DeleteStatusFromConversations(ctx context.Context, stat
 	//	    WHERE
 	//	      ("later_statuses"."id" IS NULL)
 	//	  )
-
+	latestConversationStatusesTmp := "latest_conversation_statuses_" + id.NewULID()
 	latestConversationStatusesTmpQ := tx.NewRaw(
 		tmpQ,
 		bun.Ident(latestConversationStatusesTmp),

--- a/internal/db/bundb/conversation.go
+++ b/internal/db/bundb/conversation.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"time"
 
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtscontext"
@@ -334,174 +335,286 @@ func (c *conversationDB) DeleteConversationsByOwnerAccountID(ctx context.Context
 }
 
 func (c *conversationDB) DeleteStatusFromConversations(ctx context.Context, statusID string) error {
-	// SQL returning the current time.
-	var nowSQL string
-	switch c.db.Dialect().Name() {
-	case dialect.SQLite:
-		nowSQL = "DATE('now')"
-	case dialect.PG:
-		nowSQL = "NOW()"
-	default:
-		log.Panicf(nil, "db conn %s was neither pg nor sqlite", c.db)
-	}
+	var (
+		updatedConversationIDs        = []string{}
+		deletedConversationIDs        = []string{}
+		conversationStatusesTmp       = "conversation_statuses_" + id.NewULID()
+		latestConversationStatusesTmp = "latest_conversation_statuses_" + id.NewULID()
 
-	updatedConversationIDs := []string{}
-	deletedConversationIDs := []string{}
+		// Method of creating + dropping temp
+		// tables differs depending on driver.
+		tmpQ string
+		tx   bun.Tx
+		err  error
+	)
 
-	if err := c.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-		// Delete this status from conversation-to-status links.
-		if _, err := tx.NewDelete().
-			Model((*gtsmodel.ConversationToStatus)(nil)).
-			Where("? = ?", bun.Ident("status_id"), statusID).
-			Exec(ctx); // nocollapse
-		err != nil {
-			return gtserror.Newf("error deleting conversation-to-status links while deleting status %s: %w", statusID, err)
+	if c.db.Dialect().Name() == dialect.PG {
+		// On Postgres, we can instruct PG to clean
+		// up temp tables on commit, so we can just
+		// use any connection from the pool without
+		// caring what happens to it when we're done.
+		tmpQ = "CREATE TEMPORARY TABLE ? ON COMMIT DROP AS (?)"
+
+		// Instantiate tx from the pool.
+		tx, err = c.db.BeginTx(ctx, nil)
+	} else {
+		// On SQLite, we can't instruct SQLite to drop
+		// temp tables on commit, and we can't manually
+		// drop temp tables without triggering a bug,
+		// so work around this by obtaining a new conn
+		// from the pool, and closing it when finished
+		// (thereby also cleaning up any temp tables).
+		tmpQ = "CREATE TEMPORARY TABLE ? AS (?)"
+
+		conn, cErr := c.db.Conn(ctx)
+		if cErr != nil {
+			return gtserror.Newf(
+				"error getting conn while deleting status %s: %w",
+				statusID, cErr,
+			)
 		}
-
-		// Note: Bun doesn't currently support CREATE TABLE … AS SELECT … so we need to use raw queries here.
-
-		// Create a temporary table with all statuses other than the deleted status
-		// in each conversation for which the deleted status is the last status
-		// (if there are such statuses).
-		conversationStatusesTempTable := "conversation_statuses_" + id.NewULID()
-		if _, err := tx.NewRaw(
-			"CREATE TEMPORARY TABLE ? AS ?",
-			bun.Ident(conversationStatusesTempTable),
-			tx.NewSelect().
-				ColumnExpr(
-					"? AS ?",
-					bun.Ident("conversations.id"),
-					bun.Ident("conversation_id"),
-				).
-				ColumnExpr(
-					"? AS ?",
-					bun.Ident("conversation_to_statuses.status_id"),
-					bun.Ident("id"),
-				).
-				Column("statuses.created_at").
-				Table("conversations").
-				Join("LEFT JOIN ?", bun.Ident("conversation_to_statuses")).
-				JoinOn(
-					"? = ?",
-					bun.Ident("conversations.id"),
-					bun.Ident("conversation_to_statuses.conversation_id"),
-				).
-				JoinOn(
-					"? != ?",
-					bun.Ident("conversation_to_statuses.status_id"),
-					statusID,
-				).
-				Join("LEFT JOIN ?", bun.Ident("statuses")).
-				JoinOn(
-					"? = ?",
-					bun.Ident("conversation_to_statuses.status_id"),
-					bun.Ident("statuses.id"),
-				).
-				Where(
-					"? = ?",
-					bun.Ident("conversations.last_status_id"),
-					statusID,
-				),
-		).
-			Exec(ctx); // nocollapse
-		err != nil {
-			return gtserror.Newf("error creating conversationStatusesTempTable while deleting status %s: %w", statusID, err)
-		}
-
-		// Create a temporary table with the most recently created status in each conversation
-		// for which the deleted status is the last status (if there is such a status).
-		latestConversationStatusesTempTable := "latest_conversation_statuses_" + id.NewULID()
-		if _, err := tx.NewRaw(
-			"CREATE TEMPORARY TABLE ? AS ?",
-			bun.Ident(latestConversationStatusesTempTable),
-			tx.NewSelect().
-				Column(
-					"conversation_statuses.conversation_id",
-					"conversation_statuses.id",
-				).
-				TableExpr(
-					"? AS ?",
-					bun.Ident(conversationStatusesTempTable),
-					bun.Ident("conversation_statuses"),
-				).
-				Join(
-					"LEFT JOIN ? AS ?",
-					bun.Ident(conversationStatusesTempTable),
-					bun.Ident("later_statuses"),
-				).
-				JoinOn(
-					"? = ?",
-					bun.Ident("conversation_statuses.conversation_id"),
-					bun.Ident("later_statuses.conversation_id"),
-				).
-				JoinOn(
-					"? > ?",
-					bun.Ident("later_statuses.created_at"),
-					bun.Ident("conversation_statuses.created_at"),
-				).
-				Where("? IS NULL", bun.Ident("later_statuses.id")),
-		).
-			Exec(ctx); // nocollapse
-		err != nil {
-			return gtserror.Newf("error creating latestConversationStatusesTempTable while deleting status %s: %w", statusID, err)
-		}
-
-		// For every conversation where the given status was the last one,
-		// reset its last status to the most recently created in the conversation other than that one,
-		// if there is such a status.
-		// Return conversation IDs for invalidation.
-		if err := tx.NewUpdate().
-			Model((*gtsmodel.Conversation)(nil)).
-			SetColumn("last_status_id", "?", bun.Ident("latest_conversation_statuses.id")).
-			SetColumn("updated_at", "?", bun.Safe(nowSQL)).
-			TableExpr("? AS ?", bun.Ident(latestConversationStatusesTempTable), bun.Ident("latest_conversation_statuses")).
-			Where("?TableAlias.? = ?", bun.Ident("id"), bun.Ident("latest_conversation_statuses.conversation_id")).
-			Where("? IS NOT NULL", bun.Ident("latest_conversation_statuses.id")).
-			Returning("?TableName.?", bun.Ident("id")).
-			Scan(ctx, &updatedConversationIDs); // nocollapse
-		err != nil {
-			return gtserror.Newf("error rolling back last status for conversation while deleting status %s: %w", statusID, err)
-		}
-
-		// If there is no such status, delete the conversation.
-		// Return conversation IDs for invalidation.
-		if err := tx.NewDelete().
-			Model((*gtsmodel.Conversation)(nil)).
-			Where(
-				"? IN (?)",
-				bun.Ident("id"),
-				tx.NewSelect().
-					Table(latestConversationStatusesTempTable).
-					Column("conversation_id").
-					Where("? IS NULL", bun.Ident("id")),
-			).
-			Returning("?", bun.Ident("id")).
-			Scan(ctx, &deletedConversationIDs); // nocollapse
-		err != nil {
-			return gtserror.Newf("error deleting conversation while deleting status %s: %w", statusID, err)
-		}
-
-		// Clean up.
-		for _, tempTable := range []string{
-			conversationStatusesTempTable,
-			latestConversationStatusesTempTable,
-		} {
-			if _, err := tx.NewDropTable().Table(tempTable).Exec(ctx); err != nil {
-				return gtserror.Newf(
-					"error dropping temporary table %s after deleting status %s: %w",
-					tempTable,
-					statusID,
-					err,
-				)
+		defer func() {
+			if err := conn.Close(); err != nil {
+				log.Errorf(ctx, "error closing conn: %v", err)
 			}
-		}
+		}()
 
-		return nil
-	}); err != nil {
-		return err
+		// Instantiate tx from the new conn.
+		tx, err = conn.BeginTx(ctx, nil)
 	}
 
+	if err != nil {
+		return gtserror.Newf(
+			"error starting transaction while deleting status %s: %w",
+			statusID, err,
+		)
+	}
+
+	// From this point on, we *must* trigger
+	// tx.Rollback before returning on error.
+
+	// First delete this status from
+	// conversation-to-status links.
+	_, err = tx.
+		NewDelete().
+		Table("conversation_to_statuses").
+		Where("? = ?", bun.Ident("status_id"), statusID).
+		Exec(ctx)
+	if err != nil {
+		if err := tx.Rollback(); err != nil {
+			log.Errorf(ctx, "error rolling back: %v", err)
+		}
+		return gtserror.Newf(
+			"error deleting conversation-to-status links while deleting status %s: %w",
+			statusID, err,
+		)
+	}
+
+	// Note: Bun doesn't currently support `CREATE TABLE … AS SELECT …`
+	// so we need to use raw queries to create temporary tables.
+
+	// Create a temporary table containing all statuses other than
+	// the deleted status, in each conversation for which the deleted
+	// status is the last status, if there are such statuses.
+	//
+	// This will produce a query like:
+	//
+	//	CREATE TEMPORARY TABLE "conversation_statuses_01J78T2AR0YCZ4YR12WSCZ608S"
+	//	  AS (
+	//	    SELECT
+	//	      "conversations"."id" AS "conversation_id",
+	//	      "conversation_to_statuses"."status_id" AS "id",
+	//	      "statuses"."created_at"
+	//	    FROM
+	//	      "conversations"
+	//	      LEFT JOIN "conversation_to_statuses" ON (
+	//	        "conversations"."id" = "conversation_to_statuses"."conversation_id"
+	//	      )
+	//	      AND (
+	//	        "conversation_to_statuses"."status_id" != '01J78T2BQ4TN5S2XSC9VNQ5GBS'
+	//	      )
+	//	      LEFT JOIN "statuses" ON (
+	//	        "conversation_to_statuses"."status_id" = "statuses"."id"
+	//	      )
+	//	    WHERE
+	//	      (
+	//	        "conversations"."last_status_id" = '01J78T2BQ4TN5S2XSC9VNQ5GBS'
+	//	      )
+	//	  )
+	conversationStatusesTmpQ := tx.NewRaw(
+		tmpQ,
+		bun.Ident(conversationStatusesTmp),
+		tx.NewSelect().
+			ColumnExpr(
+				"? AS ?",
+				bun.Ident("conversations.id"),
+				bun.Ident("conversation_id"),
+			).
+			ColumnExpr(
+				"? AS ?",
+				bun.Ident("conversation_to_statuses.status_id"),
+				bun.Ident("id"),
+			).
+			Column("statuses.created_at").
+			Table("conversations").
+			Join("LEFT JOIN ?", bun.Ident("conversation_to_statuses")).
+			JoinOn(
+				"? = ?",
+				bun.Ident("conversations.id"),
+				bun.Ident("conversation_to_statuses.conversation_id"),
+			).
+			JoinOn(
+				"? != ?",
+				bun.Ident("conversation_to_statuses.status_id"),
+				statusID,
+			).
+			Join("LEFT JOIN ?", bun.Ident("statuses")).
+			JoinOn(
+				"? = ?",
+				bun.Ident("conversation_to_statuses.status_id"),
+				bun.Ident("statuses.id"),
+			).
+			Where(
+				"? = ?",
+				bun.Ident("conversations.last_status_id"),
+				statusID,
+			),
+	)
+	_, err = conversationStatusesTmpQ.Exec(ctx)
+	if err != nil {
+		if err := tx.Rollback(); err != nil {
+			log.Errorf(ctx, "error rolling back: %v", err)
+		}
+		return gtserror.Newf(
+			"error creating temp table %s while deleting status %s: %w",
+			conversationStatusesTmp, statusID, err,
+		)
+	}
+
+	// Create a temporary table with the most recently created
+	// status in each conversation for which the deleted status
+	// is the last status, if there is such a status.
+	//
+	// This will produce a query like:
+	//
+	//	CREATE TEMPORARY TABLE "latest_conversation_statuses_01J78T2AR0E46SJSH6C7NRZ7MR"
+	//	  AS (
+	//	    SELECT
+	//	      "conversation_statuses"."conversation_id",
+	//	      "conversation_statuses"."id"
+	//	    FROM
+	//	      "conversation_statuses_01J78T2AR0YCZ4YR12WSCZ608S" AS "conversation_statuses"
+	//	      LEFT JOIN "conversation_statuses_01J78T2AR0YCZ4YR12WSCZ608S" AS "later_statuses" ON (
+	//	        "conversation_statuses"."conversation_id" = "later_statuses"."conversation_id"
+	//	      )
+	//	      AND (
+	//	        "later_statuses"."created_at" > "conversation_statuses"."created_at"
+	//	      )
+	//	    WHERE
+	//	      ("later_statuses"."id" IS NULL)
+	//	  )
+
+	latestConversationStatusesTmpQ := tx.NewRaw(
+		tmpQ,
+		bun.Ident(latestConversationStatusesTmp),
+		tx.NewSelect().
+			Column(
+				"conversation_statuses.conversation_id",
+				"conversation_statuses.id",
+			).
+			TableExpr(
+				"? AS ?",
+				bun.Ident(conversationStatusesTmp),
+				bun.Ident("conversation_statuses"),
+			).
+			Join(
+				"LEFT JOIN ? AS ?",
+				bun.Ident(conversationStatusesTmp),
+				bun.Ident("later_statuses"),
+			).
+			JoinOn(
+				"? = ?",
+				bun.Ident("conversation_statuses.conversation_id"),
+				bun.Ident("later_statuses.conversation_id"),
+			).
+			JoinOn(
+				"? > ?",
+				bun.Ident("later_statuses.created_at"),
+				bun.Ident("conversation_statuses.created_at"),
+			).
+			Where("? IS NULL", bun.Ident("later_statuses.id")),
+	)
+	_, err = latestConversationStatusesTmpQ.Exec(ctx)
+	if err != nil {
+		if err := tx.Rollback(); err != nil {
+			log.Errorf(ctx, "error rolling back: %v", err)
+		}
+		return gtserror.Newf(
+			"error creating temp table %s while deleting status %s: %w",
+			conversationStatusesTmp, statusID, err,
+		)
+	}
+
+	// For every conversation where the given status was the last one,
+	// reset its last status to the most recently created in the
+	// conversation other than that one, if there is such a status.
+	// Return conversation IDs for invalidation.
+	updateQ := tx.NewUpdate().
+		TableExpr("? AS ?", bun.Ident("conversations"), bun.Ident("conversation")).
+		TableExpr("? AS ?", bun.Ident(latestConversationStatusesTmp), bun.Ident("latest_conversation_statuses")).
+		Set("last_status_id = ?", bun.Ident("latest_conversation_statuses.id")).
+		Set("updated_at = ?", time.Now()).
+		Where("? = ?", bun.Ident("conversation.id"), bun.Ident("latest_conversation_statuses.conversation_id")).
+		Where("? IS NOT NULL", bun.Ident("latest_conversation_statuses.id")).
+		Returning("?", bun.Ident("conversation.id"))
+	_, err = updateQ.Exec(ctx, &updatedConversationIDs)
+	if err != nil {
+		if err := tx.Rollback(); err != nil {
+			log.Errorf(ctx, "error rolling back: %v", err)
+		}
+		return gtserror.Newf(
+			"error rolling back last status for conversation while deleting status %s: %w",
+			statusID, err,
+		)
+	}
+
+	// If there is no such status,
+	// just delete the conversation.
+	// Return IDs for invalidation.
+	_, err = tx.
+		NewDelete().
+		Table("conversations").
+		Where(
+			"? IN (?)",
+			bun.Ident("id"),
+			tx.NewSelect().
+				Table(latestConversationStatusesTmp).
+				Column("conversation_id").
+				Where("? IS NULL", bun.Ident("id")),
+		).
+		Returning("?", bun.Ident("id")).
+		Exec(ctx, &deletedConversationIDs)
+	if err != nil {
+		if err := tx.Rollback(); err != nil {
+			log.Errorf(ctx, "error rolling back: %v", err)
+		}
+		return gtserror.Newf(
+			"error deleting conversation while deleting status %s: %w",
+			statusID, err,
+		)
+	}
+
+	// We're done, commit everything.
+	if err := tx.Commit(); err != nil {
+		return gtserror.Newf(
+			"error committing transaction while deleting status %s: %w",
+			statusID, err,
+		)
+	}
+
+	// Invalidate cache entries.
 	updatedConversationIDs = append(updatedConversationIDs, deletedConversationIDs...)
+	updatedConversationIDs = util.Deduplicate(updatedConversationIDs)
 	c.state.Caches.DB.Conversation.InvalidateIDs("ID", updatedConversationIDs)
 
 	return nil

--- a/internal/db/bundb/conversation.go
+++ b/internal/db/bundb/conversation.go
@@ -360,7 +360,7 @@ func (c *conversationDB) DeleteStatusFromConversations(ctx context.Context, stat
 		tmpQ = "CREATE TEMPORARY TABLE ? AS ?"
 	}
 
-	c.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+	if err := c.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 		// First delete this status from
 		// conversation-to-status links.
 		_, err := tx.
@@ -559,7 +559,9 @@ func (c *conversationDB) DeleteStatusFromConversations(ctx context.Context, stat
 		}
 
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
 
 	// Invalidate cache entries.
 	updatedConversationIDs = append(updatedConversationIDs, deletedConversationIDs...)


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request addresses an issue we've been having with runaway memory allocations causing stress on the garbage collector. For some reason, deleting temporary tables causes SQLite to flip out and keep allocating memory, which is then immediately cleaned up.

This PR fixes the issue by changing the way we delete temporary tables: for Postgres, we can just use `ON COMMIT DROP`, which causes the temp tables to be cleaned up when the transaction ends. For SQLite, we can adjust the max conn lifetime to 5 minutes to ensure that temp tables get closed when the connection is closed + recreated.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
