### PR TITLE
[chore] Update goreleaser, add release notes template

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -94,7 +94,7 @@ steps:
           - pull_request
 
   - name: snapshot
-    image: superseriousbusiness/gotosocial-drone-build:0.6.1 # https://github.com/superseriousbusiness/gotosocial-drone-build
+    image: superseriousbusiness/gotosocial-drone-build:0.6.2 # https://github.com/superseriousbusiness/gotosocial-drone-build
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -141,7 +141,7 @@ steps:
           - main
 
   - name: release
-    image: superseriousbusiness/gotosocial-drone-build:0.6.1 # https://github.com/superseriousbusiness/gotosocial-drone-build
+    image: superseriousbusiness/gotosocial-drone-build:0.6.2 # https://github.com/superseriousbusiness/gotosocial-drone-build
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -200,7 +200,7 @@ clone:
 
 steps:
   - name: mirror
-    image: superseriousbusiness/gotosocial-drone-build:0.6.1
+    image: superseriousbusiness/gotosocial-drone-build:0.6.2
     environment:
       ORIGIN_REPO: https://github.com/superseriousbusiness/gotosocial
       TARGET_REPO: https://codeberg.org/superseriousbusiness/gotosocial
@@ -213,6 +213,6 @@ steps:
 
 ---
 kind: signature
-hmac: 475acfffed0cc2d45304f253cc8e57c6c19b8437571ec7e343a2ef85a7a270b8
+hmac: e4eddd7db143f4c7d5ab4248114da363e23d086b7438dd057375e0b5d2060f1e
 
 ...

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,9 @@
 # https://goreleaser.com
 project_name: gotosocial
+version: 2
+
+# https://goreleaser.com/customization/hooks/
 before:
-  # https://goreleaser.com/customization/hooks/
   hooks:
   # generate the swagger.yaml file using go-swagger and bundle it into the assets directory
   - swagger generate spec --scan-models --exclude-deps -o web/assets/swagger.yaml
@@ -10,8 +12,9 @@ before:
   - yarn --cwd ./web/source install
   - yarn --cwd ./web/source ts-patch install # https://typia.io/docs/setup/#manual-setup
   - yarn --cwd ./web/source build
+
+# https://goreleaser.com/customization/build/
 builds:
-  # https://goreleaser.com/customization/build/
   # DEFAULT WASM SQLITE BINARY BUILDS
   -
     id: gotosocial
@@ -109,8 +112,9 @@ builds:
       - goos: openbsd
         goarch: 386
     mod_timestamp: "{{ .CommitTimestamp }}"
+
+# https://goreleaser.com/customization/docker/
 dockers:
-  # https://goreleaser.com/customization/docker/
   # DEFAULT WASM SQLITE DOCKER BUILDS
   -
     use: buildx
@@ -301,6 +305,8 @@ dockers:
     - go.sum
     - cmd
     - internal
+
+# https://goreleaser.com/customization/docker_manifest/
 docker_manifests:
   # DEFAULT WASM SQLITE BUILDS
   - name_template: superseriousbusiness/{{ .ProjectName }}:{{ .Version }}
@@ -340,8 +346,9 @@ docker_manifests:
     - superseriousbusiness/{{ .ProjectName }}:snapshot-arm64v8-moderncsqlite
     - superseriousbusiness/{{ .ProjectName }}:snapshot-armv6-moderncsqlite
     - superseriousbusiness/{{ .ProjectName }}:snapshot-armv7-moderncsqlite
+
+# https://goreleaser.com/customization/archive/
 archives:
-  # https://goreleaser.com/customization/archive/
   # DEFAULT WASM SQLITE BUILD
   -
     id: gotosocial
@@ -385,13 +392,116 @@ archives:
     - web/template
     meta: true
     name_template: "{{ .ProjectName }}_{{ .Version }}_web-assets"
+
+# https://goreleaser.com/customization/checksum/
 checksum:
-  # https://goreleaser.com/customization/checksum/
   name_template: 'checksums.txt'
+
+# https://goreleaser.com/customization/snapshots/
 snapshot:
-  # https://goreleaser.com/customization/snapshots/
-  name_template: "{{ incpatch .Version }}-SNAPSHOT"
+  version_template: "{{ incpatch .Version }}-SNAPSHOT"
+
+# https://goreleaser.com/customization/source/
 source:
-  # https://goreleaser.com/customization/source/
   enabled: true
   name_template: "{{ .ProjectName }}-{{ .Version }}-source-code"
