### PR TITLE
[chore] Stub /api/v1/announcements implementation

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -6745,6 +6745,34 @@ paths:
             summary: View instance rule with the given id.
             tags:
                 - admin
+    /api/v1/announcements:
+        get:
+            description: 'THIS ENDPOINT IS CURRENTLY NOT FULLY IMPLEMENTED: it will always return an empty array.'
+            operationId: announcementsGet
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: ""
+                    schema:
+                        items:
+                            type: object
+                        type: array
+                        maxItems: 0
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - read:announcements
+            summary: Get an array of currently active announcements.
+            tags:
+                - announcements
     /api/v1/apps:
         post:
             consumes:

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -6757,8 +6757,8 @@ paths:
                     schema:
                         items:
                             type: object
-                        type: array
                         maxItems: 0
+                        type: array
                 "400":
                     description: bad request
                 "401":

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/accounts"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/admin"
+	"github.com/superseriousbusiness/gotosocial/internal/api/client/announcements"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/apps"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/blocks"
 	"github.com/superseriousbusiness/gotosocial/internal/api/client/bookmarks"
@@ -66,6 +67,7 @@ type Client struct {
 
 	accounts            *accounts.Module            // api/v1/accounts, api/v1/profile
 	admin               *admin.Module               // api/v1/admin
+	announcements       *announcements.Module       // api/v1/announcements
 	apps                *apps.Module                // api/v1/apps
 	blocks              *blocks.Module              // api/v1/blocks
 	bookmarks           *bookmarks.Module           // api/v1/bookmarks
@@ -117,6 +119,7 @@ func (c *Client) Route(r *router.Router, m ...gin.HandlerFunc) {
 	h := apiGroup.Handle
 	c.accounts.Route(h)
 	c.admin.Route(h)
+	c.announcements.Route(h)
 	c.apps.Route(h)
 	c.blocks.Route(h)
 	c.bookmarks.Route(h)
@@ -156,6 +159,7 @@ func NewClient(state *state.State, p *processing.Processor) *Client {
 
 		accounts:            accounts.New(p),
 		admin:               admin.New(state, p),
+		announcements:       announcements.New(p),
 		apps:                apps.New(p),
 		blocks:              blocks.New(p),
 		bookmarks:           bookmarks.New(p),

--- a/internal/api/client/announcements/announcements.go
+++ b/internal/api/client/announcements/announcements.go
@@ -1,0 +1,42 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package announcements
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/processing"
+)
+
+// BasePath is the base path for this api module, excluding the api prefix
+const BasePath = "/v1/announcements"
+
+type Module struct {
+	processor *processing.Processor
+}
+
+func New(processor *processing.Processor) *Module {
+	return &Module{
+		processor: processor,
+	}
+}
+
+func (m *Module) Route(attachHandler func(method string, path string, f ...gin.HandlerFunc) gin.IRoutes) {
+	attachHandler(http.MethodGet, BasePath, m.AnnouncementsGETHandler)
+}

--- a/internal/api/client/announcements/announcementsget.go
+++ b/internal/api/client/announcements/announcementsget.go
@@ -30,6 +30,13 @@ import (
 //
 // Get an array of currently active announcements.
 //
+//	---
+//	tags:
+//	- announcements
+//
+//	produces:
+//	- application/json
+//
 //	security:
 //	- OAuth2 Bearer:
 //		- read:announcements

--- a/internal/api/client/announcements/announcementsget.go
+++ b/internal/api/client/announcements/announcementsget.go
@@ -30,6 +30,8 @@ import (
 //
 // Get an array of currently active announcements.
 //
+// THIS ENDPOINT IS CURRENTLY NOT FULLY IMPLEMENTED: it will always return an empty array.
+//
 //	---
 //	tags:
 //	- announcements

--- a/internal/api/client/announcements/announcementsget.go
+++ b/internal/api/client/announcements/announcementsget.go
@@ -1,0 +1,65 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package announcements
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+	"github.com/superseriousbusiness/gotosocial/internal/oauth"
+)
+
+// AnnouncementsGETHandler swagger:operation GET /api/v1/announcements announcementsGet
+//
+// Get an array of currently active announcements.
+//
+//	security:
+//	- OAuth2 Bearer:
+//		- read:announcements
+//
+//	responses:
+//		'200':
+//			schema:
+//				type: array
+//				items:
+//					type: object
+//				maxItems: 0
+//		'400':
+//			description: bad request
+//		'401':
+//			description: unauthorized
+//		'406':
+//			description: not acceptable
+//		'500':
+//			description: internal server error
+func (m *Module) AnnouncementsGETHandler(c *gin.Context) {
+	_, err := oauth.Authed(c, true, true, true, true)
+	if err != nil {
+		apiutil.ErrorHandler(c, gtserror.NewErrorUnauthorized(err, err.Error()), m.processor.InstanceGetV1)
+		return
+	}
+
+	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
+		return
+	}
+
+	apiutil.JSON(c, http.StatusOK, apiutil.EmptyJSONArray)
+}


### PR DESCRIPTION
# Description

This implements the [`/api/v1/announcements`](https://docs.joinmastodon.org/methods/announcements/#get) endpoint by simply returning an empty array. This indicates there are no instance announcements.

Some clients retrieve this endpoint and get surprised by a 404. It tends to be harmless, but results in some unnecessary logging when trying to debug other things.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
