### PR TITLE
[feature] Serve bot accounts over AP as Service instead of Person

### DIFF
--- a/docs/federation/actors.md
+++ b/docs/federation/actors.md
@@ -1,5 +1,13 @@
 # Actors and Actor Properties
 
+## `Service` vs `Person` actors
+
+GoToSocial serves most accounts as the ActivityStreams `Person` type described [here](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-person).
+
+Accounts that users have selected to mark as bot accounts, however, will use the `Service` type described [here](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-service).
+
+This type distinction can be used by remote servers to distinguish between bot accounts and "regular" user accounts.
+
 ## Inbox
 
 GoToSocial implements Inboxes for Actors following the ActivityPub specification [here](https://www.w3.org/TR/activitypub/#inbox).

--- a/internal/ap/activitystreams.go
+++ b/internal/ap/activitystreams.go
@@ -17,6 +17,22 @@
 
 package ap
 
+import (
+	"net/url"
+
+	"github.com/superseriousbusiness/activity/pub"
+)
+
+// PublicURI returns a fresh copy of the *url.URL version of the
+// magic ActivityPub URI https://www.w3.org/ns/activitystreams#Public
+func PublicURI() *url.URL {
+	publicURI, err := url.Parse(pub.PublicActivityPubIRI)
+	if err != nil {
+		panic(err)
+	}
+	return publicURI
+}
+
 // https://www.w3.org/TR/activitystreams-vocabulary
 const (
 	ActivityAccept          = "Accept"          // ActivityStreamsAccept https://www.w3.org/TR/activitystreams-vocabulary/#dfn-accept

--- a/internal/ap/ap_test.go
+++ b/internal/ap/ap_test.go
@@ -24,7 +24,6 @@ import (
 	"io"
 
 	"github.com/stretchr/testify/suite"
-	"github.com/superseriousbusiness/activity/pub"
 	"github.com/superseriousbusiness/activity/streams"
 	"github.com/superseriousbusiness/activity/streams/vocab"
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
@@ -111,7 +110,7 @@ func noteWithMentions1() vocab.ActivityStreamsNote {
 
 	// Anyone can like.
 	canLikeAlwaysProp := streams.NewGoToSocialAlwaysProperty()
-	canLikeAlwaysProp.AppendIRI(testrig.URLMustParse(pub.PublicActivityPubIRI))
+	canLikeAlwaysProp.AppendIRI(ap.PublicURI())
 	canLike.SetGoToSocialAlways(canLikeAlwaysProp)
 
 	// Empty approvalRequired.
@@ -128,7 +127,7 @@ func noteWithMentions1() vocab.ActivityStreamsNote {
 
 	// Anyone can reply.
 	canReplyAlwaysProp := streams.NewGoToSocialAlwaysProperty()
-	canReplyAlwaysProp.AppendIRI(testrig.URLMustParse(pub.PublicActivityPubIRI))
+	canReplyAlwaysProp.AppendIRI(ap.PublicURI())
 	canReply.SetGoToSocialAlways(canReplyAlwaysProp)
 
 	// Set empty approvalRequired.
@@ -151,7 +150,7 @@ func noteWithMentions1() vocab.ActivityStreamsNote {
 
 	// Public requires approval to announce.
 	canAnnounceApprovalRequiredProp := streams.NewGoToSocialApprovalRequiredProperty()
-	canAnnounceApprovalRequiredProp.AppendIRI(testrig.URLMustParse(pub.PublicActivityPubIRI))
+	canAnnounceApprovalRequiredProp.AppendIRI(ap.PublicURI())
 	canAnnounce.SetGoToSocialApprovalRequired(canAnnounceApprovalRequiredProp)
 
 	// Set canAnnounce on the policy.
@@ -266,7 +265,7 @@ func addressable1() ap.Addressable {
 	note := streams.NewActivityStreamsNote()
 
 	toProp := streams.NewActivityStreamsToProperty()
-	toProp.AppendIRI(testrig.URLMustParse(pub.PublicActivityPubIRI))
+	toProp.AppendIRI(ap.PublicURI())
 
 	note.SetActivityStreamsTo(toProp)
 
@@ -288,7 +287,7 @@ func addressable2() ap.Addressable {
 	note.SetActivityStreamsTo(toProp)
 
 	ccProp := streams.NewActivityStreamsCcProperty()
-	ccProp.AppendIRI(testrig.URLMustParse(pub.PublicActivityPubIRI))
+	ccProp.AppendIRI(ap.PublicURI())
 
 	note.SetActivityStreamsCc(ccProp)
 

--- a/internal/ap/interfaces.go
+++ b/internal/ap/interfaces.go
@@ -188,6 +188,7 @@ type Accountable interface {
 	WithTag
 	WithPublished
 	WithUpdated
+	WithImage
 }
 
 // Statusable represents the minimum activitypub interface for representing a 'status'.
@@ -439,6 +440,7 @@ type WithValue interface {
 // WithImage represents an activity with ActivityStreamsImageProperty
 type WithImage interface {
 	GetActivityStreamsImage() vocab.ActivityStreamsImageProperty
+	SetActivityStreamsImage(vocab.ActivityStreamsImageProperty)
 }
 
 // WithSummary represents an activity with ActivityStreamsSummaryProperty

--- a/internal/api/activitypub/users/inboxpost.go
+++ b/internal/api/activitypub/users/inboxpost.go
@@ -18,7 +18,6 @@
 package users
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -34,8 +33,6 @@ import (
 func (m *Module) InboxPOSTHandler(c *gin.Context) {
 	_, err := m.processor.Fedi().InboxPost(c.Request.Context(), c.Writer, c.Request)
 	if err != nil {
-		fmt.Printf("\n\n\n%+v\n\n\n", err)
-
 		errWithCode := errorsv2.AsV2[gtserror.WithCode](err)
 
 		if errWithCode == nil {

--- a/internal/api/activitypub/users/inboxpost.go
+++ b/internal/api/activitypub/users/inboxpost.go
@@ -18,6 +18,7 @@
 package users
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -33,6 +34,8 @@ import (
 func (m *Module) InboxPOSTHandler(c *gin.Context) {
 	_, err := m.processor.Fedi().InboxPost(c.Request.Context(), c.Writer, c.Request)
 	if err != nil {
+		fmt.Printf("\n\n\n%+v\n\n\n", err)
+
 		errWithCode := errorsv2.AsV2[gtserror.WithCode](err)
 
 		if errWithCode == nil {

--- a/internal/federation/federator_test.go
+++ b/internal/federation/federator_test.go
@@ -75,12 +75,12 @@ func (suite *FederatorStandardTestSuite) SetupTest() {
 
 	// Ensure it's possible to deref
 	// main key of foss satan.
-	fossSatanPerson, err := suite.typeconverter.AccountToAS(context.Background(), suite.testAccounts["remote_account_1"])
+	fossSatanAS, err := suite.typeconverter.AccountToAS(context.Background(), suite.testAccounts["remote_account_1"])
 	if err != nil {
 		suite.FailNow(err.Error())
 	}
 
-	suite.httpClient = testrig.NewMockHTTPClient(nil, "../../testrig/media", fossSatanPerson)
+	suite.httpClient = testrig.NewMockHTTPClient(nil, "../../testrig/media", fossSatanAS)
 	suite.httpClient.TestRemotePeople = testrig.NewTestFediPeople()
 	suite.httpClient.TestRemoteStatuses = testrig.NewTestFediStatuses()
 

--- a/internal/processing/fedi/user.go
+++ b/internal/processing/fedi/user.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/superseriousbusiness/activity/streams/vocab"
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
@@ -72,7 +71,7 @@ func (p *Processor) UserGet(ctx context.Context, requestedUsername string, reque
 	}
 
 	// Auth passed, generate the proper AP representation.
-	person, err := p.converter.AccountToAS(ctx, receiver)
+	accountable, err := p.converter.AccountToAS(ctx, receiver)
 	if err != nil {
 		err := gtserror.Newf("error converting account: %w", err)
 		return nil, gtserror.NewErrorInternalError(err)
@@ -91,7 +90,7 @@ func (p *Processor) UserGet(ctx context.Context, requestedUsername string, reque
 		// Instead, we end up in an 'I'll show you mine if you show me
 		// yours' situation, where we sort of agree to reveal each
 		// other's profiles at the same time.
-		return data(person)
+		return data(accountable)
 	}
 
 	// Get requester from auth.
@@ -107,13 +106,13 @@ func (p *Processor) UserGet(ctx context.Context, requestedUsername string, reque
 		return nil, gtserror.NewErrorForbidden(errors.New(text))
 	}
 
-	return data(person)
+	return data(accountable)
 }
 
-func data(requestedPerson vocab.ActivityStreamsPerson) (interface{}, gtserror.WithCode) {
-	data, err := ap.Serialize(requestedPerson)
+func data(accountable ap.Accountable) (interface{}, gtserror.WithCode) {
+	data, err := ap.Serialize(accountable)
 	if err != nil {
-		err := gtserror.Newf("error serializing person: %w", err)
+		err := gtserror.Newf("error serializing accountable: %w", err)
 		return nil, gtserror.NewErrorInternalError(err)
 	}
 

--- a/internal/typeutils/internaltoas_test.go
+++ b/internal/typeutils/internaltoas_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/ap"
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
 	"github.com/superseriousbusiness/gotosocial/testrig"
 )
 
@@ -38,10 +39,10 @@ func (suite *InternalToASTestSuite) TestAccountToAS() {
 	testAccount := &gtsmodel.Account{}
 	*testAccount = *suite.testAccounts["local_account_1"] // take zork for this test
 
-	asPerson, err := suite.typeconverter.AccountToAS(context.Background(), testAccount)
+	accountable, err := suite.typeconverter.AccountToAS(context.Background(), testAccount)
 	suite.NoError(err)
 
-	ser, err := ap.Serialize(asPerson)
+	ser, err := ap.Serialize(accountable)
 	suite.NoError(err)
 
 	bytes, err := json.MarshalIndent(ser, "", "  ")
@@ -94,14 +95,80 @@ func (suite *InternalToASTestSuite) TestAccountToAS() {
 }`, string(bytes))
 }
 
+func (suite *InternalToASTestSuite) TestAccountToASBot() {
+	testAccount := &gtsmodel.Account{}
+	*testAccount = *suite.testAccounts["local_account_1"] // take zork for this test
+
+	// Update zork to be a bot.
+	testAccount.Bot = util.Ptr(true)
+	if err := suite.state.DB.UpdateAccount(context.Background(), testAccount); err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	accountable, err := suite.typeconverter.AccountToAS(context.Background(), testAccount)
+	suite.NoError(err)
+
+	ser, err := ap.Serialize(accountable)
+	suite.NoError(err)
+
+	bytes, err := json.MarshalIndent(ser, "", "  ")
+	suite.NoError(err)
+
+	suite.Equal(`{
+  "@context": [
+    "https://w3id.org/security/v1",
+    "https://www.w3.org/ns/activitystreams",
+    {
+      "discoverable": "toot:discoverable",
+      "featured": {
+        "@id": "toot:featured",
+        "@type": "@id"
+      },
+      "manuallyApprovesFollowers": "as:manuallyApprovesFollowers",
+      "toot": "http://joinmastodon.org/ns#"
+    }
+  ],
+  "discoverable": true,
+  "featured": "http://localhost:8080/users/the_mighty_zork/collections/featured",
+  "followers": "http://localhost:8080/users/the_mighty_zork/followers",
+  "following": "http://localhost:8080/users/the_mighty_zork/following",
+  "icon": {
+    "mediaType": "image/jpeg",
+    "type": "Image",
+    "url": "http://localhost:8080/fileserver/01F8MH1H7YV1Z7D2C8K2730QBF/avatar/original/01F8MH58A357CV5K7R7TJMSH6S.jpg"
+  },
+  "id": "http://localhost:8080/users/the_mighty_zork",
+  "image": {
+    "mediaType": "image/jpeg",
+    "type": "Image",
+    "url": "http://localhost:8080/fileserver/01F8MH1H7YV1Z7D2C8K2730QBF/header/original/01PFPMWK2FF0D9WMHEJHR07C3Q.jpg"
+  },
+  "inbox": "http://localhost:8080/users/the_mighty_zork/inbox",
+  "manuallyApprovesFollowers": false,
+  "name": "original zork (he/they)",
+  "outbox": "http://localhost:8080/users/the_mighty_zork/outbox",
+  "preferredUsername": "the_mighty_zork",
+  "publicKey": {
+    "id": "http://localhost:8080/users/the_mighty_zork/main-key",
+    "owner": "http://localhost:8080/users/the_mighty_zork",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwXTcOAvM1Jiw5Ffpk0qn\nr0cwbNvFe/5zQ+Tp7tumK/ZnT37o7X0FUEXrxNi+dkhmeJ0gsaiN+JQGNUewvpSk\nPIAXKvi908aSfCGjs7bGlJCJCuDuL5d6m7hZnP9rt9fJc70GElPpG0jc9fXwlz7T\nlsPb2ecatmG05Y4jPwdC+oN4MNCv9yQzEvCVMzl76EJaM602kIHC1CISn0rDFmYd\n9rSN7XPlNJw1F6PbpJ/BWQ+pXHKw3OEwNTETAUNYiVGnZU+B7a7bZC9f6/aPbJuV\nt8Qmg+UnDvW1Y8gmfHnxaWG2f5TDBvCHmcYtucIZPLQD4trAozC4ryqlmCWQNKbt\n0wIDAQAB\n-----END PUBLIC KEY-----\n"
+  },
+  "published": "2022-05-20T11:09:18Z",
+  "summary": "\u003cp\u003ehey yo this is my profile!\u003c/p\u003e",
+  "tag": [],
+  "type": "Service",
+  "url": "http://localhost:8080/@the_mighty_zork"
+}`, string(bytes))
+}
+
 func (suite *InternalToASTestSuite) TestAccountToASWithFields() {
 	testAccount := &gtsmodel.Account{}
 	*testAccount = *suite.testAccounts["local_account_2"]
 
-	asPerson, err := suite.typeconverter.AccountToAS(context.Background(), testAccount)
+	accountable, err := suite.typeconverter.AccountToAS(context.Background(), testAccount)
 	suite.NoError(err)
 
-	ser, err := ap.Serialize(asPerson)
+	ser, err := ap.Serialize(accountable)
 	suite.NoError(err)
 
 	bytes, err := json.MarshalIndent(ser, "", "  ")
@@ -176,10 +243,10 @@ func (suite *InternalToASTestSuite) TestAccountToASAliasedAndMoved() {
 		suite.FailNow(err.Error())
 	}
 
-	asPerson, err := suite.typeconverter.AccountToAS(context.Background(), testAccount)
+	accountable, err := suite.typeconverter.AccountToAS(context.Background(), testAccount)
 	suite.NoError(err)
 
-	ser, err := ap.Serialize(asPerson)
+	ser, err := ap.Serialize(accountable)
 	suite.NoError(err)
 
 	bytes, err := json.MarshalIndent(ser, "", "  ")
@@ -246,10 +313,10 @@ func (suite *InternalToASTestSuite) TestAccountToASWithOneField() {
 	*testAccount = *suite.testAccounts["local_account_2"]
 	testAccount.Fields = testAccount.Fields[0:1] // Take only one field.
 
-	asPerson, err := suite.typeconverter.AccountToAS(context.Background(), testAccount)
+	accountable, err := suite.typeconverter.AccountToAS(context.Background(), testAccount)
 	suite.NoError(err)
 
-	ser, err := ap.Serialize(asPerson)
+	ser, err := ap.Serialize(accountable)
 	suite.NoError(err)
 
 	bytes, err := json.MarshalIndent(ser, "", "  ")
@@ -308,10 +375,10 @@ func (suite *InternalToASTestSuite) TestAccountToASWithEmoji() {
 	*testAccount = *suite.testAccounts["local_account_1"] // take zork for this test
 	testAccount.Emojis = []*gtsmodel.Emoji{suite.testEmojis["rainbow"]}
 
-	asPerson, err := suite.typeconverter.AccountToAS(context.Background(), testAccount)
+	accountable, err := suite.typeconverter.AccountToAS(context.Background(), testAccount)
 	suite.NoError(err)
 
-	ser, err := ap.Serialize(asPerson)
+	ser, err := ap.Serialize(accountable)
 	suite.NoError(err)
 
 	bytes, err := json.MarshalIndent(ser, "", "  ")
@@ -381,10 +448,10 @@ func (suite *InternalToASTestSuite) TestAccountToASWithSharedInbox() {
 	sharedInbox := "http://localhost:8080/sharedInbox"
 	testAccount.SharedInboxURI = &sharedInbox
 
-	asPerson, err := suite.typeconverter.AccountToAS(context.Background(), testAccount)
+	accountable, err := suite.typeconverter.AccountToAS(context.Background(), testAccount)
 	suite.NoError(err)
 
-	ser, err := ap.Serialize(asPerson)
+	ser, err := ap.Serialize(accountable)
 	suite.NoError(err)
 
 	bytes, err := json.MarshalIndent(ser, "", "  ")

--- a/internal/typeutils/wrap_test.go
+++ b/internal/typeutils/wrap_test.go
@@ -208,6 +208,7 @@ func (suite *WrapTestSuite) TestWrapAccountableInUpdate() {
       "owner": "http://localhost:8080/users/the_mighty_zork",
       "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwXTcOAvM1Jiw5Ffpk0qn\nr0cwbNvFe/5zQ+Tp7tumK/ZnT37o7X0FUEXrxNi+dkhmeJ0gsaiN+JQGNUewvpSk\nPIAXKvi908aSfCGjs7bGlJCJCuDuL5d6m7hZnP9rt9fJc70GElPpG0jc9fXwlz7T\nlsPb2ecatmG05Y4jPwdC+oN4MNCv9yQzEvCVMzl76EJaM602kIHC1CISn0rDFmYd\n9rSN7XPlNJw1F6PbpJ/BWQ+pXHKw3OEwNTETAUNYiVGnZU+B7a7bZC9f6/aPbJuV\nt8Qmg+UnDvW1Y8gmfHnxaWG2f5TDBvCHmcYtucIZPLQD4trAozC4ryqlmCWQNKbt\n0wIDAQAB\n-----END PUBLIC KEY-----\n"
     },
+    "published": "2022-05-20T11:09:18Z",
     "summary": "\u003cp\u003ehey yo this is my profile!\u003c/p\u003e",
     "tag": [],
     "type": "Person",

--- a/internal/typeutils/wrap_test.go
+++ b/internal/typeutils/wrap_test.go
@@ -139,6 +139,85 @@ func (suite *WrapTestSuite) TestWrapNoteInCreate() {
 }`, string(bytes))
 }
 
+func (suite *WrapTestSuite) TestWrapAccountableInUpdate() {
+	testAccount := suite.testAccounts["local_account_1"]
+
+	accountable, err := suite.typeconverter.AccountToAS(context.Background(), testAccount)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	create, err := suite.typeconverter.WrapAccountableInUpdate(accountable)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	createI, err := ap.Serialize(create)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// Get the ID as it's not determinate.
+	createID := ap.GetJSONLDId(create)
+
+	bytes, err := json.MarshalIndent(createI, "", "  ")
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Equal(`{
+  "@context": [
+    "https://w3id.org/security/v1",
+    "https://www.w3.org/ns/activitystreams",
+    {
+      "discoverable": "toot:discoverable",
+      "featured": {
+        "@id": "toot:featured",
+        "@type": "@id"
+      },
+      "manuallyApprovesFollowers": "as:manuallyApprovesFollowers",
+      "toot": "http://joinmastodon.org/ns#"
+    }
+  ],
+  "actor": "http://localhost:8080/users/the_mighty_zork",
+  "bcc": "http://localhost:8080/users/the_mighty_zork/followers",
+  "id": "`+createID.String()+`",
+  "object": {
+    "discoverable": true,
+    "featured": "http://localhost:8080/users/the_mighty_zork/collections/featured",
+    "followers": "http://localhost:8080/users/the_mighty_zork/followers",
+    "following": "http://localhost:8080/users/the_mighty_zork/following",
+    "icon": {
+      "mediaType": "image/jpeg",
+      "type": "Image",
+      "url": "http://localhost:8080/fileserver/01F8MH1H7YV1Z7D2C8K2730QBF/avatar/original/01F8MH58A357CV5K7R7TJMSH6S.jpg"
+    },
+    "id": "http://localhost:8080/users/the_mighty_zork",
+    "image": {
+      "mediaType": "image/jpeg",
+      "type": "Image",
+      "url": "http://localhost:8080/fileserver/01F8MH1H7YV1Z7D2C8K2730QBF/header/original/01PFPMWK2FF0D9WMHEJHR07C3Q.jpg"
+    },
+    "inbox": "http://localhost:8080/users/the_mighty_zork/inbox",
+    "manuallyApprovesFollowers": false,
+    "name": "original zork (he/they)",
+    "outbox": "http://localhost:8080/users/the_mighty_zork/outbox",
+    "preferredUsername": "the_mighty_zork",
+    "publicKey": {
+      "id": "http://localhost:8080/users/the_mighty_zork/main-key",
+      "owner": "http://localhost:8080/users/the_mighty_zork",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwXTcOAvM1Jiw5Ffpk0qn\nr0cwbNvFe/5zQ+Tp7tumK/ZnT37o7X0FUEXrxNi+dkhmeJ0gsaiN+JQGNUewvpSk\nPIAXKvi908aSfCGjs7bGlJCJCuDuL5d6m7hZnP9rt9fJc70GElPpG0jc9fXwlz7T\nlsPb2ecatmG05Y4jPwdC+oN4MNCv9yQzEvCVMzl76EJaM602kIHC1CISn0rDFmYd\n9rSN7XPlNJw1F6PbpJ/BWQ+pXHKw3OEwNTETAUNYiVGnZU+B7a7bZC9f6/aPbJuV\nt8Qmg+UnDvW1Y8gmfHnxaWG2f5TDBvCHmcYtucIZPLQD4trAozC4ryqlmCWQNKbt\n0wIDAQAB\n-----END PUBLIC KEY-----\n"
+    },
+    "summary": "\u003cp\u003ehey yo this is my profile!\u003c/p\u003e",
+    "tag": [],
+    "type": "Person",
+    "url": "http://localhost:8080/@the_mighty_zork"
+  },
+  "to": "https://www.w3.org/ns/activitystreams#Public",
+  "type": "Update"
+}`, string(bytes))
+}
+
 func TestWrapTestSuite(t *testing.T) {
 	suite.Run(t, new(WrapTestSuite))
 }

--- a/testrig/testmodels.go
+++ b/testrig/testmodels.go
@@ -2853,7 +2853,7 @@ func NewTestActivities(accounts map[string]*gtsmodel.Account) map[string]Activit
 		"this is a public status, please forward it!",
 		"",
 		URLMustParse("http://example.org/users/Some_User"),
-		[]*url.URL{URLMustParse(pub.PublicActivityPubIRI)},
+		[]*url.URL{ap.PublicURI()},
 		nil,
 		false,
 		[]vocab.ActivityStreamsMention{},
@@ -3207,7 +3207,7 @@ func NewTestFediStatuses() map[string]vocab.ActivityStreamsNote {
 			"this is a public status, please forward it!",
 			"",
 			URLMustParse("http://example.org/users/Some_User"),
-			[]*url.URL{URLMustParse(pub.PublicActivityPubIRI)},
+			[]*url.URL{ap.PublicURI()},
 			nil,
 			false,
 			[]vocab.ActivityStreamsMention{},
@@ -3228,7 +3228,7 @@ func NewTestFediStatuses() map[string]vocab.ActivityStreamsNote {
 			"",
 			URLMustParse("https://unknown-instance.com/users/brand_new_person"),
 			[]*url.URL{
-				URLMustParse(pub.PublicActivityPubIRI),
+				ap.PublicURI(),
 			},
 			[]*url.URL{},
 			false,
@@ -3244,7 +3244,7 @@ func NewTestFediStatuses() map[string]vocab.ActivityStreamsNote {
 			"",
 			URLMustParse("https://unknown-instance.com/users/brand_new_person"),
 			[]*url.URL{
-				URLMustParse(pub.PublicActivityPubIRI),
+				ap.PublicURI(),
 			},
 			[]*url.URL{},
 			false,
@@ -3265,7 +3265,7 @@ func NewTestFediStatuses() map[string]vocab.ActivityStreamsNote {
 			"",
 			URLMustParse("https://unknown-instance.com/users/brand_new_person"),
 			[]*url.URL{
-				URLMustParse(pub.PublicActivityPubIRI),
+				ap.PublicURI(),
 			},
 			[]*url.URL{},
 			false,
@@ -3286,7 +3286,7 @@ func NewTestFediStatuses() map[string]vocab.ActivityStreamsNote {
 			"",
 			URLMustParse("https://turnip.farm/users/turniplover6969"),
 			[]*url.URL{
-				URLMustParse(pub.PublicActivityPubIRI),
+				ap.PublicURI(),
 			},
 			[]*url.URL{},
 			false,
@@ -3309,7 +3309,7 @@ func NewTestFediStatuses() map[string]vocab.ActivityStreamsNote {
 			"",
 			URLMustParse("http://fossbros-anonymous.io/users/foss_satan"),
 			[]*url.URL{
-				URLMustParse(pub.PublicActivityPubIRI),
+				ap.PublicURI(),
 			},
 			[]*url.URL{},
 			false,

--- a/testrig/transportcontroller.go
+++ b/testrig/transportcontroller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/superseriousbusiness/activity/pub"
 	"github.com/superseriousbusiness/activity/streams"
 	"github.com/superseriousbusiness/activity/streams/vocab"
+	"github.com/superseriousbusiness/gotosocial/internal/ap"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	"github.com/superseriousbusiness/gotosocial/internal/federation"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
@@ -81,7 +82,7 @@ type MockHTTPClient struct {
 // to customize how the client is mocked.
 //
 // Note that you should never ever make ACTUAL http calls with this thing.
-func NewMockHTTPClient(do func(req *http.Request) (*http.Response, error), relativeMediaPath string, extraPeople ...vocab.ActivityStreamsPerson) *MockHTTPClient {
+func NewMockHTTPClient(do func(req *http.Request) (*http.Response, error), relativeMediaPath string, extraPeople ...ap.Accountable) *MockHTTPClient {
 	mockHTTPClient := &MockHTTPClient{}
 
 	if do != nil {


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request updates our account serialization logic to take account of the fact that bot accounts should be served as actor type service, not actor type person, so that remotes can properly mark them as bot.

closes https://github.com/superseriousbusiness/gotosocial/issues/3518

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
