### PR TITLE
Do not use plainAuth when no user or password. Fixes #3320

### DIFF
--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -77,11 +77,18 @@ func NewSender() (Sender, error) {
 	port := config.GetSMTPPort()
 	from := config.GetSMTPFrom()
 	msgIDHost := config.GetHost()
+	var smtpAuth smtp.Auth
+
+	if (username == "" || password == "") {
+		smtpAuth = nil
+	} else {
+		smtpAuth = smtp.PlainAuth("", username, password, host)
+	}
 
 	return &sender{
 		hostAddress: fmt.Sprintf("%s:%d", host, port),
 		from:        from,
-		auth:        smtp.PlainAuth("", username, password, host),
+		auth:        smtpAuth,
 		msgIDHost:   msgIDHost,
 		template:    t,
 	}, nil


### PR DESCRIPTION
# Description

Do not use plainAuth when no user or password.

closes #3320

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [ ] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
