### PR TITLE
[chore] Change order of error checking after PostInbox

### DIFF
--- a/internal/federation/federatingactor.go
+++ b/internal/federation/federatingactor.go
@@ -170,12 +170,6 @@ func (f *federatingActor) PostInboxScheme(ctx context.Context, w http.ResponseWr
 	//
 	// Post the activity to the Actor's inbox and trigger side effects.
 	if err := f.sideEffectActor.PostInbox(ctx, inboxID, activity); err != nil {
-		// Check if a function in the federatingDB
-		// has returned an explicit errWithCode for us.
-		if errWithCode, ok := err.(gtserror.WithCode); ok {
-			return false, errWithCode
-		}
-
 		// Check if it's a bad request because the
 		// object or target props weren't populated,
 		// or we failed parsing activity details.
@@ -191,6 +185,12 @@ func (f *federatingActor) PostInboxScheme(ctx context.Context, w http.ResponseWr
 
 			const text = "malformed incoming activity"
 			return false, gtserror.NewErrorBadRequest(errors.New(text), text)
+		}
+
+		// Check if a function in the federatingDB
+		// has returned an explicit errWithCode for us.
+		if errWithCode, ok := err.(gtserror.WithCode); ok {
+			return false, errWithCode
 		}
 
 		// Default: there's been some real error.


### PR DESCRIPTION
Check for malformed errors embedded inside error *first*, then check for gtserror.WithCode.

# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request reorders error checking during PostInbox to check for any embedded malformed or actor missing errors *first*, then fall back to any gtserror.WithCode.

This accounts for cases where a malformed is embedded inside an 500 gtserror. In this case we care more about the embedded 400 as this is more informative for the caller.

closes https://github.com/superseriousbusiness/gotosocial/issues/3168

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
