### PR TITLE
[bugfix] Ensure `pending_approval` set on statuses + status faves

### DIFF
--- a/internal/db/bundb/migrations/20240620074530_interaction_policy.go
+++ b/internal/db/bundb/migrations/20240620074530_interaction_policy.go
@@ -40,7 +40,7 @@ func init() {
 				table      string
 				column     string
 				columnType string
-				defaultVal string
+				extra      string
 			}
 			for _, spec := range []spec{
 				// Statuses.
@@ -48,19 +48,19 @@ func init() {
 					table:      "statuses",
 					column:     "interaction_policy",
 					columnType: "JSONB",
-					defaultVal: "",
+					extra:      "",
 				},
 				{
 					table:      "statuses",
 					column:     "pending_approval",
 					columnType: "BOOLEAN",
-					defaultVal: "DEFAULT false",
+					extra:      "NOT NULL DEFAULT false",
 				},
 				{
 					table:      "statuses",
 					column:     "approved_by_uri",
 					columnType: "varchar",
-					defaultVal: "",
+					extra:      "",
 				},
 
 				// Status faves.
@@ -68,13 +68,13 @@ func init() {
 					table:      "status_faves",
 					column:     "pending_approval",
 					columnType: "BOOLEAN",
-					defaultVal: "DEFAULT false",
+					extra:      "NOT NULL DEFAULT false",
 				},
 				{
 					table:      "status_faves",
 					column:     "approved_by_uri",
 					columnType: "varchar",
-					defaultVal: "",
+					extra:      "",
 				},
 
 				// Columns that must be added to the
@@ -85,31 +85,31 @@ func init() {
 					table:      "account_settings",
 					column:     "interaction_policy_direct",
 					columnType: "JSONB",
-					defaultVal: "",
+					extra:      "",
 				},
 				{
 					table:      "account_settings",
 					column:     "interaction_policy_mutuals_only",
 					columnType: "JSONB",
-					defaultVal: "",
+					extra:      "",
 				},
 				{
 					table:      "account_settings",
 					column:     "interaction_policy_followers_only",
 					columnType: "JSONB",
-					defaultVal: "",
+					extra:      "",
 				},
 				{
 					table:      "account_settings",
 					column:     "interaction_policy_unlocked",
 					columnType: "JSONB",
-					defaultVal: "",
+					extra:      "",
 				},
 				{
 					table:      "account_settings",
 					column:     "interaction_policy_public",
 					columnType: "JSONB",
-					defaultVal: "",
+					extra:      "",
 				},
 			} {
 				exists, err := doesColumnExist(ctx, tx,
@@ -130,9 +130,9 @@ func init() {
 				}
 
 				qStr := "ALTER TABLE ? ADD COLUMN ? ?"
-				if spec.defaultVal != "" {
+				if spec.extra != "" {
 					qStr += " ?"
-					args = append(args, bun.Safe(spec.defaultVal))
+					args = append(args, bun.Safe(spec.extra))
 				}
 
 				log.Infof(ctx, "adding column '%s' to '%s'...", spec.column, spec.table)

--- a/internal/db/bundb/migrations/20241011115713_pending_approval_fix.go
+++ b/internal/db/bundb/migrations/20241011115713_pending_approval_fix.go
@@ -1,0 +1,80 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			// Previous versions of 20240620074530_interaction_policy.go
+			// didn't set NOT NULL on gtsmodel.Status.PendingApproval and
+			// gtsmodel.StatusFave.PendingApproval, resulting in NULL being
+			// set for that column for some statuses. Correct for this.
+
+			log.Info(ctx, "correcting pending_approval on statuses table...")
+			res, err := tx.
+				NewUpdate().
+				Table("statuses").
+				Set("? = ?", bun.Ident("pending_approval"), false).
+				Where("? IS NULL", bun.Ident("pending_approval")).
+				Exec(ctx)
+			if err != nil {
+				return err
+			}
+
+			rows, err := res.RowsAffected()
+			if err == nil {
+				log.Infof(ctx, "corrected %d entries", rows)
+			}
+
+			log.Info(ctx, "correcting pending_approval on status_faves table...")
+			res, err = tx.
+				NewUpdate().
+				Table("status_faves").
+				Set("? = ?", bun.Ident("pending_approval"), false).
+				Where("? IS NULL", bun.Ident("pending_approval")).
+				Exec(ctx)
+			if err != nil {
+				return err
+			}
+
+			rows, err = res.RowsAffected()
+			if err == nil {
+				log.Infof(ctx, "corrected %d entries", rows)
+			}
+
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}

--- a/internal/processing/status/create.go
+++ b/internal/processing/status/create.go
@@ -78,6 +78,10 @@ func (p *Processor) Create(
 		Sensitive:                &form.Sensitive,
 		CreatedWithApplicationID: application.ID,
 		Text:                     form.Status,
+
+		// Assume not pending approval; this may
+		// change when permissivity is checked.
+		PendingApproval: util.Ptr(false),
 	}
 
 	if form.Poll != nil {

--- a/internal/typeutils/astointernal.go
+++ b/internal/typeutils/astointernal.go
@@ -664,6 +664,10 @@ func (c *Converter) ASAnnounceToStatus(
 	boost.MentionIDs = make([]string, 0)
 	boost.EmojiIDs = make([]string, 0)
 
+	// Assume not pending approval; this may
+	// change when permissivity is checked.
+	boost.PendingApproval = util.Ptr(false)
+
 	// Remaining fields on the boost will be
 	// taken from the target status; it's not
 	// our job to do all that dereferencing here.

--- a/internal/typeutils/astointernal.go
+++ b/internal/typeutils/astointernal.go
@@ -432,6 +432,10 @@ func (c *Converter) ASStatusToStatus(ctx context.Context, statusable ap.Statusab
 		status.ApprovedByURI = approvedByURI.String()
 	}
 
+	// Assume not pending approval; this may
+	// change when permissivity is checked.
+	status.PendingApproval = util.Ptr(false)
+
 	// status.Sensitive
 	sensitive := ap.ExtractSensitive(statusable)
 	status.Sensitive = &sensitive
@@ -531,6 +535,10 @@ func (c *Converter) ASLikeToFave(ctx context.Context, likeable ap.Likeable) (*gt
 		StatusID:        target.ID,
 		Status:          target,
 		URI:             uri,
+
+		// Assume not pending approval; this may
+		// change when permissivity is checked.
+		PendingApproval: util.Ptr(false),
 	}, nil
 }
 


### PR DESCRIPTION
# Description

Fix an issue with the interaction policy migration where `pending_approval` did not have `NOT NULL` set on it, and write a migration to correct statuses and status_faves. Also ensure that this field is *always* set by adding some logic for it to the type converter.

Note, this PR *doesn't* bother completely undoing and redoing the previous migration by dropping and recreating the statuses  + status faves tables, because I'm not really keen on having folks who've run the RC having to do another massive migration. The `NOT NULL` is not actually that important as long as we remember to set it ourselves anyway.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
