### PR TITLE
[chore] skip `trusted-proxies` warning if ip excepted from rate limiting

### DIFF
--- a/cmd/gotosocial/action/server/server.go
+++ b/cmd/gotosocial/action/server/server.go
@@ -455,11 +455,10 @@ var Start action.GTSAction = func(ctx context.Context) error {
 	// create required middleware
 	// rate limiting
 	rlLimit := config.GetAdvancedRateLimitRequests()
-	rlExceptions := config.GetAdvancedRateLimitExceptions()
-	clLimit := middleware.RateLimit(rlLimit, rlExceptions)        // client api
-	s2sLimit := middleware.RateLimit(rlLimit, rlExceptions)       // server-to-server (AP)
-	fsMainLimit := middleware.RateLimit(rlLimit, rlExceptions)    // fileserver / web templates
-	fsEmojiLimit := middleware.RateLimit(rlLimit*2, rlExceptions) // fileserver (emojis only, use high limit)
+	clLimit := middleware.RateLimit(rlLimit, config.GetAdvancedRateLimitExceptionsParsed())        // client api
+	s2sLimit := middleware.RateLimit(rlLimit, config.GetAdvancedRateLimitExceptionsParsed())       // server-to-server (AP)
+	fsMainLimit := middleware.RateLimit(rlLimit, config.GetAdvancedRateLimitExceptionsParsed())    // fileserver / web templates
+	fsEmojiLimit := middleware.RateLimit(rlLimit*2, config.GetAdvancedRateLimitExceptionsParsed()) // fileserver (emojis only, use high limit)
 
 	// throttling
 	cpuMultiplier := config.GetAdvancedThrottlingMultiplier()

--- a/docs/configuration/trusted_proxies.md
+++ b/docs/configuration/trusted_proxies.md
@@ -129,7 +129,7 @@ Once you have made the necessary configuration changes, **restart your instance*
 
 If nothing else works, you can disable rate limiting entirely, which will also disable the `trusted-proxies` check and warning.
 
-!!! warnings
+!!! warning
     Turning off rate limiting entirely should be considered a last resort, as rate limiting helps protect your instance from spam and scrapers.
 
 To turn off rate limiting, set `advanced-rate-limit-requests` to 0 in your `config.yaml`.

--- a/docs/configuration/trusted_proxies.md
+++ b/docs/configuration/trusted_proxies.md
@@ -27,17 +27,17 @@ Before (default config):
 
 ```yaml
 trusted-proxies:
-    - "127.0.0.1/32"
-    - "::1"
+  - "127.0.0.1/32"
+  - "::1"
 ```
 
 After (new config):
 
 ```yaml
 trusted-proxies:
-    - "172.17.0.1/16"
-    - "127.0.0.1/32"
-    - "::1"
+  - "172.17.0.1/16"
+  - "127.0.0.1/32"
+  - "::1"
 ```
 
 If you are using [environment variables](../configuration/index.md#environment-variables) to configure your instance, you can configure `trusted-proxies` by setting the environment variable `GTS_TRUSTED_PROXIES` to a comma-separated list of IP ranges, like so:
@@ -74,6 +74,98 @@ If you still see the warning message but with a different suggested IP range to 
 
 ## I can't seem to get `trusted-proxies` configured properly, can I just disable the warning?
 
-There are some situations where it's not practically possible to get `trusted-proxies` configured correctly to detect the real client IP of incoming requests For example, if you're running GoToSocial behind a home internet router that cannot inject an `X-Forwarded-For` header, then your suggested entry to add to `trusted-proxies` will look something like `192.168.x.x`, but adding this to `trusted-proxies` won't resolve the issue.
+There are some situations where it's not practically possible to get `trusted-proxies` configured correctly to detect the real client IP of incoming requests, or where the real client IP is accurate but still shows as being within a private network.
 
-If you've tried everything, then you can disable the warning message by just turning off rate limiting entirely, ie., by setting `advanced-rate-limit-requests` to 0 in your config.yaml, or setting the environment variable `GTS_ADVANCED_RATE_LIMIT_REQUESTS` to 0. Don't forget to **restart your instance** after changing this setting.
+For example, if you're running GoToSocial on your home network, behind a home internet router that cannot inject an `X-Forwarded-For` header, then your suggested entry to add to `trusted-proxies` will look something like `192.168.x.x`, but adding this to `trusted-proxies` won't resolve the issue.
+
+Another example: you're running GoToSocial on your home network, behind a home internet router, and you are accessing the web frontend from a device that's *also* on your home network, like your laptop or phone. In this case, your router may send you directly to your GoToSocial instance without your request ever leaving the network, and so GtS will correctly see *your* client IP address as a private network address, but *other* requests coming in from the wider internet will show their real remote client IP addresses. In this scenario, the `trusted-proxies` warning does not really apply.
+
+If you've tried editing your `trusted-proxies` setting, but you still see the warning, then it's likely that one of the above examples applies to you. You can proceed in one of two ways:
+
+### Add specific exception for your home network (preferred)
+
+If the suggested IP range in the `trusted-proxies` warning looks something like `192.168.x.x`, but you still see other client IPs in your GoToSocial logs that don't start with `192.168`, then try adding a rate limiting exception only for devices on your home network, while leaving rate limiting in place for outside IP addresses.
+
+For example, if your suggestion is something like `192.168.1.128/32`, then swap the `/32` for `/24` so that the range covers `192.168.1.0` -> `192.168.1.255`, and add this to the `advanced-rate-limit-exceptions` setting in your `config.yaml` file.
+
+Before (default config):
+
+```yaml
+advanced-rate-limit-exceptions: []
+```
+
+After (new config):
+
+```yaml
+advanced-rate-limit-exceptions:
+  - "192.168.1.128/24"
+```
+
+If you are using [environment variables](../configuration/index.md#environment-variables) to configure your instance, you can configure `advanced-rate-limit-exceptions` by setting the environment variable `GTS_ADVANCED_RATE_LIMIT_EXCEPTIONS` to a comma-separated list of IP ranges, like so:
+
+```env
+GTS_ADVANCED_RATE_LIMIT_EXCEPTIONS="192.168.1.128/24"
+```
+
+If you are using docker compose, your docker-compose.yaml file should look something like this after the change (note that yaml uses `: ` and not `=`):
+
+```yaml
+################################
+# BLAH BLAH OTHER CONFIG STUFF #
+################################
+    environment:
+      ############################
+      # BLAH BLAH OTHER ENV VARS #
+      ############################
+      GTS_ADVANCED_RATE_LIMIT_EXCEPTIONS: "192.168.1.128/24"
+################################
+# BLAH BLAH OTHER CONFIG STUFF #
+################################
+```
+
+Once you have made the necessary configuration changes, **restart your instance** and refresh the home page.
+
+### Turn off rate limiting entirely (last resort)
+
+If nothing else works, you can disable rate limiting entirely, which will also disable the `trusted-proxies` check and warning.
+
+!!! warnings
+    Turning off rate limiting entirely should be considered a last resort, as rate limiting helps protect your instance from spam and scrapers.
+
+To turn off rate limiting, set `advanced-rate-limit-requests` to 0 in your `config.yaml`.
+
+Before (default config):
+
+```yaml
+advanced-rate-limit-requests: 300
+```
+
+After (new config):
+
+```yaml
+advanced-rate-limit-requests: 0
+```
+
+If you are using [environment variables](../configuration/index.md#environment-variables) to configure your instance, you can configure `advanced-rate-limit-requests` by setting the environment variable `GTS_ADVANCED_RATE_LIMIT_REQUESTS` to 0, like so:
+
+```env
+GTS_ADVANCED_RATE_LIMIT_REQUESTS="0"
+```
+
+If you are using docker compose, your docker-compose.yaml file should look something like this after the change (note that yaml uses `: ` and not `=`):
+
+```yaml
+################################
+# BLAH BLAH OTHER CONFIG STUFF #
+################################
+    environment:
+      ############################
+      # BLAH BLAH OTHER ENV VARS #
+      ############################
+      GTS_ADVANCED_RATE_LIMIT_REQUESTS: "0"
+################################
+# BLAH BLAH OTHER CONFIG STUFF #
+################################
+```
+
+Once you have made the necessary configuration changes, **restart your instance** and refresh the home page.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,15 +164,15 @@ type Configuration struct {
 	SyslogProtocol string `name:"syslog-protocol" usage:"Protocol to use when directing logs to syslog. Leave empty to connect to local syslog."`
 	SyslogAddress  string `name:"syslog-address" usage:"Address:port to send syslog logs to. Leave empty to connect to local syslog."`
 
-	AdvancedCookiesSamesite           string   `name:"advanced-cookies-samesite" usage:"'strict' or 'lax', see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite"`
-	AdvancedRateLimitRequests         int      `name:"advanced-rate-limit-requests" usage:"Amount of HTTP requests to permit within a 5 minute window. 0 or less turns rate limiting off."`
-	AdvancedRateLimitExceptions       []string `name:"advanced-rate-limit-exceptions" usage:"Slice of CIDRs to exclude from rate limit restrictions."`
-	AdvancedRateLimitExceptionsParsed []netip.Prefix
-	AdvancedThrottlingMultiplier      int           `name:"advanced-throttling-multiplier" usage:"Multiplier to use per cpu for http request throttling. 0 or less turns throttling off."`
-	AdvancedThrottlingRetryAfter      time.Duration `name:"advanced-throttling-retry-after" usage:"Retry-After duration response to send for throttled requests."`
-	AdvancedSenderMultiplier          int           `name:"advanced-sender-multiplier" usage:"Multiplier to use per cpu for batching outgoing fedi messages. 0 or less turns batching off (not recommended)."`
-	AdvancedCSPExtraURIs              []string      `name:"advanced-csp-extra-uris" usage:"Additional URIs to allow when building content-security-policy for media + images."`
-	AdvancedHeaderFilterMode          string        `name:"advanced-header-filter-mode" usage:"Set incoming request header filtering mode."`
+	AdvancedCookiesSamesite           string         `name:"advanced-cookies-samesite" usage:"'strict' or 'lax', see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite"`
+	AdvancedRateLimitRequests         int            `name:"advanced-rate-limit-requests" usage:"Amount of HTTP requests to permit within a 5 minute window. 0 or less turns rate limiting off."`
+	AdvancedRateLimitExceptions       []string       `name:"advanced-rate-limit-exceptions" usage:"Slice of CIDRs to exclude from rate limit restrictions."`
+	AdvancedRateLimitExceptionsParsed []netip.Prefix `name:"advanced-rate-limit-exceptions-parsed"`
+	AdvancedThrottlingMultiplier      int            `name:"advanced-throttling-multiplier" usage:"Multiplier to use per cpu for http request throttling. 0 or less turns throttling off."`
+	AdvancedThrottlingRetryAfter      time.Duration  `name:"advanced-throttling-retry-after" usage:"Retry-After duration response to send for throttled requests."`
+	AdvancedSenderMultiplier          int            `name:"advanced-sender-multiplier" usage:"Multiplier to use per cpu for batching outgoing fedi messages. 0 or less turns batching off (not recommended)."`
+	AdvancedCSPExtraURIs              []string       `name:"advanced-csp-extra-uris" usage:"Additional URIs to allow when building content-security-policy for media + images."`
+	AdvancedHeaderFilterMode          string         `name:"advanced-header-filter-mode" usage:"Set incoming request header filtering mode."`
 
 	// HTTPClient configuration vars.
 	HTTPClient HTTPClientConfiguration `name:"http-client"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"net/netip"
 	"reflect"
 	"time"
 
@@ -163,14 +164,15 @@ type Configuration struct {
 	SyslogProtocol string `name:"syslog-protocol" usage:"Protocol to use when directing logs to syslog. Leave empty to connect to local syslog."`
 	SyslogAddress  string `name:"syslog-address" usage:"Address:port to send syslog logs to. Leave empty to connect to local syslog."`
 
-	AdvancedCookiesSamesite      string        `name:"advanced-cookies-samesite" usage:"'strict' or 'lax', see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite"`
-	AdvancedRateLimitRequests    int           `name:"advanced-rate-limit-requests" usage:"Amount of HTTP requests to permit within a 5 minute window. 0 or less turns rate limiting off."`
-	AdvancedRateLimitExceptions  []string      `name:"advanced-rate-limit-exceptions" usage:"Slice of CIDRs to exclude from rate limit restrictions."`
-	AdvancedThrottlingMultiplier int           `name:"advanced-throttling-multiplier" usage:"Multiplier to use per cpu for http request throttling. 0 or less turns throttling off."`
-	AdvancedThrottlingRetryAfter time.Duration `name:"advanced-throttling-retry-after" usage:"Retry-After duration response to send for throttled requests."`
-	AdvancedSenderMultiplier     int           `name:"advanced-sender-multiplier" usage:"Multiplier to use per cpu for batching outgoing fedi messages. 0 or less turns batching off (not recommended)."`
-	AdvancedCSPExtraURIs         []string      `name:"advanced-csp-extra-uris" usage:"Additional URIs to allow when building content-security-policy for media + images."`
-	AdvancedHeaderFilterMode     string        `name:"advanced-header-filter-mode" usage:"Set incoming request header filtering mode."`
+	AdvancedCookiesSamesite           string   `name:"advanced-cookies-samesite" usage:"'strict' or 'lax', see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite"`
+	AdvancedRateLimitRequests         int      `name:"advanced-rate-limit-requests" usage:"Amount of HTTP requests to permit within a 5 minute window. 0 or less turns rate limiting off."`
+	AdvancedRateLimitExceptions       []string `name:"advanced-rate-limit-exceptions" usage:"Slice of CIDRs to exclude from rate limit restrictions."`
+	AdvancedRateLimitExceptionsParsed []netip.Prefix
+	AdvancedThrottlingMultiplier      int           `name:"advanced-throttling-multiplier" usage:"Multiplier to use per cpu for http request throttling. 0 or less turns throttling off."`
+	AdvancedThrottlingRetryAfter      time.Duration `name:"advanced-throttling-retry-after" usage:"Retry-After duration response to send for throttled requests."`
+	AdvancedSenderMultiplier          int           `name:"advanced-sender-multiplier" usage:"Multiplier to use per cpu for batching outgoing fedi messages. 0 or less turns batching off (not recommended)."`
+	AdvancedCSPExtraURIs              []string      `name:"advanced-csp-extra-uris" usage:"Additional URIs to allow when building content-security-policy for media + images."`
+	AdvancedHeaderFilterMode          string        `name:"advanced-header-filter-mode" usage:"Set incoming request header filtering mode."`
 
 	// HTTPClient configuration vars.
 	HTTPClient HTTPClientConfiguration `name:"http-client"`

--- a/internal/config/gen/gen.go
+++ b/internal/config/gen/gen.go
@@ -65,6 +65,7 @@ func main() {
 	fmt.Fprint(output, license)
 	fmt.Fprint(output, "package config\n\n")
 	fmt.Fprint(output, "import (\n")
+	fmt.Fprint(output, "\t\"net/netip\"\n")
 	fmt.Fprint(output, "\t\"time\"\n\n")
 	fmt.Fprint(output, "\t\"codeberg.org/gruf/go-bytesize\"\n")
 	fmt.Fprint(output, "\t\"github.com/superseriousbusiness/gotosocial/internal/language\"\n")

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -19,6 +19,7 @@
 package config
 
 import (
+	"net/netip"
 	"time"
 
 	"codeberg.org/gruf/go-bytesize"
@@ -2680,6 +2681,35 @@ func GetAdvancedRateLimitExceptions() []string { return global.GetAdvancedRateLi
 
 // SetAdvancedRateLimitExceptions safely sets the value for global configuration 'AdvancedRateLimitExceptions' field
 func SetAdvancedRateLimitExceptions(v []string) { global.SetAdvancedRateLimitExceptions(v) }
+
+// GetAdvancedRateLimitExceptionsParsed safely fetches the Configuration value for state's 'AdvancedRateLimitExceptionsParsed' field
+func (st *ConfigState) GetAdvancedRateLimitExceptionsParsed() (v []netip.Prefix) {
+	st.mutex.RLock()
+	v = st.config.AdvancedRateLimitExceptionsParsed
+	st.mutex.RUnlock()
+	return
+}
+
+// SetAdvancedRateLimitExceptionsParsed safely sets the Configuration value for state's 'AdvancedRateLimitExceptionsParsed' field
+func (st *ConfigState) SetAdvancedRateLimitExceptionsParsed(v []netip.Prefix) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.AdvancedRateLimitExceptionsParsed = v
+	st.reloadToViper()
+}
+
+// AdvancedRateLimitExceptionsParsedFlag returns the flag name for the 'AdvancedRateLimitExceptionsParsed' field
+func AdvancedRateLimitExceptionsParsedFlag() string { return "" }
+
+// GetAdvancedRateLimitExceptionsParsed safely fetches the value for global configuration 'AdvancedRateLimitExceptionsParsed' field
+func GetAdvancedRateLimitExceptionsParsed() []netip.Prefix {
+	return global.GetAdvancedRateLimitExceptionsParsed()
+}
+
+// SetAdvancedRateLimitExceptionsParsed safely sets the value for global configuration 'AdvancedRateLimitExceptionsParsed' field
+func SetAdvancedRateLimitExceptionsParsed(v []netip.Prefix) {
+	global.SetAdvancedRateLimitExceptionsParsed(v)
+}
 
 // GetAdvancedThrottlingMultiplier safely fetches the Configuration value for state's 'AdvancedThrottlingMultiplier' field
 func (st *ConfigState) GetAdvancedThrottlingMultiplier() (v int) {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -180,6 +180,7 @@ func Validate() error {
 				"invalid entry %s in %s: %w",
 				rle, AdvancedRateLimitExceptionsFlag(), err,
 			)
+			continue
 		}
 		rlesParsed = append(rlesParsed, parsed)
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -19,6 +19,7 @@ package config
 
 import (
 	"fmt"
+	"net/netip"
 	"net/url"
 	"strings"
 
@@ -167,6 +168,22 @@ func Validate() error {
 			tlsChainFlag, tlsKeyFlag,
 		)
 	}
+
+	// Parse `advanced-rate-limit-exceptions` and set
+	// parsed versions on config to avoid reparsing calls.
+	rles := GetAdvancedRateLimitExceptions()
+	rlesParsed := make([]netip.Prefix, 0, len(rles))
+	for _, rle := range rles {
+		parsed, err := netip.ParsePrefix(rle)
+		if err != nil {
+			errf(
+				"invalid entry %s in %s: %w",
+				rle, AdvancedRateLimitExceptionsFlag(), err,
+			)
+		}
+		rlesParsed = append(rlesParsed, parsed)
+	}
+	SetAdvancedRateLimitExceptionsParsed(rlesParsed)
 
 	return errs.Combine()
 }

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -48,7 +48,7 @@ const rateLimitPeriod = 5 * time.Minute
 //
 // If the config AdvancedRateLimitRequests value is <= 0, then a noop
 // handler will be returned, which performs no rate limiting.
-func RateLimit(limit int, exceptions []string) gin.HandlerFunc {
+func RateLimit(limit int, except []netip.Prefix) gin.HandlerFunc {
 	if limit <= 0 {
 		// Rate limiting is disabled.
 		// Return noop middleware.
@@ -62,12 +62,6 @@ func RateLimit(limit int, exceptions []string) gin.HandlerFunc {
 			Limit:  int64(limit),
 		},
 	)
-
-	// Convert exceptions IP ranges into prefixes.
-	exceptPrefs := make([]netip.Prefix, len(exceptions))
-	for i, str := range exceptions {
-		exceptPrefs[i] = netip.MustParsePrefix(str)
-	}
 
 	// It's prettymuch impossible to effectively
 	// rate limit the immense IPv6 address space
@@ -88,7 +82,7 @@ func RateLimit(limit int, exceptions []string) gin.HandlerFunc {
 
 		// Check if this IP is exempt from rate
 		// limits and skip further checks if so.
-		for _, prefix := range exceptPrefs {
+		for _, prefix := range except {
 			if prefix.Contains(clientIP) {
 				c.Next()
 				return

--- a/test/envparsing.sh
+++ b/test/envparsing.sh
@@ -16,6 +16,7 @@ EXPECT=$(cat << "EOF"
         "192.0.2.0/24",
         "127.0.0.1/32"
     ],
+    "advanced-rate-limit-exceptions-parsed": null,
     "advanced-rate-limit-requests": 6969,
     "advanced-sender-multiplier": -1,
     "advanced-throttling-multiplier": -1,


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request adds a check to skip injecting the trusted-proxies warning if the clientIP address is in `advanced-rate-limit-exceptions`, to encourage people to add rate limit exceptions for their home networks, and to prevent annoying warnings when accessing one's own instance on one's own network, even though rate limiting is otherwise working correctly.

closes https://github.com/superseriousbusiness/gotosocial/issues/3690

Also updates config to store a parsed slice of exceptions, to avoid re-parsing them multiple times.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
