### PR TITLE
[chore] bump to Go1.23

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,7 +38,7 @@ steps:
         path: /root/.cache/wazero
     environment:
       CGO_ENABLED: "0"
-      GTS_WAZERO_COMPILATION_CACHE: "~/.cache/wazero"
+      GTS_WAZERO_COMPILATION_CACHE: "/root/.cache/wazero"
     commands:
       - apk update --no-cache && apk add git
       - >-

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ steps:
   # We use golangci-lint for linting.
   # See: https://golangci-lint.run/
   - name: lint
-    image: golangci/golangci-lint:v1.60.3
+    image: golangci/golangci-lint:v1.62.0
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -28,7 +28,7 @@ steps:
           - pull_request
 
   - name: test
-    image: golang:1.23.0-alpine
+    image: golang:1.23-alpine
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ steps:
   # We use golangci-lint for linting.
   # See: https://golangci-lint.run/
   - name: lint
-    image: golangci/golangci-lint:v1.57.2
+    image: golangci/golangci-lint:v1.60.3
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -28,7 +28,7 @@ steps:
           - pull_request
 
   - name: test
-    image: golang:1.22-alpine
+    image: golang:1.23.0-alpine
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -38,7 +38,7 @@ steps:
         path: /root/.cache/wazero
     environment:
       CGO_ENABLED: "0"
-      GTS_WAZERO_COMPILATION_CACHE: "/root/.cache/wazero"
+      GTS_WAZERO_COMPILATION_CACHE: "~/.cache/wazero"
     commands:
       - apk update --no-cache && apk add git
       - >-
@@ -94,7 +94,11 @@ steps:
           - pull_request
 
   - name: snapshot
+<<<<<<< HEAD
     image: superseriousbusiness/gotosocial-drone-build:0.6.2 # https://github.com/superseriousbusiness/gotosocial-drone-build
+=======
+    image: superseriousbusiness/gotosocial-drone-build:0.7.0 # https://github.com/superseriousbusiness/gotosocial-drone-build
+>>>>>>> c1543c029 ([chore] Bump tooling versions, bump go -> v1.23.0)
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -141,7 +145,11 @@ steps:
           - main
 
   - name: release
+<<<<<<< HEAD
     image: superseriousbusiness/gotosocial-drone-build:0.6.2 # https://github.com/superseriousbusiness/gotosocial-drone-build
+=======
+    image: superseriousbusiness/gotosocial-drone-build:0.7.0 # https://github.com/superseriousbusiness/gotosocial-drone-build
+>>>>>>> c1543c029 ([chore] Bump tooling versions, bump go -> v1.23.0)
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -210,7 +218,11 @@ clone:
 
 steps:
   - name: mirror
+<<<<<<< HEAD
     image: superseriousbusiness/gotosocial-drone-build:0.6.2
+=======
+    image: superseriousbusiness/gotosocial-drone-build:0.7.0
+>>>>>>> c1543c029 ([chore] Bump tooling versions, bump go -> v1.23.0)
     environment:
       ORIGIN_REPO: https://github.com/superseriousbusiness/gotosocial
       TARGET_REPO: https://codeberg.org/superseriousbusiness/gotosocial
@@ -223,6 +235,10 @@ steps:
 
 ---
 kind: signature
+<<<<<<< HEAD
 hmac: 1b89e3a538fbca72eb9a0b398cd82f09a774ba3649013e19d36012eda327e83f
+=======
+hmac: 90df190a8e49e082ec2a95738bdf44fb049a7ab64b71f522e1f1add1bb061a81
+>>>>>>> c1543c029 ([chore] Bump tooling versions, bump go -> v1.23.0)
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -94,11 +94,7 @@ steps:
           - pull_request
 
   - name: snapshot
-<<<<<<< HEAD
-    image: superseriousbusiness/gotosocial-drone-build:0.6.2 # https://github.com/superseriousbusiness/gotosocial-drone-build
-=======
     image: superseriousbusiness/gotosocial-drone-build:0.7.0 # https://github.com/superseriousbusiness/gotosocial-drone-build
->>>>>>> c1543c029 ([chore] Bump tooling versions, bump go -> v1.23.0)
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -145,11 +141,7 @@ steps:
           - main
 
   - name: release
-<<<<<<< HEAD
-    image: superseriousbusiness/gotosocial-drone-build:0.6.2 # https://github.com/superseriousbusiness/gotosocial-drone-build
-=======
     image: superseriousbusiness/gotosocial-drone-build:0.7.0 # https://github.com/superseriousbusiness/gotosocial-drone-build
->>>>>>> c1543c029 ([chore] Bump tooling versions, bump go -> v1.23.0)
     volumes:
       - name: go-build-cache
         path: /root/.cache/go-build
