### PR TITLE
[bugfix] Only allow boosting post from non-interaction-policy-aware instance if public or unlisted

### DIFF
--- a/internal/filter/interaction/interactable.go
+++ b/internal/filter/interaction/interactable.go
@@ -306,7 +306,7 @@ func (f *Filter) StatusBoostable(
 			status.InteractionPolicy.CanAnnounce,
 		)
 
-	// If status is local and has no policy set,
+	// If status has no policy set but it's local,
 	// check against the default policy for this
 	// visibility, as we're interaction-policy aware.
 	case *status.Local:
@@ -318,12 +318,20 @@ func (f *Filter) StatusBoostable(
 			policy.CanAnnounce,
 		)
 
-	// Otherwise, assume the status is from an
-	// instance that does not use / does not care
-	// about interaction policies, and just return OK.
-	default:
+	// Status is from an instance that does not use
+	// or does not care about interaction policies.
+	// We can boost it if it's unlisted or public.
+	case status.Visibility == gtsmodel.VisibilityPublic ||
+		status.Visibility == gtsmodel.VisibilityUnlocked:
 		return &gtsmodel.PolicyCheckResult{
 			Permission: gtsmodel.PolicyPermissionPermitted,
+		}, nil
+
+	// Not permitted by any of the
+	// above checks, so it's forbidden.
+	default:
+		return &gtsmodel.PolicyCheckResult{
+			Permission: gtsmodel.PolicyPermissionForbidden,
 		}, nil
 	}
 }


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Fix a bug introduced by interaction policies in 0.17.0-rc1 where it was possible to try to boost a status from an instance that doesn't know about interaction policies, even when status should normally not be boostable. 

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
