### PR TITLE
[docs] Added note to documentation about mutuals-only posts not being functional.

### DIFF
--- a/docs/user_guide/posts.md
+++ b/docs/user_guide/posts.md
@@ -36,6 +36,9 @@ Direct posts are **not** accessible via a web URL on your GoToSocial instance.
 
 ### Mutuals-only
 
+!!! warning
+    Mutuals-only posts are not currently functional.
+
 Posts with a visibility of `mutuals_only` will only appear to the post author, and to *mutual follows* of the post author. In other words, they can only be seen by others if two conditions are met:
 
 1. The other account follows the post author.


### PR DESCRIPTION
# Description

A very small addition to the documentation to indicate that mutuals-only posts don't currently work.

## Checklist

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).