### PR TITLE
[docs] remove `-X POST` from curl commands

### DIFF
--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -8,7 +8,6 @@ We need to register a new application, which we can then use to request an OAuth
 
 ```bash
 curl \
-  -X POST \
   -H 'Content-Type:application/json' \
   -d '{
         "client_name": "your_app_name",
@@ -89,7 +88,6 @@ You can do this with another `POST` request that looks like the following:
 
 ```bash
 curl \
-  -X POST \
   -H 'Content-Type: application/json' \
   -d '{
         "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",

--- a/docs/locales/zh/api/authentication.md
+++ b/docs/locales/zh/api/authentication.md
@@ -8,7 +8,6 @@
 
 ```bash
 curl \
-  -X POST \
   -H 'Content-Type:application/json' \
   -d '{
         "client_name": "your_app_name",
@@ -89,7 +88,6 @@ YOUR_AUTHORIZATION_TOKEN
 
 ```bash
 curl \
-  -X POST \
   -H 'Content-Type: application/json' \
   -d '{
         "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",


### PR DESCRIPTION
# Description

This is a change for GoToSocial's documentation and updates some `curl` command line options.

curl's `-X POST` option is not necessary and even considered bad behavior. Daniel, author of curl, explains why:

https://daniel.haxx.se/blog/2015/09/11/unnecessary-use-of-curl-x/

## Checklist

- [x] I have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
