### PR TITLE
[feature] add support for sending headers to tracing system

### DIFF
--- a/docs/advanced/tracing.md
+++ b/docs/advanced/tracing.md
@@ -12,6 +12,9 @@ You'll need the files in [`example/tracing`][ext]. Once you have those you can r
 tracing-enabled: true
 tracing-transport: "grpc"
 tracing-endpoint: "localhost:4317"
+tracing-headers:
+  "Authorization": "Bearer super-secret-token"
+  "Dataset": "gotosocial"
 tracing-insecure-transport: true
 ```
 

--- a/docs/configuration/observability.md
+++ b/docs/configuration/observability.md
@@ -35,6 +35,13 @@ tracing-transport: "grpc"
 # Default: ""
 tracing-endpoint: ""
 
+# Map of strings. Additional headers to send to the trace ingester.
+# Additional HTTP or gRPC headers can be used for authentication or other additional
+# information for the tracing system.
+# Examples: {"Authorization": "Bearer super-secret-token", "Dataset": "gotosocial"}
+# Default: {}
+tracing-headers: {}
+
 # Bool. Disable TLS for the gRPC and HTTP transport protocols.
 # Default: false
 tracing-insecure-transport: false

--- a/docs/locales/zh/advanced/tracing.md
+++ b/docs/locales/zh/advanced/tracing.md
@@ -12,6 +12,9 @@ GoToSocial 内置了基于 [OpenTelemetry][otel] 的追踪功能。虽然并没�
 tracing-enabled: true
 tracing-transport: "grpc"
 tracing-endpoint: "localhost:4317"
+tracing-headers:
+  "Authorization": "Bearer super-secret-token"
+  "Dataset": "gotosocial"
 tracing-insecure-transport: true
 ```
 

--- a/docs/locales/zh/configuration/observability.md
+++ b/docs/locales/zh/configuration/observability.md
@@ -31,6 +31,11 @@ tracing-transport: "grpc"
 # 默认值: ""
 tracing-endpoint: ""
 
+# TODO
+# 示例: {"Authorization": "Bearer super-secret-token", "Dataset": "gotosocial"}
+# 默认值: {}
+tracing-headers: {}
+
 # 布尔值。禁用gRPC和HTTP传输协议的TLS。
 # 默认值: false
 tracing-insecure-transport: false

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -928,6 +928,13 @@ tracing-transport: "grpc"
 # Default: ""
 tracing-endpoint: ""
 
