### PR TITLE
[docs] Make `protocol` config option really explicit

### DIFF
--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -80,10 +80,18 @@ host: "localhost"
 # Default: ""
 account-domain: ""
 
-# String. Protocol to use for the server. Only change to http for local testing!
-# This should be the protocol part of the URI that your server is actually reachable on. So even if you're
-# running GoToSocial behind a reverse proxy that handles SSL certificates for you, instead of using built-in
-# letsencrypt, it should still be https.
+# String. Protocol over which the server is reachable from the outside world.
+#
+# ONLY CHANGE THIS TO HTTP FOR LOCAL TESTING! IN 99.99% OF CASES YOU SHOULD NOT CHANGE THIS!
+#
+# This should be the protocol part of the URI that your server is actually reachable on.
+# So even if you're running GoToSocial behind a reverse proxy that handles SSL certificates
+# for you, instead of using built-in letsencrypt, it should still be https, not http.
+#
+# Again, ONLY CHANGE THIS TO HTTP FOR LOCAL TESTING! If you set this to `http`, start your instance,
+# and then later change it to `https`, you will have already broken URI generation for any created
+# users on the instance. You should only touch this setting if you 100% know what you're doing.
+#
 # Options: ["http","https"]
 # Default: "https"
 protocol: "https"

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -88,10 +88,18 @@ host: "localhost"
 # Default: ""
 account-domain: ""
 
-# String. Protocol to use for the server. Only change to http for local testing!
-# This should be the protocol part of the URI that your server is actually reachable on. So even if you're
-# running GoToSocial behind a reverse proxy that handles SSL certificates for you, instead of using built-in
-# letsencrypt, it should still be https.
+# String. Protocol over which the server is reachable from the outside world.
+#
+# ONLY CHANGE THIS TO HTTP FOR LOCAL TESTING! IN 99.99% OF CASES YOU SHOULD NOT CHANGE THIS!
+#
+# This should be the protocol part of the URI that your server is actually reachable on.
+# So even if you're running GoToSocial behind a reverse proxy that handles SSL certificates
+# for you, instead of using built-in letsencrypt, it should still be https, not http.
+#
+# Again, ONLY CHANGE THIS TO HTTP FOR LOCAL TESTING! If you set this to `http`, start your instance,
+# and then later change it to `https`, you will have already broken URI generation for any created
+# users on the instance. You should only touch this setting if you 100% know what you're doing.
+#
 # Options: ["http","https"]
 # Default: "https"
 protocol: "https"


### PR DESCRIPTION
Puts a really loud warning on the "protocol" config option.