### PR TITLE
[bugfix] Carry-over "PinnedAt" when refreshing status

### DIFF
--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -516,10 +516,12 @@ func (d *Dereferencer) enrichStatus(
 		latestStatus.ID = status.ID
 	}
 
-	// Carry-over values and set fetch time.
-	latestStatus.UpdatedAt = status.UpdatedAt
+	// Set latest fetch time and carry-
+	// over some values from "old" status.
 	latestStatus.FetchedAt = time.Now()
+	latestStatus.UpdatedAt = status.UpdatedAt
 	latestStatus.Local = status.Local
+	latestStatus.PinnedAt = status.PinnedAt
 
 	// Carry-over approvals. Remote instances might not yet
 	// serve statuses with the `approved_by` field, but we


### PR DESCRIPTION
We weren't carrying over the "PinnedAt" value from statuses when doing refreshes, which was causing pins to get dropped. This fixes that!

Closes https://github.com/superseriousbusiness/gotosocial/issues/3351