### PR TITLE
[performance] remove the sqlite pragma optimize analysis limit on connection close

### DIFF
--- a/internal/db/sqlite/driver.go
+++ b/internal/db/sqlite/driver.go
@@ -112,7 +112,7 @@ func (c *sqliteConn) Close() (err error) {
 	raw := c.connIface.(sqlite3driver.Conn).Raw()
 
 	// see: https://www.sqlite.org/pragma.html#pragma_optimize
-	const onClose = "PRAGMA analysis_limit=1000; PRAGMA optimize;"
+	const onClose = "PRAGMA optimize;"
 	_ = raw.Exec(onClose)
 
 	// Finally, close.


### PR DESCRIPTION
See: https://www.sqlite.org/lang_analyze.html

In particular:
> The [PRAGMA optimize](https://www.sqlite.org/pragma.html#pragma_optimize) command is usually a no-op but it will occasionally run one or more ANALYZE subcommands on individual tables of the database if doing so will be useful to the query planner. Since SQLite version 3.46.0 (2024-05-23), the "PRAGMA optimize" command automatically limits the scope of ANALYZE subcommands so that the overall "PRAGMA optimize" command completes quickly even on enormous databases. There is no need to use [PRAGMA analysis_limit](https://www.sqlite.org/pragma.html#pragma_analysis_limit). This is the recommended way of running ANALYZE moving forward.