### PR TITLE
Bugfix/missing emoji urls

### DIFF
--- a/internal/cleaner/emoji.go
+++ b/internal/cleaner/emoji.go
@@ -104,13 +104,14 @@ func (e *Emoji) UncacheRemote(ctx context.Context, olderThan time.Time) (int, er
 			return total, gtserror.Newf("error getting remote emoji: %w", err)
 		}
 
-		// If no emojis / same group is returned, we reached the end.
+		// If no emojis / same group is
+		// returned, we reached the end.
 		if len(emojis) == 0 ||
 			olderThan.Equal(emojis[len(emojis)-1].CreatedAt) {
 			break
 		}
 
-		// Use last created-at as the next 'olderThan' value.
+		// Use last createdAt as next 'olderThan' value.
 		olderThan = emojis[len(emojis)-1].CreatedAt
 
 		for _, emoji := range emojis {

--- a/internal/gtsmodel/account.go
+++ b/internal/gtsmodel/account.go
@@ -94,7 +94,6 @@ func (a *Account) UsernameDomain() string {
 
 // IsLocal returns whether account is a local user account.
 func (a *Account) IsLocal() bool {
-	// TODO: can we simplify this to just domain == ""?
 	return a.Domain == "" ||
 		a.Domain == config.GetHost() ||
 		a.Domain == config.GetAccountDomain()

--- a/internal/gtsmodel/account.go
+++ b/internal/gtsmodel/account.go
@@ -31,7 +31,8 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/log"
 )
 
-// Account represents either a local or a remote fediverse account, gotosocial or otherwise (mastodon, pleroma, etc).
+// Account represents either a local or a remote fediverse
+// account, gotosocial or otherwise (mastodon, pleroma, etc).
 type Account struct {
 	ID                      string           `bun:"type:CHAR(26),pk,nullzero,notnull,unique"`                    // id of this item in the database
 	CreatedAt               time.Time        `bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"` // when was item created.
@@ -83,9 +84,20 @@ type Account struct {
 	Stats                   *AccountStats    `bun:"-"`                                                           // gtsmodel.AccountStats for this account.
 }
 
+// UsernameDomain returns account @username@domain (missing domain if local).
+func (a *Account) UsernameDomain() string {
+	if a.IsLocal() {
+		return "@" + a.Username
+	}
+	return "@" + a.Username + "@" + a.Domain
+}
+
 // IsLocal returns whether account is a local user account.
 func (a *Account) IsLocal() bool {
-	return a.Domain == "" || a.Domain == config.GetHost() || a.Domain == config.GetAccountDomain()
+	// TODO: can we simplify this to just domain == ""?
+	return a.Domain == "" ||
+		a.Domain == config.GetHost() ||
+		a.Domain == config.GetAccountDomain()
 }
 
 // IsRemote returns whether account is a remote user account.

--- a/internal/gtsmodel/emoji.go
+++ b/internal/gtsmodel/emoji.go
@@ -19,7 +19,8 @@ package gtsmodel
 
 import "time"
 
-// Emoji represents a custom emoji that's been uploaded through the admin UI or downloaded from a remote instance.
+// Emoji represents a custom emoji that's been uploaded
+// through the admin UI or downloaded from a remote instance.
 type Emoji struct {
 	ID                     string         `bun:"type:CHAR(26),pk,nullzero,notnull,unique"`                    // id of this item in the database
 	CreatedAt              time.Time      `bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"` // when was item created


### PR DESCRIPTION
# Description

This is a partial fix for #3605, but honestly we could do with some better logic for emoji refreshing of URLs that haven't been touched in a while.

Post v0.18.0 I'm think we have some kind of perma-url for emojis that triggers a refresh and redirects the client to the latest image URLs. Or something along those lines, the idea and implementation are up for discussion :p, but ultimately I would like to be the one to work on it as there's some related improvements I want to make to determining if an emoji is fresh / needs uncaching. And same goes for media.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
