### PR TITLE
[feature/OFFICIALLY UNSUPPORTED] add nowasm build tag to disable building with WebAssembly

### DIFF
--- a/internal/db/sqlite/driver.go
+++ b/internal/db/sqlite/driver.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !moderncsqlite3
+//go:build !moderncsqlite3 && !nowasm
 
 package sqlite
 

--- a/internal/db/sqlite/driver_moderncsqlite3.go
+++ b/internal/db/sqlite/driver_moderncsqlite3.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build moderncsqlite3
+//go:build moderncsqlite3 || nowasm
 
 package sqlite
 

--- a/internal/db/sqlite/errors.go
+++ b/internal/db/sqlite/errors.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !moderncsqlite3
+//go:build !moderncsqlite3 && !nowasm
 
 package sqlite
 

--- a/internal/db/sqlite/errors_moderncsqlite3.go
+++ b/internal/db/sqlite/errors_moderncsqlite3.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build moderncsqlite3
+//go:build moderncsqlite3 || nowasm
 
 package sqlite
 

--- a/internal/media/ffmpeg/args.go
+++ b/internal/media/ffmpeg/args.go
@@ -15,32 +15,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !nowasm
-
 package ffmpeg
 
 import (
-	"context"
-
 	"codeberg.org/gruf/go-ffmpreg/wasm"
 )
 
-// ffmpegRunner limits the number of
-// ffmpeg WebAssembly instances that
-// may be concurrently running, in
-// order to reduce memory usage.
-var ffmpegRunner runner
-
-// InitFfmpeg precompiles the ffmpeg WebAssembly source into memory and
-// prepares the runner to only allow max given concurrent running instances.
-func InitFfmpeg(ctx context.Context, max int) error {
-	ffmpegRunner.Init(max)
-	return compileFfmpeg(ctx)
-}
-
-// Ffmpeg runs the given arguments with an instance of ffmpeg.
-func Ffmpeg(ctx context.Context, args Args) (uint32, error) {
-	return ffmpegRunner.Run(ctx, func() (uint32, error) {
-		return wasm.Run(ctx, runtime, ffmpeg, args)
-	})
-}
+// Args encapsulates the passing of common
+// configuration options to run an instance
+// of a compiled WebAssembly module that is
+// run in a typical CLI manner.
+type Args = wasm.Args

