### PR TITLE
[feature] show status edits on frontend

### DIFF
--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -436,6 +436,10 @@ main {
 				display: flex;
 				flex-wrap: wrap;
 				column-gap: 1rem;
+
+				.edited-at {
+					font-style: italic;
+				}
 			}
 
 			.stats-item {

--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -443,7 +443,7 @@ main {
 				gap: 0.4rem;
 			}
 
-			.stats-item:not(.published-at) {
+			.stats-item:not(.published-at):not(.edited-at) {
 				z-index: 1;
 				user-select: none;
 			}

--- a/web/template/status_info.tmpl
+++ b/web/template/status_info.tmpl
@@ -30,7 +30,7 @@
         <div class="stats-item edited-at text-cutoff">
             <dt class="sr-only">Edited</dt>
             <dd>
-                (edited at <time datetime="{{- .EditedAt -}}">{{- .EditedAt | timestampPrecise -}}</time>)
+                (last edited <time datetime="{{- .EditedAt -}}">{{- .EditedAt | timestampPrecise -}}</time>)
             </dd>
         </div>
         {{ end }}

--- a/web/template/status_info.tmpl
+++ b/web/template/status_info.tmpl
@@ -26,6 +26,14 @@
                 <time datetime="{{- .CreatedAt -}}">{{- .CreatedAt | timestampPrecise -}}</time>
             </dd>
         </div>
+        {{- if .EditedAt -}}
+        <div class="stats-item edited-at text-cutoff">
+            <dt class="sr-only">Edited</dt>
+            <dd>
+                (edited at <time datetime="{{- .EditedAt -}}">{{- .EditedAt | timestampPrecise -}}</time>)
+            </dd>
+        </div>
+        {{ end }}
         <div class="stats-grouping">
             <div class="stats-item" title="Replies">
                 <dt>


### PR DESCRIPTION
# Description

Very small change to update the frontend templates to include an "edited at" for edited statuses.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
