### PR TITLE
[chore/themes] Add auto-switching themes for blurple/brutalist/solarized

### DIFF
--- a/web/assets/themes/blurple-auto.css
+++ b/web/assets/themes/blurple-auto.css
@@ -1,0 +1,10 @@
+/*
+  theme-title: Blurple (auto)
+  theme-description: Official blurple theme that adapts to system preferences
+*/
+
+/* Default to dark theme */
+@import url("blurple-dark.css");
+
+@import url("blurple-light.css") screen and (prefers-color-scheme: light);
+@import url("blurple-dark.css") screen and (prefers-color-scheme: dark);

--- a/web/assets/themes/brutalist-auto.css
+++ b/web/assets/themes/brutalist-auto.css
@@ -1,0 +1,10 @@
+/*
+  theme-title: Brutalist (auto)
+  theme-description: Official (Pseudo-)monochrome brutality theme that adapts to system preferences
+*/
+
+/* Default to brutalist theme */
+@import url("brutalist.css");
+
+@import url("brutalist.css") screen and (prefers-color-scheme: light);
+@import url("brutalist-dark.css") screen and (prefers-color-scheme: dark);

--- a/web/assets/themes/solarized-auto.css
+++ b/web/assets/themes/solarized-auto.css
@@ -1,0 +1,10 @@
+/*
+  theme-title: Solarized (auto)
+  theme-description: Solarized theme that adapts to system preferences
+*/
+
+/* Default to dark theme */
+@import url("solarized-dark.css");
+
+@import url("solarized-light.css") screen and (prefers-color-scheme: light);
+@import url("solarized-dark.css") screen and (prefers-color-scheme: dark);


### PR DESCRIPTION
# Description

Added auto-switching variants for themes that have both light and dark versions (blurple, brutalist, and solarized). These new variants use `prefers-color-scheme` media query to automatically switch between light and dark themes based on user's system preferences, as discussed in #1214 .

Each auto theme defaults to its dark version if `prefers-color-scheme` is not supported by the browser, while brutalist default to `brutalist.css`(the light version).

The auto-switching theme uses import to load the corresponding light/dark version themes. This way, in the future, they'll automatically follow the update, thus barely add any maintenance workload.

## TODO

If this PR meets expectations and gets merged, the next step is to
 - create a light version of the base CSS for GoToSocial
 - add a theme switch button.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
