### PR TITLE
[bugfix] sets the max value placeholders to MaxInt32 instead of MaxInt

### DIFF
--- a/internal/api/client/instance/instancepatch_test.go
+++ b/internal/api/client/instance/instancepatch_test.go
@@ -130,10 +130,10 @@ func (suite *InstancePatchTestSuite) TestInstancePatch1() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 9223372036854775807,
+      "image_matrix_limit": 2147483647,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 9223372036854775807,
-      "video_matrix_limit": 9223372036854775807
+      "video_frame_rate_limit": 2147483647,
+      "video_matrix_limit": 2147483647
     },
     "polls": {
       "max_options": 6,
@@ -271,10 +271,10 @@ func (suite *InstancePatchTestSuite) TestInstancePatch2() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 9223372036854775807,
+      "image_matrix_limit": 2147483647,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 9223372036854775807,
-      "video_matrix_limit": 9223372036854775807
+      "video_frame_rate_limit": 2147483647,
+      "video_matrix_limit": 2147483647
     },
     "polls": {
       "max_options": 6,
@@ -412,10 +412,10 @@ func (suite *InstancePatchTestSuite) TestInstancePatch3() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 9223372036854775807,
+      "image_matrix_limit": 2147483647,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 9223372036854775807,
-      "video_matrix_limit": 9223372036854775807
+      "video_frame_rate_limit": 2147483647,
+      "video_matrix_limit": 2147483647
     },
     "polls": {
       "max_options": 6,
@@ -604,10 +604,10 @@ func (suite *InstancePatchTestSuite) TestInstancePatch6() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 9223372036854775807,
+      "image_matrix_limit": 2147483647,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 9223372036854775807,
-      "video_matrix_limit": 9223372036854775807
+      "video_frame_rate_limit": 2147483647,
+      "video_matrix_limit": 2147483647
     },
     "polls": {
       "max_options": 6,
@@ -767,10 +767,10 @@ func (suite *InstancePatchTestSuite) TestInstancePatch8() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 9223372036854775807,
+      "image_matrix_limit": 2147483647,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 9223372036854775807,
-      "video_matrix_limit": 9223372036854775807
+      "video_frame_rate_limit": 2147483647,
+      "video_matrix_limit": 2147483647
     },
     "polls": {
       "max_options": 6,
@@ -949,10 +949,10 @@ func (suite *InstancePatchTestSuite) TestInstancePatch9() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 9223372036854775807,
+      "image_matrix_limit": 2147483647,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 9223372036854775807,
-      "video_matrix_limit": 9223372036854775807
+      "video_frame_rate_limit": 2147483647,
+      "video_matrix_limit": 2147483647
     },
     "polls": {
       "max_options": 6,

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -1576,9 +1576,9 @@ func (c *Converter) InstanceToAPIV1Instance(ctx context.Context, i *gtsmodel.Ins
 	instance.Configuration.MediaAttachments.VideoSizeLimit = int(videoSz) // #nosec G115 -- Already validated.
 
 	// we don't actually set any limits on these. set to max possible.
-	instance.Configuration.MediaAttachments.ImageMatrixLimit = math.MaxInt
-	instance.Configuration.MediaAttachments.VideoFrameRateLimit = math.MaxInt
-	instance.Configuration.MediaAttachments.VideoMatrixLimit = math.MaxInt
+	instance.Configuration.MediaAttachments.ImageMatrixLimit = math.MaxInt32
+	instance.Configuration.MediaAttachments.VideoFrameRateLimit = math.MaxInt32
+	instance.Configuration.MediaAttachments.VideoMatrixLimit = math.MaxInt32
 
 	instance.Configuration.Polls.MaxOptions = config.GetStatusesPollMaxOptions()
 	instance.Configuration.Polls.MaxCharactersPerOption = config.GetStatusesPollOptionMaxChars()
@@ -1739,9 +1739,9 @@ func (c *Converter) InstanceToAPIV2Instance(ctx context.Context, i *gtsmodel.Ins
 	instance.Configuration.MediaAttachments.VideoSizeLimit = int(videoSz) // #nosec G115 -- Already validated.
 
 	// we don't actually set any limits on these. set to max possible.
-	instance.Configuration.MediaAttachments.ImageMatrixLimit = math.MaxInt
-	instance.Configuration.MediaAttachments.VideoFrameRateLimit = math.MaxInt
-	instance.Configuration.MediaAttachments.VideoMatrixLimit = math.MaxInt
+	instance.Configuration.MediaAttachments.ImageMatrixLimit = math.MaxInt32
+	instance.Configuration.MediaAttachments.VideoFrameRateLimit = math.MaxInt32
+	instance.Configuration.MediaAttachments.VideoMatrixLimit = math.MaxInt32
 
 	instance.Configuration.Polls.MaxOptions = config.GetStatusesPollMaxOptions()
 	instance.Configuration.Polls.MaxCharactersPerOption = config.GetStatusesPollOptionMaxChars()

--- a/internal/typeutils/internaltofrontend_test.go
+++ b/internal/typeutils/internaltofrontend_test.go
@@ -1968,10 +1968,10 @@ func (suite *InternalToFrontendTestSuite) TestInstanceV1ToFrontend() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 9223372036854775807,
+      "image_matrix_limit": 2147483647,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 9223372036854775807,
-      "video_matrix_limit": 9223372036854775807
+      "video_frame_rate_limit": 2147483647,
+      "video_matrix_limit": 2147483647
     },
     "polls": {
       "max_options": 6,
@@ -2113,10 +2113,10 @@ func (suite *InternalToFrontendTestSuite) TestInstanceV2ToFrontend() {
         "video/x-matroska"
       ],
       "image_size_limit": 41943040,
-      "image_matrix_limit": 9223372036854775807,
+      "image_matrix_limit": 2147483647,
       "video_size_limit": 41943040,
-      "video_frame_rate_limit": 9223372036854775807,
-      "video_matrix_limit": 9223372036854775807
+      "video_frame_rate_limit": 2147483647,
+      "video_matrix_limit": 2147483647
     },
     "polls": {
       "max_options": 6,


### PR DESCRIPTION
closes #3516 