### PR TITLE
[chore] reduce number admin process workers

### DIFF
--- a/internal/workers/workers.go
+++ b/internal/workers/workers.go
@@ -87,7 +87,7 @@ func (w *Workers) Start() {
 	w.Dereference.Start(n)
 	log.Infof(nil, "started %d dereference workers", n)
 
-	n = 4 * maxprocs
+	n = maxprocs
 	w.Processing.Start(n)
 	log.Infof(nil, "started %d processing workers", n)
 }


### PR DESCRIPTION
# Description

Given how little they're used, just reduces this number to instead = $GOMAXPROCS. Saves having idle goroutines always sitting around.