### PR TITLE
[chore/frontend] Tweak status styling a little

### DIFF
--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -122,9 +122,10 @@ main {
 	}
 
 	.text-spoiler > summary {
-		display: inline-block;
 		list-style: none;
-
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
 		padding-bottom: 0.5rem;
 
 		&::-webkit-details-marker {
@@ -132,6 +133,7 @@ main {
 		}
 
 		.button {
+			width: fit-content;
 			white-space: nowrap;
 			cursor: pointer;
 			padding: 0.2rem 0.3rem;

--- a/web/source/css/thread.css
+++ b/web/source/css/thread.css
@@ -54,8 +54,6 @@
 	}
 
 	.status {
-
-
 		&.indent-1 {
 			margin-left: 0.5rem;
 		}
@@ -83,7 +81,7 @@
 		&.indent-5 {
 			.status-link {
 				margin-left: -0.5rem;
-				border-left: 0.1rem dashed $border-accent;
+				border-left: 0.15rem dashed $border-accent;
 			}
 		}
 


### PR DESCRIPTION
Couple of cheeky tweaks to status styling:

- Make border to the left of indented statuses a little thicker.
- Put show more / show less button on separate line to avoid funky wrapping issues when the text changes.

![Screenshot from 2024-09-18 11-16-16](https://github.com/user-attachments/assets/3dfb8649-01d8-4995-a848-338fcac8dbf6)
