### PR TITLE
[docs] Include link to a live instance in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Documentation is at [docs.gotosocial.org](https://docs.gotosocial.org). You can 
 
 To build from source, check the [CONTRIBUTING.md](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md) file.
 
-Here's a screenshot of the instance landing page!
+Here's a screenshot of the instance landing page! Check out the project's [official account](https://gts.superseriousbusiness.org/@gotosocial) running on GoToSocial.
 
 ![Screenshot of the landing page for the GoToSocial instance goblin.technology. It shows basic information about the instance; number of users and posts etc.](https://raw.githubusercontent.com/superseriousbusiness/gotosocial/main/docs/overrides/public/instancesplash.png)
 <!--overview-end-->


### PR DESCRIPTION
# Description

As a new visitor to the project on GitHub, what I really want to do is click around a server to see how it looks and feels compared with other fediverse implementations. Screenshots are great but not quite enough. I'm not sure whether it's intentional, but it takes a little effort to actually find a link to a real instance.

**Suggested change:** link to the project account near the top of the README

I'm aware that "improve readme!" PRs are a bit of a meme but in this case I'm serious. :)

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
