### PR TITLE
[chore] Add "target" uri to outgoing Accept + Reject messages

### DIFF
--- a/internal/typeutils/internaltoas.go
+++ b/internal/typeutils/internaltoas.go
@@ -2021,7 +2021,19 @@ func (c *Converter) InteractionReqToASAccept(
 
 	objectIRI, err := url.Parse(req.InteractionURI)
 	if err != nil {
-		return nil, gtserror.Newf("invalid target uri: %w", err)
+		return nil, gtserror.Newf("invalid object uri: %w", err)
+	}
+
+	if req.Status == nil {
+		req.Status, err = c.state.DB.GetStatusByID(ctx, req.StatusID)
+		if err != nil {
+			return nil, gtserror.Newf("db error getting interaction req target status: %w", err)
+		}
+	}
+
+	targetIRI, err := url.Parse(req.Status.URI)
+	if err != nil {
+		return nil, gtserror.Newf("invalid interaction req target status uri: %w", err)
 	}
 
 	toIRI, err := url.Parse(req.InteractingAccount.URI)
@@ -2039,6 +2051,10 @@ func (c *Converter) InteractionReqToASAccept(
 
 	// Object is the interaction URI.
 	ap.AppendObjectIRIs(accept, objectIRI)
+
+	// Target is the URI of the
+	// status being interacted with.
+	ap.AppendTargetIRIs(accept, targetIRI)
 
 	// Address to the owner
 	// of interaction URI.
@@ -2101,7 +2117,19 @@ func (c *Converter) InteractionReqToASReject(
 
 	objectIRI, err := url.Parse(req.InteractionURI)
 	if err != nil {
-		return nil, gtserror.Newf("invalid target uri: %w", err)
+		return nil, gtserror.Newf("invalid object uri: %w", err)
+	}
+
+	if req.Status == nil {
+		req.Status, err = c.state.DB.GetStatusByID(ctx, req.StatusID)
+		if err != nil {
+			return nil, gtserror.Newf("db error getting interaction req target status: %w", err)
+		}
+	}
+
+	targetIRI, err := url.Parse(req.Status.URI)
+	if err != nil {
+		return nil, gtserror.Newf("invalid interaction req target status uri: %w", err)
 	}
 
 	toIRI, err := url.Parse(req.InteractingAccount.URI)
@@ -2119,6 +2147,10 @@ func (c *Converter) InteractionReqToASReject(
 
 	// Object is the interaction URI.
 	ap.AppendObjectIRIs(reject, objectIRI)
+
+	// Target is the URI of the
+	// status being interacted with.
+	ap.AppendTargetIRIs(reject, targetIRI)
 
 	// Address to the owner
 	// of interaction URI.

--- a/internal/typeutils/internaltoas_test.go
+++ b/internal/typeutils/internaltoas_test.go
@@ -1235,7 +1235,9 @@ func (suite *InternalToASTestSuite) TestInteractionReqToASAcceptAnnounce() {
 	req := &gtsmodel.InteractionRequest{
 		ID:                   "01J1AKMZ8JE5NW0ZSFTRC1JJNE",
 		CreatedAt:            testrig.TimeMustParse("2022-06-09T13:12:00Z"),
-		TargetAccountID:      acceptingAccount.ID,
+    StatusID:             "01JJYCVKCXB9JTQD1XW2KB8MT3",
+		Status:               &gtsmodel.Status{URI: "http://localhost:8080/users/the_mighty_zork/statuses/01JJYCVKCXB9JTQD1XW2KB8MT3"},
+    TargetAccountID:      acceptingAccount.ID,
 		TargetAccount:        acceptingAccount,
 		InteractingAccountID: interactingAccount.ID,
 		InteractingAccount:   interactingAccount,
@@ -1272,6 +1274,7 @@ func (suite *InternalToASTestSuite) TestInteractionReqToASAcceptAnnounce() {
   ],
   "id": "http://localhost:8080/users/the_mighty_zork/accepts/01J1AKMZ8JE5NW0ZSFTRC1JJNE",
   "object": "https://fossbros-anonymous.io/users/foss_satan/statuses/01J1AKRRHQ6MDDQHV0TP716T2K",
+  "target": "http://localhost:8080/users/the_mighty_zork/statuses/01JJYCVKCXB9JTQD1XW2KB8MT3",
   "to": "http://fossbros-anonymous.io/users/foss_satan",
   "type": "Accept"
 }`, string(b))
@@ -1284,6 +1287,8 @@ func (suite *InternalToASTestSuite) TestInteractionReqToASAcceptLike() {
 	req := &gtsmodel.InteractionRequest{
 		ID:                   "01J1AKMZ8JE5NW0ZSFTRC1JJNE",
 		CreatedAt:            testrig.TimeMustParse("2022-06-09T13:12:00Z"),
+		StatusID:             "01JJYCVKCXB9JTQD1XW2KB8MT3",
+		Status:               &gtsmodel.Status{URI: "http://localhost:8080/users/the_mighty_zork/statuses/01JJYCVKCXB9JTQD1XW2KB8MT3"},
 		TargetAccountID:      acceptingAccount.ID,
 		TargetAccount:        acceptingAccount,
 		InteractingAccountID: interactingAccount.ID,
@@ -1317,6 +1322,7 @@ func (suite *InternalToASTestSuite) TestInteractionReqToASAcceptLike() {
   "actor": "http://localhost:8080/users/the_mighty_zork",
   "id": "http://localhost:8080/users/the_mighty_zork/accepts/01J1AKMZ8JE5NW0ZSFTRC1JJNE",
   "object": "https://fossbros-anonymous.io/users/foss_satan/statuses/01J1AKRRHQ6MDDQHV0TP716T2K",
+  "target": "http://localhost:8080/users/the_mighty_zork/statuses/01JJYCVKCXB9JTQD1XW2KB8MT3",
   "to": "http://fossbros-anonymous.io/users/foss_satan",
   "type": "Accept"
 }`, string(b))


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request sets the `target` field on outgoing Accepts or Rejects of interactions to the URI of the post that was interacted with, to make things a bit easier for remotes processing Accepts or Rejects.

https://github.com/superseriousbusiness/gotosocial/pull/3703 Should be updated to add this.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