@@ -218,11 +210,7 @@ clone:
 
 steps:
   - name: mirror
-<<<<<<< HEAD
-    image: superseriousbusiness/gotosocial-drone-build:0.6.2
-=======
     image: superseriousbusiness/gotosocial-drone-build:0.7.0
->>>>>>> c1543c029 ([chore] Bump tooling versions, bump go -> v1.23.0)
     environment:
       ORIGIN_REPO: https://github.com/superseriousbusiness/gotosocial
       TARGET_REPO: https://codeberg.org/superseriousbusiness/gotosocial
@@ -235,10 +223,6 @@ steps:
 
 ---
 kind: signature
-<<<<<<< HEAD
-hmac: 1b89e3a538fbca72eb9a0b398cd82f09a774ba3649013e19d36012eda327e83f
-=======
-hmac: 90df190a8e49e082ec2a95738bdf44fb049a7ab64b71f522e1f1add1bb061a81
->>>>>>> c1543c029 ([chore] Bump tooling versions, bump go -> v1.23.0)
+hmac: 9810bf692fb1029c13b0a1e2f556e2306d16f7d3eec9ca6163a0499c147280c1
 
 ...

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -389,6 +389,8 @@ checksum:
 # https://goreleaser.com/customization/snapshots/
 snapshot:
   version_template: "{{ incpatch .Version }}-SNAPSHOT"
+
+# https://goreleaser.com/customization/source/
 source:
   enabled: true
   name_template: "{{ .ProjectName }}-{{ .Version }}-source-code"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ version: 2
 before:
   hooks:
   # generate the swagger.yaml file using go-swagger and bundle it into the assets directory
-  - swagger generate spec --scan-models --exclude-deps -o web/assets/swagger.yaml
+  - go run ./vendor/github.com/go-swagger/go-swagger/cmd/swagger generate spec --scan-models --exclude-deps -o web/assets/swagger.yaml
   - sed -i "s/REPLACE_ME/{{ incpatch .Version }}/" web/assets/swagger.yaml
   # Install web deps + bundle web assets
   - yarn --cwd ./web/source install

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
-# https://goreleaser.com
+# Version 2 of GoReleaser: https://goreleaser.com/errors/version/
+version: 2
 project_name: gotosocial
 version: 2
 
@@ -388,8 +389,6 @@ checksum:
 # https://goreleaser.com/customization/snapshots/
 snapshot:
   version_template: "{{ incpatch .Version }}-SNAPSHOT"
-
-# https://goreleaser.com/customization/source/
 source:
   enabled: true
   name_template: "{{ .ProjectName }}-{{ .Version }}-source-code"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile reference: https://docs.docker.com/engine/reference/builder/
 
 # stage 1: generate up-to-date swagger.yaml to put in the final container
-FROM --platform=${BUILDPLATFORM} golang:1.22-alpine AS swagger
+FROM --platform=${BUILDPLATFORM} golang:1.23.0-alpine AS swagger
 
 RUN \
     ### Installs goswagger for building swagger definitions inside this container
@@ -28,7 +28,7 @@ RUN yarn --cwd ./web/source install && \
     rm -rf ./web/source
 
 # stage 3: build the executor container
-FROM --platform=${TARGETPLATFORM} alpine:3.19.1 as executor
+FROM --platform=${TARGETPLATFORM} alpine:3.20.2 as executor
 
 # switch to non-root user:group for GtS
 USER 1000:1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile reference: https://docs.docker.com/engine/reference/builder/
 
 # stage 1: generate up-to-date swagger.yaml to put in the final container
-FROM --platform=${BUILDPLATFORM} golang:1.23.0-alpine AS swagger
+FROM --platform=${BUILDPLATFORM} golang:1.23-alpine AS swagger
 
 RUN \
     ### Installs goswagger for building swagger definitions inside this container
@@ -28,7 +28,7 @@ RUN yarn --cwd ./web/source install && \
     rm -rf ./web/source
 
 # stage 3: build the executor container
-FROM --platform=${TARGETPLATFORM} alpine:3.20.2 as executor
+FROM --platform=${TARGETPLATFORM} alpine:3.20 as executor
 
 # switch to non-root user:group for GtS
 USER 1000:1000

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/superseriousbusiness/gotosocial
 
 go 1.23
 
+// Replace go-swagger with our version that fixes (ours particularly) use of Go1.23
+replace github.com/go-swagger/go-swagger => github.com/superseriousbusiness/go-swagger v0.31.0-gts-go1.23-fix
+
 // Replace modernc/sqlite with our version that fixes the concurrency INTERRUPT issue
 replace modernc.org/sqlite => gitlab.com/NyaaaWhatsUpDoc/sqlite v1.33.1-concurrency-workaround
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/superseriousbusiness/gotosocial
 
