### PR TITLE
[performance] reduce InboxForward->Create calls by partially implementing Exists()

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -40,17 +40,17 @@ type Caches struct {
 	// the block []headerfilter.Filter cache.
 	BlockHeaderFilters headerfilter.Cache
 
+	// TTL cache of statuses -> filterable text fields.
+	// To ensure up-to-date fields, cache is keyed as:
+	// `[status.ID][status.UpdatedAt.Unix()]`
+	StatusesFilterableFields *ttl.Cache[string, []string]
+
 	// Visibility provides access to the item visibility
 	// cache. (used by the visibility filter).
 	Visibility VisibilityCache
 
 	// Webfinger provides access to the webfinger URL cache.
 	Webfinger *ttl.Cache[string, string] // TTL=24hr, sweep=5min
-
-	// TTL cache of statuses -> filterable text fields.
-	// To ensure up-to-date fields, cache is keyed as:
-	// `[status.ID][status.UpdatedAt.Unix()]`
-	StatusesFilterableFields *ttl.Cache[string, []string]
 
 	// prevent pass-by-value.
 	_ nocopy
@@ -203,6 +203,15 @@ func (c *Caches) Sweep(threshold float64) {
 	c.Visibility.Trim(threshold)
 }
 
+func (c *Caches) initStatusesFilterableFields() {
+	c.StatusesFilterableFields = new(ttl.Cache[string, []string])
+	c.StatusesFilterableFields.Init(
+		0,
+		512,
+		1*time.Hour,
+	)
+}
+
 func (c *Caches) initWebfinger() {
 	// Calculate maximum cache size.
 	cap := calculateCacheMax(
@@ -217,14 +226,5 @@ func (c *Caches) initWebfinger() {
 		0,
 		cap,
 		24*time.Hour,
-	)
-}
-
-func (c *Caches) initStatusesFilterableFields() {
-	c.StatusesFilterableFields = new(ttl.Cache[string, []string])
-	c.StatusesFilterableFields.Init(
-		0,
-		512,
-		1*time.Hour,
 	)
 }

--- a/internal/federation/federatingdb/create.go
+++ b/internal/federation/federatingdb/create.go
@@ -63,6 +63,10 @@ func (f *federatingDB) Create(ctx context.Context, asType vocab.Type) error {
 		return nil
 	}
 
+	// Cache entry for this create activity ID for later
+	// checks in the Exist() function if we see it again.
+	f.createdIDs.Set(ap.GetJSONLDId(asType).String(), struct{}{})
+
 	switch name := asType.GetTypeName(); name {
 	case ap.ActivityBlock:
 		// BLOCK SOMETHING

--- a/internal/federation/federatingdb/create.go
+++ b/internal/federation/federatingdb/create.go
@@ -65,7 +65,7 @@ func (f *federatingDB) Create(ctx context.Context, asType vocab.Type) error {
 
 	// Cache entry for this create activity ID for later
 	// checks in the Exist() function if we see it again.
-	f.createdIDs.Set(ap.GetJSONLDId(asType).String(), struct{}{})
+	f.activityIDs.Set(ap.GetJSONLDId(asType).String(), struct{}{})
 
 	switch name := asType.GetTypeName(); name {
 	case ap.ActivityBlock:

--- a/internal/federation/federatingdb/db.go
+++ b/internal/federation/federatingdb/db.go
@@ -84,6 +84,6 @@ func New(
 		intFilter:  intFilter,
 		spamFilter: spamFilter,
 	}
-	fdb.activityIDs.Init(0, 1000)
+	fdb.activityIDs.Init(0, 2048)
 	return &fdb
 }

--- a/internal/federation/federatingdb/db.go
+++ b/internal/federation/federatingdb/db.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"net/url"
 
+	"codeberg.org/gruf/go-cache/v3/simple"
 	"github.com/superseriousbusiness/activity/pub"
 	"github.com/superseriousbusiness/activity/streams/vocab"
 	"github.com/superseriousbusiness/gotosocial/internal/filter/interaction"
@@ -61,6 +62,10 @@ type federatingDB struct {
 	visFilter  *visibility.Filter
 	intFilter  *interaction.Filter
 	spamFilter *spam.Filter
+
+	// tracks Activity IDs we have handled creates for,
+	// for use in the Exists() function during forwarding.
+	createdIDs simple.Cache[string, struct{}]
 }
 
 // New returns a DB that satisfies the pub.Database
@@ -79,5 +84,6 @@ func New(
 		intFilter:  intFilter,
 		spamFilter: spamFilter,
 	}
+	fdb.createdIDs.Init(0, 1000)
 	return &fdb
 }

--- a/internal/federation/federatingdb/db.go
+++ b/internal/federation/federatingdb/db.go
@@ -65,7 +65,7 @@ type federatingDB struct {
 
 	// tracks Activity IDs we have handled creates for,
 	// for use in the Exists() function during forwarding.
-	createdIDs simple.Cache[string, struct{}]
+	activityIDs simple.Cache[string, struct{}]
 }
 
 // New returns a DB that satisfies the pub.Database
@@ -84,6 +84,6 @@ func New(
 		intFilter:  intFilter,
 		spamFilter: spamFilter,
 	}
-	fdb.createdIDs.Init(0, 1000)
+	fdb.activityIDs.Init(0, 1000)
 	return &fdb
 }

--- a/internal/federation/federatingdb/exists.go
+++ b/internal/federation/federatingdb/exists.go
@@ -25,5 +25,5 @@ import (
 // Exists is an implementation of pub.Database{}.Exists(), optimized specifically for
 // the only usecase in which go-fed/activity/pub actually calls it. Do not use otherwise!
 func (f *federatingDB) Exists(ctx context.Context, id *url.URL) (exists bool, err error) {
-	return f.createdIDs.Has(id.String()), nil
+	return f.activityIDs.Has(id.String()), nil
 }

--- a/internal/federation/federatingdb/exists.go
+++ b/internal/federation/federatingdb/exists.go
@@ -22,12 +22,8 @@ import (
 	"net/url"
 )
 
-// Exists returns true if the database has an entry for the specified
-// id. It may not be owned by this application instance.
-//
-// The library makes this call only after acquiring a lock first.
-//
-// Implementation note: this just straight up isn't implemented, and doesn't *really* need to be either.
+// Exists is an implementation of pub.Database{}.Exists(), optimized specifically for
+// the only usecase in which go-fed/activity/pub actually calls it. Do not use otherwise!
 func (f *federatingDB) Exists(ctx context.Context, id *url.URL) (exists bool, err error) {
-	return false, nil
+	return f.createdIDs.Has(id.String()), nil
 }

--- a/internal/federation/federator.go
+++ b/internal/federation/federator.go
@@ -33,7 +33,7 @@ import (
 var _ interface {
 	pub.CommonBehavior
 	pub.FederatingProtocol
-} = &Federator{}
+} = (*Federator)(nil)
 
 type Federator struct {
 	db                  db.DB

--- a/internal/federation/transport.go
+++ b/internal/federation/transport.go
@@ -49,7 +49,7 @@ import (
 // Note that the library will not maintain a long-lived pointer to the
 // returned Transport so that any private credentials are able to be
 // garbage collected.
-func (f *Federator) NewTransport(ctx context.Context, actorBoxIRI *url.URL, gofedAgent string) (pub.Transport, error) {
+func (f *Federator) NewTransport(ctx context.Context, actorBoxIRI *url.URL, _ string) (pub.Transport, error) {
 	var username string
 	var err error
 


### PR DESCRIPTION
# Description

This adds a simple in-memory map that stores the IDs of activities that we have recently created, which allows us to partially implement Exists() and reduce the number of unnecessary calls to Create() during inbox forwarding. Unfortunately we can never return a definite answer in Exists(), since the **activity** JSONLD-ID doesn't necessarily match the stored **object**'s JSONLD-ID, which is the only part that we actually store in a lot of cases. So this provides a best-effort implementation to at least reduce unnecessary calls for recently handled activities.

In the future, I don't think we should strive to "fully" implement Exists(), instead focusing on removing our reliance on the go-fed code for federation logic.

Partially handles #1891 

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
