### PR TITLE
[bugfix] Ensure id set on outgoing Reject + Accept

### DIFF
--- a/internal/processing/workers/federate.go
+++ b/internal/processing/workers/federate.go
@@ -1149,40 +1149,17 @@ func (f *federate) AcceptInteraction(
 		return nil
 	}
 
-	// Parse relevant URI(s).
+	// Parse outbox URI.
 	outboxIRI, err := parseURI(req.TargetAccount.OutboxURI)
 	if err != nil {
 		return err
 	}
 
-	acceptingAcctIRI, err := parseURI(req.TargetAccount.URI)
+	// Convert req to Accept.
+	accept, err := f.converter.InteractionReqToASAccept(ctx, req)
 	if err != nil {
-		return err
+		return gtserror.Newf("error converting request to Accept: %w", err)
 	}
-
-	interactingAcctURI, err := parseURI(req.InteractingAccount.URI)
-	if err != nil {
-		return err
-	}
-
-	interactionURI, err := parseURI(req.InteractionURI)
-	if err != nil {
-		return err
-	}
-
-	// Create a new Accept.
-	accept := streams.NewActivityStreamsAccept()
-
-	// Set interacted-with account
-	// as Actor of the Accept.
-	ap.AppendActorIRIs(accept, acceptingAcctIRI)
-
-	// Set the interacted-with object
-	// as Object of the Accept.
-	ap.AppendObjectIRIs(accept, interactionURI)
-
-	// Address the Accept To the interacting acct.
-	ap.AppendTo(accept, interactingAcctURI)
 
 	// Send the Accept via the Actor's outbox.
 	if _, err := f.FederatingActor().Send(
@@ -1221,40 +1198,17 @@ func (f *federate) RejectInteraction(
 		return nil
 	}
 
-	// Parse relevant URI(s).
+	// Parse outbox URI.
 	outboxIRI, err := parseURI(req.TargetAccount.OutboxURI)
 	if err != nil {
 		return err
 	}
 
-	rejectingAcctIRI, err := parseURI(req.TargetAccount.URI)
+	// Convert req to Reject.
+	reject, err := f.converter.InteractionReqToASReject(ctx, req)
 	if err != nil {
-		return err
+		return gtserror.Newf("error converting request to Reject: %w", err)
 	}
-
-	interactingAcctURI, err := parseURI(req.InteractingAccount.URI)
-	if err != nil {
-		return err
-	}
-
-	interactionURI, err := parseURI(req.InteractionURI)
-	if err != nil {
-		return err
-	}
-
-	// Create a new Reject.
-	reject := streams.NewActivityStreamsReject()
-
-	// Set interacted-with account
-	// as Actor of the Reject.
-	ap.AppendActorIRIs(reject, rejectingAcctIRI)
-
-	// Set the interacted-with object
-	// as Object of the Reject.
-	ap.AppendObjectIRIs(reject, interactionURI)
-
-	// Address the Reject To the interacting acct.
-	ap.AppendTo(reject, interactingAcctURI)
 
 	// Send the Reject via the Actor's outbox.
 	if _, err := f.FederatingActor().Send(

--- a/internal/typeutils/internaltoas.go
+++ b/internal/typeutils/internaltoas.go
@@ -2005,3 +2005,49 @@ func (c *Converter) InteractionReqToASAccept(
 
 	return accept, nil
 }
+
+// InteractionReqToASReject converts a *gtsmodel.InteractionRequest
+// to an ActivityStreams Reject, addressed to the interacting account.
+func (c *Converter) InteractionReqToASReject(
+	ctx context.Context,
+	req *gtsmodel.InteractionRequest,
+) (vocab.ActivityStreamsReject, error) {
+	reject := streams.NewActivityStreamsReject()
+
+	rejectID, err := url.Parse(req.URI)
+	if err != nil {
+		return nil, gtserror.Newf("invalid reject uri: %w", err)
+	}
+
+	actorIRI, err := url.Parse(req.TargetAccount.URI)
+	if err != nil {
+		return nil, gtserror.Newf("invalid account uri: %w", err)
+	}
+
+	objectIRI, err := url.Parse(req.InteractionURI)
+	if err != nil {
+		return nil, gtserror.Newf("invalid target uri: %w", err)
+	}
+
+	toIRI, err := url.Parse(req.InteractingAccount.URI)
+	if err != nil {
+		return nil, gtserror.Newf("invalid interacting account uri: %w", err)
+	}
+
+	// Set id to the URI of
+	// interaction request.
+	ap.SetJSONLDId(reject, rejectID)
+
+	// Actor is the account that
+	// owns the approval / reject.
+	ap.AppendActorIRIs(reject, actorIRI)
+
+	// Object is the interaction URI.
+	ap.AppendObjectIRIs(reject, objectIRI)
+
+	// Address to the owner
+	// of interaction URI.
+	ap.AppendTo(reject, toIRI)
+
+	return reject, nil
+}


### PR DESCRIPTION
Fix an issue where `id` property was not being set correctly on outgoing Accept + Reject for interactions :facepalm: 