### PR TITLE
[bugfix] Account for nil reply when serializing int req

### DIFF
--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -2680,7 +2680,7 @@ func (c *Converter) InteractionReqToAPIInteractionReq(
 	}
 
 	var reply *apimodel.Status
-	if req.InteractionType == gtsmodel.InteractionReply {
+	if req.InteractionType == gtsmodel.InteractionReply && req.Reply != nil {
 		reply, err = c.statusToAPIStatus(
 			ctx,
 			req.Reply,


### PR DESCRIPTION
Check for nil Reply when serializing interaction requests (fix nil pointer when reply has been deleted but interaction request still exists).