### PR TITLE
[chore] Reject replies to rejected replies

### DIFF
--- a/internal/federation/dereferencing/status_permitted.go
+++ b/internal/federation/dereferencing/status_permitted.go
@@ -162,7 +162,7 @@ func (d *Dereferencer) isPermittedReply(
 		// borrow fields from the up-thread rejection.
 		// This collapses the chain beyond the first
 		// rejected reply and allows us to avoid derefing
-		// lots of statuses we already know we don't want.
+		// further replies we already know we don't want.
 		statusID := req.StatusID
 		targetAccountID := req.TargetAccountID
 		uri := strings.ReplaceAll(req.URI, req.ID, id)
@@ -172,7 +172,7 @@ func (d *Dereferencer) isPermittedReply(
 			StatusID:             statusID,
 			TargetAccountID:      targetAccountID,
 			InteractingAccountID: status.AccountID,
-			InteractionURI:       status.URI,
+			InteractionURI:       statusURI,
 			InteractionType:      gtsmodel.InteractionReply,
 			URI:                  uri,
 			RejectedAt:           time.Now(),
@@ -246,7 +246,7 @@ func (d *Dereferencer) isPermittedReply(
 			StatusID:             inReplyTo.ID,
 			TargetAccountID:      inReplyTo.AccountID,
 			InteractingAccountID: status.AccountID,
-			InteractionURI:       status.URI,
+			InteractionURI:       statusURI,
 			InteractionType:      gtsmodel.InteractionReply,
 			URI:                  uris.GenerateURIForReject(inReplyTo.Account.Username, id),
 			RejectedAt:           time.Now(),

--- a/internal/federation/dereferencing/status_permitted.go
+++ b/internal/federation/dereferencing/status_permitted.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
@@ -150,8 +149,8 @@ func (d *Dereferencer) isPermittedReply(
 	}
 
 	if req != nil && req.IsRejected() {
-		// This status's parent was rejected,
-		// so this reply should be rejected too.
+		// This status's parent was rejected, so
+		// implicitly this reply should be rejected too.
 		//
 		// We know already that we haven't inserted
 		// a rejected interaction request for this
@@ -165,7 +164,12 @@ func (d *Dereferencer) isPermittedReply(
 		// further replies we already know we don't want.
 		statusID := req.StatusID
 		targetAccountID := req.TargetAccountID
-		uri := strings.ReplaceAll(req.URI, req.ID, id)
+
+		// As nobody is actually Rejecting the reply
+		// directly, but it's an implicit Reject coming
+		// from our internal logic, don't bother setting
+		// a URI (it's not a required field anyway).
+		uri := ""
 
 		rejection := &gtsmodel.InteractionRequest{
 			ID:                   id,


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates our permissivity checks in the dereferencer to store a pre-rejected interaction request for rejected replies, and to check if a status tries to reply to a previously-rejected reply. This should help to avoid situations where someone replies to a status, their reply is rejected, and then they reply *to their own reply*, which is allowed through, causing all sorts of mess.

Closes https://github.com/superseriousbusiness/gotosocial/issues/3057 as this is the last part.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
