### PR TITLE
[feature] Implement backfilling statuses thru scheduled_at

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -10397,10 +10397,14 @@ paths:
                   x-go-name: Federated
                 - description: |-
                     ISO 8601 Datetime at which to schedule a status.
-                    Providing this parameter will cause ScheduledStatus to be returned instead of Status.
-                    Must be at least 5 minutes in the future.
 
-                    This feature isn't implemented yet; attemping to set it will return 501 Not Implemented.
+                    Providing this parameter with a *future* time will cause ScheduledStatus to be returned instead of Status.
+                    Must be at least 5 minutes in the future.
+                    This feature isn't implemented yet.
+
+                    Providing this parameter with a *past* time will cause the status to be backdated,
+                    and will not push it to the user's followers. This is intended for importing old statuses.
+                  format: date-time
                   in: formData
                   name: scheduled_at
                   type: string

--- a/docs/configuration/instance.md
+++ b/docs/configuration/instance.md
@@ -171,4 +171,17 @@ instance-subscriptions-process-every: "24h"
 # Options: ["", "zero", "serve", "baffle"]
 # Default: ""
 instance-stats-mode: ""
+
+# Bool. This flag controls whether local accounts may backdate statuses
+# using past dates with the scheduled_at param to /api/v1/statuses.
+# This flag does not affect scheduling posts in the future
+# (which is currently not implemented anyway),
+# nor can it prevent remote accounts from backdating their own statuses.
+#
+# If true, all local accounts may backdate statuses.
+# If false, status backdating will be disabled and an error will be returned if it's used.
+#
+# Options: [true, false]
+# Default: true
+instance-allow-backdating-statuses: true
 ```

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -458,6 +458,19 @@ instance-subscriptions-process-every: "24h"
 # Default: ""
 instance-stats-mode: ""
 
+# Bool. This flag controls whether local accounts may backdate statuses
+# using past dates with the scheduled_at param to /api/v1/statuses.
+# This flag does not affect scheduling posts in the future
+# (which is currently not implemented anyway),
+# nor can it prevent remote accounts from backdating their own statuses.
+#
+# If true, all local accounts may backdate statuses.
+# If false, status backdating will be disabled and an error will be returned if it's used.
+#
+# Options: [true, false]
+# Default: true
+instance-allow-backdating-statuses: true
+
 ###########################
 ##### ACCOUNTS CONFIG #####
 ###########################

--- a/internal/api/client/statuses/statuscreate.go
+++ b/internal/api/client/statuses/statuscreate.go
@@ -179,11 +179,15 @@ import (
 //		x-go-name: ScheduledAt
 //		description: |-
 //			ISO 8601 Datetime at which to schedule a status.
-//			Providing this parameter will cause ScheduledStatus to be returned instead of Status.
-//			Must be at least 5 minutes in the future.
 //
-//			This feature isn't implemented yet; attemping to set it will return 501 Not Implemented.
+//			Providing this parameter with a *future* time will cause ScheduledStatus to be returned instead of Status.
+//			Must be at least 5 minutes in the future.
+//			This feature isn't implemented yet.
+//
+//			Providing this parameter with a *past* time will cause the status to be backdated,
+//			and will not push it to the user's followers. This is intended for importing old statuses.
 //		type: string
+//		format: date-time
 //		in: formData
 //	-
 //		name: language
@@ -382,12 +386,6 @@ func parseStatusCreateForm(c *gin.Context) (*apimodel.StatusCreateRequest, gtser
 		text := fmt.Sprintf("content-type %s not supported for this endpoint; supported content-types are %s, %s, %s",
 			ct, binding.MIMEJSON, binding.MIMEPOSTForm, binding.MIMEMultipartPOSTForm)
 		return nil, gtserror.NewErrorNotAcceptable(errors.New(text), text)
-	}
-
-	// Check not scheduled status.
-	if form.ScheduledAt != "" {
-		const text = "scheduled_at is not yet implemented"
-		return nil, gtserror.NewErrorNotImplemented(errors.New(text), text)
 	}
 
 	// Check if the deprecated "federated" field was

--- a/internal/api/client/statuses/statuscreate_test.go
+++ b/internal/api/client/statuses/statuscreate_test.go
@@ -368,7 +368,7 @@ func (suite *StatusCreateTestSuite) TestPostNewStatusMessedUpIntPolicy() {
 }`, out)
 }
 
