### PR TITLE
[bugfix] fix media limit reader check

### DIFF
--- a/internal/gtserror/error.go
+++ b/internal/gtserror/error.go
@@ -43,13 +43,15 @@ const (
 	limitReachedKey
 )
 
-// LimitReached ...
+// LimitReached indicates that this error was caused by
+// some kind of limit being reached, e.g. media upload limit.
 func LimitReached(err error) bool {
 	_, ok := errors.Value(err, limitReachedKey).(struct{})
 	return ok
 }
 
-// SetLimitReached ...
+// SetLimitReached will wrap the given error to store a "limit reached"
+// flag, returning wrapped error. See LimitReached() for example use-cases.
 func SetLimitReached(err error) error {
 	return errors.WithValue(err, limitReachedKey, struct{}{})
 }

--- a/internal/gtserror/error.go
+++ b/internal/gtserror/error.go
@@ -40,7 +40,19 @@ const (
 	notRelevantKey
 	spamKey
 	notPermittedKey
+	limitReachedKey
 )
+
+// LimitReached ...
+func LimitReached(err error) bool {
+	_, ok := errors.Value(err, limitReachedKey).(struct{})
+	return ok
+}
+
+// SetLimitReached ...
+func SetLimitReached(err error) error {
+	return errors.WithValue(err, limitReachedKey, struct{}{})
+}
 
 // IsUnretrievable indicates that a call to retrieve a resource
 // (account, status, attachment, etc) could not be fulfilled, either

--- a/internal/media/util.go
+++ b/internal/media/util.go
@@ -29,6 +29,7 @@ import (
 	"codeberg.org/gruf/go-bytesize"
 	"codeberg.org/gruf/go-iotools"
 	"codeberg.org/gruf/go-mimetypes"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 )
 
 // file represents one file
@@ -144,7 +145,8 @@ func drainToTmp(rc io.ReadCloser) (string, error) {
 	// Check to see if limit was reached,
 	// (produces more useful error messages).
 	if lr != nil && !iotools.AtEOF(lr.R) {
-		return path, fmt.Errorf("reached read limit %s", bytesize.Size(limit))
+		err := fmt.Errorf("reached read limit %s", bytesize.Size(limit))
+		return path, gtserror.SetLimitReached(err)
 	}
 
 	return path, nil

--- a/internal/media/util.go
+++ b/internal/media/util.go
@@ -144,7 +144,7 @@ func drainToTmp(rc io.ReadCloser) (string, error) {
 
 	// Check to see if limit was reached,
 	// (produces more useful error messages).
-	if lr != nil && !iotools.AtEOF(lr.R) {
+	if lr != nil && lr.N <= 0 {
 		err := fmt.Errorf("reached read limit %s", bytesize.Size(limit))
 		return path, gtserror.SetLimitReached(err)
 	}


### PR DESCRIPTION
# Description

So it turns out that doing an empty read to check for io.EOF only works with *some* readers.  This fixes that! And improves some of the errors we return to API callers when local media limits have been reached.

This is a partial fix for #3362 which encompasses 2 issues.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
