### PR TITLE
[bugfix] Store LastModified for domain perm subs + send as `If-Modified-Since`

### DIFF
--- a/docs/configuration/instance.md
+++ b/docs/configuration/instance.md
@@ -128,4 +128,14 @@ instance-deliver-to-shared-inboxes: true
 # Options: [true, false]
 # Default: false
 instance-inject-mastodon-version: false
+
+# String. 24hr time of day formatted as hh:mm.
+# Examples: ["14:30", "00:00", "04:00"]
+# Default: "23:00" (11pm).
+instance-subscriptions-process-from: "23:00"
+
+# Duration. Period between subscription updates.
+# Examples: ["24h", "72h", "12h"]
+# Default: "24h" (once per day).
+instance-subscriptions-process-every: "24h"
 ```

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -415,6 +415,15 @@ instance-deliver-to-shared-inboxes: true
 # Default: false
 instance-inject-mastodon-version: false
 
+# String. 24hr time of day formatted as hh:mm.
+# Examples: ["14:30", "00:00", "04:00"]
+# Default: "23:00" (11pm).
+instance-subscriptions-process-from: "23:00"
+
+# Duration. Period between subscription updates.
+# Examples: ["24h", "72h", "12h"]
+# Default: "24h" (once per day).
+instance-subscriptions-process-every: "24h"
 
 ###########################
 ##### ACCOUNTS CONFIG #####

--- a/internal/cache/size.go
+++ b/internal/cache/size.go
@@ -372,6 +372,7 @@ func sizeofDomainPermissionSubscription() uintptr {
 		FetchedAt:             exampleTime,
 		SuccessfullyFetchedAt: exampleTime,
 		ETag:                  exampleID,
+		LastModified:          exampleTime,
 		Error:                 exampleTextSmall,
 	}))
 }

--- a/internal/db/bundb/migrations/20241022153016_domain_permission_subscriptions/domainpermissionsubscription.go
+++ b/internal/db/bundb/migrations/20241022153016_domain_permission_subscriptions/domainpermissionsubscription.go
@@ -33,6 +33,7 @@ type DomainPermissionSubscription struct {
 	FetchPassword         string    `bun:",nullzero"`
 	FetchedAt             time.Time `bun:"type:timestamptz,nullzero"`
 	SuccessfullyFetchedAt time.Time `bun:"type:timestamptz,nullzero"`
+	LastModified          time.Time `bun:"type:timestamptz,nullzero"`
 	ETag                  string    `bun:"etag,nullzero"`
 	Error                 string    `bun:",nullzero"`
 }

--- a/internal/db/bundb/migrations/20250119112746_domain_perm_sub_caching_tweaks.go
+++ b/internal/db/bundb/migrations/20250119112746_domain_perm_sub_caching_tweaks.go
@@ -1,0 +1,76 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			// Bail if "last_modified"
+			// column already created.
+			if exists, err := doesColumnExist(
+				ctx,
+				tx,
+				"domain_permission_subscriptions",
+				"last_modified",
+			); err != nil {
+				return err
+			} else if exists {
+				return nil
+			}
+
+			// Derive column definition.
+			var permSub *gtsmodel.DomainPermissionSubscription
+			permSubType := reflect.TypeOf(permSub)
+			colDef, err := getBunColumnDef(tx, permSubType, "LastModified")
+			if err != nil {
+				return fmt.Errorf("error making column def: %w", err)
+			}
+
+			log.Info(ctx, "adding domain_permission_subscriptions.last_modified column...")
+			if _, err := tx.
+				NewAddColumn().
+				Model(permSub).
+				ColumnExpr(colDef).
+				Exec(ctx); err != nil {
+				return fmt.Errorf("error adding column: %w", err)
+			}
+
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+			return nil
+		})
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}

--- a/internal/gtsmodel/domainpermissionsubscription.go
+++ b/internal/gtsmodel/domainpermissionsubscription.go
@@ -34,7 +34,8 @@ type DomainPermissionSubscription struct {
 	FetchPassword         string                   `bun:",nullzero"`                                // Password to send when doing a GET of URI using basic auth.
 	FetchedAt             time.Time                `bun:"type:timestamptz,nullzero"`                // Time when fetch of URI was last attempted.
 	SuccessfullyFetchedAt time.Time                `bun:"type:timestamptz,nullzero"`                // Time when the domain permission list was last *successfuly* fetched, to be transmitted as If-Modified-Since header.
-	ETag                  string                   `bun:"etag,nullzero"`                            // Etag last received from the server (if any) on successful fetch.
+	LastModified          time.Time                `bun:"type:timestamptz,nullzero"`                // "Last-Modified" time received from the server (if any) on last successful fetch. Used for HTTP request caching.
+	ETag                  string                   `bun:"etag,nullzero"`                            // "ETag" header last received from the server (if any) on last successful fetch. Used for HTTP request caching.
 	Error                 string                   `bun:",nullzero"`                                // If latest fetch attempt errored, this field stores the error message. Cleared on latest successful fetch.
 }
 

--- a/internal/subscriptions/domainperms.go
+++ b/internal/subscriptions/domainperms.go
@@ -253,13 +253,9 @@ func (s *Subscriptions) ProcessDomainPermissionSubscription(
 	// to indicate a successful fetch, and return.
 	if resp.Unmodified {
 		l.Debug("received 304 Not Modified from remote")
+		permSub.ETag = resp.ETag
+		permSub.LastModified = resp.LastModified
 		permSub.SuccessfullyFetchedAt = permSub.FetchedAt
-		if permSub.ETag == "" && resp.ETag != "" {
-			// We didn't have an ETag before but
-			// we have one now: probably the remote
-			// added ETag support in the meantime.
-			permSub.ETag = resp.ETag
-		}
 		return nil, nil
 	}
 
@@ -308,6 +304,7 @@ func (s *Subscriptions) ProcessDomainPermissionSubscription(
 	// This can now be considered a successful fetch.
 	permSub.SuccessfullyFetchedAt = permSub.FetchedAt
 	permSub.ETag = resp.ETag
+	permSub.LastModified = resp.LastModified
 	permSub.Error = ""
 
 	// Keep track of which domain perms are

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -81,7 +81,7 @@ type Transport interface {
 	// DereferenceDomainPermissions dereferences the
 	// permissions list present at the given permSub's URI.
 	//
-	// If "force", then If-Modified-Since and If-None-Match
+	// If "skipCache", then If-Modified-Since and If-None-Match
 	// headers will *NOT* be sent with the outgoing request.
 	//
 	// If err == nil and Unmodified == false, then it's up
@@ -89,7 +89,7 @@ type Transport interface {
 	DereferenceDomainPermissions(
 		ctx context.Context,
 		permSub *gtsmodel.DomainPermissionSubscription,
-		force bool,
+		skipCache bool,
 	) (*DereferenceDomainPermissionsResp, error)
 
 	// Finger performs a webfinger request with the given username and domain, and returns the bytes from the response body.


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request adds a LastModified column to domain permission subscriptions, which is used to store the `Last-Modified` header (if any) returned from a domain perm subscription fetch. This value is then transmitted as `If-Modified-Since` along with subsequent requests instead of the LastSuccessfulFetch value, as a more reliable way of ensuring that remotes can return 304 if nothing has changed.

(Also adds some docs I forgot to add before to the config.yaml example, oops.)

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
