### PR TITLE
[bugfix] support classifying correct video codec without audio as webm

### DIFF
--- a/internal/media/ffmpeg.go
+++ b/internal/media/ffmpeg.go
@@ -392,18 +392,31 @@ func (res *result) GetFileType() (gtsmodel.FileType, string) {
 	case "matroska,webm":
 		switch {
 		case len(res.video) > 0:
+			var isWebm bool
+
 			switch res.video[0].codec {
 			case "vp8", "vp9", "av1":
-			default:
-				return gtsmodel.FileTypeVideo, "mkv"
-			}
-			if len(res.audio) > 0 {
-				switch res.audio[0].codec {
-				case "vorbis", "opus", "libopus":
-					// webm only supports [VP8/VP9/AV1]+[vorbis/opus]
-					return gtsmodel.FileTypeVideo, "webm"
+				if len(res.audio) > 0 {
+					switch res.audio[0].codec {
+					case "vorbis", "opus", "libopus":
+						// webm only supports [VP8/VP9/AV1] +
+						//                    [vorbis/opus]
+						isWebm = true
+					}
+				} else {
+					// no audio with correct
+					// video codec also fine.
+					isWebm = true
 				}
 			}
+
+			if isWebm {
+				// Check for valid webm codec config.
+				return gtsmodel.FileTypeVideo, "webm"
+			}
+
+			// All else falls under generic mkv.
+			return gtsmodel.FileTypeVideo, "mkv"
 		case len(res.audio) > 0:
 			return gtsmodel.FileTypeAudio, "mka"
 		}

--- a/internal/media/processingemoji.go
+++ b/internal/media/processingemoji.go
@@ -158,7 +158,7 @@ func (p *ProcessingEmoji) store(ctx context.Context) error {
 	if err != nil && !isUnsupportedTypeErr(err) {
 		return gtserror.Newf("ffprobe error: %w", err)
 	} else if result == nil {
-		log.Warn(ctx, "unsupported data type")
+		log.Warnf(ctx, "unsupported data type by ffprobe: %v", err)
 		return nil
 	}
 

--- a/internal/media/processingmedia.go
+++ b/internal/media/processingmedia.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	errorsv2 "codeberg.org/gruf/go-errors/v2"
+	"codeberg.org/gruf/go-kv"
 	"codeberg.org/gruf/go-runners"
 
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
@@ -166,7 +167,7 @@ func (p *ProcessingMedia) store(ctx context.Context) error {
 	if err != nil && !isUnsupportedTypeErr(err) {
 		return gtserror.Newf("ffprobe error: %w", err)
 	} else if result == nil {
-		log.Warn(ctx, "unsupported data type")
+		log.Warnf(ctx, "unsupported data type by ffprobe: %v", err)
 		return nil
 	}
 
@@ -214,7 +215,10 @@ func (p *ProcessingMedia) store(ctx context.Context) error {
 		// metadata, in order to keep tags.
 
 	default:
-		log.Warn(ctx, "unsupported data type: %s", result.format)
+		log.WarnKVs(ctx, kv.Fields{
+			{K: "format", V: result.format},
+			{K: "msg", V: "unsupported data type"},
+		}...)
 		return nil
 	}
 


### PR DESCRIPTION
# Description

Fixes an issue where a webm filetype (with correct video codec) without any audio codec might get mistakenly classified as an mkv. Also adds much improved logging in the case of unsupported data types.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
