### PR TITLE
[chore] updates exported interface types to match ncruces/go-sqlite3/driver types

### DIFF
--- a/internal/db/sqlite/driver.go
+++ b/internal/db/sqlite/driver.go
@@ -198,6 +198,7 @@ type stmtIface interface {
 	driver.Stmt
 	driver.StmtExecContext
 	driver.StmtQueryContext
+	driver.NamedValueChecker
 }
 
 // RowsIface is the driver.Rows interface
@@ -207,4 +208,5 @@ type stmtIface interface {
 type rowsIface interface {
 	driver.Rows
 	driver.RowsColumnTypeDatabaseTypeName
+	driver.RowsColumnTypeNullable
 }


### PR DESCRIPTION
this ensures `sql/db` has full access to all the methods available, (which in some cases, maybe not this one, can help improve performance)