### PR TITLE
[chore] Update frontend bug report issue title prefix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_frontend.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_frontend.yaml
@@ -1,6 +1,6 @@
 name: Frontend Bug Report
 description: Report an issue related to the web frontend
-title: "[bug] Issue Title"
+title: "[bug/frontend] Issue Title"
 labels: ["bug", "frontend"]
 assignees: []
 


### PR DESCRIPTION
# Description

It just came to my notice that GoToSocial uses the `[type/subtype]` style as a prefix for issue titles. Since we have a separate issue template for frontend issues, using a consistent `[bug/frontend]` prefix might help with searching and categorization.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [ ] I/we have not leveraged AI to create the proposed changes.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
