### PR TITLE
[bugfix] Swagger: fix media_ids[] param for creating statuses

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -10261,7 +10261,8 @@ paths:
                   name: status
                   type: string
                   x-go-name: Status
-                - description: |-
+                - collectionFormat: multi
+                  description: |-
                     Array of Attachment ids to be attached as media.
                     If provided, status becomes optional, and poll cannot be used.
 
@@ -10270,10 +10271,12 @@ paths:
                   in: formData
                   items:
                     type: string
-                  name: media_ids
+                  name: media_ids[]
                   type: array
+                  uniqueItems: true
                   x-go-name: MediaIDs
-                - description: |-
+                - collectionFormat: multi
+                  description: |-
                     Array of possible poll answers.
                     If provided, media_ids cannot be used, and poll[expires_in] must be provided.
                   in: formData
@@ -10281,6 +10284,7 @@ paths:
                     type: string
                   name: poll[options][]
                   type: array
+                  uniqueItems: true
                   x-go-name: PollOptions
                 - description: |-
                     Duration the poll should be open, in seconds.

--- a/internal/api/client/statuses/statuscreate.go
+++ b/internal/api/client/statuses/statuscreate.go
@@ -75,7 +75,7 @@ import (
 //		type: string
 //		in: formData
 //	-
-//		name: media_ids
+//		name: media_ids[]
 //		x-go-name: MediaIDs
 //		description: |-
 //			Array of Attachment ids to be attached as media.
@@ -87,6 +87,8 @@ import (
 //		items:
 //			type: string
 //		in: formData
+//		collectionFormat: multi
+//		uniqueItems: true
 //	-
 //		name: poll[options][]
 //		x-go-name: PollOptions
@@ -97,6 +99,8 @@ import (
 //		items:
 //			type: string
 //		in: formData
+//		collectionFormat: multi
+//		uniqueItems: true
 //	-
 //		name: poll[expires_in]
 //		x-go-name: PollExpiresIn


### PR DESCRIPTION
# Description

This pull request makes it possible to post media with a generated Swagger client by fixing the param name and format.

It also fixes a similar issue with poll options. There may be other places in the codebase where we forgot to apply `collectionFormat: multi`, so keep an eye out. Without it, with multiple values for a param, you get `foo[]=AAA,BBB` when what a Mastodon-compatible API generally expects is instead `foo[]=AAA&foo[]=BBB`.

`uniqueItems: true` is useful as documentation but I'm not sure that generators actually care about it.

Discovered while working on `slurp`.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
