### PR TITLE
[bugfix] Load instance-wide custom css in page stylesheets template

### DIFF
--- a/internal/web/about.go
+++ b/internal/web/about.go
@@ -54,7 +54,7 @@ func (m *Module) aboutGETHandler(c *gin.Context) {
 		Template:    "about.tmpl",
 		Instance:    instance,
 		OGMeta:      apiutil.OGBase(instance),
-		Stylesheets: []string{cssAbout, instanceCustomCSSPath},
+		Stylesheets: []string{cssAbout},
 		Extra: map[string]any{
 			"showStrap":        true,
 			"blocklistExposed": config.GetInstanceExposeSuspendedWeb(),

--- a/internal/web/confirmemail.go
+++ b/internal/web/confirmemail.go
@@ -127,9 +127,8 @@ func (m *Module) confirmEmailPOSTHandler(c *gin.Context) {
 	// Serve page informing user that their
 	// email address is now confirmed.
 	page := apiutil.WebPage{
-		Template:    "confirmed_email.tmpl",
-		Instance:    instance,
-		Stylesheets: []string{instanceCustomCSSPath},
+		Template: "confirmed_email.tmpl",
+		Instance: instance,
 		Extra: map[string]any{
 			"email":    user.Email,
 			"username": user.Account.Username,

--- a/internal/web/domain-blocklist.go
+++ b/internal/web/domain-blocklist.go
@@ -67,7 +67,7 @@ func (m *Module) domainBlockListGETHandler(c *gin.Context) {
 		Template:    "domain-blocklist.tmpl",
 		Instance:    instance,
 		OGMeta:      apiutil.OGBase(instance),
-		Stylesheets: []string{cssFA, instanceCustomCSSPath},
+		Stylesheets: []string{cssFA},
 		Javascript:  []string{jsFrontend},
 		Extra:       map[string]any{"blocklist": domainBlocks},
 	}

--- a/internal/web/index.go
+++ b/internal/web/index.go
@@ -59,7 +59,7 @@ func (m *Module) indexHandler(c *gin.Context) {
 		Template:    "index.tmpl",
 		Instance:    instance,
 		OGMeta:      apiutil.OGBase(instance),
-		Stylesheets: []string{cssAbout, cssIndex, instanceCustomCSSPath},
+		Stylesheets: []string{cssAbout, cssIndex},
 		Extra:       map[string]any{"showStrap": true},
 	}
 

--- a/internal/web/profile.go
+++ b/internal/web/profile.go
@@ -142,7 +142,6 @@ func (m *Module) profileGETHandler(c *gin.Context) {
 			cssStatus,
 			cssThread,
 			cssProfile,
-			instanceCustomCSSPath,
 		}...,
 	)
 

--- a/internal/web/settings-panel.go
+++ b/internal/web/settings-panel.go
@@ -53,7 +53,6 @@ func (m *Module) SettingsPanelHandler(c *gin.Context) {
 			cssProfile, // Used for rendering stub/fake profiles.
 			cssStatus,  // Used for rendering stub/fake statuses.
 			cssSettings,
-			instanceCustomCSSPath,
 		},
 		Javascript: []string{jsSettings},
 	}

--- a/internal/web/signup.go
+++ b/internal/web/signup.go
@@ -126,10 +126,9 @@ func (m *Module) signupPOSTHandler(c *gin.Context) {
 	// Serve a page informing the
 	// user that they've signed up.
 	page := apiutil.WebPage{
-		Template:    "signed-up.tmpl",
-		Instance:    instance,
-		Stylesheets: []string{instanceCustomCSSPath},
-		OGMeta:      apiutil.OGBase(instance),
+		Template: "signed-up.tmpl",
+		Instance: instance,
+		OGMeta:   apiutil.OGBase(instance),
 		Extra: map[string]any{
 			"email":    user.UnconfirmedEmail,
 			"username": user.Account.Username,

--- a/internal/web/tag.go
+++ b/internal/web/tag.go
@@ -59,7 +59,7 @@ func (m *Module) tagGETHandler(c *gin.Context) {
 		Template:    "tag.tmpl",
 		Instance:    instance,
 		OGMeta:      apiutil.OGBase(instance),
-		Stylesheets: []string{cssFA, cssThread, cssTag, instanceCustomCSSPath},
+		Stylesheets: []string{cssFA, cssThread, cssTag},
 		Extra:       map[string]any{"tagName": tagName},
 	}
 

--- a/internal/web/thread.go
+++ b/internal/web/thread.go
@@ -124,7 +124,6 @@ func (m *Module) threadGETHandler(c *gin.Context) {
 			cssFA,
 			cssStatus,
 			cssThread,
-			instanceCustomCSSPath,
 		}...,
 	)
 

--- a/web/template/page_stylesheets.tmpl
+++ b/web/template/page_stylesheets.tmpl
@@ -32,10 +32,16 @@
 {{- range .stylesheets }}
 <link rel="preload" href="{{- . -}}" as="style">
 {{- end }}
+{{- if .instance.CustomCSS }}
+<link rel="preload" href="/custom.css" as="style">
+{{- end }}
 <link rel="stylesheet" href="/assets/dist/_colors.css">
 <link rel="stylesheet" href="/assets/dist/base.css">
 <link rel="stylesheet" href="/assets/dist/page.css">
 {{- range .stylesheets }}
 <link rel="stylesheet" href="{{- . -}}">
+{{- end }}
+{{- if .instance.CustomCSS }}
+<link rel="stylesheet" href="/custom.css">
 {{- end }}
 {{- end }}


### PR DESCRIPTION
# Description

closes #3600

After making this modification to `page_stylesheets.tmpl`, all pages mentioned in #3600 can now load `/custom.css`. On the profile page, `/custom.css` still loads before `/@username/custom.css`, and it seems there’s no redundant import for pages like `/about` where `instanceCustomCSSPath` was loaded in `internal/web` beforehand. So I’m not entirely sure if we should remove the reference to `instanceCustomCSSPath` in `internal/web`.

Additionally, the changes in this PR use a hardcoded path for `/custom.css`. When updating `instanceCustomCSSPath` in the future, we'll also need to update the content in `page_stylesheets.tmpl`. Alternatively, we could consider changing `customCSS` to `customCSSPath` in the instance model, which would allow for unified referencing in the Go template imo.

Edit: sorry, pushed wrong commit

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
