### PR TITLE
[performance] minimise log field allocations

### DIFF
--- a/internal/db/bundb/account.go
+++ b/internal/db/bundb/account.go
@@ -36,6 +36,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/paging"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
 	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect"
 )
@@ -86,7 +87,7 @@ func (a *accountDB) GetAccountsByIDs(ctx context.Context, ids []string) ([]*gtsm
 	// Reorder the statuses by their
 	// IDs to ensure in correct order.
 	getID := func(a *gtsmodel.Account) string { return a.ID }
-	util.OrderBy(accounts, ids, getID)
+	xslices.OrderBy(accounts, ids, getID)
 
 	if gtscontext.Barebones(ctx) {
 		// no need to fully populate.

--- a/internal/db/bundb/application.go
+++ b/internal/db/bundb/application.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -169,7 +169,7 @@ func (a *applicationDB) GetAllTokens(ctx context.Context) ([]*gtsmodel.Token, er
 	// Reoroder the tokens by their
 	// IDs to ensure in correct order.
 	getID := func(t *gtsmodel.Token) string { return t.ID }
-	util.OrderBy(tokens, tokenIDs, getID)
+	xslices.OrderBy(tokens, tokenIDs, getID)
 
 	return tokens, nil
 }

--- a/internal/db/bundb/conversation.go
+++ b/internal/db/bundb/conversation.go
@@ -31,7 +31,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/paging"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect"
 )
@@ -209,7 +209,7 @@ func (c *conversationDB) getConversationsByLastStatusIDs(
 
 	// Reorder the conversations by their last status IDs to ensure correct order.
 	getID := func(b *gtsmodel.Conversation) string { return b.ID }
-	util.OrderBy(conversations, conversationLastStatusIDs, getID)
+	xslices.OrderBy(conversations, conversationLastStatusIDs, getID)
 
 	if gtscontext.Barebones(ctx) {
 		// no need to fully populate.
@@ -558,7 +558,7 @@ func (c *conversationDB) DeleteStatusFromConversations(ctx context.Context, stat
 
 	// Invalidate cache entries.
 	updatedConversationIDs = append(updatedConversationIDs, deletedConversationIDs...)
-	updatedConversationIDs = util.Deduplicate(updatedConversationIDs)
+	updatedConversationIDs = xslices.Deduplicate(updatedConversationIDs)
 	c.state.Caches.DB.Conversation.InvalidateIDs("ID", updatedConversationIDs)
 
 	return nil

--- a/internal/db/bundb/emoji.go
+++ b/internal/db/bundb/emoji.go
@@ -31,7 +31,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/paging"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect"
 )
@@ -597,7 +597,7 @@ func (e *emojiDB) GetEmojisByIDs(ctx context.Context, ids []string) ([]*gtsmodel
 	// Reorder the emojis by their
 	// IDs to ensure in correct order.
 	getID := func(e *gtsmodel.Emoji) string { return e.ID }
-	util.OrderBy(emojis, ids, getID)
+	xslices.OrderBy(emojis, ids, getID)
 
 	if gtscontext.Barebones(ctx) {
 		// no need to fully populate.
@@ -661,7 +661,7 @@ func (e *emojiDB) GetEmojiCategoriesByIDs(ctx context.Context, ids []string) ([]
 	// Reorder the categories by their
 	// IDs to ensure in correct order.
 	getID := func(c *gtsmodel.EmojiCategory) string { return c.ID }
-	util.OrderBy(categories, ids, getID)
+	xslices.OrderBy(categories, ids, getID)
 
 	return categories, nil
 }

--- a/internal/db/bundb/filter.go
+++ b/internal/db/bundb/filter.go
@@ -27,7 +27,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -99,7 +99,7 @@ func (f *filterDB) GetFiltersForAccountID(ctx context.Context, accountID string)
 	}
 
 	// Put the filter structs in the same order as the filter IDs.
-	util.OrderBy(filters, filterIDs, func(filter *gtsmodel.Filter) string { return filter.ID })
+	xslices.OrderBy(filters, filterIDs, func(filter *gtsmodel.Filter) string { return filter.ID })
 
 	if gtscontext.Barebones(ctx) {
 		return filters, nil

--- a/internal/db/bundb/filterkeyword.go
+++ b/internal/db/bundb/filterkeyword.go
@@ -26,7 +26,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -140,7 +140,7 @@ func (f *filterDB) getFilterKeywords(ctx context.Context, idColumn string, id st
 	}
 
 	// Put the filter keyword structs in the same order as the filter keyword IDs.
-	util.OrderBy(filterKeywords, filterKeywordIDs, func(filterKeyword *gtsmodel.FilterKeyword) string {
+	xslices.OrderBy(filterKeywords, filterKeywordIDs, func(filterKeyword *gtsmodel.FilterKeyword) string {
 		return filterKeyword.ID
 	})
 

--- a/internal/db/bundb/filterstatus.go
+++ b/internal/db/bundb/filterstatus.go
@@ -25,7 +25,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtscontext"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -116,7 +116,7 @@ func (f *filterDB) getFilterStatuses(ctx context.Context, idColumn string, id st
 	}
 
 	// Put the filter status structs in the same order as the filter status IDs.
-	util.OrderBy(filterStatuses, filterStatusIDs, func(filterStatus *gtsmodel.FilterStatus) string {
+	xslices.OrderBy(filterStatuses, filterStatusIDs, func(filterStatus *gtsmodel.FilterStatus) string {
 		return filterStatus.ID
 	})
 

--- a/internal/db/bundb/interaction.go
+++ b/internal/db/bundb/interaction.go
@@ -29,7 +29,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/paging"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -113,7 +113,7 @@ func (i *interactionDB) GetInteractionRequestsByIDs(ctx context.Context, ids []s
 	// Reorder the requests by their
 	// IDs to ensure in correct order.
 	getID := func(r *gtsmodel.InteractionRequest) string { return r.ID }
-	util.OrderBy(requests, ids, getID)
+	xslices.OrderBy(requests, ids, getID)
 
 	if gtscontext.Barebones(ctx) {
 		// no need to fully populate.

--- a/internal/db/bundb/list.go
+++ b/internal/db/bundb/list.go
@@ -31,7 +31,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/paging"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -333,7 +333,7 @@ func (l *listDB) GetListsByIDs(ctx context.Context, ids []string) ([]*gtsmodel.L
 	// Reorder the lists by their
 	// IDs to ensure in correct order.
 	getID := func(l *gtsmodel.List) string { return l.ID }
-	util.OrderBy(lists, ids, getID)
+	xslices.OrderBy(lists, ids, getID)
 
 	if gtscontext.Barebones(ctx) {
 		// no need to fully populate.
@@ -387,12 +387,12 @@ func (l *listDB) PutListEntries(ctx context.Context, entries []*gtsmodel.ListEnt
 	}
 
 	// Collect unique list IDs from the provided list entries.
-	listIDs := util.Collate(entries, func(e *gtsmodel.ListEntry) string {
+	listIDs := xslices.Collate(entries, func(e *gtsmodel.ListEntry) string {
 		return e.ListID
 	})
 
 	// Collect unique follow IDs from the provided list entries.
-	followIDs := util.Collate(entries, func(e *gtsmodel.ListEntry) string {
+	followIDs := xslices.Collate(entries, func(e *gtsmodel.ListEntry) string {
 		return e.FollowID
 	})
 
@@ -441,7 +441,7 @@ func (l *listDB) DeleteAllListEntriesByFollows(ctx context.Context, followIDs ..
 	}
 
 	// Deduplicate IDs before invalidate.
-	listIDs = util.Deduplicate(listIDs)
+	listIDs = xslices.Deduplicate(listIDs)
 
 	// Invalidate all related list entry caches.
 	l.invalidateEntryCaches(ctx, listIDs, followIDs)

--- a/internal/db/bundb/media.go
+++ b/internal/db/bundb/media.go
@@ -28,7 +28,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/paging"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -78,7 +78,7 @@ func (m *mediaDB) GetAttachmentsByIDs(ctx context.Context, ids []string) ([]*gts
 	// Reorder the media by their
 	// IDs to ensure in correct order.
 	getID := func(m *gtsmodel.MediaAttachment) string { return m.ID }
-	util.OrderBy(media, ids, getID)
+	xslices.OrderBy(media, ids, getID)
 
 	return media, nil
 }

--- a/internal/db/bundb/mention.go
+++ b/internal/db/bundb/mention.go
@@ -28,7 +28,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -91,7 +91,7 @@ func (m *mentionDB) GetMentions(ctx context.Context, ids []string) ([]*gtsmodel.
 	// Reorder the mentions by their
 	// IDs to ensure in correct order.
 	getID := func(m *gtsmodel.Mention) string { return m.ID }
-	util.OrderBy(mentions, ids, getID)
+	xslices.OrderBy(mentions, ids, getID)
 
 	if gtscontext.Barebones(ctx) {
 		// no need to fully populate.

--- a/internal/db/bundb/notification.go
+++ b/internal/db/bundb/notification.go
@@ -29,7 +29,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/id"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -130,7 +130,7 @@ func (n *notificationDB) GetNotificationsByIDs(ctx context.Context, ids []string
 	// Reorder the notifs by their
 	// IDs to ensure in correct order.
 	getID := func(n *gtsmodel.Notification) string { return n.ID }
-	util.OrderBy(notifs, ids, getID)
+	xslices.OrderBy(notifs, ids, getID)
 
 	if gtscontext.Barebones(ctx) {
 		// no need to fully populate.

--- a/internal/db/bundb/poll.go
+++ b/internal/db/bundb/poll.go
@@ -29,7 +29,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -315,7 +315,7 @@ func (p *pollDB) GetPollVotes(ctx context.Context, pollID string) ([]*gtsmodel.P
 	// Reorder the poll votes by their
 	// IDs to ensure in correct order.
 	getID := func(v *gtsmodel.PollVote) string { return v.ID }
-	util.OrderBy(votes, voteIDs, getID)
+	xslices.OrderBy(votes, voteIDs, getID)
 
 	if gtscontext.Barebones(ctx) {
 		// no need to fully populate.

--- a/internal/db/bundb/relationship_block.go
+++ b/internal/db/bundb/relationship_block.go
@@ -27,7 +27,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -127,7 +127,7 @@ func (r *relationshipDB) GetBlocksByIDs(ctx context.Context, ids []string) ([]*g
 	// Reorder the blocks by their
 	// IDs to ensure in correct order.
 	getID := func(b *gtsmodel.Block) string { return b.ID }
-	util.OrderBy(blocks, ids, getID)
+	xslices.OrderBy(blocks, ids, getID)
 
 	if gtscontext.Barebones(ctx) {
 		// no need to fully populate.

--- a/internal/db/bundb/relationship_follow.go
+++ b/internal/db/bundb/relationship_follow.go
@@ -28,7 +28,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -103,7 +103,7 @@ func (r *relationshipDB) GetFollowsByIDs(ctx context.Context, ids []string) ([]*
 	// Reorder the follows by their
 	// IDs to ensure in correct order.
 	getID := func(f *gtsmodel.Follow) string { return f.ID }
-	util.OrderBy(follows, ids, getID)
+	xslices.OrderBy(follows, ids, getID)
 
 	if gtscontext.Barebones(ctx) {
 		// no need to fully populate.
@@ -376,7 +376,7 @@ func (r *relationshipDB) DeleteAccountFollows(ctx context.Context, accountID str
 	}
 
 	// Gather the follow IDs that were deleted for removing related list entries.
-	followIDs := util.Gather(nil, deleted, func(follow *gtsmodel.Follow) string {
+	followIDs := xslices.Gather(nil, deleted, func(follow *gtsmodel.Follow) string {
 		return follow.ID
 	})
 

--- a/internal/db/bundb/relationship_follow_req.go
+++ b/internal/db/bundb/relationship_follow_req.go
@@ -28,7 +28,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -103,7 +103,7 @@ func (r *relationshipDB) GetFollowRequestsByIDs(ctx context.Context, ids []strin
 	// Reorder the requests by their
 	// IDs to ensure in correct order.
 	getID := func(f *gtsmodel.FollowRequest) string { return f.ID }
-	util.OrderBy(follows, ids, getID)
+	xslices.OrderBy(follows, ids, getID)
 
 	if gtscontext.Barebones(ctx) {
 		// no need to fully populate.

--- a/internal/db/bundb/relationship_mute.go
+++ b/internal/db/bundb/relationship_mute.go
@@ -28,7 +28,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/paging"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect"
 )
@@ -109,7 +109,7 @@ func (r *relationshipDB) getMutesByIDs(ctx context.Context, ids []string) ([]*gt
 	// Reorder the mutes by their
 	// IDs to ensure in correct order.
 	getID := func(b *gtsmodel.UserMute) string { return b.ID }
-	util.OrderBy(mutes, ids, getID)
+	xslices.OrderBy(mutes, ids, getID)
 
 	if gtscontext.Barebones(ctx) {
 		// no need to fully populate.

--- a/internal/db/bundb/status.go
+++ b/internal/db/bundb/status.go
@@ -29,7 +29,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -76,7 +76,7 @@ func (s *statusDB) GetStatusesByIDs(ctx context.Context, ids []string) ([]*gtsmo
 	// Reorder the statuses by their
 	// IDs to ensure in correct order.
 	getID := func(s *gtsmodel.Status) string { return s.ID }
-	util.OrderBy(statuses, ids, getID)
+	xslices.OrderBy(statuses, ids, getID)
 
 	if gtscontext.Barebones(ctx) {
 		// no need to fully populate.

--- a/internal/db/bundb/statusbookmark.go
+++ b/internal/db/bundb/statusbookmark.go
@@ -28,7 +28,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -95,7 +95,7 @@ func (s *statusBookmarkDB) GetStatusBookmarksByIDs(ctx context.Context, ids []st
 	// Reorder the bookmarks by their
 	// IDs to ensure in correct order.
 	getID := func(b *gtsmodel.StatusBookmark) string { return b.ID }
-	util.OrderBy(bookmarks, ids, getID)
+	xslices.OrderBy(bookmarks, ids, getID)
 
 	// Populate all loaded bookmarks, removing those we fail
 	// to populate (removes needing so many later nil checks).

--- a/internal/db/bundb/statusfave.go
+++ b/internal/db/bundb/statusfave.go
@@ -31,7 +31,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -155,7 +155,7 @@ func (s *statusFaveDB) GetStatusFaves(ctx context.Context, statusID string) ([]*
 	// Reorder the statuses by their
 	// IDs to ensure in correct order.
 	getID := func(f *gtsmodel.StatusFave) string { return f.ID }
-	util.OrderBy(faves, faveIDs, getID)
+	xslices.OrderBy(faves, faveIDs, getID)
 
 	if gtscontext.Barebones(ctx) {
 		// no need to fully populate.
@@ -339,7 +339,7 @@ func (s *statusFaveDB) DeleteStatusFaves(ctx context.Context, targetAccountID st
 	}
 
 	// Deduplicate determined status IDs.
-	statusIDs = util.Deduplicate(statusIDs)
+	statusIDs = xslices.Deduplicate(statusIDs)
 
 	// Invalidate any cached status faves for this status ID.
 	s.state.Caches.DB.StatusFave.InvalidateIDs("ID", statusIDs)

--- a/internal/db/bundb/tag.go
+++ b/internal/db/bundb/tag.go
@@ -28,7 +28,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/paging"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 	"github.com/uptrace/bun"
 )
 
@@ -102,7 +102,7 @@ func (t *tagDB) GetTags(ctx context.Context, ids []string) ([]*gtsmodel.Tag, err
 	// Reorder the tags by their
 	// IDs to ensure in correct order.
 	getID := func(t *gtsmodel.Tag) string { return t.ID }
-	util.OrderBy(tags, ids, getID)
+	xslices.OrderBy(tags, ids, getID)
 
 	return tags, nil
 }
@@ -301,5 +301,5 @@ func (t *tagDB) GetAccountIDsFollowingTagIDs(ctx context.Context, tagIDs []strin
 
 	// Accounts might be following multiple tags in list,
 	// but we only want to return each account once.
-	return util.Deduplicate(accountIDs), nil
+	return xslices.Deduplicate(accountIDs), nil
 }

--- a/internal/federation/federatingprotocol.go
+++ b/internal/federation/federatingprotocol.go
@@ -35,7 +35,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/uris"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 )
 
 type errOtherIRIBlocked struct {
@@ -162,7 +162,7 @@ func (f *Federator) PostInboxRequestBodyHook(ctx context.Context, r *http.Reques
 
 	// OtherIRIs will likely contain some
 	// duplicate entries now, so remove them.
-	otherIRIs = util.DeduplicateFunc(otherIRIs,
+	otherIRIs = xslices.DeduplicateFunc(otherIRIs,
 		(*url.URL).String, // serialized URL is 'key()'
 	)
 

--- a/internal/gtsmodel/conversation.go
+++ b/internal/gtsmodel/conversation.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 )
 
 // Conversation represents direct messages between the owner account and a set of other accounts.
@@ -62,7 +62,7 @@ type Conversation struct {
 
 // ConversationOtherAccountsKey creates an OtherAccountsKey from a list of OtherAccountIDs.
 func ConversationOtherAccountsKey(otherAccountIDs []string) string {
-	otherAccountIDs = util.Deduplicate(otherAccountIDs)
+	otherAccountIDs = xslices.Deduplicate(otherAccountIDs)
 	slices.Sort(otherAccountIDs)
 	return strings.Join(otherAccountIDs, ",")
 }

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -413,8 +413,8 @@ func logf(ctx context.Context, depth int, lvl LEVEL, fields []kv.Field, s string
 	buf.B = append(buf.B, ' ')
 
 	if ctx != nil && len(ctxhooks) > 0 {
-		// Ensure fields have extra necessary space.
-		fields = xslices.GrowJust(fields, len(ctxhooks))
+		// Ensure fields have space for hooks (+1 for below).
+		fields = xslices.GrowJust(fields, len(ctxhooks)+1)
 
 		// Pass context through hooks.
 		for _, hook := range ctxhooks {
@@ -423,7 +423,7 @@ func logf(ctx context.Context, depth int, lvl LEVEL, fields []kv.Field, s string
 	}
 
 	if s != "" {
-		// Append message as final log field.
+		// Append message (if given) as final log field.
 		fields = xslices.AppendJust(fields, kv.Field{
 			K: "msg", V: fmt.Sprintf(s, a...),
 		})

--- a/internal/processing/account/alias.go
+++ b/internal/processing/account/alias.go
@@ -27,7 +27,7 @@ import (
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 )
 
 func (p *Processor) Alias(
@@ -137,8 +137,8 @@ func (p *Processor) Alias(
 	// Dedupe URIs + accounts, in case someone
 	// provided both an account URL and an
 	// account URI above, for the same account.
-	account.AlsoKnownAsURIs = util.Deduplicate(account.AlsoKnownAsURIs)
-	account.AlsoKnownAs = util.DeduplicateFunc(
+	account.AlsoKnownAsURIs = xslices.Deduplicate(account.AlsoKnownAsURIs)
+	account.AlsoKnownAs = xslices.DeduplicateFunc(
 		account.AlsoKnownAs,
 		func(a *gtsmodel.Account) string {
 			return a.URI

--- a/internal/processing/status/create.go
+++ b/internal/processing/status/create.go
@@ -36,6 +36,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/typeutils"
 	"github.com/superseriousbusiness/gotosocial/internal/uris"
 	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 )
 
 // Create processes the given form to create a new status, returning the api model representation of that status if it's OK.
@@ -536,9 +537,9 @@ func (p *Processor) processContent(ctx context.Context, parseMention gtsmodel.Pa
 	}
 
 	// Gather all the database IDs from each of the gathered status mentions, tags, and emojis.
-	status.MentionIDs = util.Gather(nil, status.Mentions, func(mention *gtsmodel.Mention) string { return mention.ID })
-	status.TagIDs = util.Gather(nil, status.Tags, func(tag *gtsmodel.Tag) string { return tag.ID })
-	status.EmojiIDs = util.Gather(nil, status.Emojis, func(emoji *gtsmodel.Emoji) string { return emoji.ID })
+	status.MentionIDs = xslices.Gather(nil, status.Mentions, func(mention *gtsmodel.Mention) string { return mention.ID })
+	status.TagIDs = xslices.Gather(nil, status.Tags, func(tag *gtsmodel.Tag) string { return tag.ID })
+	status.EmojiIDs = xslices.Gather(nil, status.Emojis, func(emoji *gtsmodel.Emoji) string { return emoji.ID })
 
 	if status.ContentWarning != "" && len(status.AttachmentIDs) > 0 {
 		// If a content-warning is set, and

--- a/internal/typeutils/internaltoas.go
+++ b/internal/typeutils/internaltoas.go
@@ -36,7 +36,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/uris"
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 )
 
 // AccountToAS converts a gts model account into an activity streams person, suitable for federation
@@ -1819,7 +1819,7 @@ func populateValuesForProp[T ap.WithIRI](
 	// Deduplicate the iri strings to
 	// make sure we're not parsing + adding
 	// the same string multiple times.
-	iriStrs = util.Deduplicate(iriStrs)
+	iriStrs = xslices.Deduplicate(iriStrs)
 
 	// Append them to the property.
 	for _, iriStr := range iriStrs {

--- a/internal/util/xslices/slices.go
+++ b/internal/util/xslices/slices.go
@@ -15,11 +15,43 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package util
+package xslices
 
 import (
 	"slices"
 )
+
+// GrowJust increases slice capacity to guarantee
+// extra room 'size', where in the case that it does
+// need to allocate more it ONLY allocates 'size' extra.
+// This is different to typical slices.Grow behaviour,
+// which simply guarantees extra through append() which
+// may allocate more than necessary extra size.
+func GrowJust[T any](in []T, size int) []T {
+	if cap(in)-len(in) < size {
+		in2 := make([]T, len(in)+size)
+		_ = copy(in2, in)
+		in = in2
+	}
+	return in
+}
+
+// AppendJust appends extra elements to slice,
+// ONLY allocating at most len(extra) elements. This
+// is different to the typical append behaviour which
+// will append extra, in a manner to reduce the need
+// for new allocations on every call to append.
+func AppendJust[T any](in []T, extra ...T) []T {
+	if cap(in)-len(in) < len(extra) {
+		in2 := make([]T, len(in)+len(extra))
+		_ = copy(in2, in)
+		in = in2
+	} else {
+		in = in[:len(in)+len(extra)]
+	}
+	_ = copy(in[len(in):], extra)
+	return in
+}
 
 // Deduplicate deduplicates entries in the given slice.
 func Deduplicate[T comparable](in []T) []T {

--- a/internal/util/xslices/slices.go
+++ b/internal/util/xslices/slices.go
@@ -28,11 +28,14 @@ import (
 // which simply guarantees extra through append() which
 // may allocate more than necessary extra size.
 func GrowJust[T any](in []T, size int) []T {
+
 	if cap(in)-len(in) < size {
+		// Reallocate enough for in + size.
 		in2 := make([]T, len(in), len(in)+size)
 		_ = copy(in2, in)
 		in = in2
 	}
+
 	return in
 }
 
@@ -42,14 +45,20 @@ func GrowJust[T any](in []T, size int) []T {
 // will append extra, in a manner to reduce the need
 // for new allocations on every call to append.
 func AppendJust[T any](in []T, extra ...T) []T {
-	if cap(in)-len(in) < len(extra) {
-		in2 := make([]T, len(in)+len(extra))
+	l := len(in)
+
+	if cap(in)-l < len(extra) {
+		// Reallocate enough for + extra.
+		in2 := make([]T, l+len(extra))
 		_ = copy(in2, in)
 		in = in2
 	} else {
-		in = in[:len(in)+len(extra)]
+		// Reslice for + extra.
+		in = in[:l+len(extra)]
 	}
-	_ = copy(in[len(in):], extra)
+
+	// Copy extra into slice.
+	_ = copy(in[l:], extra)
 	return in
 }
 

--- a/internal/util/xslices/slices.go
+++ b/internal/util/xslices/slices.go
@@ -29,7 +29,7 @@ import (
 // may allocate more than necessary extra size.
 func GrowJust[T any](in []T, size int) []T {
 	if cap(in)-len(in) < size {
-		in2 := make([]T, len(in)+size)
+		in2 := make([]T, len(in), len(in)+size)
 		_ = copy(in2, in)
 		in = in2
 	}

--- a/internal/util/xslices/slices_test.go
+++ b/internal/util/xslices/slices_test.go
@@ -18,6 +18,7 @@
 package xslices_test
 
 import (
+	"math/rand"
 	"net/url"
 	"slices"
 	"testing"
@@ -57,12 +58,27 @@ func TestAppendJust(t *testing.T) {
 	for _, l := range []int{0, 2, 4, 8, 16, 32, 64} {
 		for _, x := range []int{0, 2, 4, 8, 16, 32, 64} {
 			s := make([]int, l, l+x)
+
+			// Randomize slice.
+			for i := range s {
+				s[i] = rand.Int()
+			}
+
 			for _, a := range []int{0, 2, 4, 8, 16, 32, 64} {
 				toAppend := make([]int, a)
+
+				// Randomize appended vals.
+				for i := range toAppend {
+					toAppend[i] = rand.Int()
+				}
+
 				s2 := xslices.AppendJust(s, toAppend...)
 
 				// Slice length should be as expected.
-				assert.Equal(t, len(s2), len(s)+a)
+				assert.Equal(t, len(s)+a, len(s2))
+
+				// Slice contents should be as expected.
+				assert.Equal(t, append(s, toAppend...), s2)
 
 				switch {
 				// If slice already has capacity for
@@ -74,7 +90,7 @@ func TestAppendJust(t *testing.T) {
 				// have capacity for original length
 				// plus extra elements, NOTHING MORE.
 				default:
-					assert.Equal(t, cap(s2), len(s)+a)
+					assert.Equal(t, len(s)+a, cap(s2))
 				}
 			}
 		}

--- a/internal/util/xslices/slices_test.go
+++ b/internal/util/xslices/slices_test.go
@@ -33,6 +33,9 @@ func TestGrowJust(t *testing.T) {
 			for _, g := range []int{0, 2, 4, 8, 16, 32, 64} {
 				s2 := xslices.GrowJust(s, g)
 
+				// Slice length should not be different.
+				assert.Equal(t, len(s), len(s2))
+
 				switch {
 				// If slice already has capacity for
 				// 'g' then it should not be changed.
@@ -58,6 +61,9 @@ func TestAppendJust(t *testing.T) {
 				toAppend := make([]int, a)
 				s2 := xslices.AppendJust(s, toAppend...)
 
+				// Slice length should be as expected.
+				assert.Equal(t, len(s2), len(s)+a)
+
 				switch {
 				// If slice already has capacity for
 				// 'toAppend' then it should not change.
@@ -68,7 +74,7 @@ func TestAppendJust(t *testing.T) {
 				// have capacity for original length
 				// plus extra elements, NOTHING MORE.
 				default:
-					assert.Equal(t, cap(s2), len(s)+len(toAppend))
+					assert.Equal(t, cap(s2), len(s)+a)
 				}
 			}
 		}

--- a/internal/util/xslices/slices_test.go
+++ b/internal/util/xslices/slices_test.go
@@ -15,22 +15,68 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package util_test
+package xslices_test
 
 import (
 	"net/url"
 	"slices"
 	"testing"
 
-	"github.com/superseriousbusiness/gotosocial/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/superseriousbusiness/gotosocial/internal/util/xslices"
 )
 
-var (
-	testURLSlice = []*url.URL{}
-)
+func TestGrowJust(t *testing.T) {
+	for _, l := range []int{0, 2, 4, 8, 16, 32, 64} {
+		for _, x := range []int{0, 2, 4, 8, 16, 32, 64} {
+			s := make([]int, l, l+x)
+			for _, g := range []int{0, 2, 4, 8, 16, 32, 64} {
+				s2 := xslices.GrowJust(s, g)
+
+				switch {
+				// If slice already has capacity for
+				// 'g' then it should not be changed.
+				case cap(s) >= len(s)+g:
+					assert.Equal(t, cap(s), cap(s2))
+
+				// Else, returned slice should only
+				// have capacity for original length
+				// plus extra elements, NOTHING MORE.
+				default:
+					assert.Equal(t, cap(s2), len(s)+g)
+				}
+			}
+		}
+	}
+}
+
+func TestAppendJust(t *testing.T) {
+	for _, l := range []int{0, 2, 4, 8, 16, 32, 64} {
+		for _, x := range []int{0, 2, 4, 8, 16, 32, 64} {
+			s := make([]int, l, l+x)
+			for _, a := range []int{0, 2, 4, 8, 16, 32, 64} {
+				toAppend := make([]int, a)
+				s2 := xslices.AppendJust(s, toAppend...)
+
+				switch {
+				// If slice already has capacity for
+				// 'toAppend' then it should not change.
+				case cap(s) >= len(s)+a:
+					assert.Equal(t, cap(s), cap(s2))
+
+				// Else, returned slice should only
+				// have capacity for original length
+				// plus extra elements, NOTHING MORE.
+				default:
+					assert.Equal(t, cap(s2), len(s)+len(toAppend))
+				}
+			}
+		}
+	}
+}
 
 func TestGather(t *testing.T) {
-	out := util.Gather(nil, []*url.URL{
+	out := xslices.Gather(nil, []*url.URL{
 		{Scheme: "https", Host: "google.com", Path: "/some-search"},
 		{Scheme: "http", Host: "example.com", Path: "/robots.txt"},
 	}, (*url.URL).String)
@@ -41,7 +87,7 @@ func TestGather(t *testing.T) {
 		t.Fatal("unexpected gather output")
 	}
 
-	out = util.Gather([]string{
+	out = xslices.Gather([]string{
 		"starting input string",
 		"another starting input",
 	}, []*url.URL{
@@ -59,7 +105,7 @@ func TestGather(t *testing.T) {
 }
 
 func TestGatherIf(t *testing.T) {
-	out := util.GatherIf(nil, []string{
+	out := xslices.GatherIf(nil, []string{
 		"hello world",
 		"not hello world",
 		"hello world",
@@ -73,7 +119,7 @@ func TestGatherIf(t *testing.T) {
 		t.Fatal("unexpected gatherif output")
 	}
 
-	out = util.GatherIf([]string{
+	out = xslices.GatherIf([]string{
 		"starting input string",
 		"another starting input",
 	}, []string{


### PR DESCRIPTION
- moves slice functions to separate internal/util/xslices package to fix an import cycle
- adds new xslices.AppendJust() and xslices.GrowJust() functions to grow a slice in similar manners to append() and slices.Grow() but ONLY by the necessary number of elements, not any extra as normally happens in those functions typically
- makes use of xslices.AppendJust() and xslices.GrowJust() in our log package