### PR TITLE
[chore] Don't cc Accept of likes to followers

### DIFF
--- a/internal/typeutils/internaltoas.go
+++ b/internal/typeutils/internaltoas.go
@@ -1988,16 +1988,6 @@ func (c *Converter) InteractionReqToASAccept(
 		return nil, gtserror.Newf("invalid interacting account uri: %w", err)
 	}
 
-	publicIRI, err := url.Parse(pub.PublicActivityPubIRI)
-	if err != nil {
-		return nil, gtserror.Newf("invalid public uri: %w", err)
-	}
-
-	followersIRI, err := url.Parse(req.TargetAccount.FollowersURI)
-	if err != nil {
-		return nil, gtserror.Newf("invalid followers uri: %w", err)
-	}
-
 	// Set id to the URI of
 	// interaction request.
 	ap.SetJSONLDId(accept, acceptID)
@@ -2013,8 +2003,39 @@ func (c *Converter) InteractionReqToASAccept(
 	// of interaction URI.
 	ap.AppendTo(accept, toIRI)
 
-	// Cc to the actor's followers, and to Public.
-	ap.AppendCc(accept, publicIRI, followersIRI)
+	// Whether or not we cc this Accept to
+	// followers and public depends on the
+	// type of interaction it Accepts.
+
+	var cc bool
+	switch req.InteractionType {
+
+	case gtsmodel.InteractionLike:
+		// Accept of Like doesn't get cc'd
+		// because it's not that important.
+
+	case gtsmodel.InteractionReply:
+		// Accept of reply gets cc'd.
+		cc = true
+
+	case gtsmodel.InteractionAnnounce:
+		// Accept of announce gets cc'd.
+		cc = true
+	}
+
+	if cc {
+		publicIRI, err := url.Parse(pub.PublicActivityPubIRI)
+		if err != nil {
+			return nil, gtserror.Newf("invalid public uri: %w", err)
+		}
+
+		followersIRI, err := url.Parse(req.TargetAccount.FollowersURI)
+		if err != nil {
+			return nil, gtserror.Newf("invalid followers uri: %w", err)
+		}
+
+		ap.AppendCc(accept, publicIRI, followersIRI)
+	}
 
 	return accept, nil
 }
@@ -2047,16 +2068,6 @@ func (c *Converter) InteractionReqToASReject(
 		return nil, gtserror.Newf("invalid interacting account uri: %w", err)
 	}
 
-	publicIRI, err := url.Parse(pub.PublicActivityPubIRI)
-	if err != nil {
-		return nil, gtserror.Newf("invalid public uri: %w", err)
-	}
-
-	followersIRI, err := url.Parse(req.TargetAccount.FollowersURI)
-	if err != nil {
-		return nil, gtserror.Newf("invalid followers uri: %w", err)
-	}
-
 	// Set id to the URI of
 	// interaction request.
 	ap.SetJSONLDId(reject, rejectID)
@@ -2072,8 +2083,39 @@ func (c *Converter) InteractionReqToASReject(
 	// of interaction URI.
 	ap.AppendTo(reject, toIRI)
 
-	// Cc to the actor's followers, and to Public.
-	ap.AppendCc(reject, publicIRI, followersIRI)
+	// Whether or not we cc this Reject to
+	// followers and public depends on the
+	// type of interaction it Rejects.
+
+	var cc bool
+	switch req.InteractionType {
+
+	case gtsmodel.InteractionLike:
+		// Reject of Like doesn't get cc'd
+		// because it's not that important.
+
+	case gtsmodel.InteractionReply:
+		// Reject of reply gets cc'd.
+		cc = true
+
+	case gtsmodel.InteractionAnnounce:
+		// Reject of announce gets cc'd.
+		cc = true
+	}
+
+	if cc {
+		publicIRI, err := url.Parse(pub.PublicActivityPubIRI)
+		if err != nil {
+			return nil, gtserror.Newf("invalid public uri: %w", err)
+		}
+
+		followersIRI, err := url.Parse(req.TargetAccount.FollowersURI)
+		if err != nil {
+			return nil, gtserror.Newf("invalid followers uri: %w", err)
+		}
+
+		ap.AppendCc(reject, publicIRI, followersIRI)
+	}
 
 	return reject, nil
 }

--- a/internal/typeutils/internaltoas_test.go
+++ b/internal/typeutils/internaltoas_test.go
@@ -1143,7 +1143,7 @@ func (suite *InternalToASTestSuite) TestPollVoteToASCreate() {
 }`, string(bytes))
 }
 
-func (suite *InternalToASTestSuite) TestInteractionReqToASAccept() {
+func (suite *InternalToASTestSuite) TestInteractionReqToASAcceptAnnounce() {
 	acceptingAccount := suite.testAccounts["local_account_1"]
 	interactingAccount := suite.testAccounts["remote_account_1"]
 
@@ -1185,6 +1185,51 @@ func (suite *InternalToASTestSuite) TestInteractionReqToASAccept() {
     "https://www.w3.org/ns/activitystreams#Public",
     "http://localhost:8080/users/the_mighty_zork/followers"
   ],
+  "id": "http://localhost:8080/users/the_mighty_zork/accepts/01J1AKMZ8JE5NW0ZSFTRC1JJNE",
+  "object": "https://fossbros-anonymous.io/users/foss_satan/statuses/01J1AKRRHQ6MDDQHV0TP716T2K",
+  "to": "http://fossbros-anonymous.io/users/foss_satan",
+  "type": "Accept"
+}`, string(b))
+}
+
+func (suite *InternalToASTestSuite) TestInteractionReqToASAcceptLike() {
+	acceptingAccount := suite.testAccounts["local_account_1"]
+	interactingAccount := suite.testAccounts["remote_account_1"]
+
+	req := &gtsmodel.InteractionRequest{
+		ID:                   "01J1AKMZ8JE5NW0ZSFTRC1JJNE",
+		CreatedAt:            testrig.TimeMustParse("2022-06-09T13:12:00Z"),
+		TargetAccountID:      acceptingAccount.ID,
+		TargetAccount:        acceptingAccount,
+		InteractingAccountID: interactingAccount.ID,
+		InteractingAccount:   interactingAccount,
+		InteractionURI:       "https://fossbros-anonymous.io/users/foss_satan/statuses/01J1AKRRHQ6MDDQHV0TP716T2K",
+		InteractionType:      gtsmodel.InteractionLike,
+		URI:                  "http://localhost:8080/users/the_mighty_zork/accepts/01J1AKMZ8JE5NW0ZSFTRC1JJNE",
+		AcceptedAt:           testrig.TimeMustParse("2022-06-09T13:12:00Z"),
+	}
+
+	accept, err := suite.typeconverter.InteractionReqToASAccept(
+		context.Background(),
+		req,
+	)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	i, err := ap.Serialize(accept)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	b, err := json.MarshalIndent(i, "", "  ")
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Equal(`{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "actor": "http://localhost:8080/users/the_mighty_zork",
   "id": "http://localhost:8080/users/the_mighty_zork/accepts/01J1AKMZ8JE5NW0ZSFTRC1JJNE",
   "object": "https://fossbros-anonymous.io/users/foss_satan/statuses/01J1AKRRHQ6MDDQHV0TP716T2K",
   "to": "http://fossbros-anonymous.io/users/foss_satan",


### PR DESCRIPTION
Sending accept or reject of Likes on a popular post to all followers is likely to be pretty expensive and cause lots of network requests (similar to what happens now for a popular poll). This change makes it so we only cc Accept or Reject for boosts and replies.