+# Map of strings. Additional headers to send to the trace ingester.
+# Additional HTTP or gRPC headers can be used for authentication or other additional
+# information for the tracing system.
+# Examples: {"Authorization": "Bearer super-secret-token", "Dataset": "gotosocial"}
+# Default: {}
+tracing-headers: {}
+
 # Bool. Disable TLS for the gRPC and HTTP transport protocols.
 # Default: false
 tracing-insecure-transport: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -140,10 +140,11 @@ type Configuration struct {
 	OIDCAllowedGroups    []string `name:"oidc-allowed-groups" usage:"Membership of one of the listed groups allows access to GtS. If this is empty, all groups are allowed."`
 	OIDCAdminGroups      []string `name:"oidc-admin-groups" usage:"Membership of one of the listed groups makes someone a GtS admin"`
 
-	TracingEnabled           bool   `name:"tracing-enabled" usage:"Enable OTLP Tracing"`
-	TracingTransport         string `name:"tracing-transport" usage:"grpc or http"`
-	TracingEndpoint          string `name:"tracing-endpoint" usage:"Endpoint of your trace collector. Eg., 'localhost:4317' for gRPC, 'localhost:4318' for http"`
-	TracingInsecureTransport bool   `name:"tracing-insecure-transport" usage:"Disable TLS for the gRPC or HTTP transport protocol"`
+	TracingEnabled           bool              `name:"tracing-enabled" usage:"Enable OTLP Tracing"`
+	TracingTransport         string            `name:"tracing-transport" usage:"grpc or http"`
+	TracingEndpoint          string            `name:"tracing-endpoint" usage:"Endpoint of your trace collector. Eg., 'localhost:4317' for gRPC, 'localhost:4318' for http"`
+	TracingHeaders           map[string]string `name:"tracing-headers" usage:"Headers for your trace collector. Eg., 'Authorization: Bearer super-secret-token' for sending an 'Authorization' header"`
+	TracingInsecureTransport bool              `name:"tracing-insecure-transport" usage:"Disable TLS for the gRPC or HTTP transport protocol"`
 
 	MetricsEnabled      bool   `name:"metrics-enabled" usage:"Enable OpenTelemetry based metrics support."`
 	MetricsAuthEnabled  bool   `name:"metrics-auth-enabled" usage:"Enable HTTP Basic Authentication for Prometheus metrics endpoint"`

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -120,6 +120,7 @@ var Defaults = Configuration{
 	TracingEnabled:           false,
 	TracingTransport:         "grpc",
 	TracingEndpoint:          "",
+	TracingHeaders:           map[string]string{},
 	TracingInsecureTransport: false,
 
 	MetricsEnabled:     false,

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -2191,6 +2191,22 @@ func (st *ConfigState) SetTracingEndpoint(v string) {
 	st.reloadToViper()
 }
 
+// GetTracingHeaders safely fetches the Configuration value for state's 'TracingHeaders' field
+func (st *ConfigState) GetTracingHeaders() (v map[string]string) {
+	st.mutex.RLock()
+	v = st.config.TracingHeaders
+	st.mutex.RUnlock()
+	return
+}
+
+// SetTracingEndpoint safely sets the Configuration value for state's 'TracingHeaders' field
+func (st *ConfigState) SetTracingHeaders(v map[string]string) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.TracingHeaders = v
+	st.reloadToViper()
+}
+
 // TracingEndpointFlag returns the flag name for the 'TracingEndpoint' field
 func TracingEndpointFlag() string { return "tracing-endpoint" }
 

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -2,7 +2,7 @@
 // GoToSocial
 // Copyright (C) GoToSocial Authors admin@gotosocial.org
 // SPDX-License-Identifier: AGPL-3.0-or-later
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -2191,22 +2191,6 @@ func (st *ConfigState) SetTracingEndpoint(v string) {
 	st.reloadToViper()
 }
 
-// GetTracingHeaders safely fetches the Configuration value for state's 'TracingHeaders' field
-func (st *ConfigState) GetTracingHeaders() (v map[string]string) {
-	st.mutex.RLock()
-	v = st.config.TracingHeaders
-	st.mutex.RUnlock()
-	return
-}
-
-// SetTracingEndpoint safely sets the Configuration value for state's 'TracingHeaders' field
-func (st *ConfigState) SetTracingHeaders(v map[string]string) {
-	st.mutex.Lock()
-	defer st.mutex.Unlock()
-	st.config.TracingHeaders = v
-	st.reloadToViper()
-}
-
 // TracingEndpointFlag returns the flag name for the 'TracingEndpoint' field
 func TracingEndpointFlag() string { return "tracing-endpoint" }
 
@@ -2215,6 +2199,31 @@ func GetTracingEndpoint() string { return global.GetTracingEndpoint() }
 
 // SetTracingEndpoint safely sets the value for global configuration 'TracingEndpoint' field
 func SetTracingEndpoint(v string) { global.SetTracingEndpoint(v) }
+
+// GetTracingHeaders safely fetches the Configuration value for state's 'TracingHeaders' field
+func (st *ConfigState) GetTracingHeaders() (v map[string]string) {
+	st.mutex.RLock()
+	v = st.config.TracingHeaders
+	st.mutex.RUnlock()
+	return
+}
+
+// SetTracingHeaders safely sets the Configuration value for state's 'TracingHeaders' field
+func (st *ConfigState) SetTracingHeaders(v map[string]string) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.TracingHeaders = v
+	st.reloadToViper()
+}
+
+// TracingHeadersFlag returns the flag name for the 'TracingHeaders' field
+func TracingHeadersFlag() string { return "tracing-headers" }
+
+// GetTracingHeaders safely fetches the value for global configuration 'TracingHeaders' field
+func GetTracingHeaders() map[string]string { return global.GetTracingHeaders() }
+
+// SetTracingHeaders safely sets the value for global configuration 'TracingHeaders' field
+func SetTracingHeaders(v map[string]string) { global.SetTracingHeaders(v) }
 
 // GetTracingInsecureTransport safely fetches the Configuration value for state's 'TracingInsecureTransport' field
 func (st *ConfigState) GetTracingInsecureTransport() (v bool) {
@@ -3158,19 +3167,13 @@ func (st *ConfigState) SetCacheConversationLastStatusIDsMemRatio(v float64) {
 }
 
 // CacheConversationLastStatusIDsMemRatioFlag returns the flag name for the 'Cache.ConversationLastStatusIDsMemRatio' field
-func CacheConversationLastStatusIDsMemRatioFlag() string {
-	return "cache-conversation-last-status-ids-mem-ratio"
-}
+func CacheConversationLastStatusIDsMemRatioFlag() string { return "cache-conversation-last-status-ids-mem-ratio" }
 
 // GetCacheConversationLastStatusIDsMemRatio safely fetches the value for global configuration 'Cache.ConversationLastStatusIDsMemRatio' field
-func GetCacheConversationLastStatusIDsMemRatio() float64 {
-	return global.GetCacheConversationLastStatusIDsMemRatio()
-}
+func GetCacheConversationLastStatusIDsMemRatio() float64 { return global.GetCacheConversationLastStatusIDsMemRatio() }
 
 // SetCacheConversationLastStatusIDsMemRatio safely sets the value for global configuration 'Cache.ConversationLastStatusIDsMemRatio' field
-func SetCacheConversationLastStatusIDsMemRatio(v float64) {
-	global.SetCacheConversationLastStatusIDsMemRatio(v)
-}
+func SetCacheConversationLastStatusIDsMemRatio(v float64) { global.SetCacheConversationLastStatusIDsMemRatio(v) }
 
 // GetCacheDomainPermissionDraftMemRation safely fetches the Configuration value for state's 'Cache.DomainPermissionDraftMemRation' field
 func (st *ConfigState) GetCacheDomainPermissionDraftMemRation() (v float64) {
@@ -3189,19 +3192,13 @@ func (st *ConfigState) SetCacheDomainPermissionDraftMemRation(v float64) {
 }
 
 // CacheDomainPermissionDraftMemRationFlag returns the flag name for the 'Cache.DomainPermissionDraftMemRation' field
-func CacheDomainPermissionDraftMemRationFlag() string {
-	return "cache-domain-permission-draft-mem-ratio"
-}
+func CacheDomainPermissionDraftMemRationFlag() string { return "cache-domain-permission-draft-mem-ratio" }
 
 // GetCacheDomainPermissionDraftMemRation safely fetches the value for global configuration 'Cache.DomainPermissionDraftMemRation' field
-func GetCacheDomainPermissionDraftMemRation() float64 {
-	return global.GetCacheDomainPermissionDraftMemRation()
-}
+func GetCacheDomainPermissionDraftMemRation() float64 { return global.GetCacheDomainPermissionDraftMemRation() }
 
 // SetCacheDomainPermissionDraftMemRation safely sets the value for global configuration 'Cache.DomainPermissionDraftMemRation' field
-func SetCacheDomainPermissionDraftMemRation(v float64) {
-	global.SetCacheDomainPermissionDraftMemRation(v)
-}
+func SetCacheDomainPermissionDraftMemRation(v float64) { global.SetCacheDomainPermissionDraftMemRation(v) }
 
 // GetCacheEmojiMemRatio safely fetches the Configuration value for state's 'Cache.EmojiMemRatio' field
 func (st *ConfigState) GetCacheEmojiMemRatio() (v float64) {
@@ -4427,3 +4424,4 @@ func GetRequestIDHeader() string { return global.GetRequestIDHeader() }
 
 // SetRequestIDHeader safely sets the value for global configuration 'RequestIDHeader' field
 func SetRequestIDHeader(v string) { global.SetRequestIDHeader(v) }
+

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -2,7 +2,7 @@
 // GoToSocial
 // Copyright (C) GoToSocial Authors admin@gotosocial.org
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -3167,13 +3167,19 @@ func (st *ConfigState) SetCacheConversationLastStatusIDsMemRatio(v float64) {
 }
 
 // CacheConversationLastStatusIDsMemRatioFlag returns the flag name for the 'Cache.ConversationLastStatusIDsMemRatio' field
-func CacheConversationLastStatusIDsMemRatioFlag() string { return "cache-conversation-last-status-ids-mem-ratio" }
+func CacheConversationLastStatusIDsMemRatioFlag() string {
+	return "cache-conversation-last-status-ids-mem-ratio"
+}
 
 // GetCacheConversationLastStatusIDsMemRatio safely fetches the value for global configuration 'Cache.ConversationLastStatusIDsMemRatio' field
-func GetCacheConversationLastStatusIDsMemRatio() float64 { return global.GetCacheConversationLastStatusIDsMemRatio() }
+func GetCacheConversationLastStatusIDsMemRatio() float64 {
+	return global.GetCacheConversationLastStatusIDsMemRatio()
+}
 
 // SetCacheConversationLastStatusIDsMemRatio safely sets the value for global configuration 'Cache.ConversationLastStatusIDsMemRatio' field
-func SetCacheConversationLastStatusIDsMemRatio(v float64) { global.SetCacheConversationLastStatusIDsMemRatio(v) }
+func SetCacheConversationLastStatusIDsMemRatio(v float64) {
+	global.SetCacheConversationLastStatusIDsMemRatio(v)
+}
 
 // GetCacheDomainPermissionDraftMemRation safely fetches the Configuration value for state's 'Cache.DomainPermissionDraftMemRation' field
 func (st *ConfigState) GetCacheDomainPermissionDraftMemRation() (v float64) {
@@ -3192,13 +3198,19 @@ func (st *ConfigState) SetCacheDomainPermissionDraftMemRation(v float64) {
 }
 
 // CacheDomainPermissionDraftMemRationFlag returns the flag name for the 'Cache.DomainPermissionDraftMemRation' field
-func CacheDomainPermissionDraftMemRationFlag() string { return "cache-domain-permission-draft-mem-ratio" }
+func CacheDomainPermissionDraftMemRationFlag() string {
+	return "cache-domain-permission-draft-mem-ratio"
+}
 
 // GetCacheDomainPermissionDraftMemRation safely fetches the value for global configuration 'Cache.DomainPermissionDraftMemRation' field
-func GetCacheDomainPermissionDraftMemRation() float64 { return global.GetCacheDomainPermissionDraftMemRation() }
+func GetCacheDomainPermissionDraftMemRation() float64 {
+	return global.GetCacheDomainPermissionDraftMemRation()
+}
 
 // SetCacheDomainPermissionDraftMemRation safely sets the value for global configuration 'Cache.DomainPermissionDraftMemRation' field
-func SetCacheDomainPermissionDraftMemRation(v float64) { global.SetCacheDomainPermissionDraftMemRation(v) }
+func SetCacheDomainPermissionDraftMemRation(v float64) {
+	global.SetCacheDomainPermissionDraftMemRation(v)
+}
 
 // GetCacheEmojiMemRatio safely fetches the Configuration value for state's 'Cache.EmojiMemRatio' field
 func (st *ConfigState) GetCacheEmojiMemRatio() (v float64) {
@@ -4424,4 +4436,3 @@ func GetRequestIDHeader() string { return global.GetRequestIDHeader() }
 
 // SetRequestIDHeader safely sets the value for global configuration 'RequestIDHeader' field
 func SetRequestIDHeader(v string) { global.SetRequestIDHeader(v) }
-

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -60,6 +60,7 @@ func Initialize() error {
 	case "grpc":
 		opts := []otlptracegrpc.Option{
 			otlptracegrpc.WithEndpoint(config.GetTracingEndpoint()),
+			otlptracegrpc.WithHeaders(config.NewState().GetTracingHeaders()),
 		}
 		if insecure {
 			opts = append(opts, otlptracegrpc.WithInsecure())

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -60,7 +60,7 @@ func Initialize() error {
 	case "grpc":
 		opts := []otlptracegrpc.Option{
 			otlptracegrpc.WithEndpoint(config.GetTracingEndpoint()),
-			otlptracegrpc.WithHeaders(config.NewState().GetTracingHeaders()),
+			otlptracegrpc.WithHeaders(config.GetTracingHeaders()),
 		}
 		if insecure {
 			opts = append(opts, otlptracegrpc.WithInsecure())

--- a/test/envparsing.sh
+++ b/test/envparsing.sh
@@ -190,6 +190,7 @@ EXPECT=$(cat << "EOF"
     "tls-certificate-key": "",
     "tracing-enabled": false,
     "tracing-endpoint": "localhost:4317",
+    "tracing-headers": {},
     "tracing-insecure-transport": true,
     "tracing-transport": "grpc",
     "trusted-proxies": [


### PR DESCRIPTION
# Description

Add support for sending additional HTTP or gRPC headers which can be used for authentication or other additional information for the tracing system without having to set up a local instance of the OpenTelemetry Collector to add these headers.

Example with [Dash0](https://www.dash0.com/):

```yaml
tracing-enabled: false
tracing-transport: "grpc"
tracing-endpoint: "ingress.eu-west-1.aws.dash0.com:4317"
tracing-headers:
  "Authorization": "Bearer DASH0_AUTH_TOKEN"
  "Dash0-Dataset": "gotosocial"
```

Example with [Honeycomb](https://www.honeycomb.io/):

```yaml
tracing-enabled: false
tracing-transport: "grpc"
tracing-endpoint: "api.honeycomb.io:443"
tracing-headers:
  "x-honeycomb-team": "YOUR_API_KEY"
  "x-honeycomb-dataset": "YOUR_DATASET"
```

refs #1230

See also https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp@v1.32.0#WithHeaders.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
