### PR TITLE
[bugfix] Hoist filterable text field extraction out of loop

### DIFF
--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -934,6 +934,14 @@ func (c *Converter) statusToAPIFilterResults(
 	}
 
 	// At this point, the status isn't muted, but might still be filtered.
+	if len(filters) == 0 {
+		// If it can't be filtered because there are no filters, we're done.
+		return nil, nil
+	}
+
+	// Extract text fields from the status that we will match filters against.
+	fields := filterableTextFields(s)
+
 	// Record all matching warn filters and the reasons they matched.
 	filterResults := make([]apimodel.FilterResult, 0, len(filters))
 	for _, filter := range filters {
@@ -947,7 +955,6 @@ func (c *Converter) statusToAPIFilterResults(
 
 		// List all matching keywords.
 		keywordMatches := make([]string, 0, len(filter.Keywords))
-		fields := filterableTextFields(s)
 		for _, filterKeyword := range filter.Keywords {
 			var isMatch bool
 			for _, field := range fields {


### PR DESCRIPTION
# Description

This doesn't change within the loop, so there's no point in repeating it. This should make filter processing faster in the common case where a user has more than one applicable filter.

Discovered while investigating #3128

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
