### PR TITLE
[chore] Update apparmor example file

### DIFF
--- a/docs/advanced/security/sandboxing.md
+++ b/docs/advanced/security/sandboxing.md
@@ -24,7 +24,7 @@ $ sudo apparmor_parser -Kr /etc/apparmor.d/gotosocial
 ```
 
 !!! tip
-    If you're using SQLite, the AppArmor profile expects the database in `/gotosocial/db/` so you'll need to adjust your configuration paths or the policy accordingly.
+    The provided AppArmor example is just intended to get you started. It will still need to be edited depending on your exact setup; consult the comments in the example profile file for more information.
 
 With the policy installed, you'll need to configure your system to use it to constrain the permissions GoToSocial has.
 

--- a/example/apparmor/gotosocial
+++ b/example/apparmor/gotosocial
@@ -7,23 +7,44 @@ profile gotosocial flags=(attach_disconnected, mediate_deleted) {
   include <abstractions/nameservice>
   include <abstractions/user-tmp>
 
+  # Allow common binary install paths.
+  #
+  # You can change or remove these depending on
+  # where you've installed your GoToSocial binary.
   /gotosocial/gotosocial mrix,
   /usr/local/bin/gotosocial mrix,
   /usr/bin/gotosocial mrix,
   /usr/sbin/gotosocial mrix,
 
+  # Allow access to GoToSocial's storage and database paths.
+  # Change these depending on your db + storage locations.
   owner /gotosocial/{,**} r,
   owner /gotosocial/db/* wk,
   owner /gotosocial/storage/** wk,
 
-  # Allow GoToSocial to write logs
-  # NOTE: you only need to allow write permissions to /var/log/syslog if you've
-  # enabled logging to syslog.
+  # Embedded ffmpeg needs read
+  # permission on /dev/urandom.
+  owner /dev/ r,
+  owner /dev/urandom r,
+
+  # Temp dir access is needed for storing
+  # files briefly during media processing.
+  owner /tmp/ r,
+  owner /tmp/* rwk,
+
+  # If running with GTS_WAZERO_COMPILATION_CACHE set,
+  # change + uncomment the below lines as appropriate:
+  # owner /your/wazero/cache/directory/ r,
+  # owner /your/wazero/cache/directory/** rwk,
+
+  # If you've enabled logging to syslog, allow GoToSocial
+  # to write logs by uncommenting the following line:
   # owner /var/log/syslog w,
 
-  # These directories are not currently used by any of the recommended
-  # GoToSocial installation methods, but they may be used in the future and/or
-  # for custom installations.
+  # These directories are not currently used by any of
+  # the recommended GoToSocial installation methods, but
+  # may be used in the future and/or for custom installs.
+  # Delete them if you prefer.
   owner /etc/gotosocial/{,**} r,
   owner /usr/local/etc/gotosocial/{,**} r,
   owner /usr/share/gotosocial/{,**} r,
@@ -55,9 +76,10 @@ profile gotosocial flags=(attach_disconnected, mediate_deleted) {
   network inet dgram,
   network inet6 dgram,
 
-  # Allow GoToSocial to receive signals from unconfined processes
+  # Allow GoToSocial to receive signals from unconfined processes.
   signal (receive) peer=unconfined,
-  # Allow GoToSocial to send signals to/receive signals from worker processes
+
+  # Allow GoToSocial to send signals to/receive signals from worker processes.
   signal (send,receive) peer=gotosocial,
 }
 


### PR DESCRIPTION
Adds some additional permissions to the example AppArmor profile, to account for access to `/tmp` and `/dev/urandom` required by embedded ffmpeg.

Closes https://github.com/superseriousbusiness/gotosocial/issues/3359