### PR TITLE
[docs] Add missing --config-path arg in backup documentation

### DIFF
--- a/docs/admin/backup_and_restore.md
+++ b/docs/admin/backup_and_restore.md
@@ -186,7 +186,7 @@ You'll need to put that file on your GoToSocial instance and make sure the file 
     For this to work reliably, you should ensure that the [storage-local-base-path](../configuration/storage.md) in your GoToSocial configuration uses an absolute path. Otherwise you'll have to tweak the paths yourself.
 
 ```sh
-$ gotosocial admin media list-attachments --local-only | \
+$ gotosocial --config-path /path/to/config.yaml admin media list-attachments --local-only | \
     /path/to/media-to-borg-patterns.py \
     <storage-local-base-path>
 ```
@@ -210,7 +210,7 @@ If you're running Borgmatic as a systemd service, you can [create a drop-in](htt
 
 ```ini
 [Service]
-ExecStartPre=/path/to/gotosocial admin media list-attachments --local-only | /path/to/media-to-borg-patterns.py <storage-local-base-path> /etc/borgmatic/gotosocial_patterns
+ExecStartPre=/path/to/gotosocial --config-path /path/to/config.yaml admin media list-attachments --local-only | /path/to/media-to-borg-patterns.py <storage-local-base-path> /etc/borgmatic/gotosocial_patterns
 ```
 
 Documentation that's good to review:


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates the documentation for backups using Borgmatic.  The commands for generating storage paths were missing the `--config-path` argument.

closes #3603 

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] Ihave discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.

