### PR TITLE
[feature] Use maintenance router to serve 503 while server is starting/migrating

### DIFF
--- a/cmd/gotosocial/server.go
+++ b/cmd/gotosocial/server.go
@@ -41,5 +41,19 @@ func serverCommands() *cobra.Command {
 	}
 	config.AddServerFlags(serverStartCmd)
 	serverCmd.AddCommand(serverStartCmd)
+
+	serverMaintenanceCmd := &cobra.Command{
+		Use:   "maintenance",
+		Short: "start the gotosocial server in maintenance mode (returns 503 for almost all requests)",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return preRun(preRunArgs{cmd: cmd})
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd.Context(), server.Maintenance)
+		},
+	}
+	config.AddServerFlags(serverMaintenanceCmd)
+	serverCmd.AddCommand(serverMaintenanceCmd)
+
 	return serverCmd
 }

--- a/internal/web/etag.go
+++ b/internal/web/etag.go
@@ -29,6 +29,10 @@ import (
 	"codeberg.org/gruf/go-cache/v3"
 )
 
+type withETagCache interface {
+	ETagCache() cache.Cache[string, eTagCacheEntry]
+}
+
 func newETagCache() cache.TTLCache[string, eTagCacheEntry] {
 	eTagCache := cache.NewTTL[string, eTagCacheEntry](0, 1000, 0)
 	eTagCache.SetTTL(time.Hour, false)

--- a/internal/web/maintenance.go
+++ b/internal/web/maintenance.go
@@ -1,0 +1,53 @@
+package web
+
+import (
+	"net/http"
+	"time"
+
+	"codeberg.org/gruf/go-cache/v3"
+	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/api/health"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
+	"github.com/superseriousbusiness/gotosocial/internal/router"
+)
+
+type MaintenanceModule struct {
+	eTagCache cache.Cache[string, eTagCacheEntry]
+}
+
+// NewMaintenance returns a module that routes only
+// static assets, and returns a code 503 maintenance
+// message template to all other requests.
+func NewMaintenance() *MaintenanceModule {
+	return &MaintenanceModule{
+		eTagCache: newETagCache(),
+	}
+}
+
+// ETagCache implements withETagCache.
+func (m *MaintenanceModule) ETagCache() cache.Cache[string, eTagCacheEntry] {
+	return m.eTagCache
+}
+
+func (m *MaintenanceModule) Route(r *router.Router, mi ...gin.HandlerFunc) {
+	// Route static assets.
+	routeAssets(m, r, mi...)
+
+	// Serve OK in response to live
+	// requests, but not ready requests.
+	liveHandler := func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	}
+	r.AttachHandler(http.MethodGet, health.LivePath, liveHandler)
+	r.AttachHandler(http.MethodHead, health.LivePath, liveHandler)
+
+	// For everything else, serve maintenance template.
+	obj := map[string]string{"host": config.GetHost()}
+	r.AttachNoRouteHandler(func(c *gin.Context) {
+		retryAfter := time.Now().Add(120 * time.Second).UTC()
+		c.Writer.Header().Add("Retry-After", "120")
+		c.Writer.Header().Add("Retry-After", retryAfter.Format(http.TimeFormat))
+		c.Header("Cache-Control", "no-store")
+		c.HTML(http.StatusServiceUnavailable, "maintenance.tmpl", obj)
+	})
+}

--- a/web/template/maintenance.tmpl
+++ b/web/template/maintenance.tmpl
@@ -1,0 +1,76 @@
+{{- /*
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/ -}}
+
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="robots" content="noindex, nofollow">
+        <link rel="icon" href="/assets/logo.webp" type="image/webp">
+        <link rel="apple-touch-icon" href="/assets/logo.webp" type="image/webp">
+        <link rel="apple-touch-startup-image" href="/assets/logo.webp" type="image/webp">
+        <link rel="preload" href="/assets/dist/_colors.css" as="style">
+        <link rel="preload" href="/assets/dist/base.css" as="style">
+        <link rel="preload" href="/assets/dist/page.css" as="style">
+        <link rel="stylesheet" href="/assets/dist/_colors.css">
+        <link rel="stylesheet" href="/assets/dist/base.css">
+        <link rel="stylesheet" href="/assets/dist/page.css">
+        <title>{{- .host -}}</title>
+    </head>
+    <body>
+        <div class="page">
+        <header class="page-header">
+            <a aria-label="{{- .host -}}. Go to instance homepage" href="/" class="nounderline">
+                <picture>
+                    <img
+                        src="/assets/logo.webp"
+                        alt="A cartoon sloth smiling happily."
+                        title="A cartoon sloth smiling happily."
+                    />
+                </picture>
+                <h1>{{- .host -}}</h1>
+            </a>
+        </header>
+        <div class="page-content">
+            <p>This GoToSocial instance is currently down for maintenance, starting up, or running database migrations. Please wait.</p>
+            <p>If you are the admin of this instance, check your GoToSocial logs for more details, and make sure to <strong>not interrupt any running database migrations</strong>!</p>
+        </div>
+        <footer class="page-footer">
+            <nav>
+                <ul class="nodot">
+                    <li id="version">
+                        <a
+                            href="https://github.com/superseriousbusiness/gotosocial"
+                            class="nounderline"
+                            rel="nofollow noreferrer noopener"
+                            target="_blank"
+                        >
+                            <span aria-hidden="true">🦥</span>
+                            Source - GoToSocial
+                            <span aria-hidden="true">🦥</span>
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+        </footer>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request adds a simple barebones router that's initialized during startup, hangs around until db migrations are complete, and then is closed and replaced with the "main" server router.

The maintenance router serves static assets, serves 200 OK for "live" checks (*not* "ready" checks), and serves a 503 page for everything else, with `Retry-After` set to 2 minutes.

![Screenshot from 2025-01-29 16-28-32](https://github.com/user-attachments/assets/7b0db9cd-2f64-4a15-bc54-2fa7e50cdd6f)

Should make things a little clearer for users when an instance is down running database migrations :) And should reassure admins that stuff is working, as well.

The command `gotosocial server maintenance` has also been added just to test the maintenance mode.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