-go 1.22.2
+go 1.23
 
 // Replace modernc/sqlite with our version that fixes the concurrency INTERRUPT issue
 replace modernc.org/sqlite => gitlab.com/NyaaaWhatsUpDoc/sqlite v1.33.1-concurrency-workaround

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,6 @@ github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91
 github.com/go-playground/validator/v10 v10.20.0 h1:K9ISHbSaI0lyB2eWMPJo+kOS/FBExVwjEviJTixqxL8=
 github.com/go-playground/validator/v10 v10.20.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/go-session/session v3.1.2+incompatible/go.mod h1:8B3iivBQjrz/JtC68Np2T1yBBLxTan3mn/3OM0CyRt0=
-github.com/go-swagger/go-swagger v0.31.0 h1:H8eOYQnY2u7vNKWDNykv2xJP3pBhRG/R+SOCAmKrLlc=
-github.com/go-swagger/go-swagger v0.31.0/go.mod h1:WSigRRWEig8zV6t6Sm8Y+EmUjlzA/HoaZJ5edupq7po=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b h1:khEcpUM4yFcxg4/FHQWkvVRmgijNXRfzkIDHh23ggEo=
@@ -330,8 +328,6 @@ github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pw
 github.com/gorilla/sessions v1.2.2 h1:lqzMYz6bOfvn2WriPUjNByzeXIlVzURcPmgMczkmTjY=
 github.com/gorilla/sessions v1.2.2/go.mod h1:ePLdVu+jbEgHH+KWw8I1z2wqd0BAdAQh/8LRvBeoNcQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/gorilla/websocket v1.5.2 h1:qoW6V1GT3aZxybsbC6oLnailWnB+qTMVwMreOso9XUw=
-github.com/gorilla/websocket v1.5.2/go.mod h1:0n9H61RBAcf5/38py2MCYbxzPIY9rOkpvvMT24Rqs30=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 h1:asbCHRVmodnJTuQ3qamDwqVOIjwqUPTYmYuemVOx+Ys=
@@ -538,6 +534,8 @@ github.com/superseriousbusiness/go-jpeg-image-structure/v2 v2.0.0-20220321154430
 github.com/superseriousbusiness/go-jpeg-image-structure/v2 v2.0.0-20220321154430-d89a106fdabe/go.mod h1:gH4P6gN1V+wmIw5o97KGaa1RgXB/tVpC2UNzijhg3E4=
 github.com/superseriousbusiness/go-png-image-structure/v2 v2.0.1-SSB h1:8psprYSK1KdOSH7yQ4PbJq0YYaGQY+gzdW/B0ExDb/8=
 github.com/superseriousbusiness/go-png-image-structure/v2 v2.0.1-SSB/go.mod h1:ymKGfy9kg4dIdraeZRAdobMS/flzLk3VcRPLpEWOAXg=
+github.com/superseriousbusiness/go-swagger v0.31.0-gts-go1.23-fix h1:CXcjArOyxBPFgsNAu4As+RK9BwOUEG1LL7ja4g7iax0=
+github.com/superseriousbusiness/go-swagger v0.31.0-gts-go1.23-fix/go.mod h1:WSigRRWEig8zV6t6Sm8Y+EmUjlzA/HoaZJ5edupq7po=
 github.com/superseriousbusiness/httpsig v1.2.0-SSB h1:BinBGKbf2LSuVT5+MuH0XynHN9f0XVshx2CTDtkaWj0=
 github.com/superseriousbusiness/httpsig v1.2.0-SSB/go.mod h1:+rxfATjFaDoDIVaJOTSP0gj6UrbicaYPEptvCLC9F28=
 github.com/superseriousbusiness/oauth2/v4 v4.3.2-SSB.0.20230227143000-f4900831d6c8 h1:nTIhuP157oOFcscuoK1kCme1xTeGIzztSw70lX9NrDQ=

