### PR TITLE
[chore] Ensure current tag not set as `GORELEASER_PREVIOUS_TAG`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -157,15 +157,16 @@ steps:
       - git fetch --tags
       - /go/dockerlogin.sh
       
-      # When releasing, compare commits to the most recent tag
-      # that is not the current one AND is not a release candidate
-      # version (ie., no "rc" in the tag name).
+      # When releasing, compare commits to the most recent tag that is not the
+      # current one AND is not a release candidate tag (ie., no "rc" in the name).
       #
-      # Note, this may cause annoyances when doing backport releases
-      # (ie., releasing v0.10.1 when we've already released v0.15.0
-      # or whatever), but they should only be superficial annoyances.
-      - export GORELEASER_PREVIOUS_TAG=$(git tag -l | grep -v "rc\|${DRONE_TAG}" | sort -V -r | head -n 1)
-      - goreleaser release --clean
+      # The DRONE_TAG env var should point to the tag that triggered this build.
+      # See: https://docs.drone.io/pipeline/environment/reference/drone-tag/ 
+      #
+      # Note, this may cause annoyances when doing backport releases, for example,
+      # releasing v0.10.1 when we've already released v0.15.0 or whatever, but
+      # they should only be superficial annoyances related to the release notes.
+      - GORELEASER_PREVIOUS_TAG=$(git tag -l | grep -v "rc\|${DRONE_TAG}" | sort -V -r | head -n 1) goreleaser release --clean
     when:
       event:
         include:
@@ -222,6 +223,6 @@ steps:
 
 ---
 kind: signature
-hmac: 883be019998713a2e52465918f62a3289459b425f3aa7dffada505ffdccc4cba
+hmac: 1b89e3a538fbca72eb9a0b398cd82f09a774ba3649013e19d36012eda327e83f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -113,7 +113,7 @@ steps:
     commands:
       # Create a snapshot build with GoReleaser.
       - git fetch --tags
-      - GORELEASER_PREVIOUS_TAG=$(git tag -l | grep -v rc | sort -V -r | head -n 1) goreleaser release --clean --snapshot
+      - goreleaser release --clean --snapshot
       
       # Login to Docker, push Docker image snapshots + manifests.
       - /go/dockerlogin.sh
@@ -156,7 +156,16 @@ steps:
     commands:
       - git fetch --tags
       - /go/dockerlogin.sh
-      - GORELEASER_PREVIOUS_TAG=$(git tag -l | grep -v rc | sort -V -r | head -n 1) goreleaser release --clean
+      
+      # When releasing, compare commits to the most recent tag
+      # that is not the current one AND is not a release candidate
+      # version (ie., no "rc" in the tag name).
+      #
+      # Note, this may cause annoyances when doing backport releases
+      # (ie., releasing v0.10.1 when we've already released v0.15.0
+      # or whatever), but they should only be superficial annoyances.
+      - export GORELEASER_PREVIOUS_TAG=$(git tag -l | grep -v "rc\|${DRONE_TAG}" | sort -V -r | head -n 1)
+      - goreleaser release --clean
     when:
       event:
         include:
@@ -213,6 +222,6 @@ steps:
 
 ---
 kind: signature
-hmac: 3f2066e1e1f7f05b7cdb51327d6c9aea5d06a3dbceb518421110d9c1c3b325f8
+hmac: 883be019998713a2e52465918f62a3289459b425f3aa7dffada505ffdccc4cba
 
 ...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,7 +195,7 @@ Then install Node and Yarn as described in [Stylesheet / Web dev](#stylesheet--w
 Finally, to create a snapshot build, do:
 
 ```bash
-GORELEASER_PREVIOUS_TAG=$(git tag -l | grep -v rc | sort -V -r | head -n 1) goreleaser --clean --snapshot
+goreleaser release --clean --snapshot
 ```
 
 If all goes according to plan, you should now have a number of multiple-architecture binaries and tars inside the `./dist` folder, and snapshot Docker images should be built (check your terminal output for version).


### PR DESCRIPTION
Just updates the goreleaser previous tag thingy to not bother with it during snapshots, as it's not important there, and also to exclude whatever current tag triggered the release, as we don't want to compare a tag to itself :facepalm: 