### PR TITLE
[bugfix] small editing tweaks

### DIFF
--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -1160,7 +1160,7 @@ func (d *Dereferencer) handleStatusEdit(
 	switch {
 	// We prefer to use provided 'upated_at', but ensure
 	// it fits chronologically with creation / last update.
-
+	//
 	// updated_at has jumped backward, safety check it.
 	case existing.UpdatedAt.Before(status.UpdatedAt):
 		cols = append(cols, "updated_at")

--- a/internal/federation/dereferencing/status.go
+++ b/internal/federation/dereferencing/status.go
@@ -477,12 +477,6 @@ func (d *Dereferencer) enrichStatus(
 		)
 	}
 
-	// Ensure that status isn't trying to re-date itself.
-	if !latestStatus.CreatedAt.Equal(status.CreatedAt) {
-		err := gtserror.Newf("status %s 'published' changed", uri)
-		return nil, nil, gtserror.SetMalformed(err)
-	}
-
 	// Ensure the final parsed status URI or URL matches
 	// the input URI we fetched (or received) it as.
 	matches, err := util.URIMatches(uri,
@@ -510,6 +504,12 @@ func (d *Dereferencer) enrichStatus(
 		// Generate new status ID from the provided creation date.
 		latestStatus.ID = id.NewULIDFromTime(latestStatus.CreatedAt)
 	} else {
+
+		// Ensure that status isn't trying to re-date itself.
+		if !latestStatus.CreatedAt.Equal(status.CreatedAt) {
+			err := gtserror.Newf("status %s 'published' changed", uri)
+			return nil, nil, gtserror.SetMalformed(err)
+		}
 
 		// Reuse existing status ID.
 		latestStatus.ID = status.ID

--- a/internal/typeutils/astointernal.go
+++ b/internal/typeutils/astointernal.go
@@ -364,7 +364,7 @@ func (c *Converter) ASStatusToStatus(ctx context.Context, statusable ap.Statusab
 	// status.Updated
 	//
 	// Extract and validate update time for status. Defaults to published.
-	if upd := ap.GetUpdated(statusable); upd.After(status.CreatedAt) {
+	if upd := ap.GetUpdated(statusable); !upd.Before(status.CreatedAt) {
 		status.UpdatedAt = upd
 	} else if upd.IsZero() {
 		status.UpdatedAt = status.CreatedAt

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -1383,11 +1383,13 @@ func (c *Converter) baseStatusToFrontend(
 		InteractionPolicy:  *apiInteractionPolicy,
 	}
 
-	// Nullable fields.
-	if !s.UpdatedAt.Equal(s.CreatedAt) {
+	// Only set edited_at if this is a non-boost-wrapper
+	// with an updated_at date different to creation date.
+	if !s.UpdatedAt.Equal(s.CreatedAt) && s.BoostOfID == "" {
 		timestamp := util.FormatISO8601(s.UpdatedAt)
 		apiStatus.EditedAt = util.Ptr(timestamp)
 	}
+
 	apiStatus.InReplyToID = util.PtrIf(s.InReplyToID)
 	apiStatus.InReplyToAccountID = util.PtrIf(s.InReplyToAccountID)
 	apiStatus.Language = util.PtrIf(s.Language)


### PR DESCRIPTION
# Description

- ensures that edited_at is never set for boosts
- adds better handling of the updated_at field for remote statuses

sometime soon i'll make a PR that just drops the updated_at column and instead has an optional edited_at column. though for now this should make it behave a bit better for users currently on main, and the PR for dropping that column and adding a new one will be a monstrous migration that requires iterating the entire statuses table :')

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
