### PR TITLE
[bugfix] Don't panic on delivery of Activity with no `object`

### DIFF
--- a/internal/federation/federatingprotocol.go
+++ b/internal/federation/federatingprotocol.go
@@ -116,33 +116,36 @@ func (f *Federator) PostInboxRequestBodyHook(ctx context.Context, r *http.Reques
 		otherIRIs = append(otherIRIs, ap.ExtractCcURIs(addressable)...)
 	}
 
-	// Now perform the same checks, but for the Object(s) of the Activity.
+	// Now perform the same checks, but
+	// for any Object(s) of the Activity.
 	objectProp := activity.GetActivityStreamsObject()
-	for iter := objectProp.Begin(); iter != objectProp.End(); iter = iter.Next() {
-		if iter.IsIRI() {
-			otherIRIs = append(otherIRIs, iter.GetIRI())
-			continue
-		}
-
-		t := iter.GetType()
-		if t == nil {
-			continue
-		}
-
-		objectID, err := pub.GetId(t)
-		if err == nil {
-			otherIRIs = append(otherIRIs, objectID)
-		}
-
-		if replyToable, ok := t.(ap.ReplyToable); ok {
-			if inReplyToURI := ap.ExtractInReplyToURI(replyToable); inReplyToURI != nil {
-				otherIRIs = append(otherIRIs, inReplyToURI)
+	if objectProp != nil {
+		for iter := objectProp.Begin(); iter != objectProp.End(); iter = iter.Next() {
+			if iter.IsIRI() {
+				otherIRIs = append(otherIRIs, iter.GetIRI())
+				continue
 			}
-		}
 
-		if addressable, ok := t.(ap.Addressable); ok {
-			otherIRIs = append(otherIRIs, ap.ExtractToURIs(addressable)...)
-			otherIRIs = append(otherIRIs, ap.ExtractCcURIs(addressable)...)
+			t := iter.GetType()
+			if t == nil {
+				continue
+			}
+
+			objectID, err := pub.GetId(t)
+			if err == nil {
+				otherIRIs = append(otherIRIs, objectID)
+			}
+
+			if replyToable, ok := t.(ap.ReplyToable); ok {
+				if inReplyToURI := ap.ExtractInReplyToURI(replyToable); inReplyToURI != nil {
+					otherIRIs = append(otherIRIs, inReplyToURI)
+				}
+			}
+
+			if addressable, ok := t.(ap.Addressable); ok {
+				otherIRIs = append(otherIRIs, ap.ExtractToURIs(addressable)...)
+				otherIRIs = append(otherIRIs, ap.ExtractCcURIs(addressable)...)
+			}
 		}
 	}
 


### PR DESCRIPTION
Addresses https://github.com/superseriousbusiness/gotosocial/issues/3652 from GoToSocial's side by not panicking on an empty/null/unset `object` property on an incoming activity. I think the other part of the bug still needs to be fixed from Owncast's side but this is a good start :) 