--- a/internal/media/ffmpeg/exec_nowasm.go
+++ b/internal/media/ffmpeg/exec_nowasm.go
@@ -33,7 +33,8 @@ import (
 
 func init() {
 	fmt.Println("!! you are using an unsupported build configuration of gotosocial with WebAssembly disabled !!")
-	fmt.Println("!! please do not file bug reports, this build configuration is provided as a nice-to-have !!")
+	fmt.Println("!! please do not file bug reports regarding media processing with this configuration !!")
+	fmt.Println("!! it is also less secure; this does not enforce version checks on ffmpeg / ffprobe versions !!")
 }
 
 // runCmd will run 'name' with the given arguments, returning exit code or error.

--- a/internal/media/ffmpeg/exec_nowasm.go
+++ b/internal/media/ffmpeg/exec_nowasm.go
@@ -1,0 +1,141 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build nowasm
+
+package ffmpeg
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os/exec"
+
+	"codeberg.org/gruf/go-ffmpreg/wasm"
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/sys"
+)
+
+func init() {
+	fmt.Println("!! you are using an unsupported build configuration of gotosocial with WebAssembly disabled !!")
+	fmt.Println("!! please do not file bug reports, this build configuration is provided as a nice-to-have !!")
+}
+
+// runCmd will run 'name' with the given arguments, returning exit code or error.
+func runCmd(ctx context.Context, name string, args wasm.Args) (uint32, error) {
+	cmd := exec.CommandContext(ctx, name, args.Args...) //nolint:gosec
+
+	// Set provided std files.
+	cmd.Stdin = args.Stdin
+	cmd.Stdout = args.Stdout
+	cmd.Stderr = args.Stderr
+
+	if args.Config != nil {
+		// Gather some information
+		// from module config func.
+		var cfg falseModuleConfig
+		_ = args.Config(&cfg)
+
+		// Extract from conf.
+		cmd.Env = cfg.env
+	}
+
+	// Run prepared command, catching err type.
+	switch err := cmd.Run(); err := err.(type) {
+
+	// Extract code from
+	// any exit error type.
+	case *exec.ExitError:
+		rc := err.ExitCode()
+		return uint32(rc), err
+
+	default:
+		return 0, err
+	}
+}
+
+type falseModuleConfig struct{ env []string }
+
+func (cfg *falseModuleConfig) WithArgs(...string) wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithEnv(key string, value string) wazero.ModuleConfig {
+	cfg.env = append(cfg.env, key+"="+value)
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithFS(fs.FS) wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithFSConfig(wazero.FSConfig) wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithName(string) wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithStartFunctions(...string) wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithStderr(io.Writer) wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithStdin(io.Reader) wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithStdout(io.Writer) wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithWalltime(sys.Walltime, sys.ClockResolution) wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithSysWalltime() wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithNanotime(sys.Nanotime, sys.ClockResolution) wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithSysNanotime() wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithNanosleep(sys.Nanosleep) wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithOsyield(sys.Osyield) wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithSysNanosleep() wazero.ModuleConfig {
+	return cfg // noop
+}
+
+func (cfg *falseModuleConfig) WithRandSource(io.Reader) wazero.ModuleConfig {
+	return cfg // noop
+}

--- a/internal/media/ffmpeg/ffprobe.go
+++ b/internal/media/ffmpeg/ffprobe.go
@@ -15,10 +15,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+//go:build !nowasm
+
 package ffmpeg
 
 import (
 	"context"
+
+	"codeberg.org/gruf/go-ffmpreg/wasm"
 )
 
 // ffprobeRunner limits the number of
@@ -36,5 +40,7 @@ func InitFfprobe(ctx context.Context, max int) error {
 
 // Ffprobe runs the given arguments with an instance of ffprobe.
 func Ffprobe(ctx context.Context, args Args) (uint32, error) {
-	return ffprobeRunner.Run(ctx, ffprobe, args)
+	return ffmpegRunner.Run(ctx, func() (uint32, error) {
+		return wasm.Run(ctx, runtime, ffprobe, args)
+	})
 }

--- a/internal/media/ffmpeg/runner.go
+++ b/internal/media/ffmpeg/runner.go
@@ -19,9 +19,6 @@ package ffmpeg
 
 import (
 	"context"
-
-	"codeberg.org/gruf/go-ffmpreg/wasm"
-	"github.com/tetratelabs/wazero"
 )
 
 // runner simply abstracts away the complexities
@@ -53,7 +50,7 @@ func (r *runner) Init(n int) {
 
 // Run will attempt to pass the given compiled WebAssembly module with args to run(), waiting on
 // the receiving runner until a free slot is available to run an instance, (if a limit is enabled).
-func (r *runner) Run(ctx context.Context, cmod wazero.CompiledModule, args Args) (uint32, error) {
+func (r *runner) Run(ctx context.Context, run func() (uint32, error)) (uint32, error) {
 	select {
 	// Context canceled.
 	case <-ctx.Done():
@@ -66,6 +63,6 @@ func (r *runner) Run(ctx context.Context, cmod wazero.CompiledModule, args Args)
 	// Release slot back to pool on end.
 	defer func() { r.pool <- struct{}{} }()
 
-	// Pass to main module runner function.
-	return wasm.Run(ctx, runtime, cmod, args)
+	// Call run.
+	return run()
 }

--- a/internal/media/ffmpeg/wasm.go
+++ b/internal/media/ffmpeg/wasm.go
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+//go:build !nowasm
+
 package ffmpeg
 
 import (

--- a/internal/media/ffmpeg/wasm.go
+++ b/internal/media/ffmpeg/wasm.go
@@ -43,12 +43,6 @@ var (
 	ffprobe wazero.CompiledModule
 )
 
-// Args encapsulates the passing of common
-// configuration options to run an instance
-// of a compiled WebAssembly module that is
-// run in a typical CLI manner.
-type Args = wasm.Args
-
 // compileFfmpeg ensures the ffmpeg WebAssembly has been
 // pre-compiled into memory. If already compiled is a no-op.
 func compileFfmpeg(ctx context.Context) error {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,14 +15,16 @@ GO_GCFLAGS=${GO_GCFLAGS-}
     GO_BUILDTAGS="${GO_BUILDTAGS} debugenv"
 
 # Available Go build tags, with explanation, followed by benefits of enabling it:
-# - kvformat:       enables prettier output of log fields                       (slightly better performance)
-# - timetzdata:     embed timezone database inside binary                       (allow setting local time inside Docker containers, at cost of 450KB)
-# - notracing:      disables compiling-in otel tracing support                  (reduced binary size, better performance)
-# - nometrics:      disables compiling-in otel metrics support                  (reduced binary size, better performance)
-# - noerrcaller:    disables caller function prefix in errors                   (slightly better performance, at cost of err readability)
-# - debug:          enables /debug/pprof endpoint                               (adds debug, at performance cost)
-# - debugenv:       enables /debug/pprof endpoint if DEBUG=1 env during runtime (adds debug, at performance cost)
-# - moderncsqlite3: reverts to using the C-to-Go transpiled SQLite driver       (disables the WASM-based SQLite driver)
+# - kvformat:       enables prettier output of log fields                          (slightly better performance)
+# - timetzdata:     embed timezone database inside binary                          (allow setting local time inside Docker containers, at cost of 450KB)
+# - notracing:      disables compiling-in otel tracing support                     (reduced binary size, better performance)
+# - nometrics:      disables compiling-in otel metrics support                     (reduced binary size, better performance)
+# - noerrcaller:    disables caller function prefix in errors                      (slightly better performance, at cost of err readability)
+# - debug:          enables /debug/pprof endpoint                                  (adds debug, at performance cost)
+# - debugenv:       enables /debug/pprof endpoint if DEBUG=1 env during runtime    (adds debug, at performance cost)
+# - moderncsqlite3: reverts to using the C-to-Go transpiled SQLite driver          (disables the WASM-based SQLite driver)
+# - nowasm:         [UNSUPPORTED] removes all WebAssembly from builds including 
+#                   ffmpeg, ffprobe and SQLite (instead falling back to modernc).
 log_exec env CGO_ENABLED=0 go build -trimpath -v \
                        -tags "${GO_BUILDTAGS}" \
                        -ldflags="${GO_LDFLAGS}" \


### PR DESCRIPTION
This adds a `nowasm` build tag that allows building GoToSocial without any WebAssembly modules. This will instead rely on modernc.org/sqlite and locally installed versions of ffmpeg / ffprobe. It prints a warning on server start telling the user not to make any bug reports for media processing issues, and specifically warns them that it may be less secure is it enforces no version checks.

THIS IS AN OFFICIALLY UNSUPPORTED BUILD CONFIGURATION.

This probably needs updating with some improved documentation for this, not specifically to tell people about it, but to emphasise specifically how it is unsupported and we are not interested in bug reports produced by the products of these build changes, since we have no idea what their version of ffmpeg / ffprobe could be compiled with support for etc.