### PR TITLE
[feature] Distribute Accepts to followers; process Accepts of remote interactions

### DIFF
--- a/docs/federation/posts.md
+++ b/docs/federation/posts.md
@@ -569,6 +569,7 @@ For example, the following json object `Reject`s the attempt of `@someone@somewh
 
 ```json
 {
+  "@context": "https://www.w3.org/ns/activitystreams",
   "actor": "https://example.org/users/post_author",
   "to": "https://somewhere.else.example.org/users/someone",
   "id": "https://example.org/users/post_author/activities/reject/01J0K2YXP9QCT5BE1JWQSAM3B6",
@@ -591,7 +592,12 @@ For example, the following json object `Accept`s the attempt of `@someone@somewh
 
 ```json
 {
+  "@context": "https://www.w3.org/ns/activitystreams",
   "actor": "https://example.org/users/post_author",
+  "cc": [
+    "https://www.w3.org/ns/activitystreams#Public",
+    "https://example.org/users/post_author/followers"
+  ],
   "to": "https://somewhere.else.example.org/users/someone",
   "id": "https://example.org/users/post_author/activities/reject/01J0K2YXP9QCT5BE1JWQSAM3B6",
   "object": "https://somewhere.else.example.org/users/someone/statuses/01J17XY2VXGMNNPH1XR7BG2524",
@@ -600,6 +606,9 @@ For example, the following json object `Accept`s the attempt of `@someone@somewh
 ```
 
 If this happens, `@someone@somewhere.else.example.org` (and their instance) should consider the interaction as having been approved / accepted. The instance can then feel free to distribute the interaction `Activity` to all of the recipients targed by `to`, `cc`, etc, with the additional property `approvedBy` ([see below](#approvedby)).
+
+!!! Note
+    In the above example, actor `https://example.org/users/post_author` addresses the `Accept` activity not just to the interacting actor `https://somewhere.else.example.org/users/someone`, but to their followers collection as well (and, implicitly, to the public). This allows followers of `https://example.org/users/post_author` on other servers to also mark the interaction as accepted, and to show the interaction alongside the interacted-with post.
 
 ### Validating presence in a Followers / Following collection
 

--- a/internal/ap/activitystreams.go
+++ b/internal/ap/activitystreams.go
@@ -77,6 +77,10 @@ const (
 	// See https://www.w3.org/TR/activitystreams-vocabulary/#microsyntaxes
 	// and https://www.w3.org/TR/activitystreams-vocabulary/#dfn-tag
 	TagHashtag = "Hashtag"
+
+	// Not in the AS spec, just used internally to indicate
+	// that we don't *yet* know what type of Object something is.
+	ObjectUnknown = "Unknown"
 )
 
 // isActivity returns whether AS type name is of an Activity (NOT IntransitiveActivity).

--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -527,8 +527,9 @@ func (d *Dereferencer) enrichStatus(
 	// serve statuses with the `approved_by` field, but we
 	// might have marked a status as pre-approved on our side
 	// based on the author's inclusion in a followers/following
-	// collection. By carrying over previously-set values we
-	// can avoid marking such statuses as "pending" again.
+	// collection, or by providing pre-approval URI on the bare
+	// status passed to RefreshStatus. By carrying over previously
+	// set values we can avoid marking such statuses as "pending".
 	//
 	// If a remote has in the meantime retracted its approval,
 	// the next call to 'isPermittedStatus' will catch that.

--- a/internal/federation/federatingdb/accept.go
+++ b/internal/federation/federatingdb/accept.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/superseriousbusiness/activity/streams/vocab"
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
@@ -68,6 +69,20 @@ func (f *federatingDB) Accept(ctx context.Context, accept vocab.ActivityStreamsA
 		return gtserror.NewErrorBadRequest(errors.New(text), text)
 	}
 
+	// Ensure requester is the same as the
+	// Actor of the Accept; you can't Accept
+	// something on someone else's behalf.
+	actorURI, err := ap.ExtractActorURI(accept)
+	if err != nil {
+		const text = "Accept had empty or invalid actor property"
+		return gtserror.NewErrorBadRequest(errors.New(text), text)
+	}
+
+	if requestingAcct.URI != actorURI.String() {
+		const text = "Accept actor and requesting account were not the same"
+		return gtserror.NewErrorBadRequest(errors.New(text), text)
+	}
+
 	// Iterate all provided objects in the activity,
 	// handling the ones we know how to handle.
 	for _, object := range ap.ExtractObjects(accept) {
@@ -108,18 +123,6 @@ func (f *federatingDB) Accept(ctx context.Context, accept vocab.ActivityStreamsA
 					return err
 				}
 
-			// ACCEPT STATUS (reply/boost)
-			case uris.IsStatusesPath(objIRI):
-				if err := f.acceptStatusIRI(
-					ctx,
-					activityID.String(),
-					objIRI.String(),
-					receivingAcct,
-					requestingAcct,
-				); err != nil {
-					return err
-				}
-
 			// ACCEPT LIKE
 			case uris.IsLikePath(objIRI):
 				if err := f.acceptLikeIRI(
@@ -132,9 +135,20 @@ func (f *federatingDB) Accept(ctx context.Context, accept vocab.ActivityStreamsA
 					return err
 				}
 
-			// UNHANDLED
+			// ACCEPT OTHER (reply? boost?)
+			//
+			// Don't check on IsStatusesPath
+			// as this may be a remote status.
 			default:
-				log.Debugf(ctx, "unhandled iri type: %s", objIRI)
+				if err := f.acceptOtherIRI(
+					ctx,
+					activityID,
+					objIRI,
+					receivingAcct,
+					requestingAcct,
+				); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -276,38 +290,90 @@ func (f *federatingDB) acceptFollowIRI(
 	return nil
 }
 
-func (f *federatingDB) acceptStatusIRI(
+func (f *federatingDB) acceptOtherIRI(
 	ctx context.Context,
-	activityID string,
-	objectIRI string,
+	activityID *url.URL,
+	objectIRI *url.URL,
 	receivingAcct *gtsmodel.Account,
 	requestingAcct *gtsmodel.Account,
 ) error {
-	// Lock on this potential status
-	// URI as we may be updating it.
-	unlock := f.state.FedLocks.Lock(objectIRI)
-	defer unlock()
-
-	// Get the status from the db.
-	status, err := f.state.DB.GetStatusByURI(ctx, objectIRI)
+	// See if we can get a status from the db.
+	status, err := f.state.DB.GetStatusByURI(ctx, objectIRI.String())
 	if err != nil && !errors.Is(err, db.ErrNoEntries) {
 		err := gtserror.Newf("db error getting status: %w", err)
 		return gtserror.NewErrorInternalError(err)
 	}
 
-	if status == nil {
-		// We didn't have a status with
-		// this URI, so nothing to do.
-		// Just return.
+	if status != nil {
+		// We had a status stored with this
+		// objectIRI, proceed to accept it.
+		return f.acceptStoredStatus(
+			ctx,
+			activityID,
+			status,
+			receivingAcct,
+			requestingAcct,
+		)
+	}
+
+	if objectIRI.Host == config.GetHost() ||
+		objectIRI.Host == config.GetAccountDomain() {
+		// Claims to be Accepting something of ours,
+		// but we don't have a status stored for this
+		// URI, so most likely it's been deleted in
+		// the meantime, just bail.
 		return nil
 	}
 
-	if !status.IsLocal() {
-		// We don't process Accepts of statuses
-		// that weren't created on our instance.
-		// Just return.
+	// This must be an Accept of a remote Activity
+	// or Object. Ensure relevance of this message
+	// by checking that receiver follows requester.
+	following, err := f.state.DB.IsFollowing(
+		ctx,
+		receivingAcct.ID,
+		requestingAcct.ID,
+	)
+	if err != nil {
+		err := gtserror.Newf("db error checking following: %w", err)
+		return gtserror.NewErrorInternalError(err)
+	}
+
+	if !following {
+		// If we don't follow this person, and
+		// they're not Accepting something we know
+		// about, then we don't give a good goddamn.
 		return nil
 	}
+
+	// This may be a reply, or it may be a boost,
+	// we can't know yet without dereferencing it,
+	// but let the processor worry about that.
+	apObjectType := ap.ObjectUnknown
+
+	// Pass to the processor and let them handle side effects.
+	f.state.Workers.Federator.Queue.Push(&messages.FromFediAPI{
+		APObjectType:   apObjectType,
+		APActivityType: ap.ActivityAccept,
+		APIRI:          activityID,
+		APObject:       objectIRI,
+		Receiving:      receivingAcct,
+		Requesting:     requestingAcct,
+	})
+
+	return nil
+}
+
+func (f *federatingDB) acceptStoredStatus(
+	ctx context.Context,
+	activityID *url.URL,
+	status *gtsmodel.Status,
+	receivingAcct *gtsmodel.Account,
+	requestingAcct *gtsmodel.Account,
+) error {
+	// Lock on this status URI
+	// as we may be updating it.
+	unlock := f.state.FedLocks.Lock(status.URI)
+	defer unlock()
 
 	pendingApproval := util.PtrOrValue(status.PendingApproval, false)
 	if !pendingApproval {
@@ -315,14 +381,6 @@ func (f *federatingDB) acceptStatusIRI(
 		// already been approved by an Accept.
 		// Just return.
 		return nil
-	}
-
-	// Make sure the creator of the original status
-	// is the same as the inbox processing the Accept;
-	// this also ensures the status is local.
-	if status.AccountID != receivingAcct.ID {
-		const text = "status author account and inbox account were not the same"
-		return gtserror.NewErrorUnprocessableEntity(errors.New(text), text)
 	}
 
 	// Make sure the target of the interaction (reply/boost)
@@ -335,7 +393,7 @@ func (f *federatingDB) acceptStatusIRI(
 
 	// Mark the status as approved by this Accept URI.
 	status.PendingApproval = util.Ptr(false)
-	status.ApprovedByURI = activityID
+	status.ApprovedByURI = activityID.String()
 	if err := f.state.DB.UpdateStatus(
 		ctx,
 		status,

--- a/internal/gtsmodel/interaction.go
+++ b/internal/gtsmodel/interaction.go
@@ -69,25 +69,29 @@ type InteractionRequest struct {
 	Like                 *StatusFave     `bun:"-"`                                                           // Not stored in DB. Only set if InteractionType = InteractionLike.
 	Reply                *Status         `bun:"-"`                                                           // Not stored in DB. Only set if InteractionType = InteractionReply.
 	Announce             *Status         `bun:"-"`                                                           // Not stored in DB. Only set if InteractionType = InteractionAnnounce.
-	URI                  string          `bun:",nullzero,unique"`                                            // ActivityPub URI of the Accept (if accepted) or Reject (if rejected). Null/empty if currently neither accepted not rejected.
 	AcceptedAt           time.Time       `bun:"type:timestamptz,nullzero"`                                   // If interaction request was accepted, time at which this occurred.
 	RejectedAt           time.Time       `bun:"type:timestamptz,nullzero"`                                   // If interaction request was rejected, time at which this occurred.
+
+	// ActivityPub URI of the Accept (if accepted) or Reject (if rejected).
+	// Field may be empty if currently neither accepted not rejected, or if
+	// acceptance/rejection was implicit (ie., not resulting from an Activity).
+	URI string `bun:",nullzero,unique"`
 }
 
 // IsHandled returns true if interaction
 // request has been neither accepted or rejected.
 func (ir *InteractionRequest) IsPending() bool {
-	return ir.URI == "" && ir.AcceptedAt.IsZero() && ir.RejectedAt.IsZero()
+	return !ir.IsAccepted() && !ir.IsRejected()
 }
 
 // IsAccepted returns true if this
 // interaction request has been accepted.
 func (ir *InteractionRequest) IsAccepted() bool {
-	return ir.URI != "" && !ir.AcceptedAt.IsZero()
+	return !ir.AcceptedAt.IsZero()
 }
 
 // IsRejected returns true if this
 // interaction request has been rejected.
 func (ir *InteractionRequest) IsRejected() bool {
-	return ir.URI != "" && !ir.RejectedAt.IsZero()
+	return !ir.RejectedAt.IsZero()
 }

--- a/internal/typeutils/internaltoas.go
+++ b/internal/typeutils/internaltoas.go
@@ -1988,6 +1988,16 @@ func (c *Converter) InteractionReqToASAccept(
 		return nil, gtserror.Newf("invalid interacting account uri: %w", err)
 	}
 
+	publicIRI, err := url.Parse(pub.PublicActivityPubIRI)
+	if err != nil {
+		return nil, gtserror.Newf("invalid public uri: %w", err)
+	}
+
+	followersIRI, err := url.Parse(req.TargetAccount.FollowersURI)
+	if err != nil {
+		return nil, gtserror.Newf("invalid followers uri: %w", err)
+	}
+
 	// Set id to the URI of
 	// interaction request.
 	ap.SetJSONLDId(accept, acceptID)
@@ -2002,6 +2012,9 @@ func (c *Converter) InteractionReqToASAccept(
 	// Address to the owner
 	// of interaction URI.
 	ap.AppendTo(accept, toIRI)
+
+	// Cc to the actor's followers, and to Public.
+	ap.AppendCc(accept, publicIRI, followersIRI)
 
 	return accept, nil
 }
@@ -2034,6 +2047,16 @@ func (c *Converter) InteractionReqToASReject(
 		return nil, gtserror.Newf("invalid interacting account uri: %w", err)
 	}
 
+	publicIRI, err := url.Parse(pub.PublicActivityPubIRI)
+	if err != nil {
+		return nil, gtserror.Newf("invalid public uri: %w", err)
+	}
+
+	followersIRI, err := url.Parse(req.TargetAccount.FollowersURI)
+	if err != nil {
+		return nil, gtserror.Newf("invalid followers uri: %w", err)
+	}
+
 	// Set id to the URI of
 	// interaction request.
 	ap.SetJSONLDId(reject, rejectID)
@@ -2048,6 +2071,9 @@ func (c *Converter) InteractionReqToASReject(
 	// Address to the owner
 	// of interaction URI.
 	ap.AppendTo(reject, toIRI)
+
+	// Cc to the actor's followers, and to Public.
+	ap.AppendCc(reject, publicIRI, followersIRI)
 
 	return reject, nil
 }

--- a/internal/typeutils/internaltoas_test.go
+++ b/internal/typeutils/internaltoas_test.go
@@ -1181,6 +1181,10 @@ func (suite *InternalToASTestSuite) TestInteractionReqToASAccept() {
 	suite.Equal(`{
   "@context": "https://www.w3.org/ns/activitystreams",
   "actor": "http://localhost:8080/users/the_mighty_zork",
+  "cc": [
+    "https://www.w3.org/ns/activitystreams#Public",
+    "http://localhost:8080/users/the_mighty_zork/followers"
+  ],
   "id": "http://localhost:8080/users/the_mighty_zork/accepts/01J1AKMZ8JE5NW0ZSFTRC1JJNE",
   "object": "https://fossbros-anonymous.io/users/foss_satan/statuses/01J1AKRRHQ6MDDQHV0TP716T2K",
   "to": "http://fossbros-anonymous.io/users/foss_satan",


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates distribution of Accept activities for interactions on statuses, to send the Accept also to the accepter's followers, and CC it to public as well.

The PR also adds code to process incoming Accepts of interactions that target remote statuses.

The goal here is to ease interoperability with servers that don't yet know about interaction policies and therefore can't append the "approvedBy" field to statuses when sending them out. We can use the receipt of an Accept from an interaction-policy-aware instance to go and dereference the approved status from a non-interaction-policy-aware instance, and add the `approved_by_uri` to the db model ourselves. This should lead to fewer perceived gaps in followers-only conversations taking place between Mastodon (and other) servers and GtS servers, from the perspective of a GtS server.

Also updates the interaction policy documentation to mention this type of addressing.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
