### PR TITLE
[chore] local instance count query caching, improved status context endpoint logging, don't log ErrHideStatus when timelining

### DIFF
--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -138,8 +138,9 @@ type DBCaches struct {
 	// Instance provides access to the gtsmodel Instance database cache.
 	Instance StructCache[*gtsmodel.Instance]
 
-	// InstanceCounts ...
-	InstanceCounts struct {
+	// LocalInstance provides caching
+	// for common local instance queries.
+	LocalInstance struct {
 		Domains  atomic.Pointer[int]
 		Statuses atomic.Pointer[int]
 		Users    atomic.Pointer[int]

--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -18,6 +18,8 @@
 package cache
 
 import (
+	"sync/atomic"
+
 	"codeberg.org/gruf/go-structr"
 	"github.com/superseriousbusiness/gotosocial/internal/cache/domain"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
@@ -135,6 +137,13 @@ type DBCaches struct {
 
 	// Instance provides access to the gtsmodel Instance database cache.
 	Instance StructCache[*gtsmodel.Instance]
+
+	// InstanceCounts ...
+	InstanceCounts struct {
+		Domains  atomic.Pointer[int]
+		Statuses atomic.Pointer[int]
+		Users    atomic.Pointer[int]
+	}
 
 	// InteractionRequest provides access to the gtsmodel InteractionRequest database cache.
 	InteractionRequest StructCache[*gtsmodel.InteractionRequest]
@@ -849,9 +858,10 @@ func (c *Caches) initInstance() {
 			{Fields: "ID"},
 			{Fields: "Domain"},
 		},
-		MaxSize:   cap,
-		IgnoreErr: ignoreErrors,
-		Copy:      copyF,
+		MaxSize:    cap,
+		IgnoreErr:  ignoreErrors,
+		Copy:       copyF,
+		Invalidate: c.OnInvalidateInstance,
 	})
 }
 

--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -138,8 +138,8 @@ type DBCaches struct {
 	// Instance provides access to the gtsmodel Instance database cache.
 	Instance StructCache[*gtsmodel.Instance]
 
-	// LocalInstance provides caching
-	// for common local instance queries.
+	// LocalInstance provides caching for
+	// simple + common local instance queries.
 	LocalInstance struct {
 		Domains  atomic.Pointer[int]
 		Statuses atomic.Pointer[int]

--- a/internal/cache/invalidate.go
+++ b/internal/cache/invalidate.go
@@ -181,7 +181,7 @@ func (c *Caches) OnInvalidateFollowRequest(followReq *gtsmodel.FollowRequest) {
 
 func (c *Caches) OnInvalidateInstance(instance *gtsmodel.Instance) {
 	// Invalidate the local domains count.
-	c.DB.InstanceCounts.Domains.Store(nil)
+	c.DB.LocalInstance.Domains.Store(nil)
 }
 
 func (c *Caches) OnInvalidateList(list *gtsmodel.List) {
@@ -264,7 +264,7 @@ func (c *Caches) OnInvalidateStatus(status *gtsmodel.Status) {
 
 	if util.PtrOrZero(status.Local) {
 		// Invalidate the local statuses count.
-		c.DB.InstanceCounts.Statuses.Store(nil)
+		c.DB.LocalInstance.Statuses.Store(nil)
 	}
 }
 
@@ -284,7 +284,7 @@ func (c *Caches) OnInvalidateUser(user *gtsmodel.User) {
 	c.Visibility.Invalidate("RequesterID", user.AccountID)
 
 	// Invalidate the local users count.
-	c.DB.InstanceCounts.Users.Store(nil)
+	c.DB.LocalInstance.Users.Store(nil)
 }
 
 func (c *Caches) OnInvalidateUserMute(mute *gtsmodel.UserMute) {

--- a/internal/cache/invalidate.go
+++ b/internal/cache/invalidate.go
@@ -19,6 +19,7 @@ package cache
 
 import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
 
 // Below are cache invalidation hooks between other caches,
@@ -178,6 +179,11 @@ func (c *Caches) OnInvalidateFollowRequest(followReq *gtsmodel.FollowRequest) {
 	)
 }
 
+func (c *Caches) OnInvalidateInstance(instance *gtsmodel.Instance) {
+	// Invalidate the local domains count.
+	c.DB.InstanceCounts.Domains.Store(nil)
+}
+
 func (c *Caches) OnInvalidateList(list *gtsmodel.List) {
 	// Invalidate list IDs cache.
 	c.DB.ListIDs.Invalidate(
@@ -255,6 +261,11 @@ func (c *Caches) OnInvalidateStatus(status *gtsmodel.Status) {
 		// Invalidate cache of attached poll ID.
 		c.DB.Poll.Invalidate("ID", status.PollID)
 	}
+
+	if util.PtrOrZero(status.Local) {
+		// Invalidate the local statuses count.
+		c.DB.InstanceCounts.Statuses.Store(nil)
+	}
 }
 
 func (c *Caches) OnInvalidateStatusBookmark(bookmark *gtsmodel.StatusBookmark) {
@@ -271,6 +282,9 @@ func (c *Caches) OnInvalidateUser(user *gtsmodel.User) {
 	// Invalidate local account ID cached visibility.
 	c.Visibility.Invalidate("ItemID", user.AccountID)
 	c.Visibility.Invalidate("RequesterID", user.AccountID)
+
+	// Invalidate the local users count.
+	c.DB.InstanceCounts.Users.Store(nil)
 }
 
 func (c *Caches) OnInvalidateUserMute(mute *gtsmodel.UserMute) {

--- a/internal/db/bundb/instance.go
+++ b/internal/db/bundb/instance.go
@@ -41,10 +41,11 @@ type instanceDB struct {
 func (i *instanceDB) CountInstanceUsers(ctx context.Context, domain string) (int, error) {
 	localhost := (domain == config.GetHost() || domain == config.GetAccountDomain())
 
-	// Check for a cached instance user count, if so return this.
-	if n := i.state.Caches.DB.InstanceCounts.Users.Load(); n != nil &&
-		localhost {
-		return *n, nil
+	if localhost {
+		// Check for a cached instance user count, if so return this.
+		if n := i.state.Caches.DB.LocalInstance.Users.Load(); n != nil {
+			return *n, nil
+		}
 	}
 
 	q := i.db.
@@ -69,7 +70,7 @@ func (i *instanceDB) CountInstanceUsers(ctx context.Context, domain string) (int
 
 	if localhost {
 		// Update cached instance users account value.
-		i.state.Caches.DB.InstanceCounts.Users.Store(&count)
+		i.state.Caches.DB.LocalInstance.Users.Store(&count)
 	}
 
 	return count, nil
@@ -78,10 +79,11 @@ func (i *instanceDB) CountInstanceUsers(ctx context.Context, domain string) (int
 func (i *instanceDB) CountInstanceStatuses(ctx context.Context, domain string) (int, error) {
 	localhost := (domain == config.GetHost() || domain == config.GetAccountDomain())
 
-	// Check for a cached instance statuses count, if so return this.
-	if n := i.state.Caches.DB.InstanceCounts.Statuses.Load(); n != nil &&
-		localhost {
-		return *n, nil
+	if localhost {
+		// Check for a cached instance statuses count, if so return this.
+		if n := i.state.Caches.DB.LocalInstance.Statuses.Load(); n != nil {
+			return *n, nil
+		}
 	}
 
 	q := i.db.
@@ -108,7 +110,7 @@ func (i *instanceDB) CountInstanceStatuses(ctx context.Context, domain string) (
 
 	if localhost {
 		// Update cached instance statuses account value.
-		i.state.Caches.DB.InstanceCounts.Statuses.Store(&count)
+		i.state.Caches.DB.LocalInstance.Statuses.Store(&count)
 	}
 
 	return count, nil
@@ -117,10 +119,11 @@ func (i *instanceDB) CountInstanceStatuses(ctx context.Context, domain string) (
 func (i *instanceDB) CountInstanceDomains(ctx context.Context, domain string) (int, error) {
 	localhost := (domain == config.GetHost() || domain == config.GetAccountDomain())
 
-	// Check for a cached instance domains count, if so return this.
-	if n := i.state.Caches.DB.InstanceCounts.Domains.Load(); n != nil &&
-		localhost {
-		return *n, nil
+	if localhost {
+		// Check for a cached instance domains count, if so return this.
+		if n := i.state.Caches.DB.LocalInstance.Domains.Load(); n != nil {
+			return *n, nil
+		}
 	}
 
 	q := i.db.
@@ -145,7 +148,7 @@ func (i *instanceDB) CountInstanceDomains(ctx context.Context, domain string) (i
 
 	if localhost {
 		// Update cached instance domains account value.
-		i.state.Caches.DB.InstanceCounts.Domains.Store(&count)
+		i.state.Caches.DB.LocalInstance.Domains.Store(&count)
 	}
 
 	return count, nil

--- a/internal/filter/visibility/status.go
+++ b/internal/filter/visibility/status.go
@@ -104,18 +104,20 @@ func (f *Filter) isStatusVisible(
 		return false, nil
 	}
 
-	if util.PtrOrValue(status.PendingApproval, false) {
+	if util.PtrOrZero(status.PendingApproval) {
 		// Use a different visibility heuristic
 		// for pending approval statuses.
-		return f.isPendingStatusVisible(ctx,
+		return isPendingStatusVisible(
 			requester, status,
-		)
+		), nil
 	}
 
 	if requester == nil {
 		// Use a different visibility
 		// heuristic for unauthed requests.
-		return f.isStatusVisibleUnauthed(ctx, status)
+		return f.isStatusVisibleUnauthed(
+			ctx, status,
+		)
 	}
 
 	/*
@@ -210,45 +212,42 @@ func (f *Filter) isStatusVisible(
 	}
 }
 
-func (f *Filter) isPendingStatusVisible(
-	_ context.Context,
-	requester *gtsmodel.Account,
-	status *gtsmodel.Status,
-) (bool, error) {
+// isPendingStatusVisible returns whether a status pending approval is visible to requester.
+func isPendingStatusVisible(requester *gtsmodel.Account, status *gtsmodel.Status) bool {
 	if requester == nil {
 		// Any old tom, dick, and harry can't
 		// see pending-approval statuses,
 		// no matter what their visibility.
-		return false, nil
+		return false
 	}
 
 	if status.AccountID == requester.ID {
 		// This is requester's status,
 		// so they can always see it.
-		return true, nil
+		return true
 	}
 
 	if status.InReplyToAccountID == requester.ID {
 		// This status replies to requester,
 		// so they can always see it (else
 		// they can't approve it).
-		return true, nil
+		return true
 	}
 
 	if status.BoostOfAccountID == requester.ID {
 		// This status boosts requester,
 		// so they can always see it.
-		return true, nil
+		return true
 	}
 
-	// Nobody else can see this.
-	return false, nil
+	// Nobody else
+	// can see this.
+	return false
 }
 
-func (f *Filter) isStatusVisibleUnauthed(
-	ctx context.Context,
-	status *gtsmodel.Status,
-) (bool, error) {
+// isStatusVisibleUnauthed returns whether status is visible without any unauthenticated account.
+func (f *Filter) isStatusVisibleUnauthed(ctx context.Context, status *gtsmodel.Status) (bool, error) {
+
 	// For remote accounts, only show
 	// Public statuses via the web.
 	if status.Account.IsRemote() {
@@ -275,8 +274,7 @@ func (f *Filter) isStatusVisibleUnauthed(
 		}
 	}
 
-	webVisibility := status.Account.Settings.WebVisibility
-	switch webVisibility {
+	switch webvis := status.Account.Settings.WebVisibility; webvis {
 
 	// public_only: status must be Public.
 	case gtsmodel.VisibilityPublic:
@@ -296,7 +294,7 @@ func (f *Filter) isStatusVisibleUnauthed(
 	default:
 		return false, gtserror.Newf(
 			"unrecognized web visibility for account %s: %s",
-			status.Account.ID, webVisibility,
+			status.Account.ID, webvis,
 		)
 	}
 }

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -48,9 +48,6 @@ var (
 
 	// ErrReservedAddr is returned if a dialed address resolves to an IP within a blocked or reserved net.
 	ErrReservedAddr = errors.New("dial within blocked / reserved IP range")
-
-	// ErrBodyTooLarge is returned when a received response body is above predefined limit (default 40MB).
-	ErrBodyTooLarge = errors.New("body size too large")
 )
 
 // Config provides configuration details for setting up a new
@@ -302,7 +299,6 @@ func (c *Client) do(r *Request) (rsp *http.Response, retry bool, err error) {
 		if errorsv2.IsV2(err,
 			context.DeadlineExceeded,
 			context.Canceled,
-			ErrBodyTooLarge,
 			ErrReservedAddr,
 		) {
 			// Non-retryable errors.

--- a/internal/processing/common/account.go
+++ b/internal/processing/common/account.go
@@ -42,6 +42,7 @@ func (p *Processor) GetTargetAccountBy(
 	// Fetch the target account from db.
 	target, err := getTargetFromDB()
 	if err != nil && !errors.Is(err, db.ErrNoEntries) {
+		err := gtserror.Newf("error getting from db: %w", err)
 		return nil, false, gtserror.NewErrorInternalError(err)
 	}
 
@@ -57,6 +58,7 @@ func (p *Processor) GetTargetAccountBy(
 	// Check whether target account is visible to requesting account.
 	visible, err = p.visFilter.AccountVisible(ctx, requester, target)
 	if err != nil {
+		err := gtserror.Newf("error checking visibility: %w", err)
 		return nil, false, gtserror.NewErrorInternalError(err)
 	}
 
@@ -128,7 +130,8 @@ func (p *Processor) GetVisibleTargetAccount(
 	return target, nil
 }
 
-// GetAPIAccount fetches the appropriate API account model depending on whether requester = target.
+// GetAPIAccount fetches the appropriate API account
+// model depending on whether requester = target.
 func (p *Processor) GetAPIAccount(
 	ctx context.Context,
 	requester *gtsmodel.Account,
@@ -148,14 +151,15 @@ func (p *Processor) GetAPIAccount(
 	}
 
 	if err != nil {
-		err := gtserror.Newf("error converting account: %w", err)
+		err := gtserror.Newf("error converting: %w", err)
 		return nil, gtserror.NewErrorInternalError(err)
 	}
 
 	return apiAcc, nil
 }
 
-// GetAPIAccountBlocked fetches the limited "blocked" account model for given target.
+// GetAPIAccountBlocked fetches the limited
+// "blocked" account model for given target.
 func (p *Processor) GetAPIAccountBlocked(
 	ctx context.Context,
 	targetAcc *gtsmodel.Account,
@@ -165,7 +169,7 @@ func (p *Processor) GetAPIAccountBlocked(
 ) {
 	apiAccount, err := p.converter.AccountToAPIAccountBlocked(ctx, targetAcc)
 	if err != nil {
-		err = gtserror.Newf("error converting account: %w", err)
+		err := gtserror.Newf("error converting: %w", err)
 		return nil, gtserror.NewErrorInternalError(err)
 	}
 	return apiAccount, nil
@@ -182,7 +186,7 @@ func (p *Processor) GetAPIAccountSensitive(
 ) {
 	apiAccount, err := p.converter.AccountToAPIAccountSensitive(ctx, targetAcc)
 	if err != nil {
-		err = gtserror.Newf("error converting account: %w", err)
+		err := gtserror.Newf("error converting: %w", err)
 		return nil, gtserror.NewErrorInternalError(err)
 	}
 	return apiAccount, nil
@@ -226,8 +230,7 @@ func (p *Processor) getVisibleAPIAccounts(
 ) []*apimodel.Account {
 	// Start new log entry with
 	// the above calling func's name.
-	l := log.
-		WithContext(ctx).
+	l := log.WithContext(ctx).
 		WithField("caller", log.Caller(calldepth+1))
 
 	// Preallocate slice according to expected length.

--- a/internal/processing/common/status.go
+++ b/internal/processing/common/status.go
@@ -25,6 +25,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/federation/dereferencing"
 	statusfilter "github.com/superseriousbusiness/gotosocial/internal/filter/status"
+	"github.com/superseriousbusiness/gotosocial/internal/filter/usermute"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
@@ -174,12 +175,70 @@ func (p *Processor) GetAPIStatus(
 	apiStatus *apimodel.Status,
 	errWithCode gtserror.WithCode,
 ) {
-	apiStatus, err := p.converter.StatusToAPIStatus(ctx, target, requester, statusfilter.FilterContextNone, nil, nil)
+	apiStatus, err := p.converter.StatusToAPIStatus(ctx,
+		target,
+		requester,
+		statusfilter.FilterContextNone,
+		nil,
+		nil,
+	)
 	if err != nil {
-		err = gtserror.Newf("error converting status: %w", err)
+		err := gtserror.Newf("error converting status: %w", err)
 		return nil, gtserror.NewErrorInternalError(err)
 	}
 	return apiStatus, nil
+}
+
+// GetVisibleAPIStatuses converts a slice of statuses to API
+// model statuses, filtering according to visibility to requester
+// along with given filter context, filters and user mutes.
+func (p *Processor) GetVisibleAPIStatuses(
+	ctx context.Context,
+	requester *gtsmodel.Account,
+	statuses []*gtsmodel.Status,
+	filterContext statusfilter.FilterContext,
+	filters []*gtsmodel.Filter,
+	userMutes []*gtsmodel.UserMute,
+) []apimodel.Status {
+	// Compile mutes to useable user mutes for type converter.
+	compUserMutes := usermute.NewCompiledUserMuteList(userMutes)
+
+	// Iterate filtered statuses for conversion to API model.
+	apiStatuses := make([]apimodel.Status, 0, len(statuses))
+	for _, status := range statuses {
+
+		// Check whether status is visible to requester.
+		visible, err := p.visFilter.StatusVisible(ctx,
+			requester,
+			status,
+		)
+		if err != nil {
+			log.Errorf(ctx, "error checking status visibility: %v", err)
+			continue
+		}
+
+		if !visible {
+			continue
+		}
+
+		// Convert to API status, taking mute / filter into account.
+		apiStatus, err := p.converter.StatusToAPIStatus(ctx,
+			status,
+			requester,
+			filterContext,
+			filters,
+			compUserMutes,
+		)
+		if err != nil && !errors.Is(err, statusfilter.ErrHideStatus) {
+			log.Errorf(ctx, "error converting to api model: %v", err)
+			continue
+		}
+
+		// Append converted status to return slice.
+		apiStatuses = append(apiStatuses, *apiStatus)
+	}
+
+	return apiStatuses
 }
 
 // InvalidateTimelinedStatus is a shortcut function for invalidating the cached

--- a/internal/processing/common/status.go
+++ b/internal/processing/common/status.go
@@ -51,6 +51,7 @@ func (p *Processor) GetTargetStatusBy(
 	// Fetch the target status from db.
 	target, err := getTargetFromDB()
 	if err != nil && !errors.Is(err, db.ErrNoEntries) {
+		err := gtserror.Newf("error getting from db: %w", err)
 		return nil, false, gtserror.NewErrorInternalError(err)
 	}
 
@@ -66,6 +67,7 @@ func (p *Processor) GetTargetStatusBy(
 	// Check whether target status is visible to requesting account.
 	visible, err = p.visFilter.StatusVisible(ctx, requester, target)
 	if err != nil {
+		err := gtserror.Newf("error checking visibility: %w", err)
 		return nil, false, gtserror.NewErrorInternalError(err)
 	}
 
@@ -183,7 +185,7 @@ func (p *Processor) GetAPIStatus(
 		nil,
 	)
 	if err != nil {
-		err := gtserror.Newf("error converting status: %w", err)
+		err := gtserror.Newf("error converting: %w", err)
 		return nil, gtserror.NewErrorInternalError(err)
 	}
 	return apiStatus, nil
@@ -213,7 +215,7 @@ func (p *Processor) GetVisibleAPIStatuses(
 			status,
 		)
 		if err != nil {
-			log.Errorf(ctx, "error checking status visibility: %v", err)
+			log.Errorf(ctx, "error checking visibility: %v", err)
 			continue
 		}
 
@@ -230,7 +232,7 @@ func (p *Processor) GetVisibleAPIStatuses(
 			compUserMutes,
 		)
 		if err != nil && !errors.Is(err, statusfilter.ErrHideStatus) {
-			log.Errorf(ctx, "error converting to api model: %v", err)
+			log.Errorf(ctx, "error converting: %v", err)
 			continue
 		}
 

--- a/internal/processing/workers/surfacetimeline.go
+++ b/internal/processing/workers/surfacetimeline.go
@@ -384,8 +384,9 @@ func (s *Surface) timelineStatus(
 ) (bool, error) {
 
 	// Ingest status into given timeline using provided function.
-	if inserted, err := ingest(ctx, timelineID, status); err != nil {
-		err = gtserror.Newf("error ingesting status %s: %w", status.ID, err)
+	if inserted, err := ingest(ctx, timelineID, status); err != nil &&
+		!errors.Is(err, statusfilter.ErrHideStatus) {
+		err := gtserror.Newf("error ingesting status %s: %w", status.ID, err)
 		return false, err
 	} else if !inserted {
 		// Nothing more to do.
@@ -401,7 +402,7 @@ func (s *Surface) timelineStatus(
 		mutes,
 	)
 	if err != nil {
-		err = gtserror.Newf("error converting status %s to frontend representation: %w", status.ID, err)
+		err := gtserror.Newf("error converting status %s to frontend representation: %w", status.ID, err)
 		return true, err
 	}
 

--- a/internal/processing/workers/surfacetimeline.go
+++ b/internal/processing/workers/surfacetimeline.go
@@ -401,15 +401,19 @@ func (s *Surface) timelineStatus(
 		filters,
 		mutes,
 	)
-	if err != nil {
+	if err != nil && !errors.Is(err, statusfilter.ErrHideStatus) {
 		err := gtserror.Newf("error converting status %s to frontend representation: %w", status.ID, err)
 		return true, err
 	}
 
-	// The status was inserted so stream it to the user.
-	s.Stream.Update(ctx, account, apiStatus, streamType)
+	if apiStatus != nil {
+		// The status was inserted so stream it to the user.
+		s.Stream.Update(ctx, account, apiStatus, streamType)
+		return true, nil
+	}
 
-	return true, nil
+	// Status was hidden.
+	return false, nil
 }
 
 // timelineAndNotifyStatusForTagFollowers inserts the status into the


### PR DESCRIPTION
# Description

- adds caching for local instance count queries (e.g. statuses, users, known other instances)
- adds improved logging for status context fetching endpoint + consolidates some code
- ensures we don't end up logging ErrHideStatus as errors in the worker timelining code
- removes some unused httpclient code (an error type)

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