+
+# https://goreleaser.com/customization/release/
+release:
+  draft: true
+  header: |
+    Here's version {{ .Version }} of GoToSocial.
+
+    Please read the [migration notes](#migration-notes) carefully for instructions on how to upgrade to this version.
+    
+    ## Release highlights
+
+    - Pee pee
+    - Poo poo
+    - Wee wee
+    
+    ## Migration notes
+    
+    ### Upgrading
+    
+    To upgrade to {{ .Tag }} from a previous release:
+    
+    #### Binary/tar
+    
+    1. Stop GoToSocial.
+    2. **Back up your database!** If you're running on SQLite, this is as simple as copying your `sqlite.db` file, eg., `cp sqlite.db sqlite.db.backup`.
+    3. Download and untar the new release, including the web assets and html templates.
+    4. Edit your config.yaml file if necessary (see below).
+    5. Start GoToSocial.
+    6. Wait patiently for any migrations to run, **do not interrupt migrations or you could leave your db in a broken state and will have to restore from backup**!
+    7. Enjoy your updated instance.
+
+    #### Docker
+    
+    1. Stop GoToSocial.
+    2. **Back up your database!** If you're running on SQLite, this is as simple as copying your `sqlite.db` file, eg., `cp sqlite.db sqlite.db.backup`.
+    3. Pull the new docker container (`superseriousbusiness/gotosocial:{{ .Version }}` or `superseriousbusiness/gotosocial:latest`)
+    4. Edit your config.yaml file or environment variables if necessary (see below).
+    5. Start GoToSocial.
+    6. Wait patiently for any migrations to run, **do not interrupt migrations or you could leave your db in a broken state and will have to restore from backup**!
+    7. Enjoy your updated instance.
+    
+    ### config.yaml
+    
+    The configuration file has changed since the previous release.
+    
+    - Changed `pee pee` to `poo poo`.
+    - Changed `wee wee` to `more wee wee`.
+
+    You can see a diff of the config file here: https://github.com/superseriousbusiness/gotosocial/compare/{{ .PreviousTag }}...{{ .Tag }}#diff-c071e03510b2c57e193a44503fd9528a785f0f411497cc75841a9f8d0b1ac622
+    
+    ### Database Migrations
+    
+    ⚠️⚠️⚠️
+    
+    This release may contain database migrations which will run the first time you start up this new version.
+    
+    Be sure not to interrupt this migration process.
+    
+    This will take anywhere between a couple seconds and ten minutes or more (on slower hardware).
+    
+    **Please be patient!**
+
+    ⚠️⚠️⚠️
+    
+    ### Which release archive/container should I use?
+    
+    Tl;dr: Regardless of whether you're using SQLite or Postgres as your DB driver, you most likely you want the regular version without `moderncsqlite` in the name.
+    
+    However, if you're on FreeBSD or OpenBSD, use the `moderncsqlite` version instead. See the table below:
+    
+    | OS      | Architecture            | Binary archive                                                                                                                                                                     | Docker                                                         |
+    | ------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+    | Linux   | x86-64/AMD64 (64-bit)   | [linux_amd64.tar.gz](https://github.com/superseriousbusiness/gotosocial/releases/download/{{ .Tag }}/gotosocial_{{ .Version }}_linux_amd64.tar.gz)                                 | `superseriousbusiness/gotosocial:{{ .Version }}`               |
+    | Linux   | x86-32/i386 (32-bit)    | [linux_386.tar.gz](https://github.com/superseriousbusiness/gotosocial/releases/download/{{ .Tag }}/gotosocial_{{ .Version }}_linux_386.tar.gz)                                     | `superseriousbusiness/gotosocial:{{ .Version }}`               |
+    | Linux   | Armv8/ARM64 (64-bit)    | [linux_arm64.tar.gz](https://github.com/superseriousbusiness/gotosocial/releases/download/{{ .Tag }}/gotosocial_{{ .Version }}_linux_arm64.tar.gz)                                 | `superseriousbusiness/gotosocial:{{ .Version }}`               |
+    | Linux   | Armv7/ARM32 (32-bit)    | [linux_armv7.tar.gz](https://github.com/superseriousbusiness/gotosocial/releases/download/{{ .Tag }}/gotosocial_{{ .Version }}_linux_armv7.tar.gz)                                 | `superseriousbusiness/gotosocial:{{ .Version }}`               |
+    | Linux   | Armv6/ARM32 (32-bit)    | [linux_armv6.tar.gz](https://github.com/superseriousbusiness/gotosocial/releases/download/{{ .Tag }}/gotosocial_{{ .Version }}_linux_armv6.tar.gz)                                 | `superseriousbusiness/gotosocial:{{ .Version }}`               |
+    | OpenBSD | x86-64/AMD64 (64-bit)   | [openbsd_amd64_moderncsqlite.tar.gz](https://github.com/superseriousbusiness/gotosocial/releases/download/{{ .Tag }}/gotosocial_{{ .Version }}_openbsd_amd64_moderncsqlite.tar.gz) | `superseriousbusiness/gotosocial:{{ .Version }}-moderncsqlite` |
+    | FreeBSD | x86-64/AMD64 (64-bit)   | [freebsd_amd64_moderncsqlite.tar.gz](https://github.com/superseriousbusiness/gotosocial/releases/download/{{ .Tag }}/gotosocial_{{ .Version }}_freebsd_amd64_moderncsqlite.tar.gz) | `superseriousbusiness/gotosocial:{{ .Version }}-moderncsqlite` |
+
+# https://goreleaser.com/customization/changelog/
+changelog:
+  use: github
+  abbrev: 9
+  format: "{{ .Message }}, by {{ with .AuthorUsername }}@{{ . }}{{ else }}{{ .AuthorName }} <{{ .AuthorEmail }}>{{ end }} ({{ .SHA }})"
+  groups:
+    - title: Features and performance
+      regexp: '^\[(?:feature|performance).*\].*$'
+      order: 0
+    - title: Bug fixes
+      regexp: '^\[bug.*\].*$'
+      order: 1
+    - title: Chores & version bumps
+      regexp: '^\[chore.*\].*$'
+      order: 2
+    - title: Documentation
+      regexp: '^\[doc.*\].*$'
+      order: 3
+    - title: Other
+      order: 999


### PR DESCRIPTION
# Description

Updates goreleaser to v2.3.2 in gotosocial-drone-build v0.6.2, and adds a release notes template and changelog categories to make my life a little bit easier!
