### PR TITLE
[feature] add more granularity to nowasm builds

### DIFF
--- a/internal/media/ffmpeg/exec_nowasm.go
+++ b/internal/media/ffmpeg/exec_nowasm.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build nowasm
+//go:build nowasmffmpeg || nowasm
 
 package ffmpeg
 

--- a/internal/media/ffmpeg/ffmpeg.go
+++ b/internal/media/ffmpeg/ffmpeg.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !nowasm
+//go:build !nowasmffmpeg && !nowasm
 
 package ffmpeg
 

--- a/internal/media/ffmpeg/ffmpeg_nowasm.go
+++ b/internal/media/ffmpeg/ffmpeg_nowasm.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build nowasm
+//go:build nowasmffmpeg || nowasm
 
 package ffmpeg
 

--- a/internal/media/ffmpeg/ffprobe.go
+++ b/internal/media/ffmpeg/ffprobe.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !nowasm
+//go:build !nowasmffmpeg && !nowasm
 
 package ffmpeg
 

--- a/internal/media/ffmpeg/ffprobe_nowasm.go
+++ b/internal/media/ffmpeg/ffprobe_nowasm.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build nowasm
+//go:build nowasmffmpeg || nowasm
 
 package ffmpeg
 

--- a/internal/media/ffmpeg/wasm.go
+++ b/internal/media/ffmpeg/wasm.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !nowasm
+//go:build !nowasmffmpeg && !nowasm
 
 package ffmpeg
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,8 +23,9 @@ GO_GCFLAGS=${GO_GCFLAGS-}
 # - debug:          enables /debug/pprof endpoint                                  (adds debug, at performance cost)
 # - debugenv:       enables /debug/pprof endpoint if DEBUG=1 env during runtime    (adds debug, at performance cost)
 # - moderncsqlite3: reverts to using the C-to-Go transpiled SQLite driver          (disables the WASM-based SQLite driver)
-# - nowasm:         [UNSUPPORTED] removes all WebAssembly from builds including 
-#                   ffmpeg, ffprobe and SQLite (instead falling back to modernc).
+#
+# - nowasmffmpeg: [UNSUPPORTED] removes WebAssembly ffmpeg, ffprobe, relying instead on host-installed ffmpeg, ffprobe binaries.
+# - nowasm:       [UNSUPPORTED] removes all WebAssembly from build. It is the same as passing "nowasmffmpeg, moderncsqlite3".
 log_exec env CGO_ENABLED=0 go build -trimpath -v \
                        -tags "${GO_BUILDTAGS}" \
                        -ldflags="${GO_LDFLAGS}" \


### PR DESCRIPTION
# Description

This specifically allows building without wasm ffmpeg, but still maintaining wasm sqlite. This may be useful on very memory-constrained devices e.g. routers since the ffmpeg compilation stage can take considerable memory, while still allowing them to use our first-choice in sqlite driver.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