-func (suite *StatusCreateTestSuite) TestPostNewScheduledStatus() {
+func (suite *StatusCreateTestSuite) TestPostNewFutureScheduledStatus() {
 	out, recorder := suite.postStatus(map[string][]string{
 		"status":       {"this is a brand new status! #helloworld"},
 		"spoiler_text": {"hello hello"},
@@ -383,7 +383,7 @@ func (suite *StatusCreateTestSuite) TestPostNewScheduledStatus() {
 
 	// We should have a helpful error message.
 	suite.Equal(`{
-  "error": "Not Implemented: scheduled_at is not yet implemented"
+  "error": "Not Implemented: scheduled statuses are not yet supported"
 }`, out)
 }
 

--- a/internal/api/model/status.go
+++ b/internal/api/model/status.go
@@ -17,7 +17,11 @@
 
 package model
 
-import "github.com/superseriousbusiness/gotosocial/internal/language"
+import (
+	"time"
+
+	"github.com/superseriousbusiness/gotosocial/internal/language"
+)
 
 // Status models a status or post.
 //
@@ -231,9 +235,14 @@ type StatusCreateRequest struct {
 	Federated *bool `form:"federated" json:"federated"`
 
 	// ISO 8601 Datetime at which to schedule a status.
-	// Providing this parameter will cause ScheduledStatus to be returned instead of Status.
+	//
+	// Providing this parameter with a *future* time will cause ScheduledStatus to be returned instead of Status.
 	// Must be at least 5 minutes in the future.
-	ScheduledAt string `form:"scheduled_at" json:"scheduled_at"`
+	// This feature isn't implemented yet.
+	//
+	// Providing this parameter with a *past* time will cause the status to be backdated,
+	// and will not push it to the user's followers. This is intended for importing old statuses.
+	ScheduledAt *time.Time `form:"scheduled_at" json:"scheduled_at"`
 
 	// ISO 639 language code for this status.
 	Language string `form:"language" json:"language"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,7 @@ type Configuration struct {
 	InstanceSubscriptionsProcessFrom  string             `name:"instance-subscriptions-process-from" usage:"Time of day from which to start running instance subscriptions processing jobs. Should be in the format 'hh:mm:ss', eg., '15:04:05'."`
 	InstanceSubscriptionsProcessEvery time.Duration      `name:"instance-subscriptions-process-every" usage:"Period to elapse between instance subscriptions processing jobs, starting from instance-subscriptions-process-from."`
 	InstanceStatsMode                 string             `name:"instance-stats-mode" usage:"Allows you to customize the way stats are served to crawlers: one of '', 'serve', 'zero', 'baffle'. Home page stats remain unchanged."`
+	InstanceAllowBackdatingStatuses   bool               `name:"instance-allow-backdating-statuses" usage:"Allow local accounts to backdate statuses using the scheduled_at param to /api/v1/statuses"`
 
 	AccountsRegistrationOpen         bool `name:"accounts-registration-open" usage:"Allow anyone to submit an account signup request. If false, server will be invite-only."`
 	AccountsReasonRequired           bool `name:"accounts-reason-required" usage:"Do new account signups require a reason to be submitted on registration?"`

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -67,6 +67,7 @@ var Defaults = Configuration{
 	InstanceLanguages:                 make(language.Languages, 0),
 	InstanceSubscriptionsProcessFrom:  "23:00",        // 11pm,
 	InstanceSubscriptionsProcessEvery: 24 * time.Hour, // 1/day.
+	InstanceAllowBackdatingStatuses:   true,
 
 	AccountsRegistrationOpen:         false,
 	AccountsReasonRequired:           true,

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -93,6 +93,7 @@ func (s *ConfigState) AddServerFlags(cmd *cobra.Command) {
 		cmd.Flags().String(InstanceSubscriptionsProcessFromFlag(), cfg.InstanceSubscriptionsProcessFrom, fieldtag("InstanceSubscriptionsProcessFrom", "usage"))
 		cmd.Flags().Duration(InstanceSubscriptionsProcessEveryFlag(), cfg.InstanceSubscriptionsProcessEvery, fieldtag("InstanceSubscriptionsProcessEvery", "usage"))
 		cmd.Flags().String(InstanceStatsModeFlag(), cfg.InstanceStatsMode, fieldtag("InstanceStatsMode", "usage"))
+		cmd.Flags().Bool(InstanceAllowBackdatingStatusesFlag(), cfg.InstanceAllowBackdatingStatuses, fieldtag("InstanceAllowBackdatingStatuses", "usage"))
 
 		// Accounts
 		cmd.Flags().Bool(AccountsRegistrationOpenFlag(), cfg.AccountsRegistrationOpen, fieldtag("AccountsRegistrationOpen", "usage"))

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -1082,6 +1082,31 @@ func GetInstanceStatsMode() string { return global.GetInstanceStatsMode() }
 // SetInstanceStatsMode safely sets the value for global configuration 'InstanceStatsMode' field
 func SetInstanceStatsMode(v string) { global.SetInstanceStatsMode(v) }
 
+// GetInstanceAllowBackdatingStatuses safely fetches the Configuration value for state's 'InstanceAllowBackdatingStatuses' field
+func (st *ConfigState) GetInstanceAllowBackdatingStatuses() (v bool) {
+	st.mutex.RLock()
+	v = st.config.InstanceAllowBackdatingStatuses
+	st.mutex.RUnlock()
+	return
+}
+
+// SetInstanceAllowBackdatingStatuses safely sets the Configuration value for state's 'InstanceAllowBackdatingStatuses' field
+func (st *ConfigState) SetInstanceAllowBackdatingStatuses(v bool) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.InstanceAllowBackdatingStatuses = v
+	st.reloadToViper()
+}
+
+// InstanceAllowBackdatingStatusesFlag returns the flag name for the 'InstanceAllowBackdatingStatuses' field
+func InstanceAllowBackdatingStatusesFlag() string { return "instance-allow-backdating-statuses" }
+
+// GetInstanceAllowBackdatingStatuses safely fetches the value for global configuration 'InstanceAllowBackdatingStatuses' field
+func GetInstanceAllowBackdatingStatuses() bool { return global.GetInstanceAllowBackdatingStatuses() }
+
+// SetInstanceAllowBackdatingStatuses safely sets the value for global configuration 'InstanceAllowBackdatingStatuses' field
+func SetInstanceAllowBackdatingStatuses(v bool) { global.SetInstanceAllowBackdatingStatuses(v) }
+
 // GetAccountsRegistrationOpen safely fetches the Configuration value for state's 'AccountsRegistrationOpen' field
 func (st *ConfigState) GetAccountsRegistrationOpen() (v bool) {
 	st.mutex.RLock()

--- a/internal/federation/dereferencing/instance_test.go
+++ b/internal/federation/dereferencing/instance_test.go
@@ -50,7 +50,7 @@ func (suite *InstanceTestSuite) TestDerefInstance() {
 			//
 			// Debug-level logs should show something like:
 			//
-			//   - "can't fetch /nodeinfo/2.1: robots.txt disallows it" 
+			//   - "can't fetch /nodeinfo/2.1: robots.txt disallows it"
 			instanceIRI:      testrig.URLMustParse("https://furtive-nerds.example.org"),
 			expectedSoftware: "",
 		},
@@ -60,7 +60,7 @@ func (suite *InstanceTestSuite) TestDerefInstance() {
 			//
 			// Debug-level logs should show something like:
 			//
-			//   - "can't fetch api/v1/instance: robots.txt disallows it" 
+			//   - "can't fetch api/v1/instance: robots.txt disallows it"
 			//   - "can't fetch .well-known/nodeinfo: robots.txt disallows it"
 			instanceIRI:      testrig.URLMustParse("https://robotic.furtive-nerds.example.org"),
 			expectedSoftware: "",
@@ -71,7 +71,7 @@ func (suite *InstanceTestSuite) TestDerefInstance() {
 			//
 			// Debug-level logs should show something like:
 			//
-			//   - "can't use fetched .well-known/nodeinfo: robots tags disallows it" 
+			//   - "can't use fetched .well-known/nodeinfo: robots tags disallows it"
 			instanceIRI:      testrig.URLMustParse("https://really.furtive-nerds.example.org"),
 			expectedSoftware: "",
 		},

--- a/internal/gtsmodel/status.go
+++ b/internal/gtsmodel/status.go
@@ -86,7 +86,7 @@ func (s *Status) GetAccountID() string {
 	return s.AccountID
 }
 
-// GetBoostID implements timeline.Timelineable{}.
+// GetBoostOfID implements timeline.Timelineable{}.
 func (s *Status) GetBoostOfID() string {
 	return s.BoostOfID
 }
@@ -171,7 +171,7 @@ func (s *Status) EditsPopulated() bool {
 	return true
 }
 
-// EmojissUpToDate returns whether status emoji attachments of receiving status are up-to-date
+// EmojisUpToDate returns whether status emoji attachments of receiving status are up-to-date
 // according to emoji attachments of the passed status, by comparing their emoji URIs. We don't
 // use IDs as this is used to determine whether there are new emojis to fetch.
 func (s *Status) EmojisUpToDate(other *Status) bool {
@@ -385,4 +385,9 @@ func (v Visibility) String() string {
 type Content struct {
 	Content    string
 	ContentMap map[string]string
+}
+
+// BackfillStatus is a wrapper for creating a status without pushing notifications to followers.
+type BackfillStatus struct {
+	*Status
 }

--- a/internal/processing/status/create.go
+++ b/internal/processing/status/create.go
@@ -107,7 +107,7 @@ func (p *Processor) Create(
 		if now.Before(scheduledAt) {
 			const errText = "scheduled statuses are not yet supported"
 			err := gtserror.New(errText)
-			return nil, gtserror.NewErrorBadRequest(err, errText)
+			return nil, gtserror.NewErrorNotImplemented(err, errText)
 		}
 
 		// If not scheduled into the future, this status is being backfilled.
@@ -168,7 +168,7 @@ func (p *Processor) Create(
 			if mention.TargetAccountID != requester.ID {
 				const errText = "statuses mentioning others can't be backfilled"
 				err := gtserror.New(errText)
-				return nil, gtserror.NewErrorBadRequest(err, errText)
+				return nil, gtserror.NewErrorForbidden(err, errText)
 			}
 		}
 	}
@@ -208,7 +208,7 @@ func (p *Processor) Create(
 		if backfill {
 			const errText = "statuses with polls can't be backfilled"
 			err := gtserror.New(errText)
-			return nil, gtserror.NewErrorBadRequest(err, errText)
+			return nil, gtserror.NewErrorForbidden(err, errText)
 		}
 
 		// Process poll, inserting into database.
@@ -356,7 +356,7 @@ func (p *Processor) processInReplyTo(
 	if backfill && requester.ID != inReplyTo.AccountID {
 		const errText = "replies to others can't be backfilled"
 		err := gtserror.New(errText)
-		return gtserror.NewErrorBadRequest(err, errText)
+		return gtserror.NewErrorForbidden(err, errText)
 	}
 
 	// Derive pendingApproval status.

--- a/internal/processing/status/create_test.go
+++ b/internal/processing/status/create_test.go
@@ -48,7 +48,7 @@ func (suite *StatusCreateTestSuite) TestProcessContentWarningWithQuotationMarks(
 		SpoilerText: "\"test\"", // these should not be html-escaped when the final text is rendered
 		Visibility:  apimodel.VisibilityPublic,
 		LocalOnly:   util.Ptr(false),
-		ScheduledAt: "",
+		ScheduledAt: nil,
 		Language:    "en",
 		ContentType: apimodel.StatusContentTypePlain,
 	}
@@ -75,7 +75,7 @@ func (suite *StatusCreateTestSuite) TestProcessContentWarningWithHTMLEscapedQuot
 		SpoilerText: "&#34test&#34", // the html-escaped quotation marks should appear as normal quotation marks in the finished text
 		Visibility:  apimodel.VisibilityPublic,
 		LocalOnly:   util.Ptr(false),
-		ScheduledAt: "",
+		ScheduledAt: nil,
 		Language:    "en",
 		ContentType: apimodel.StatusContentTypePlain,
 	}
@@ -106,7 +106,7 @@ func (suite *StatusCreateTestSuite) TestProcessStatusMarkdownWithUnderscoreEmoji
 		Sensitive:   false,
 		Visibility:  apimodel.VisibilityPublic,
 		LocalOnly:   util.Ptr(false),
-		ScheduledAt: "",
+		ScheduledAt: nil,
 		Language:    "en",
 		ContentType: apimodel.StatusContentTypeMarkdown,
 	}
@@ -133,7 +133,7 @@ func (suite *StatusCreateTestSuite) TestProcessStatusMarkdownWithSpoilerTextEmoj
 		Sensitive:   false,
 		Visibility:  apimodel.VisibilityPublic,
 		LocalOnly:   util.Ptr(false),
-		ScheduledAt: "",
+		ScheduledAt: nil,
 		Language:    "en",
 		ContentType: apimodel.StatusContentTypeMarkdown,
 	}
@@ -164,7 +164,7 @@ func (suite *StatusCreateTestSuite) TestProcessMediaDescriptionTooShort() {
 		SpoilerText: "",
 		Visibility:  apimodel.VisibilityPublic,
 		LocalOnly:   util.Ptr(false),
-		ScheduledAt: "",
+		ScheduledAt: nil,
 		Language:    "en",
 		ContentType: apimodel.StatusContentTypePlain,
 	}
@@ -189,7 +189,7 @@ func (suite *StatusCreateTestSuite) TestProcessLanguageWithScriptPart() {
 		SpoilerText: "",
 		Visibility:  apimodel.VisibilityPublic,
 		LocalOnly:   util.Ptr(false),
-		ScheduledAt: "",
+		ScheduledAt: nil,
 		Language:    "zh-Hans",
 		ContentType: apimodel.StatusContentTypePlain,
 	}
@@ -219,7 +219,7 @@ func (suite *StatusCreateTestSuite) TestProcessReplyToUnthreadedRemoteStatus() {
 		SpoilerText: "this is a reply",
 		Visibility:  apimodel.VisibilityPublic,
 		LocalOnly:   util.Ptr(false),
-		ScheduledAt: "",
+		ScheduledAt: nil,
 		Language:    "en",
 		ContentType: apimodel.StatusContentTypePlain,
 	}

--- a/internal/processing/workers/fromclientapi.go
+++ b/internal/processing/workers/fromclientapi.go
@@ -260,9 +260,16 @@ func (p *clientAPI) CreateUser(ctx context.Context, cMsg *messages.FromClientAPI
 }
 
 func (p *clientAPI) CreateStatus(ctx context.Context, cMsg *messages.FromClientAPI) error {
-	status, ok := cMsg.GTSModel.(*gtsmodel.Status)
-	if !ok {
-		return gtserror.Newf("%T not parseable as *gtsmodel.Status", cMsg.GTSModel)
+	var status *gtsmodel.Status
+	backfill := false
+	if backfillStatus, ok := cMsg.GTSModel.(*gtsmodel.BackfillStatus); ok {
+		status = backfillStatus.Status
+		backfill = true
+	} else {
+		status, ok = cMsg.GTSModel.(*gtsmodel.Status)
+		if !ok {
+			return gtserror.Newf("%T not parseable as *gtsmodel.Status or *gtsmodel.BackfillStatus", cMsg.GTSModel)
+		}
 	}
 
 	// If pending approval is true then status must
@@ -344,12 +351,14 @@ func (p *clientAPI) CreateStatus(ctx context.Context, cMsg *messages.FromClientA
 		log.Errorf(ctx, "error updating account stats: %v", err)
 	}
 
-	if err := p.surface.timelineAndNotifyStatus(ctx, status); err != nil {
-		log.Errorf(ctx, "error timelining and notifying status: %v", err)
-	}
+	if !backfill {
+		if err := p.surface.timelineAndNotifyStatus(ctx, status); err != nil {
+			log.Errorf(ctx, "error timelining and notifying status: %v", err)
+		}
 
-	if err := p.federate.CreateStatus(ctx, status); err != nil {
-		log.Errorf(ctx, "error federating status: %v", err)
+		if err := p.federate.CreateStatus(ctx, status); err != nil {
+			log.Errorf(ctx, "error federating status: %v", err)
+		}
 	}
 
 	if status.InReplyToID != "" {

--- a/internal/processing/workers/fromclientapi_test.go
+++ b/internal/processing/workers/fromclientapi_test.go
@@ -441,7 +441,7 @@ func (suite *FromClientAPITestSuite) TestProcessCreateBackfilledStatusWithNotifi
 	)
 
 	// No notification should appear for the status.
-	if !testrig.WaitFor(func() bool {
+	if testrig.WaitFor(func() bool {
 		var err error
 		_, err = testStructs.State.DB.GetNotification(
 			ctx,
@@ -450,9 +450,9 @@ func (suite *FromClientAPITestSuite) TestProcessCreateBackfilledStatusWithNotifi
 			postingAccount.ID,
 			status.ID,
 		)
-		return errors.Is(err, db.ErrNoEntries)
+		return err == nil
 	}) {
-		suite.FailNow("timed out waiting for absence of status notification")
+		suite.FailNow("a status notification was created, but should not have been")
 	}
 
 	// There should be no message in the notification stream.

--- a/test/envparsing.sh
+++ b/test/envparsing.sh
@@ -108,6 +108,7 @@ EXPECT=$(cat << "EOF"
         "timeout": 30000000000,
         "tls-insecure-skip-verify": false
     },
+    "instance-allow-backdating-statuses": true,
     "instance-deliver-to-shared-inboxes": false,
     "instance-expose-peers": true,
     "instance-expose-public-timeline": true,

--- a/testrig/config.go
+++ b/testrig/config.go
@@ -101,6 +101,7 @@ func testDefaults() config.Configuration {
 		},
 		InstanceSubscriptionsProcessFrom:  "23:00",        // 11pm,
 		InstanceSubscriptionsProcessEvery: 24 * time.Hour, // 1/day.
+		InstanceAllowBackdatingStatuses:   true,
 
 		AccountsRegistrationOpen:         true,
 		AccountsReasonRequired:           true,


### PR DESCRIPTION
# Description

This pull request overloads `scheduled_at` to allow creating statuses with creation times and ULIDs backdated to a _previous_ time in `scheduled_at`, with the following caveats:
- Backfilled statuses aren't inserted into home or list timelines on the instance, and don't generate notifications
- Backfilled statuses aren't pushed to other instances through federation (but may be federated normally later through boosts, searches, etc.)
- Backfilled statuses may only mention or reply to the account creating them
- Backfilled statuses can't contain polls

## Context

This feature is intended to allow external tools to import statuses from previous instances. The only difference between a backfilled status vs. simply reposting the same text and attachments as the original post is that backfilled statuses are quieter and have the original posting date. They don't have the same URLs or IDs as the original posts.

- Related to #2
- Related to #896

## Non-features

This PR doesn't implement scheduling statuses to be posted in the _future_, but it shouldn't break anything we'd need for that.

This PR doesn't implement any import functionality that would let users upload a Mastodon, etc. archive directly. Importing foreign formats would be handled by external tools calling the existing GTS API, plus this modified status-create API method. (I'll do a PoC with [`slurp`](https://github.com/VyrCossont/slurp) at some point.)

This PR doesn't attempt to backdate the ULIDs of status-linked objects such as media attachments, only the ULID of the status itself. 

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat. *(2024-07-04)*
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
