### PR TITLE
[bugfix] Fix setting immediate `expires_at` value on filter endpoints

### DIFF
--- a/internal/api/client/accounts/mute.go
+++ b/internal/api/client/accounts/mute.go
@@ -149,7 +149,7 @@ func normalizeCreateUpdateMute(form *apimodel.UserMuteCreateUpdateRequest) error
 		form.Duration = duration
 	}
 
-	// Ensure no zero duration is set.
+	// Interpret zero as indefinite duration.
 	if form.Duration != nil && *form.Duration == 0 {
 		form.Duration = nil
 	}

--- a/internal/api/client/accounts/mute.go
+++ b/internal/api/client/accounts/mute.go
@@ -19,9 +19,7 @@ package accounts
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
@@ -140,28 +138,18 @@ func normalizeCreateUpdateMute(form *apimodel.UserMuteCreateUpdateRequest) error
 	// Apply defaults for missing fields.
 	form.Notifications = util.Ptr(util.PtrOrValue(form.Notifications, false))
 
-	// Normalize mute duration if necessary.
-	// If we parsed this as JSON, expires_in
-	// may be either a float64 or a string.
-	if ei := form.DurationI; ei != nil {
-		switch e := ei.(type) {
-		case float64:
-			form.Duration = util.Ptr(int(e))
-
-		case string:
-			duration, err := strconv.Atoi(e)
-			if err != nil {
-				return fmt.Errorf("could not parse duration value %s as integer: %w", e, err)
-			}
-
-			form.Duration = &duration
-
-		default:
-			return fmt.Errorf("could not parse expires_in type %T as integer", ei)
+	// Normalize duration if necessary.
+	if form.DurationI != nil {
+		// If we parsed this as JSON, duration
+		// may be either a float64 or a string.
+		duration, err := apiutil.ParseDuration(form.DurationI, "duration")
+		if err != nil {
+			return err
 		}
+		form.Duration = duration
 	}
 
-	// Interpret zero as indefinite duration.
+	// Ensure no zero duration is set.
 	if form.Duration != nil && *form.Duration == 0 {
 		form.Duration = nil
 	}

--- a/internal/api/client/filters/v1/validate.go
+++ b/internal/api/client/filters/v1/validate.go
@@ -60,7 +60,7 @@ func validateNormalizeCreateUpdateFilter(form *apimodel.FilterCreateUpdateReques
 		}
 	}
 
-	// Ensure no zero duration is set.
+	// Interpret zero as indefinite duration..
 	if form.ExpiresIn != nil && *form.ExpiresIn == 0 {
 		form.ExpiresIn = nil
 	}

--- a/internal/api/client/filters/v1/validate.go
+++ b/internal/api/client/filters/v1/validate.go
@@ -19,15 +19,14 @@ package v1
 
 import (
 	"errors"
-	"fmt"
-	"strconv"
 
-	"github.com/superseriousbusiness/gotosocial/internal/api/model"
+	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
+	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
 	"github.com/superseriousbusiness/gotosocial/internal/util"
 	"github.com/superseriousbusiness/gotosocial/internal/validate"
 )
 
-func validateNormalizeCreateUpdateFilter(form *model.FilterCreateUpdateRequestV1) error {
+func validateNormalizeCreateUpdateFilter(form *apimodel.FilterCreateUpdateRequestV1) error {
 	if err := validate.FilterKeyword(form.Phrase); err != nil {
 		return err
 	}
@@ -48,24 +47,22 @@ func validateNormalizeCreateUpdateFilter(form *model.FilterCreateUpdateRequestV1
 	}
 
 	// Normalize filter expiry if necessary.
-	// If we parsed this as JSON, expires_in
-	// may be either a float64 or a string.
-	if ei := form.ExpiresInI; ei != nil {
-		switch e := ei.(type) {
-		case float64:
-			form.ExpiresIn = util.Ptr(int(e))
-
-		case string:
-			expiresIn, err := strconv.Atoi(e)
-			if err != nil {
-				return fmt.Errorf("could not parse expires_in value %s as integer: %w", e, err)
-			}
-
-			form.ExpiresIn = &expiresIn
-
-		default:
-			return fmt.Errorf("could not parse expires_in type %T as integer", ei)
+	if form.ExpiresInI != nil {
+		// If we parsed this as JSON, expires_in
+		// may be either a float64 or a string.
+		var err error
+		form.ExpiresIn, err = apiutil.ParseDuration(
+			form.ExpiresInI,
+			"expires_in",
+		)
+		if err != nil {
+			return err
 		}
+	}
+
+	// Ensure no zero duration is set.
+	if form.ExpiresIn != nil && *form.ExpiresIn == 0 {
+		form.ExpiresIn = nil
 	}
 
 	return nil

--- a/internal/api/client/filters/v1/validate.go
+++ b/internal/api/client/filters/v1/validate.go
@@ -60,7 +60,7 @@ func validateNormalizeCreateUpdateFilter(form *apimodel.FilterCreateUpdateReques
 		}
 	}
 
-	// Interpret zero as indefinite duration..
+	// Interpret zero as indefinite duration.
 	if form.ExpiresIn != nil && *form.ExpiresIn == 0 {
 		form.ExpiresIn = nil
 	}

--- a/internal/api/client/filters/v2/filterpost.go
+++ b/internal/api/client/filters/v2/filterpost.go
@@ -239,7 +239,7 @@ func validateNormalizeCreateFilter(form *apimodel.FilterCreateRequestV2) error {
 		}
 	}
 
-	// Interpret zero as indefinite duration..
+	// Interpret zero as indefinite duration.
 	if form.ExpiresIn != nil && *form.ExpiresIn == 0 {
 		form.ExpiresIn = nil
 	}

--- a/internal/api/client/filters/v2/filterpost.go
+++ b/internal/api/client/filters/v2/filterpost.go
@@ -239,7 +239,7 @@ func validateNormalizeCreateFilter(form *apimodel.FilterCreateRequestV2) error {
 		}
 	}
 
-	// Ensure no zero duration is set.
+	// Interpret zero as indefinite duration..
 	if form.ExpiresIn != nil && *form.ExpiresIn == 0 {
 		form.ExpiresIn = nil
 	}

--- a/internal/api/client/filters/v2/filterpost.go
+++ b/internal/api/client/filters/v2/filterpost.go
@@ -18,9 +18,7 @@
 package v2
 
 import (
-	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
@@ -228,24 +226,22 @@ func validateNormalizeCreateFilter(form *apimodel.FilterCreateRequestV2) error {
 	form.FilterAction = util.Ptr(action)
 
 	// Normalize filter expiry if necessary.
-	// If we parsed this as JSON, expires_in
-	// may be either a float64 or a string.
-	if ei := form.ExpiresInI; ei != nil {
-		switch e := ei.(type) {
-		case float64:
-			form.ExpiresIn = util.Ptr(int(e))
-
-		case string:
-			expiresIn, err := strconv.Atoi(e)
-			if err != nil {
-				return fmt.Errorf("could not parse expires_in value %s as integer: %w", e, err)
-			}
-
-			form.ExpiresIn = &expiresIn
-
-		default:
-			return fmt.Errorf("could not parse expires_in type %T as integer", ei)
+	if form.ExpiresInI != nil {
+		// If we parsed this as JSON, expires_in
+		// may be either a float64 or a string.
+		var err error
+		form.ExpiresIn, err = apiutil.ParseDuration(
+			form.ExpiresInI,
+			"expires_in",
+		)
+		if err != nil {
+			return err
 		}
+	}
+
+	// Ensure no zero duration is set.
+	if form.ExpiresIn != nil && *form.ExpiresIn == 0 {
+		form.ExpiresIn = nil
 	}
 
 	// Normalize and validate new keywords and statuses.

--- a/internal/api/client/filters/v2/filterput.go
+++ b/internal/api/client/filters/v2/filterput.go
@@ -19,9 +19,7 @@ package v2
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
@@ -272,24 +270,22 @@ func validateNormalizeUpdateFilter(form *apimodel.FilterUpdateRequestV2) error {
 	}
 
 	// Normalize filter expiry if necessary.
-	// If we parsed this as JSON, expires_in
-	// may be either a float64 or a string.
-	if ei := form.ExpiresInI; ei != nil {
-		switch e := ei.(type) {
-		case float64:
-			form.ExpiresIn = util.Ptr(int(e))
-
-		case string:
-			expiresIn, err := strconv.Atoi(e)
-			if err != nil {
-				return fmt.Errorf("could not parse expires_in value %s as integer: %w", e, err)
-			}
-
-			form.ExpiresIn = &expiresIn
-
-		default:
-			return fmt.Errorf("could not parse expires_in type %T as integer", ei)
+	if form.ExpiresInI != nil {
+		// If we parsed this as JSON, expires_in
+		// may be either a float64 or a string.
+		var err error
+		form.ExpiresIn, err = apiutil.ParseDuration(
+			form.ExpiresInI,
+			"expires_in",
+		)
+		if err != nil {
+			return err
 		}
+	}
+
+	// Ensure no zero duration is set.
+	if form.ExpiresIn != nil && *form.ExpiresIn == 0 {
+		form.ExpiresIn = nil
 	}
 
 	// Normalize and validate updates.

--- a/internal/api/client/filters/v2/filterput.go
+++ b/internal/api/client/filters/v2/filterput.go
@@ -283,7 +283,7 @@ func validateNormalizeUpdateFilter(form *apimodel.FilterUpdateRequestV2) error {
 		}
 	}
 
-	// Interpret zero as indefinite duration..
+	// Interpret zero as indefinite duration.
 	if form.ExpiresIn != nil && *form.ExpiresIn == 0 {
 		form.ExpiresIn = nil
 	}

--- a/internal/api/client/filters/v2/filterput.go
+++ b/internal/api/client/filters/v2/filterput.go
@@ -283,7 +283,7 @@ func validateNormalizeUpdateFilter(form *apimodel.FilterUpdateRequestV2) error {
 		}
 	}
 
-	// Ensure no zero duration is set.
+	// Interpret zero as indefinite duration..
 	if form.ExpiresIn != nil && *form.ExpiresIn == 0 {
 		form.ExpiresIn = nil
 	}

--- a/internal/api/util/parseform.go
+++ b/internal/api/util/parseform.go
@@ -1,0 +1,70 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package util
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// ParseDuration parses the given raw interface belonging to
+// the given fieldName as an integer duration.
+//
+// Will return nil, nil if rawI is the zero value of its type.
+func ParseDuration(rawI any, fieldName string) (*int, error) {
+	var (
+		asInteger int
+		err       error
+	)
+
+	switch raw := rawI.(type) {
+	case float64:
+		// Submitted as JSON number
+		// (casts to float64 by default).
+		asInteger = int(raw)
+
+	case string:
+		// Submitted as JSON string or form field.
+		asInteger, err = strconv.Atoi(raw)
+		if err != nil {
+			err = fmt.Errorf(
+				"could not parse %s value %s as integer: %w",
+				fieldName, raw, err,
+			)
+		}
+
+	default:
+		// Submitted as god-knows-what.
+		err = fmt.Errorf(
+			"could not parse %s type %T as integer",
+			fieldName, rawI,
+		)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Someone submitted 0,
+	// don't point to this.
+	if asInteger == 0 {
+		return nil, nil
+	}
+
+	return &asInteger, nil
+}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request puts our generous duration parsing (can be either float64 or string) into its own util function, and also ensures that empty form field string is interpreted as infinite duration, which closes https://github.com/superseriousbusiness/gotosocial/issues/3497

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
