### PR TITLE
[feature] add support for hinting via api/v_/instance preferred image / video max sizes

### DIFF
--- a/docs/configuration/media.md
+++ b/docs/configuration/media.md
@@ -18,6 +18,24 @@
 # Default: 40MiB (41943040 bytes)
 media-local-max-size: 40MiB
 
+# Size. Size in bytes of max image size referred to on /api/v_/instance endpoints,
+# used by applications like Tusky to automatically scale locally uploaded media.
+#
+# Leaving this unset will default to media-local-max-size.
+#
+# Examples: [64, 500, 5MiB, 5MB, 50M]
+# Default: unset
+media-image-size-hint: 5MiB
+
+# Size. Size in bytes of max video size referred to on /api/v_/instance endpoints,
+# used by applications like Tusky to automatically scale locally uploaded media.
+#
+# Leaving this unset will default to media-local-max-size.
+#
+# Examples: [64, 4096, 4MiB, 4MB, 40M]
+# Default: unset
+media-video-size-hint: 40MiB
+
 # Size. Max size in bytes of media to download from other instances.
 #
 # Lowering this limit may cause your instance not to fetch post media.

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -471,6 +471,24 @@ accounts-custom-css-length: 10000
 # Default: 40MiB (41943040 bytes)
 media-local-max-size: 40MiB
 
+# Size. Size in bytes of max image size referred to on /api/v_/instance endpoints,
+# used by applications like Tusky to automatically scale locally uploaded media.
+#
+# Leaving this unset will default to media-local-max-size.
+#
+# Examples: [64, 500, 5MiB, 5MB, 50M]
+# Default: unset
+media-image-size-hint: 5MiB
+
+# Size. Size in bytes of max video size referred to on /api/v_/instance endpoints,
+# used by applications like Tusky to automatically scale locally uploaded media.
+#
+# Leaving this unset will default to media-local-max-size.
+#
+# Examples: [64, 4096, 4MiB, 4MB, 40M]
+# Default: unset
+media-video-size-hint: 40MiB
+
 # Size. Max size in bytes of media to download from other instances.
 #
 # Lowering this limit may cause your instance not to fetch post media.

