### PR TITLE
Replace Semaphore recommendation with Pinafore.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ These contribution guidelines were adapted from / inspired by those of Gitea (ht
     - [Finding your way around the code](#finding-your-way-around-the-code)
   - [Style / Linting / Formatting](#style--linting--formatting)
   - [Testing](#testing)
-    - [Standalone Testrig with Semaphore](#standalone-testrig-with-semaphore)
+    - [Standalone Testrig with Pinafore](#standalone-testrig-with-pinafore)
     - [Running automated tests](#running-automated-tests)
       - [SQLite](#sqlite)
       - [Postgres](#postgres)
@@ -401,9 +401,9 @@ GoToSocial provides a [testrig](https://github.com/superseriousbusiness/gotosoci
 
 One thing that *isn't* mocked is the Database interface because it's just easier to use an in-memory SQLite database than to mock everything out.
 
-#### Standalone Testrig with Semaphore
+#### Standalone Testrig with Pinafore
 
-You can launch a testrig as a standalone server running at localhost, which you can connect to using something like [Semaphore](https://github.com/NickColley/semaphore/).
+You can launch a testrig as a standalone server running at localhost, which you can connect to using something like [Pinafore](https://github.com/nolanlawson/pinafore/).
 
 To do this, first build the gotosocial binary with `DEBUG=1 ./scripts/build.sh`.
 
@@ -413,14 +413,14 @@ Then, launch the testrig with the `DEBUG` environment variable set by invoking t
 DEBUG=1 ./gotosocial testrig start
 ```
 
-To run Semaphore locally in dev mode, first clone the [Semaphore](https://github.com/NickColley/semaphore/) repository, and then run the following commands in the cloned directory:
+To run Pinafore locally in dev mode, first clone the [Pinafore](https://github.com/nolanlawson/pinafore/) repository, and then run the following commands in the cloned directory:
 
 ```bash
 yarn # install dependencies
 yarn run dev
 ```
 
-The Semaphore instance will start running on `localhost:4002`.
+The Pinafore instance will start running on `localhost:4002`.
 
 To connect to the testrig, navigate to `http://localhost:4002` and enter your instance name as `localhost:8080`.
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The Mastodon API has become the de facto standard for client communication with 
 Though most apps that implement the Mastodon API should work, GoToSocial is tested and works reliably with beautiful apps like:
 
 * [Tusky](https://tusky.app/) for Android
-* [Semaphore](https://semaphore.social/) in the browser
+* [Pinafore](https://pinafore.social/) in the browser
 * [Feditext](https://github.com/feditext/feditext) (beta) on iOS, iPadOS and macOS
 
 If you've used Mastodon with a third-party app before, you'll find using GoToSocial a breeze.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 ## Where's the user interface?
 
-GoToSocial is just a bare server for the most part and is designed to be used thru external applications. [Semaphore](https://semaphore.social/) in the browser, [Tusky](https://tusky.app/) for Android and [Feditext](https://github.com/feditext/feditext) for iOS, iPadOS and macOS are the best-supported. Anything that supports the Mastodon API should work, other than the features GoToSocial doesn't yet have. Permalinks and profile pages are served directly through GoToSocial as well as the settings panel, but most interaction goes through the apps.
+GoToSocial is just a bare server for the most part and is designed to be used thru external applications. [Pinafore](https://pinafore.social/) in the browser, [Tusky](https://tusky.app/) for Android and [Feditext](https://github.com/feditext/feditext) for iOS, iPadOS and macOS are the best-supported. Anything that supports the Mastodon API should work, other than the features GoToSocial doesn't yet have. Permalinks and profile pages are served directly through GoToSocial as well as the settings panel, but most interaction goes through the apps.
 
 ## Why aren't my posts showing up on my profile page?
 

--- a/docs/getting_started/reverse_proxy/websocket.md
+++ b/docs/getting_started/reverse_proxy/websocket.md
@@ -1,6 +1,6 @@
 # WebSocket
 
-GoToSocial uses the secure [WebSocket protocol](https://en.wikipedia.org/wiki/WebSocket) (aka `wss`) to allow for streaming updates of statuses and notifications via client apps like Semaphore.
+GoToSocial uses the secure [WebSocket protocol](https://en.wikipedia.org/wiki/WebSocket) (aka `wss`) to allow for streaming updates of statuses and notifications via client apps like Pinafore.
 
 In order to use this functionality, you need to ensure that whatever proxy you've configured GoToSocial to run behind allows WebSocket connections through.
 

--- a/docs/locales/zh/faq.md
+++ b/docs/locales/zh/faq.md
@@ -2,7 +2,7 @@
 
 ## 用户界面在哪？
 
-GoToSocial 的大部分内容只是一个裸服务端，用于通过第三方应用程序进行使用。可通过 [Semaphore](https://semaphore.social/) 在浏览器使用，可通过 [Tusky](https://tusky.app/) 在 Android 使用，可通过 [Feditext](https://github.com/feditext/feditext) 在 iOS、iPadOS 和 macOS 使用。这些应用程序兼容性最好。任何由 Mastodon API 提供的实例功能都应该可以工作，除非它们是 GoToSocial 尚不具备的功能。永久链接和个账户页是通过 GoToSocial 直接提供的，设置面板也是如此，但大多数交互都是通过应用程序完成的。
+GoToSocial 的大部分内容只是一个裸服务端，用于通过第三方应用程序进行使用。可通过 [Pinafore](https://pinafore.social/) 在浏览器使用，可通过 [Tusky](https://tusky.app/) 在 Android 使用，可通过 [Feditext](https://github.com/feditext/feditext) 在 iOS、iPadOS 和 macOS 使用。这些应用程序兼容性最好。任何由 Mastodon API 提供的实例功能都应该可以工作，除非它们是 GoToSocial 尚不具备的功能。永久链接和个账户页是通过 GoToSocial 直接提供的，设置面板也是如此，但大多数交互都是通过应用程序完成的。
 
 ## 为什么我的贴文没有显示在我的账户页面上？
 

--- a/docs/locales/zh/getting_started/reverse_proxy/websocket.md
+++ b/docs/locales/zh/getting_started/reverse_proxy/websocket.md
@@ -1,6 +1,6 @@
 # WebSocket
 
-GoToSocial 使用安全的 [WebSocket 协议](https://en.wikipedia.org/wiki/WebSocket)（即 `wss`）来通过客户端应用程序（如 Semaphore）实现贴文和通知的实时更新。
+GoToSocial 使用安全的 [WebSocket 协议](https://en.wikipedia.org/wiki/WebSocket)（即 `wss`）来通过客户端应用程序（如 Pinafore）实现贴文和通知的实时更新。
 
 为了使用此功能，你需要确保配置 GoToSocial 所在的代理允许 WebSocket 连接通过。
 

--- a/docs/locales/zh/repo/CONTRIBUTING.md
+++ b/docs/locales/zh/repo/CONTRIBUTING.md
@@ -24,7 +24,7 @@
     - [浏览代码结构](#浏览代码结构)
   - [风格/代码检查/格式化](#风格代码检查格式化)
   - [测试](#测试)
-    - [独立测试环境与 Semaphore](#独立测试环境与-semaphore)
+    - [独立测试环境与 Pinafore](#独立测试环境与-pinafore)
     - [运行自动化测试](#运行自动化测试)
       - [SQLite](#sqlite)
       - [Postgres](#postgres)
@@ -400,9 +400,9 @@ GoToSocial 提供了一个 [testrig](https://github.com/superseriousbusiness/got
 
 没有模拟的一个东西是数据库接口，因为使用内存中的 SQLite 数据库比模拟所有东西要简单得多。
 
-#### 独立测试环境与 Semaphore
+#### 独立测试环境与 Pinafore
 
-你可以启动一个在本地主机运行的独立测试服务器 testrig，可以通过 [Semaphore](https://github.com/NickColley/semaphore/) 连接。
+你可以启动一个在本地主机运行的独立测试服务器 testrig，可以通过 [Pinafore](https://github.com/NickColley/pinafore/) 连接。
 
 要做到这一点，首先用 `DEBUG=1 ./scripts/build.sh` 构建 gotosocial 二进制文件。
 
@@ -412,14 +412,14 @@ GoToSocial 提供了一个 [testrig](https://github.com/superseriousbusiness/got
 DEBUG=1 ./gotosocial testrig start
 ```
 
-要在本地开发模式下运行 Semaphore，首先克隆 [Semaphore](https://github.com/NickColley/semaphore/) 存储库，然后在克隆的目录中运行以下命令：
+要在本地开发模式下运行 Pinafore，首先克隆 [Pinafore](https://github.com/nolanlawson/pinafore/) 存储库，然后在克隆的目录中运行以下命令：
 
 ```bash
 yarn # 安装依赖
 yarn run dev
 ```
 
-Semaphore 实例将在 `localhost:4002` 上启动。
+Pinafore 实例将在 `localhost:4002` 上启动。
 
 要连接到 testrig，导航至 `http://localhost:4002`，并将在实例域名栏输入 `localhost:8080`。
 

--- a/docs/locales/zh/repo/README.md
+++ b/docs/locales/zh/repo/README.md
@@ -113,7 +113,7 @@ Mastodon API 已成为客户端与联邦宇宙服务端通信的事实标准，�
 大多数实现 Mastodon API 的应用程序都应该可以使用 GoToSocial，但以下这些优秀的应用程序已经过测试，可与 GoToSocial 可靠地配合使用：
 
 * [Tusky](https://tusky.app/) 适用于 Android
-* [Semaphore](https://semaphore.social/) 适用于浏览器
+* [Pinafore](https://pinafore.social/) 适用于浏览器
 * [Feditext](https://github.com/feditext/feditext) (beta) 适用于 iOS, iPadOS 和 macOS
 
 如果你之前通过第三方应用来使用 Mastodon，使用 GoToSocial 将是轻而易举的。

--- a/web/template/index_apps.tmpl
+++ b/web/template/index_apps.tmpl
@@ -29,27 +29,27 @@
         <ul class="applist nodot" role="group">
             <li class="applist-entry">
                 <div class="applist-text">
-                    <p><strong>Semaphore</strong> is a web client designed for speed and simplicity.</p>
+                    <p><strong>Pinafore</strong> is a web client designed for speed and simplicity.</p>
                     <a
-                        href="https://semaphore.social/"
+                        href="https://pinafore.social/"
                         rel="nofollow noreferrer noopener"
                         target="_blank"
                     >
-                        Use Semaphore
+                        Use Pinafore
                     </a>
                 </div>
                 <svg
                     role="img"
-                    aria-labelledby="semaphore-title semaphore-desc"
+                    aria-labelledby="pinafore-title pinafore-desc"
                     class="applist-logo redraw"
                     xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 146 120"
+                    viewBox="0 0 10000 10000"
                     width="100"
                     height="100"
                 >
-                    <title id="semaphore-title">The Semaphore logo</title>
-                    <desc id="semaphore-desc">A waving flag</desc>
-                    <path d="M68.13 0C53.94 0 42.81 20 13.9 27.1l-2.23-5.29a6.5 6.5 0 0 0-5.17-10.4 6.5 6.5 0 0 0-.81 12.95L46.2 120l5.99-2.5-14.42-33.33c22.8-6.86 32.51-22.16 49.83-20.58 9.9.9 4.87 19.56 8.11 17.93 16.22-8.15 32.44-11.41 50.29-11.41-7.96-9.78-17.38-20.55-22.71-31.74L120.8 32c-2.32-7.33-2.56-14.75.87-22.22-9.74-3.26-21.1 0-32.45 4.9C82.2 9.77 79.5 0 68.13 0zM15.26 30.42c8.95 6.63 13.63 13.86 16.07 20.94l1.62 6.32c1.24 6.58 1.07 12.8 1.27 18.03z"></path>
+                    <title id="pinafore-title">The Pinafore logo</title>
+                    <desc id="pinafore-desc">A sailboat</desc>
+                    <path d="M9212 5993H5987V823c1053 667 2747 2177 3225 5170zM3100 2690A12240 12240 0 01939 6035h2161zm676 7210h2448a3067 3067 0 003067-3067H5052V627a527 527 0 00-1052 0v6206H709a3067 3067 0 003067 3067z"></path>
                 </svg>
             </li>
             <li class="applist-entry">


### PR DESCRIPTION
As discussed on chat earlier.

Neither Semaphore nor Pinafore are under active development, but Semaphore has archived its repository while Pinafore still gets occasional minor maintenance.

Enafore has newer features, but it has accessibility bugs affecting screen readers that prevent it from being recommended at this time.

# Description

Replace all mentions of Semaphore with Pinafore.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.

I've checked it manually; the new `index_apps.tmpl` is in use on https://hey.hagelb.org if you want to confirm the SVG looks good. Remaining matches for "semaphore" in the code are either comments, or mentioning actual semaphores, not the app.