### PR TITLE
[bugfix] better handle ogg container format

### DIFF
--- a/internal/media/ffmpeg.go
+++ b/internal/media/ffmpeg.go
@@ -381,11 +381,19 @@ func (res *result) GetFileType() (gtsmodel.FileType, string) {
 			return gtsmodel.FileTypeAudio, "wma"
 		}
 	case "ogg":
-		switch {
-		case len(res.video) > 0:
-			return gtsmodel.FileTypeVideo, "ogv"
-		case len(res.audio) > 0:
-			return gtsmodel.FileTypeAudio, "ogg"
+		if len(res.video) > 0 {
+			switch res.video[0].codec {
+			case "theora", "dirac": // daala, tarkin
+				return gtsmodel.FileTypeVideo, "ogv"
+			}
+		}
+		if len(res.audio) > 0 {
+			switch res.audio[0].codec {
+			case "opus", "libopus":
+				return gtsmodel.FileTypeAudio, "opus"
+			default:
+				return gtsmodel.FileTypeAudio, "ogg"
+			}
 		}
 	case "matroska,webm":
 		switch {


### PR DESCRIPTION
# Description

This improves our handling of ogg container format in the media processor. It now correctly recognizes that video streams outside of theora, dirac, daala, tarkin will not actually be an ogv type (ogg container format, primarily containing video), but instead more likely be album art in an ogg audio file. It was the call to clean metadata from an audio file that was causing trouble.

This is the last piece of the puzzle to #3362 

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