--- a/internal/api/client/instance/instancepatch_test.go
+++ b/internal/api/client/instance/instancepatch_test.go
@@ -130,10 +130,10 @@ func (suite *InstancePatchTestSuite) TestInstancePatch1() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 16777216,
+      "image_matrix_limit": 9223372036854775807,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 60,
-      "video_matrix_limit": 16777216
+      "video_frame_rate_limit": 9223372036854775807,
+      "video_matrix_limit": 9223372036854775807
     },
     "polls": {
       "max_options": 6,
@@ -271,10 +271,10 @@ func (suite *InstancePatchTestSuite) TestInstancePatch2() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 16777216,
+      "image_matrix_limit": 9223372036854775807,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 60,
-      "video_matrix_limit": 16777216
+      "video_frame_rate_limit": 9223372036854775807,
+      "video_matrix_limit": 9223372036854775807
     },
     "polls": {
       "max_options": 6,
@@ -412,10 +412,10 @@ func (suite *InstancePatchTestSuite) TestInstancePatch3() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 16777216,
+      "image_matrix_limit": 9223372036854775807,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 60,
-      "video_matrix_limit": 16777216
+      "video_frame_rate_limit": 9223372036854775807,
+      "video_matrix_limit": 9223372036854775807
     },
     "polls": {
       "max_options": 6,
@@ -604,10 +604,10 @@ func (suite *InstancePatchTestSuite) TestInstancePatch6() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 16777216,
+      "image_matrix_limit": 9223372036854775807,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 60,
-      "video_matrix_limit": 16777216
+      "video_frame_rate_limit": 9223372036854775807,
+      "video_matrix_limit": 9223372036854775807
     },
     "polls": {
       "max_options": 6,
@@ -767,10 +767,10 @@ func (suite *InstancePatchTestSuite) TestInstancePatch8() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 16777216,
+      "image_matrix_limit": 9223372036854775807,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 60,
-      "video_matrix_limit": 16777216
+      "video_frame_rate_limit": 9223372036854775807,
+      "video_matrix_limit": 9223372036854775807
     },
     "polls": {
       "max_options": 6,
@@ -949,10 +949,10 @@ func (suite *InstancePatchTestSuite) TestInstancePatch9() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 16777216,
+      "image_matrix_limit": 9223372036854775807,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 60,
-      "video_matrix_limit": 16777216
+      "video_frame_rate_limit": 9223372036854775807,
+      "video_matrix_limit": 9223372036854775807
     },
     "polls": {
       "max_options": 6,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,8 @@ type Configuration struct {
 	MediaRemoteCacheDays     int           `name:"media-remote-cache-days" usage:"Number of days to locally cache media from remote instances. If set to 0, remote media will be kept indefinitely."`
 	MediaEmojiLocalMaxSize   bytesize.Size `name:"media-emoji-local-max-size" usage:"Max size in bytes of emojis uploaded to this instance via the admin API."`
 	MediaEmojiRemoteMaxSize  bytesize.Size `name:"media-emoji-remote-max-size" usage:"Max size in bytes of emojis to download from other instances."`
+	MediaImageSizeHint       bytesize.Size `name:"media-image-size-hint" usage:"Size in bytes of max image size referred to on /api/v_/instance endpoints (else, local max size)"`
+	MediaVideoSizeHint       bytesize.Size `name:"media-video-size-hint" usage:"Size in bytes of max video size referred to on /api/v_/instance endpoints (else, local max size)"`
 	MediaLocalMaxSize        bytesize.Size `name:"media-local-max-size" usage:"Max size in bytes of media uploaded to this instance via API"`
 	MediaRemoteMaxSize       bytesize.Size `name:"media-remote-max-size" usage:"Max size in bytes of media to download from other instances"`
 	MediaCleanupFrom         string        `name:"media-cleanup-from" usage:"Time of day from which to start running media cleanup/prune jobs. Should be in the format 'hh:mm:ss', eg., '15:04:05'."`

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -1225,6 +1225,56 @@ func GetMediaEmojiRemoteMaxSize() bytesize.Size { return global.GetMediaEmojiRem
 // SetMediaEmojiRemoteMaxSize safely sets the value for global configuration 'MediaEmojiRemoteMaxSize' field
 func SetMediaEmojiRemoteMaxSize(v bytesize.Size) { global.SetMediaEmojiRemoteMaxSize(v) }
 
+// GetMediaImageSizeHint safely fetches the Configuration value for state's 'MediaImageSizeHint' field
+func (st *ConfigState) GetMediaImageSizeHint() (v bytesize.Size) {
+	st.mutex.RLock()
+	v = st.config.MediaImageSizeHint
+	st.mutex.RUnlock()
+	return
+}
+
+// SetMediaImageSizeHint safely sets the Configuration value for state's 'MediaImageSizeHint' field
+func (st *ConfigState) SetMediaImageSizeHint(v bytesize.Size) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.MediaImageSizeHint = v
+	st.reloadToViper()
+}
+
+// MediaImageSizeHintFlag returns the flag name for the 'MediaImageSizeHint' field
+func MediaImageSizeHintFlag() string { return "media-image-size-hint" }
+
+// GetMediaImageSizeHint safely fetches the value for global configuration 'MediaImageSizeHint' field
+func GetMediaImageSizeHint() bytesize.Size { return global.GetMediaImageSizeHint() }
+
+// SetMediaImageSizeHint safely sets the value for global configuration 'MediaImageSizeHint' field
+func SetMediaImageSizeHint(v bytesize.Size) { global.SetMediaImageSizeHint(v) }
+
+// GetMediaVideoSizeHint safely fetches the Configuration value for state's 'MediaVideoSizeHint' field
+func (st *ConfigState) GetMediaVideoSizeHint() (v bytesize.Size) {
+	st.mutex.RLock()
+	v = st.config.MediaVideoSizeHint
+	st.mutex.RUnlock()
+	return
+}
+
+// SetMediaVideoSizeHint safely sets the Configuration value for state's 'MediaVideoSizeHint' field
+func (st *ConfigState) SetMediaVideoSizeHint(v bytesize.Size) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.MediaVideoSizeHint = v
+	st.reloadToViper()
+}
+
+// MediaVideoSizeHintFlag returns the flag name for the 'MediaVideoSizeHint' field
+func MediaVideoSizeHintFlag() string { return "media-video-size-hint" }
+
+// GetMediaVideoSizeHint safely fetches the value for global configuration 'MediaVideoSizeHint' field
+func GetMediaVideoSizeHint() bytesize.Size { return global.GetMediaVideoSizeHint() }
+
+// SetMediaVideoSizeHint safely sets the value for global configuration 'MediaVideoSizeHint' field
+func SetMediaVideoSizeHint(v bytesize.Size) { global.SetMediaVideoSizeHint(v) }
+
 // GetMediaLocalMaxSize safely fetches the Configuration value for state's 'MediaLocalMaxSize' field
 func (st *ConfigState) GetMediaLocalMaxSize() (v bytesize.Size) {
 	st.mutex.RLock()

--- a/internal/typeutils/internaltofrontend_test.go
+++ b/internal/typeutils/internaltofrontend_test.go
@@ -1968,10 +1968,10 @@ func (suite *InternalToFrontendTestSuite) TestInstanceV1ToFrontend() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 16777216,
+      "image_matrix_limit": 9223372036854775807,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 60,
-      "video_matrix_limit": 16777216
+      "video_frame_rate_limit": 9223372036854775807,
+      "video_matrix_limit": 9223372036854775807
     },
     "polls": {
       "max_options": 6,
@@ -2113,10 +2113,10 @@ func (suite *InternalToFrontendTestSuite) TestInstanceV2ToFrontend() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 16777216,
+      "image_matrix_limit": 9223372036854775807,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 60,
-      "video_matrix_limit": 16777216
+      "video_frame_rate_limit": 9223372036854775807,
+      "video_matrix_limit": 9223372036854775807
     },
     "polls": {
       "max_options": 6,

--- a/test/envparsing.sh
+++ b/test/envparsing.sh
@@ -129,9 +129,11 @@ EXPECT=$(cat << "EOF"
     "media-emoji-local-max-size": 420,
     "media-emoji-remote-max-size": 420,
     "media-ffmpeg-pool-size": 8,
+    "media-image-size-hint": 5242880,
     "media-local-max-size": 420,
     "media-remote-cache-days": 30,
     "media-remote-max-size": 420,
+    "media-video-size-hint": 41943040,
     "metrics-auth-enabled": false,
     "metrics-auth-password": "",
     "metrics-auth-username": "",
@@ -244,12 +246,14 @@ GTS_ACCOUNTS_REGISTRATION_OPEN=true \
 GTS_ACCOUNTS_REASON_REQUIRED=false \
 GTS_MEDIA_DESCRIPTION_MIN_CHARS=69 \
 GTS_MEDIA_DESCRIPTION_MAX_CHARS=5000 \
+GTS_MEDIA_IMAGE_SIZE_HINT='5MiB' \
 GTS_MEDIA_LOCAL_MAX_SIZE=420 \
 GTS_MEDIA_REMOTE_MAX_SIZE=420 \
 GTS_MEDIA_REMOTE_CACHE_DAYS=30 \
 GTS_MEDIA_EMOJI_LOCAL_MAX_SIZE=420 \
 GTS_MEDIA_EMOJI_REMOTE_MAX_SIZE=420 \
 GTS_MEDIA_FFMPEG_POOL_SIZE=8 \
+GTS_MEDIA_VIDEO_SIZE_HINT='40MiB' \
 GTS_METRICS_AUTH_ENABLED=false \
 GTS_METRICS_ENABLED=false \
 GTS_STORAGE_BACKEND='local' \


### PR DESCRIPTION
# Description

When left unset, defaults to local max size. The reason i didn't actually add local-image-max-size and local-video-max-size is in doing that it potentially opens us up for requiring local-audio-max-size, and potentially any other file types that we separate on in the future. It makes more sense to have a single local max size, and allow tweaking the frontend hinting that applications like Tusky use for autosizing.

It also updates the unused media limits (framerate, image / video dimensions) to just be the maximum possible int sizes. In case Tusky does try to limit based on those since we can support anything under the local max size.

closes #3449

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
