### PR TITLE
[feature] Allow emoji shortcode to be 1-character length

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -4920,7 +4920,7 @@ paths:
                 - description: The code to use for the emoji, which will be used by instance denizens to select it. This must be unique on the instance.
                   in: formData
                   name: shortcode
-                  pattern: \w{2,30}
+                  pattern: \w{1,30}
                   required: true
                   type: string
                 - description: A png or gif image of the emoji. Animated pngs work too! To ensure compatibility with other fedi implementations, emoji size limit is 50kb by default.
@@ -5066,7 +5066,7 @@ paths:
                 - description: The code to use for the emoji, which will be used by instance denizens to select it. This must be unique on the instance. Works for the `copy` action type only.
                   in: formData
                   name: shortcode
-                  pattern: \w{2,30}
+                  pattern: \w{1,30}
                   type: string
                 - description: A new png or gif image to use for the emoji. Animated pngs work too! To ensure compatibility with other fedi implementations, emoji size limit is 50kb by default. Works for LOCAL emojis only.
                   in: formData

--- a/internal/api/client/admin/emojicreate.go
+++ b/internal/api/client/admin/emojicreate.go
@@ -53,7 +53,7 @@ import (
 //			The code to use for the emoji, which will be used by instance denizens to select it.
 //			This must be unique on the instance.
 //		type: string
-//		pattern: \w{2,30}
+//		pattern: \w{1,30}
 //		required: true
 //	-
 //		name: image

--- a/internal/api/client/admin/emojiupdate.go
+++ b/internal/api/client/admin/emojiupdate.go
@@ -85,7 +85,7 @@ import (
 //			The code to use for the emoji, which will be used by instance denizens to select it.
 //			This must be unique on the instance. Works for the `copy` action type only.
 //		type: string
-//		pattern: \w{2,30}
+//		pattern: \w{1,30}
 //	-
 //		name: image
 //		in: formData

--- a/internal/api/client/admin/emojiupdate_test.go
+++ b/internal/api/client/admin/emojiupdate_test.go
@@ -560,7 +560,7 @@ func (suite *EmojiUpdateTestSuite) TestEmojiUpdateCopyEmptyShortcode() {
 	b, err := io.ReadAll(result.Body)
 	suite.NoError(err)
 
-	suite.Equal(`{"error":"Bad Request: shortcode  did not pass validation, must be between 2 and 30 characters, letters, numbers, and underscores only"}`, string(b))
+	suite.Equal(`{"error":"Bad Request: shortcode  did not pass validation, must be between 1 and 30 characters, letters, numbers, and underscores only"}`, string(b))
 }
 
 func (suite *EmojiUpdateTestSuite) TestEmojiUpdateCopyNoShortcode() {

--- a/internal/regexes/regexes.go
+++ b/internal/regexes/regexes.go
@@ -46,7 +46,7 @@ const (
 	domainGrp                = `(?:` + alphaNumeric + `|\.|\-|\:)`                       // Non-capturing group that matches against a single valid domain character.
 	mentionName              = `^@(` + usernameGrp + `+)(?:@(` + domainGrp + `+))?$`     // Extract parts of one mention, maybe including domain.
 	mentionFinder            = `(?:^|\s)(@` + usernameGrp + `+(?:@` + domainGrp + `+)?)` // Extract all mentions from a text, each mention may include domain.
-	emojiShortcode           = `\w{2,30}`                                                // Pattern for emoji shortcodes. maximumEmojiShortcodeLength = 30
+	emojiShortcode           = `\w{1,30}`                                                // Pattern for emoji shortcodes. maximumEmojiShortcodeLength = 30
 	emojiFinder              = `(?:\b)?:(` + emojiShortcode + `):(?:\b)?`                // Extract all emoji shortcodes from a text.
 	emojiValidator           = `^` + emojiShortcode + `$`                                // Validate a single emoji shortcode.
 	usernameStrict           = `^[a-z0-9_]{1,64}$`                                       // Pattern for usernames on THIS instance. maximumUsernameLength = 64

--- a/internal/validate/formvalidation.go
+++ b/internal/validate/formvalidation.go
@@ -190,11 +190,11 @@ func CustomCSS(customCSS string) error {
 }
 
 // EmojiShortcode just runs the given shortcode through the regular expression
-// for emoji shortcodes, to figure out whether it's a valid shortcode, ie., 2-30 characters,
+// for emoji shortcodes, to figure out whether it's a valid shortcode, ie., 1-30 characters,
 // a-zA-Z, numbers, and underscores.
 func EmojiShortcode(shortcode string) error {
 	if !regexes.EmojiValidator.MatchString(shortcode) {
-		return fmt.Errorf("shortcode %s did not pass validation, must be between 2 and 30 characters, letters, numbers, and underscores only", shortcode)
+		return fmt.Errorf("shortcode %s did not pass validation, must be between 1 and 30 characters, letters, numbers, and underscores only", shortcode)
 	}
 	return nil
 }

--- a/internal/validate/formvalidation_test.go
+++ b/internal/validate/formvalidation_test.go
@@ -345,7 +345,7 @@ func (suite *ValidationTestSuite) TestValidateEmojiShortcode() {
 		},
 		{
 			shortcode: "p",
-			ok:        false,
+			ok:        true,
 		},
 		{
 			shortcode: "pp",
@@ -361,6 +361,10 @@ func (suite *ValidationTestSuite) TestValidateEmojiShortcode() {
 		},
 		{
 			shortcode: "_",
+			ok:        true,
+		},
+		{
+			shortcode: "",
 			ok:        false,
 		},
 		{

--- a/web/source/settings/views/admin/emoji/local/new-emoji.tsx
+++ b/web/source/settings/views/admin/emoji/local/new-emoji.tsx
@@ -119,7 +119,7 @@ export default function NewEmojiForm() {
 					label="Shortcode, must be unique among the instance's local emoji"
 					autoCapitalize="none"
 					spellCheck="false"
-					{...{pattern: "^\\w{2,30}$"}}
+					{...{pattern: "^\\w{1,30}$"}}
 				/>
 
 				<CategorySelect

--- a/web/source/settings/views/admin/emoji/local/use-shortcode.ts
+++ b/web/source/settings/views/admin/emoji/local/use-shortcode.ts
@@ -22,7 +22,7 @@ import { useMemo } from "react";
 import { useTextInput } from "../../../../lib/form";
 import { useListEmojiQuery } from "../../../../lib/query/admin/custom-emoji";
 
-const shortcodeRegex = /^\w{2,30}$/;
+const shortcodeRegex = /^\w{1,30}$/;
 
 export default function useShortcode() {
 	const { data: emoji = [] } = useListEmojiQuery({
@@ -42,8 +42,8 @@ export default function useShortcode() {
 				return "Shortcode already in use";
 			}
 
-			if (code.length < 2 || code.length > 30) {
-				return "Shortcode must be between 2 and 30 characters";
+			if (code.length < 1 || code.length > 30) {
+				return "Shortcode must be between 1 and 30 characters";
 			}
 
 			if (!shortcodeRegex.test(code)) {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates our emoji validator to allow upload of emojis with 1-character shortcodes.

Closes https://github.com/superseriousbusiness/gotosocial/issues/3532

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
