### PR TITLE
[docs/bugfix] Fix access to /dev and /tmp in AppArmor profile

### DIFF
--- a/example/apparmor/gotosocial
+++ b/example/apparmor/gotosocial
@@ -24,12 +24,12 @@ profile gotosocial flags=(attach_disconnected, mediate_deleted) {
 
   # Embedded ffmpeg needs read
   # permission on /dev/urandom.
-  owner /dev/ r,
-  owner /dev/urandom r,
+  /dev/ r,
+  /dev/urandom r,
 
   # Temp dir access is needed for storing
   # files briefly during media processing.
-  owner /tmp/ r,
+  /tmp/ r,
   owner /tmp/* rwk,
 
   # If running with GTS_WAZERO_COMPILATION_CACHE set,
@@ -39,7 +39,7 @@ profile gotosocial flags=(attach_disconnected, mediate_deleted) {
 
   # If you've enabled logging to syslog, allow GoToSocial
   # to write logs by uncommenting the following line:
-  # owner /var/log/syslog w,
+  # /var/log/syslog w,
 
   # These directories are not currently used by any of
   # the recommended GoToSocial installation methods, but
@@ -65,6 +65,7 @@ profile gotosocial flags=(attach_disconnected, mediate_deleted) {
   /etc/services r,
   /proc/sys/net/core/somaxconn r,
   /sys/fs/cgroup/system.slice/gotosocial.service/{,*} r,
+  /sys/kernel/mm/hugepages/ r,
   /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
   owner /proc/*/cgroup r,
   owner /proc/*/cpuset r,


### PR DESCRIPTION
# Description

Drop the `owner` keyword from paths that we need to access but that are not owned by the gotosocial user.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