--- a/internal/db/bundb/bundb.go
+++ b/internal/db/bundb/bundb.go
@@ -420,13 +420,12 @@ func maxOpenConns() int {
 // deriveBunDBPGOptions takes an application config and returns either a ready-to-use set of options
 // with sensible defaults, or an error if it's not satisfied by the provided config.
 func deriveBunDBPGOptions() (*pgx.ConnConfig, error) {
-	url := config.GetDbPostgresConnectionString()
-
-	// if database URL is defined, ignore other DB related configuration fields
-	if url != "" {
-		cfg, err := pgx.ParseConfig(url)
-		return cfg, err
+	// If database URL is defined, ignore
+	// other DB-related configuration fields.
+	if url := config.GetDbPostgresConnectionString(); url != "" {
+		return pgx.ParseConfig(url)
 	}
+
 	// these are all optional, the db adapter figures out defaults
 	address := config.GetDbAddress()
 

--- a/internal/media/imaging.go
+++ b/internal/media/imaging.go
@@ -514,9 +514,6 @@ func (s *scanner) scan(x1, y1, x2, y2 int, dst []uint8) {
 				} else {
 					r = ^(r >> 31)
 				}
-				if r > math.MaxUint8 {
-					panic("overflow r")
-				}
 
 				g := yy1 - 22554*cb1 - 46802*cr1
 				if uint32(g)&0xff000000 == 0 { //nolint:gosec
@@ -524,18 +521,12 @@ func (s *scanner) scan(x1, y1, x2, y2 int, dst []uint8) {
 				} else {
 					g = ^(g >> 31)
 				}
-				if g > math.MaxUint8 {
-					panic("overflow g")
-				}
 
 				b := yy1 + 116130*cb1
 				if uint32(b)&0xff000000 == 0 { //nolint:gosec
 					b >>= 16
 				} else {
 					b = ^(b >> 31)
-				}
-				if b > math.MaxUint8 {
-					panic("overflow b")
 				}
 
 				d := dst[j : j+4 : j+4]

--- a/internal/media/imaging.go
+++ b/internal/media/imaging.go
@@ -514,6 +514,9 @@ func (s *scanner) scan(x1, y1, x2, y2 int, dst []uint8) {
 				} else {
 					r = ^(r >> 31)
 				}
+				if r > math.MaxUint8 {
+					panic("overflow r")
+				}
 
 				g := yy1 - 22554*cb1 - 46802*cr1
 				if uint32(g)&0xff000000 == 0 { //nolint:gosec
@@ -521,12 +524,18 @@ func (s *scanner) scan(x1, y1, x2, y2 int, dst []uint8) {
 				} else {
 					g = ^(g >> 31)
 				}
+				if g > math.MaxUint8 {
+					panic("overflow g")
+				}
 
 				b := yy1 + 116130*cb1
 				if uint32(b)&0xff000000 == 0 { //nolint:gosec
 					b >>= 16
 				} else {
 					b = ^(b >> 31)
+				}
+				if b > math.MaxUint8 {
+					panic("overflow b")
 				}
 
 				d := dst[j : j+4 : j+4]

--- a/test/swagger.sh
+++ b/test/swagger.sh
@@ -5,7 +5,7 @@
 set -eu
 
 swagger_cmd() {
-  go run github.com/go-swagger/go-swagger/cmd/swagger "$@"
+  go run ./vendor/github.com/go-swagger/go-swagger/cmd/swagger "$@"
 }
 swagger_spec='docs/api/swagger.yaml'
 

--- a/vendor/github.com/go-swagger/go-swagger/codescan/schema.go
+++ b/vendor/github.com/go-swagger/go-swagger/codescan/schema.go
@@ -303,6 +303,8 @@ func (s *schemaBuilder) buildFromType(tpe types.Type, tgt swaggerTypable) error 
 	}
 
 	switch titpe := tpe.(type) {
+	case *types.Alias:
+		return nil // resolves panic
 	case *types.Basic:
 		return swaggerSchemaForType(titpe.String(), tgt)
 	case *types.Pointer:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -300,7 +300,7 @@ github.com/go-playground/universal-translator
 # github.com/go-playground/validator/v10 v10.20.0
 ## explicit; go 1.18
 github.com/go-playground/validator/v10
-# github.com/go-swagger/go-swagger v0.31.0
+# github.com/go-swagger/go-swagger v0.31.0 => github.com/superseriousbusiness/go-swagger v0.31.0-gts-go1.23-fix
 ## explicit; go 1.21
 github.com/go-swagger/go-swagger/cmd/swagger
 github.com/go-swagger/go-swagger/cmd/swagger/commands
@@ -1344,6 +1344,7 @@ modernc.org/token
 # mvdan.cc/xurls/v2 v2.5.0
 ## explicit; go 1.19
 mvdan.cc/xurls/v2
+# github.com/go-swagger/go-swagger => github.com/superseriousbusiness/go-swagger v0.31.0-gts-go1.23-fix
 # modernc.org/sqlite => gitlab.com/NyaaaWhatsUpDoc/sqlite v1.33.1-concurrency-workaround
 # go.opentelemetry.io/otel => go.opentelemetry.io/otel v1.29.0
 # go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc => go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.29.0


### PR DESCRIPTION
this is a copy of #3258 but rebased on current main and updated to latest golangci-lint version, and with docker image version strings updated to just use the latest minor version of a particular major image version (this ensures we stay up-to-date with bugfixes but without breaking changes).

i made this a separate PR just because i wasn't totally comfortable doing a force push to something that wasn't my PR :p