### PR TITLE
[bugfix] migration to cleanup dropped status edits

### DIFF
--- a/internal/db/bundb/migrations/20250106165529_cleanup_dropped_edits.go
+++ b/internal/db/bundb/migrations/20250106165529_cleanup_dropped_edits.go
@@ -37,7 +37,7 @@ func init() {
 			// the status they reference.
 			if err := tx.NewSelect().
 				Model(&edits).
-				Join("? AS ? ON ? = ?",
+				Join("JOIN ? AS ? ON ? = ?",
 					bun.Ident("statuses"),
 					bun.Ident("status"),
 					bun.Ident("status.id"),
@@ -47,6 +47,7 @@ func init() {
 					bun.Ident("status.edits"),
 					"%", bun.Ident("status_edit.id"), "%",
 				).
+				Column("id", "status_id", "created_at").
 				Scan(ctx, &edits); err != nil {
 				return err
 			}

--- a/internal/db/bundb/migrations/20250106165529_cleanup_dropped_edits.go
+++ b/internal/db/bundb/migrations/20250106165529_cleanup_dropped_edits.go
@@ -117,7 +117,7 @@ func init() {
 					Column("edits").
 					Where("? = ?",
 						bun.Ident("id"),
-						status.ID,
+						edit.StatusID,
 					).
 					Exec(ctx); err != nil {
 					return fmt.Errorf("error updating status.edits: %w", err)

--- a/internal/db/bundb/migrations/20250106165529_cleanup_dropped_edits.go
+++ b/internal/db/bundb/migrations/20250106165529_cleanup_dropped_edits.go
@@ -45,9 +45,7 @@ func init() {
 				).
 				Where("? NOT LIKE concat(?, ?, ?)",
 					bun.Ident("status.edits"),
-					bun.Ident("%"),
-					bun.Ident("status_edit.id"),
-					bun.Ident("%"),
+					"%", bun.Ident("status_edit.id"), "%",
 				).
 				Scan(ctx, &edits); err != nil {
 				return err


### PR DESCRIPTION
# Description

A migration that fixes the resulting data of a bug introduced with status edits, but fixed in #3636 

This finds all the dropped status edits with a status to relink to and reinserts it back into the status' list of edits.

This shouldn't do anything for anyone that has this migration run on the final release (as they won't have had the bug!), but it will fix up the databases of those running the snapshot currently :)

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
