### PR TITLE
[feature] Add `instance-stats-randomize` config option

### DIFF
--- a/docs/configuration/instance.md
+++ b/docs/configuration/instance.md
@@ -138,4 +138,15 @@ instance-subscriptions-process-from: "23:00"
 # Examples: ["24h", "72h", "12h"]
 # Default: "24h" (once per day).
 instance-subscriptions-process-every: "24h"
+
+# Bool. Set this to true to randomize stats served at
+# the /api/v1|v2/instance and /nodeinfo/2.0 endpoints.
+#
+# This can be useful when you don't want bots to obtain
+# reliable information about the amount of users and
+# statuses on your instance.
+#
+# Options: [true, false]
+# Default: false
+instance-stats-randomize: false
 ```

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -425,6 +425,17 @@ instance-subscriptions-process-from: "23:00"
 # Default: "24h" (once per day).
 instance-subscriptions-process-every: "24h"
 
+# Bool. Set this to true to randomize stats served at
+# the /api/v1|v2/instance and /nodeinfo/2.0 endpoints.
+#
+# This can be useful when you don't want bots to obtain
+# reliable information about the amount of users and
+# statuses on your instance.
+#
+# Options: [true, false]
+# Default: false
+instance-stats-randomize: false
+
 ###########################
 ##### ACCOUNTS CONFIG #####
 ###########################

--- a/internal/api/client/instance/instanceget.go
+++ b/internal/api/client/instance/instanceget.go
@@ -21,7 +21,9 @@ import (
 	"net/http"
 
 	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
 
 	"github.com/gin-gonic/gin"
 )
@@ -58,6 +60,12 @@ func (m *Module) InstanceInformationGETHandlerV1(c *gin.Context) {
 		return
 	}
 
+	if config.GetInstanceStatsRandomize() {
+		// Replace actual stats with cached randomized ones.
+		instance.Stats["user_count"] = util.Ptr(int(instance.RandomStats.TotalUsers))
+		instance.Stats["status_count"] = util.Ptr(int(instance.RandomStats.Statuses))
+	}
+
 	apiutil.JSON(c, http.StatusOK, instance)
 }
 
@@ -91,6 +99,11 @@ func (m *Module) InstanceInformationGETHandlerV2(c *gin.Context) {
 	if errWithCode != nil {
 		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
 		return
+	}
+
+	if config.GetInstanceStatsRandomize() {
+		// Replace actual stats with cached randomized ones.
+		instance.Usage.Users.ActiveMonth = int(instance.RandomStats.MonthlyActiveUsers)
 	}
 
 	apiutil.JSON(c, http.StatusOK, instance)

--- a/internal/api/model/instance.go
+++ b/internal/api/model/instance.go
@@ -17,7 +17,10 @@
 
 package model
 
-import "mime/multipart"
+import (
+	"mime/multipart"
+	"time"
+)
 
 // InstanceSettingsUpdateRequest models an instance update request.
 //
@@ -154,4 +157,5 @@ type RandomStats struct {
 	Statuses           int64
 	TotalUsers         int64
 	MonthlyActiveUsers int64
+	Generated          time.Time
 }

--- a/internal/api/model/instance.go
+++ b/internal/api/model/instance.go
@@ -148,3 +148,10 @@ type InstanceConfigurationEmojis struct {
 	// example: 51200
 	EmojiSizeLimit int `json:"emoji_size_limit"`
 }
+
+// swagger:ignore
+type RandomStats struct {
+	Statuses           int64
+	TotalUsers         int64
+	MonthlyActiveUsers int64
+}

--- a/internal/api/model/instancev1.go
+++ b/internal/api/model/instancev1.go
@@ -110,6 +110,13 @@ type InstanceV1 struct {
 	Terms string `json:"terms,omitempty"`
 	// Raw (unparsed) version of terms.
 	TermsRaw string `json:"terms_text,omitempty"`
+
+	// Random stats generated for the instance.
+	// Only used if `instance-stats-randomize` is true.
+	// Not serialized to the frontend.
+	//
+	// swagger:ignore
+	RandomStats `json:"-"`
 }
 
 // InstanceV1URLs models instance-relevant URLs for client application consumption.

--- a/internal/api/model/instancev2.go
+++ b/internal/api/model/instancev2.go
@@ -74,6 +74,13 @@ type InstanceV2 struct {
 	Terms string `json:"terms,omitempty"`
 	// Raw (unparsed) version of terms.
 	TermsText string `json:"terms_text,omitempty"`
+
+	// Random stats generated for the instance.
+	// Only used if `instance-stats-randomize` is true.
+	// Not serialized to the frontend.
+	//
+	// swagger:ignore
+	RandomStats `json:"-"`
 }
 
 // Usage data for this instance.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,7 @@ type Configuration struct {
 	InstanceLanguages                 language.Languages `name:"instance-languages" usage:"BCP47 language tags for the instance. Used to indicate the preferred languages of instance residents (in order from most-preferred to least-preferred)."`
 	InstanceSubscriptionsProcessFrom  string             `name:"instance-subscriptions-process-from" usage:"Time of day from which to start running instance subscriptions processing jobs. Should be in the format 'hh:mm:ss', eg., '15:04:05'."`
 	InstanceSubscriptionsProcessEvery time.Duration      `name:"instance-subscriptions-process-every" usage:"Period to elapse between instance subscriptions processing jobs, starting from instance-subscriptions-process-from."`
+	InstanceStatsRandomize            bool               `name:"instance-stats-randomize" usage:"Set to true to randomize the stats served at api/v1/instance and api/v2/instance endpoints. Home page stats remain unchanged."`
 
 	AccountsRegistrationOpen bool `name:"accounts-registration-open" usage:"Allow anyone to submit an account signup request. If false, server will be invite-only."`
 	AccountsReasonRequired   bool `name:"accounts-reason-required" usage:"Do new account signups require a reason to be submitted on registration?"`

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -92,6 +92,7 @@ func (s *ConfigState) AddServerFlags(cmd *cobra.Command) {
 		cmd.Flags().StringSlice(InstanceLanguagesFlag(), cfg.InstanceLanguages.TagStrs(), fieldtag("InstanceLanguages", "usage"))
 		cmd.Flags().String(InstanceSubscriptionsProcessFromFlag(), cfg.InstanceSubscriptionsProcessFrom, fieldtag("InstanceSubscriptionsProcessFrom", "usage"))
 		cmd.Flags().Duration(InstanceSubscriptionsProcessEveryFlag(), cfg.InstanceSubscriptionsProcessEvery, fieldtag("InstanceSubscriptionsProcessEvery", "usage"))
+		cmd.Flags().Bool(InstanceStatsRandomizeFlag(), cfg.InstanceStatsRandomize, fieldtag("InstanceStatsRandomize", "usage"))
 
 		// Accounts
 		cmd.Flags().Bool(AccountsRegistrationOpenFlag(), cfg.AccountsRegistrationOpen, fieldtag("AccountsRegistrationOpen", "usage"))

--- a/internal/config/helpers.gen.go
+++ b/internal/config/helpers.gen.go
@@ -1057,6 +1057,31 @@ func SetInstanceSubscriptionsProcessEvery(v time.Duration) {
 	global.SetInstanceSubscriptionsProcessEvery(v)
 }
 
+// GetInstanceStatsRandomize safely fetches the Configuration value for state's 'InstanceStatsRandomize' field
+func (st *ConfigState) GetInstanceStatsRandomize() (v bool) {
+	st.mutex.RLock()
+	v = st.config.InstanceStatsRandomize
+	st.mutex.RUnlock()
+	return
+}
+
+// SetInstanceStatsRandomize safely sets the Configuration value for state's 'InstanceStatsRandomize' field
+func (st *ConfigState) SetInstanceStatsRandomize(v bool) {
+	st.mutex.Lock()
+	defer st.mutex.Unlock()
+	st.config.InstanceStatsRandomize = v
+	st.reloadToViper()
+}
+
+// InstanceStatsRandomizeFlag returns the flag name for the 'InstanceStatsRandomize' field
+func InstanceStatsRandomizeFlag() string { return "instance-stats-randomize" }
+
+// GetInstanceStatsRandomize safely fetches the value for global configuration 'InstanceStatsRandomize' field
+func GetInstanceStatsRandomize() bool { return global.GetInstanceStatsRandomize() }
+
+// SetInstanceStatsRandomize safely sets the value for global configuration 'InstanceStatsRandomize' field
+func SetInstanceStatsRandomize(v bool) { global.SetInstanceStatsRandomize(v) }
+
 // GetAccountsRegistrationOpen safely fetches the Configuration value for state's 'AccountsRegistrationOpen' field
 func (st *ConfigState) GetAccountsRegistrationOpen() (v bool) {
 	st.mutex.RLock()
@@ -2699,7 +2724,7 @@ func (st *ConfigState) SetAdvancedRateLimitExceptionsParsed(v []netip.Prefix) {
 }
 
 // AdvancedRateLimitExceptionsParsedFlag returns the flag name for the 'AdvancedRateLimitExceptionsParsed' field
-func AdvancedRateLimitExceptionsParsedFlag() string { return "" }
+func AdvancedRateLimitExceptionsParsedFlag() string { return "advanced-rate-limit-exceptions-parsed" }
 
 // GetAdvancedRateLimitExceptionsParsed safely fetches the value for global configuration 'AdvancedRateLimitExceptionsParsed' field
 func GetAdvancedRateLimitExceptionsParsed() []netip.Prefix {

--- a/internal/typeutils/converter.go
+++ b/internal/typeutils/converter.go
@@ -18,10 +18,18 @@
 package typeutils
 
 import (
+	crand "crypto/rand"
+	"math/big"
+	"math/rand"
 	"sync"
+	"time"
 
+	"codeberg.org/gruf/go-cache/v3"
+	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
+	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/filter/interaction"
 	"github.com/superseriousbusiness/gotosocial/internal/filter/visibility"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
 )
 
@@ -31,13 +39,64 @@ type Converter struct {
 	randAvatars    sync.Map
 	visFilter      *visibility.Filter
 	intFilter      *interaction.Filter
+	randStatsCache cache.TTLCache[struct{}, apimodel.RandomStats]
 }
 
 func NewConverter(state *state.State) *Converter {
+	// If randomizing instance stats, create a cache so we
+	// don't have to generate them every time, and set a 1hr
+	// ttl on the cache so they're not always the same.
+	var randStatsCache cache.TTLCache[struct{}, apimodel.RandomStats]
+	if config.GetInstanceStatsRandomize() {
+		randStatsCache = cache.NewTTL[struct{}, apimodel.RandomStats](0, 1, 0)
+		randStatsCache.SetTTL(time.Hour, false)
+		if !randStatsCache.Start(time.Minute) {
+			log.Panicf(nil, "couldn't start randStatsCache")
+		}
+	}
+
 	return &Converter{
 		state:          state,
 		defaultAvatars: populateDefaultAvatars(),
 		visFilter:      visibility.NewFilter(state),
 		intFilter:      interaction.NewFilter(state),
+		randStatsCache: randStatsCache,
 	}
+}
+
+// RandomStats returns or generates
+// and returns random instance stats.
+func (c *Converter) RandomStats() apimodel.RandomStats {
+	const (
+		statusesMax = 10000000
+		usersMax    = 1000000
+	)
+
+	stats, ok := c.randStatsCache.Get(struct{}{})
+	if !ok {
+		statusesB, err := crand.Int(crand.Reader, big.NewInt(statusesMax))
+		if err != nil {
+			// Only errs if something is buggered with the OS.
+			log.Panicf(nil, "error randomly generating statuses count: %v", err)
+		}
+
+		totalUsersB, err := crand.Int(crand.Reader, big.NewInt(usersMax))
+		if err != nil {
+			// Only errs if something is buggered with the OS.
+			log.Panicf(nil, "error randomly generating users count: %v", err)
+		}
+
+		totalUsers := totalUsersB.Int64()
+		activeRatio := rand.Float64() //nolint
+		mau := int64(float64(totalUsers) * activeRatio)
+
+		stats = apimodel.RandomStats{
+			Statuses:           statusesB.Int64(),
+			TotalUsers:         totalUsers,
+			MonthlyActiveUsers: mau,
+		}
+		c.randStatsCache.Set(struct{}{}, stats)
+	}
+
+	return stats
 }

--- a/internal/typeutils/converter.go
+++ b/internal/typeutils/converter.go
@@ -22,11 +22,10 @@ import (
 	"math/big"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
-	"codeberg.org/gruf/go-cache/v3"
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
-	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/filter/interaction"
 	"github.com/superseriousbusiness/gotosocial/internal/filter/visibility"
 	"github.com/superseriousbusiness/gotosocial/internal/log"
@@ -39,64 +38,64 @@ type Converter struct {
 	randAvatars    sync.Map
 	visFilter      *visibility.Filter
 	intFilter      *interaction.Filter
-	randStatsCache cache.TTLCache[struct{}, apimodel.RandomStats]
+	randStats      atomic.Pointer[apimodel.RandomStats]
 }
 
 func NewConverter(state *state.State) *Converter {
-	// If randomizing instance stats, create a cache so we
-	// don't have to generate them every time, and set a 1hr
-	// ttl on the cache so they're not always the same.
-	var randStatsCache cache.TTLCache[struct{}, apimodel.RandomStats]
-	if config.GetInstanceStatsRandomize() {
-		randStatsCache = cache.NewTTL[struct{}, apimodel.RandomStats](0, 1, 0)
-		randStatsCache.SetTTL(time.Hour, false)
-		if !randStatsCache.Start(time.Minute) {
-			log.Panicf(nil, "couldn't start randStatsCache")
-		}
-	}
-
 	return &Converter{
 		state:          state,
 		defaultAvatars: populateDefaultAvatars(),
 		visFilter:      visibility.NewFilter(state),
 		intFilter:      interaction.NewFilter(state),
-		randStatsCache: randStatsCache,
 	}
 }
 
 // RandomStats returns or generates
 // and returns random instance stats.
 func (c *Converter) RandomStats() apimodel.RandomStats {
+	now := time.Now()
+	stats := c.randStats.Load()
+	if stats != nil && time.Since(stats.Generated) < time.Hour {
+		// Random stats are still
+		// fresh (less than 1hr old),
+		// so return them as-is.
+		return *stats
+	}
+
+	// Generate new random stats.
+	newStats := genRandStats()
+	newStats.Generated = now
+	c.randStats.Store(&newStats)
+	return newStats
+}
+
+func genRandStats() apimodel.RandomStats {
 	const (
 		statusesMax = 10000000
 		usersMax    = 1000000
 	)
 
-	stats, ok := c.randStatsCache.Get(struct{}{})
-	if !ok {
-		statusesB, err := crand.Int(crand.Reader, big.NewInt(statusesMax))
-		if err != nil {
-			// Only errs if something is buggered with the OS.
-			log.Panicf(nil, "error randomly generating statuses count: %v", err)
-		}
-
-		totalUsersB, err := crand.Int(crand.Reader, big.NewInt(usersMax))
-		if err != nil {
-			// Only errs if something is buggered with the OS.
-			log.Panicf(nil, "error randomly generating users count: %v", err)
-		}
-
-		totalUsers := totalUsersB.Int64()
-		activeRatio := rand.Float64() //nolint
-		mau := int64(float64(totalUsers) * activeRatio)
-
-		stats = apimodel.RandomStats{
-			Statuses:           statusesB.Int64(),
-			TotalUsers:         totalUsers,
-			MonthlyActiveUsers: mau,
-		}
-		c.randStatsCache.Set(struct{}{}, stats)
+	statusesB, err := crand.Int(crand.Reader, big.NewInt(statusesMax))
+	if err != nil {
+		// Only errs if something is buggered with the OS.
+		log.Panicf(nil, "error randomly generating statuses count: %v", err)
 	}
 
-	return stats
+	totalUsersB, err := crand.Int(crand.Reader, big.NewInt(usersMax))
+	if err != nil {
+		// Only errs if something is buggered with the OS.
+		log.Panicf(nil, "error randomly generating users count: %v", err)
+	}
+
+	// Monthly users should only ever
+	// be <= 100% of total users.
+	totalUsers := totalUsersB.Int64()
+	activeRatio := rand.Float64() //nolint
+	mau := int64(float64(totalUsers) * activeRatio)
+
+	return apimodel.RandomStats{
+		Statuses:           statusesB.Int64(),
+		TotalUsers:         totalUsers,
+		MonthlyActiveUsers: mau,
+	}
 }

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -1745,6 +1745,12 @@ func (c *Converter) InstanceToAPIV1Instance(ctx context.Context, i *gtsmodel.Ins
 	stats["domain_count"] = util.Ptr(domainCount)
 	instance.Stats = stats
 
+	if config.GetInstanceStatsRandomize() {
+		// Whack some random stats on the instance
+		// to be injected by API handlers.
+		instance.RandomStats = c.RandomStats()
+	}
+
 	// thumbnail
 	iAccount, err := c.state.DB.GetInstanceAccount(ctx, "")
 	if err != nil {
@@ -1819,6 +1825,12 @@ func (c *Converter) InstanceToAPIV2Instance(ctx context.Context, i *gtsmodel.Ins
 
 	if debug.DEBUG {
 		instance.Debug = util.Ptr(true)
+	}
+
+	if config.GetInstanceStatsRandomize() {
+		// Whack some random stats on the instance
+		// to be injected by API handlers.
+		instance.RandomStats = c.RandomStats()
 	}
 
 	// thumbnail

--- a/test/envparsing.sh
+++ b/test/envparsing.sh
@@ -118,6 +118,7 @@ EXPECT=$(cat << "EOF"
         "nl",
         "en-GB"
     ],
+    "instance-stats-randomize": true,
     "instance-subscriptions-process-every": 86400000000000,
     "instance-subscriptions-process-from": "23:00",
     "landing-page-user": "admin",
@@ -248,6 +249,7 @@ GTS_INSTANCE_FEDERATION_SPAM_FILTER=true \
 GTS_INSTANCE_DELIVER_TO_SHARED_INBOXES=false \
 GTS_INSTANCE_INJECT_MASTODON_VERSION=true \
 GTS_INSTANCE_LANGUAGES="nl,en-gb" \
+GTS_INSTANCE_STATS_RANDOMIZE=true \
 GTS_ACCOUNTS_ALLOW_CUSTOM_CSS=true \
 GTS_ACCOUNTS_CUSTOM_CSS_LENGTH=5000 \
 GTS_ACCOUNTS_REGISTRATION_OPEN=true \


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Adds a config option `instance-stats-randomize` to randomize user + post stats at `/api/v1|v2/instance` and `/nodeinfo/2.0` endpoints. Does not affect web views. Stats are re-randomized every hour thanks to the ttlcache.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
