### PR TITLE
[bug] Add missing `group` property to the Account model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ In case this post disappears, here are the steps (slightly modified):
 >
 > Add your fork as origin:
 >
-> `git remote add origin git@github.com/yourgithubname/gotosocial`
+> `git remote add origin git@github.com:yourgithubname/gotosocial`
 >
 
 Be sure to run `git fetch` before building the project for the first time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -489,7 +489,7 @@ You can install go-swagger following the instructions [here](https://goswagger.i
 If you change Swagger annotations on any of the API paths, you can generate a new Swagger file at `./docs/api/swagger.yaml` by running:
 
 ```bash
-swagger generate spec --scan-models --exclude-deps -o docs/api/swagger.yaml
+go run github.com/go-swagger/go-swagger/cmd/swagger generate spec --scan-models --exclude-deps --output docs/api/swagger.yaml
 ```
 
 ### CI/CD configuration

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -300,6 +300,11 @@ definitions:
                 format: int64
                 type: integer
                 x-go-name: FollowingCount
+            group:
+                description: Indicates that the account represents a Group actor.
+                format: boolean
+                type: boolean
+                x-go-name: Group
             header:
                 description: Web location of the account's header image.
                 example: https://example.org/media/some_user/header/original/header.jpeg

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -301,8 +301,7 @@ definitions:
                 type: integer
                 x-go-name: FollowingCount
             group:
-                description: Indicates that the account represents a Group actor.
-                format: boolean
+                description: Account identifies as a Group actor.
                 type: boolean
                 x-go-name: Group
             header:
@@ -2444,6 +2443,10 @@ definitions:
                 format: int64
                 type: integer
                 x-go-name: FollowingCount
+            group:
+                description: Account identifies as a Group actor.
+                type: boolean
+                x-go-name: Group
             header:
                 description: Web location of the account's header image.
                 example: https://example.org/media/some_user/header/original/header.jpeg

--- a/internal/api/client/admin/accountsgetv2_test.go
+++ b/internal/api/client/admin/accountsgetv2_test.go
@@ -114,7 +114,8 @@ func (suite *AccountsGetTestSuite) TestAccountsGetFromTop() {
           "verified_at": null
         }
       ],
-      "hide_collections": true
+      "hide_collections": true,
+      "group": false
     },
     "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
   },
@@ -169,7 +170,8 @@ func (suite *AccountsGetTestSuite) TestAccountsGetFromTop() {
           "name": "admin",
           "color": ""
         }
-      ]
+      ],
+      "group": false
     },
     "created_by_application_id": "01F8MGXQRHYF5QPMTMXP78QC2F"
   },
@@ -216,7 +218,8 @@ func (suite *AccountsGetTestSuite) TestAccountsGetFromTop() {
       "statuses_count": 0,
       "last_status_at": null,
       "emojis": [],
-      "fields": []
+      "fields": [],
+      "group": false
     }
   },
   {
@@ -266,7 +269,8 @@ func (suite *AccountsGetTestSuite) TestAccountsGetFromTop() {
       "last_status_at": "2024-11-01",
       "emojis": [],
       "fields": [],
-      "enable_rss": true
+      "enable_rss": true,
+      "group": false
     },
     "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
   },
@@ -313,7 +317,8 @@ func (suite *AccountsGetTestSuite) TestAccountsGetFromTop() {
       "statuses_count": 0,
       "last_status_at": null,
       "emojis": [],
-      "fields": []
+      "fields": [],
+      "group": false
     },
     "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
   },
@@ -360,7 +365,8 @@ func (suite *AccountsGetTestSuite) TestAccountsGetFromTop() {
       "statuses_count": 1,
       "last_status_at": "2023-11-02",
       "emojis": [],
-      "fields": []
+      "fields": [],
+      "group": false
     }
   },
   {
@@ -406,7 +412,8 @@ func (suite *AccountsGetTestSuite) TestAccountsGetFromTop() {
       "statuses_count": 4,
       "last_status_at": "2024-11-01",
       "emojis": [],
-      "fields": []
+      "fields": [],
+      "group": false
     }
   },
   {
@@ -453,7 +460,8 @@ func (suite *AccountsGetTestSuite) TestAccountsGetFromTop() {
       "statuses_count": 0,
       "last_status_at": null,
       "emojis": [],
-      "fields": []
+      "fields": [],
+      "group": false
     }
   },
   {
@@ -499,7 +507,8 @@ func (suite *AccountsGetTestSuite) TestAccountsGetFromTop() {
       "statuses_count": 0,
       "last_status_at": null,
       "emojis": [],
-      "fields": []
+      "fields": [],
+      "group": false
     }
   }
 ]`, dst.String())
@@ -584,7 +593,8 @@ func (suite *AccountsGetTestSuite) TestAccountsMinID() {
       "statuses_count": 0,
       "last_status_at": null,
       "emojis": [],
-      "fields": []
+      "fields": [],
+      "group": false
     }
   }
 ]`, dst.String())

--- a/internal/api/client/admin/reportsget_test.go
+++ b/internal/api/client/admin/reportsget_test.go
@@ -189,7 +189,8 @@ func (suite *ReportsGetTestSuite) TestReportsGetAll() {
         "statuses_count": 4,
         "last_status_at": "2024-11-01",
         "emojis": [],
-        "fields": []
+        "fields": [],
+        "group": false
       }
     },
     "target_account": {
@@ -247,7 +248,8 @@ func (suite *ReportsGetTestSuite) TestReportsGetAll() {
             "verified_at": null
           }
         ],
-        "hide_collections": true
+        "hide_collections": true,
+        "group": false
       },
       "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
     },
@@ -302,7 +304,8 @@ func (suite *ReportsGetTestSuite) TestReportsGetAll() {
             "name": "admin",
             "color": ""
           }
-        ]
+        ],
+        "group": false
       },
       "created_by_application_id": "01F8MGXQRHYF5QPMTMXP78QC2F"
     },
@@ -357,7 +360,8 @@ func (suite *ReportsGetTestSuite) TestReportsGetAll() {
             "name": "admin",
             "color": ""
           }
-        ]
+        ],
+        "group": false
       },
       "created_by_application_id": "01F8MGXQRHYF5QPMTMXP78QC2F"
     },
@@ -429,7 +433,8 @@ func (suite *ReportsGetTestSuite) TestReportsGetAll() {
             "verified_at": null
           }
         ],
-        "hide_collections": true
+        "hide_collections": true,
+        "group": false
       },
       "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
     },
@@ -476,7 +481,8 @@ func (suite *ReportsGetTestSuite) TestReportsGetAll() {
         "statuses_count": 4,
         "last_status_at": "2024-11-01",
         "emojis": [],
-        "fields": []
+        "fields": [],
+        "group": false
       }
     },
     "assigned_account": null,
@@ -525,7 +531,8 @@ func (suite *ReportsGetTestSuite) TestReportsGetAll() {
           "statuses_count": 4,
           "last_status_at": "2024-11-01",
           "emojis": [],
-          "fields": []
+          "fields": [],
+          "group": false
         },
         "media_attachments": [
           {
@@ -683,7 +690,8 @@ func (suite *ReportsGetTestSuite) TestReportsGetCreatedByAccount() {
             "verified_at": null
           }
         ],
-        "hide_collections": true
+        "hide_collections": true,
+        "group": false
       },
       "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
     },
@@ -730,7 +738,8 @@ func (suite *ReportsGetTestSuite) TestReportsGetCreatedByAccount() {
         "statuses_count": 4,
         "last_status_at": "2024-11-01",
         "emojis": [],
-        "fields": []
+        "fields": [],
+        "group": false
       }
     },
     "assigned_account": null,
@@ -779,7 +788,8 @@ func (suite *ReportsGetTestSuite) TestReportsGetCreatedByAccount() {
           "statuses_count": 4,
           "last_status_at": "2024-11-01",
           "emojis": [],
-          "fields": []
+          "fields": [],
+          "group": false
         },
         "media_attachments": [
           {
@@ -937,7 +947,8 @@ func (suite *ReportsGetTestSuite) TestReportsGetTargetAccount() {
             "verified_at": null
           }
         ],
-        "hide_collections": true
+        "hide_collections": true,
+        "group": false
       },
       "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
     },
@@ -984,7 +995,8 @@ func (suite *ReportsGetTestSuite) TestReportsGetTargetAccount() {
         "statuses_count": 4,
         "last_status_at": "2024-11-01",
         "emojis": [],
-        "fields": []
+        "fields": [],
+        "group": false
       }
     },
     "assigned_account": null,
@@ -1033,7 +1045,8 @@ func (suite *ReportsGetTestSuite) TestReportsGetTargetAccount() {
           "statuses_count": 4,
           "last_status_at": "2024-11-01",
           "emojis": [],
-          "fields": []
+          "fields": [],
+          "group": false
         },
         "media_attachments": [
           {

--- a/internal/api/client/followrequests/get_test.go
+++ b/internal/api/client/followrequests/get_test.go
@@ -103,7 +103,8 @@ func (suite *GetTestSuite) TestGet() {
     "statuses_count": 1,
     "last_status_at": "2023-11-02",
     "emojis": [],
-    "fields": []
+    "fields": [],
+    "group": false
   }
 ]`, dst.String())
 }

--- a/internal/api/client/instance/instancepatch_test.go
+++ b/internal/api/client/instance/instancepatch_test.go
@@ -191,7 +191,8 @@ func (suite *InstancePatchTestSuite) TestInstancePatch1() {
         "name": "admin",
         "color": ""
       }
-    ]
+    ],
+    "group": false
   },
   "max_toot_chars": 5000,
   "rules": [
@@ -333,7 +334,8 @@ func (suite *InstancePatchTestSuite) TestInstancePatch2() {
         "name": "admin",
         "color": ""
       }
-    ]
+    ],
+    "group": false
   },
   "max_toot_chars": 5000,
   "rules": [
@@ -475,7 +477,8 @@ func (suite *InstancePatchTestSuite) TestInstancePatch3() {
         "name": "admin",
         "color": ""
       }
-    ]
+    ],
+    "group": false
   },
   "max_toot_chars": 5000,
   "rules": [
@@ -668,7 +671,8 @@ func (suite *InstancePatchTestSuite) TestInstancePatch6() {
         "name": "admin",
         "color": ""
       }
-    ]
+    ],
+    "group": false
   },
   "max_toot_chars": 5000,
   "rules": [
@@ -836,7 +840,8 @@ func (suite *InstancePatchTestSuite) TestInstancePatch8() {
         "name": "admin",
         "color": ""
       }
-    ]
+    ],
+    "group": false
   },
   "max_toot_chars": 5000,
   "rules": [
@@ -1015,7 +1020,8 @@ func (suite *InstancePatchTestSuite) TestInstancePatch9() {
         "name": "admin",
         "color": ""
       }
-    ]
+    ],
+    "group": false
   },
   "max_toot_chars": 5000,
   "rules": [

--- a/internal/api/client/mutes/mutesget_test.go
+++ b/internal/api/client/mutes/mutesget_test.go
@@ -148,7 +148,7 @@ func (suite *MutesTestSuite) TestIndefinitelyMutedAccountSerializesMuteExpiratio
 
 	// Fetch all muted accounts for the logged-in account.
 	// The expected body contains `"mute_expires_at":null`.
-	_, err = suite.getMutedAccounts(http.StatusOK, `[{"id":"01F8MH5ZK5VRH73AKHQM6Y9VNX","username":"foss_satan","acct":"foss_satan@fossbros-anonymous.io","display_name":"big gerald","locked":false,"discoverable":true,"bot":false,"created_at":"2021-09-26T10:52:36.000Z","note":"i post about like, i dunno, stuff, or whatever!!!!","url":"http://fossbros-anonymous.io/@foss_satan","avatar":"","avatar_static":"","header":"http://localhost:8080/assets/default_header.webp","header_static":"http://localhost:8080/assets/default_header.webp","header_description":"Flat gray background (default header).","followers_count":0,"following_count":0,"statuses_count":4,"last_status_at":"2024-11-01","emojis":[],"fields":[],"mute_expires_at":null}]`)
+	_, err = suite.getMutedAccounts(http.StatusOK, `[{"id":"01F8MH5ZK5VRH73AKHQM6Y9VNX","username":"foss_satan","acct":"foss_satan@fossbros-anonymous.io","display_name":"big gerald","locked":false,"discoverable":true,"bot":false,"created_at":"2021-09-26T10:52:36.000Z","note":"i post about like, i dunno, stuff, or whatever!!!!","url":"http://fossbros-anonymous.io/@foss_satan","avatar":"","avatar_static":"","header":"http://localhost:8080/assets/default_header.webp","header_static":"http://localhost:8080/assets/default_header.webp","header_description":"Flat gray background (default header).","followers_count":0,"following_count":0,"statuses_count":4,"last_status_at":"2024-11-01","emojis":[],"fields":[],"group":false,"mute_expires_at":null}]`)
 	if err != nil {
 		suite.FailNow(err.Error())
 	}

--- a/internal/api/client/reports/reportget_test.go
+++ b/internal/api/client/reports/reportget_test.go
@@ -133,7 +133,8 @@ func (suite *ReportGetTestSuite) TestGetReport1() {
     "statuses_count": 4,
     "last_status_at": "2024-11-01",
     "emojis": [],
-    "fields": []
+    "fields": [],
+    "group": false
   }
 }`, string(b))
 }

--- a/internal/api/client/reports/reportsget_test.go
+++ b/internal/api/client/reports/reportsget_test.go
@@ -159,7 +159,8 @@ func (suite *ReportsGetTestSuite) TestGetReports() {
       "statuses_count": 4,
       "last_status_at": "2024-11-01",
       "emojis": [],
-      "fields": []
+      "fields": [],
+      "group": false
     }
   }
 ]`, string(b))
@@ -250,7 +251,8 @@ func (suite *ReportsGetTestSuite) TestGetReports4() {
       "statuses_count": 4,
       "last_status_at": "2024-11-01",
       "emojis": [],
-      "fields": []
+      "fields": [],
+      "group": false
     }
   }
 ]`, string(b))
@@ -325,7 +327,8 @@ func (suite *ReportsGetTestSuite) TestGetReports6() {
       "statuses_count": 4,
       "last_status_at": "2024-11-01",
       "emojis": [],
-      "fields": []
+      "fields": [],
+      "group": false
     }
   }
 ]`, string(b))
@@ -384,7 +387,8 @@ func (suite *ReportsGetTestSuite) TestGetReports7() {
       "statuses_count": 4,
       "last_status_at": "2024-11-01",
       "emojis": [],
-      "fields": []
+      "fields": [],
+      "group": false
     }
   }
 ]`, string(b))

--- a/internal/api/client/statuses/statushistory_test.go
+++ b/internal/api/client/statuses/statushistory_test.go
@@ -120,7 +120,8 @@ func (suite *StatusHistoryTestSuite) TestGetHistory() {
       "last_status_at": "2024-11-01",
       "emojis": [],
       "fields": [],
-      "enable_rss": true
+      "enable_rss": true,
+      "group": false
     },
     "poll": null,
     "media_attachments": [],

--- a/internal/api/client/statuses/statusmute_test.go
+++ b/internal/api/client/statuses/statusmute_test.go
@@ -139,7 +139,8 @@ func (suite *StatusMuteTestSuite) TestMuteUnmuteStatus() {
     "last_status_at": "2024-11-01",
     "emojis": [],
     "fields": [],
-    "enable_rss": true
+    "enable_rss": true,
+    "group": false
   },
   "media_attachments": [],
   "mentions": [],
@@ -227,7 +228,8 @@ func (suite *StatusMuteTestSuite) TestMuteUnmuteStatus() {
     "last_status_at": "2024-11-01",
     "emojis": [],
     "fields": [],
-    "enable_rss": true
+    "enable_rss": true,
+    "group": false
   },
   "media_attachments": [],
   "mentions": [],

--- a/internal/api/model/account.go
+++ b/internal/api/model/account.go
@@ -126,6 +126,8 @@ type Account struct {
 	// If set, indicates that this account is currently inactive, and has migrated to the given account.
 	// Key/value omitted for accounts that haven't moved, and for suspended accounts.
 	Moved *Account `json:"moved,omitempty"`
+	// Account identifies as a Group actor
+	Group bool `json:"group"`
 }
 
 // WebAccount is like Account, but with

--- a/internal/api/model/account.go
+++ b/internal/api/model/account.go
@@ -126,7 +126,7 @@ type Account struct {
 	// If set, indicates that this account is currently inactive, and has migrated to the given account.
 	// Key/value omitted for accounts that haven't moved, and for suspended accounts.
 	Moved *Account `json:"moved,omitempty"`
-	// Account identifies as a Group actor
+	// Account identifies as a Group actor.
 	Group bool `json:"group"`
 }
 

--- a/internal/processing/stream/notification_test.go
+++ b/internal/processing/stream/notification_test.go
@@ -82,7 +82,8 @@ func (suite *NotificationTestSuite) TestStreamNotification() {
     "statuses_count": 4,
     "last_status_at": "2024-11-01",
     "emojis": [],
-    "fields": []
+    "fields": [],
+    "group": false
   }
 }`, dst.String())
 }

--- a/internal/processing/stream/statusupdate_test.go
+++ b/internal/processing/stream/statusupdate_test.go
@@ -94,7 +94,8 @@ func (suite *StatusUpdateTestSuite) TestStreamNotification() {
     "statuses_count": 4,
     "last_status_at": "2024-11-01",
     "emojis": [],
-    "fields": []
+    "fields": [],
+    "group": false
   },
   "media_attachments": [
     {

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -388,6 +388,7 @@ func (c *Converter) accountToAPIAccountPublic(ctx context.Context, a *gtsmodel.A
 		EnableRSS:         enableRSS,
 		HideCollections:   hideCollections,
 		Roles:             roles,
+		Group:             false,
 	}
 
 	// Bodge default avatar + header in,

--- a/internal/typeutils/internaltofrontend_test.go
+++ b/internal/typeutils/internaltofrontend_test.go
@@ -72,7 +72,8 @@ func (suite *InternalToFrontendTestSuite) TestAccountToFrontend() {
   "last_status_at": "2024-11-01",
   "emojis": [],
   "fields": [],
-  "enable_rss": true
+  "enable_rss": true,
+  "group": false
 }`, string(b))
 }
 
@@ -178,8 +179,10 @@ func (suite *InternalToFrontendTestSuite) TestAccountToFrontendAliasedAndMoved()
         "verified_at": null
       }
     ],
-    "hide_collections": true
-  }
+    "hide_collections": true,
+    "group": false
+  },
+  "group": false
 }`, string(b))
 }
 
@@ -230,7 +233,8 @@ func (suite *InternalToFrontendTestSuite) TestAccountToFrontendWithEmojiStruct()
     }
   ],
   "fields": [],
-  "enable_rss": true
+  "enable_rss": true,
+  "group": false
 }`, string(b))
 }
 
@@ -279,7 +283,8 @@ func (suite *InternalToFrontendTestSuite) TestAccountToFrontendWithEmojiIDs() {
     }
   ],
   "fields": [],
-  "enable_rss": true
+  "enable_rss": true,
+  "group": false
 }`, string(b))
 }
 
@@ -333,7 +338,8 @@ func (suite *InternalToFrontendTestSuite) TestAccountToFrontendSensitive() {
     "color": "",
     "permissions": "0",
     "highlighted": false
-  }
+  },
+  "group": false
 }`, string(b))
 }
 
@@ -370,7 +376,8 @@ func (suite *InternalToFrontendTestSuite) TestAccountToFrontendPublicPunycode() 
   "statuses_count": 0,
   "last_status_at": null,
   "emojis": [],
-  "fields": []
+  "fields": [],
+  "group": false
 }`, string(b))
 }
 
@@ -409,7 +416,8 @@ func (suite *InternalToFrontendTestSuite) TestLocalInstanceAccountToFrontendPubl
   "statuses_count": 0,
   "last_status_at": null,
   "emojis": [],
-  "fields": []
+  "fields": [],
+  "group": false
 }`, string(b))
 }
 
@@ -448,7 +456,8 @@ func (suite *InternalToFrontendTestSuite) TestLocalInstanceAccountToFrontendBloc
   "statuses_count": 0,
   "last_status_at": null,
   "emojis": [],
-  "fields": []
+  "fields": [],
+  "group": false
 }`, string(b))
 }
 
@@ -516,7 +525,8 @@ func (suite *InternalToFrontendTestSuite) TestStatusToFrontend() {
         "name": "admin",
         "color": ""
       }
-    ]
+    ],
+    "group": false
   },
   "media_attachments": [
     {
@@ -2644,10 +2654,10 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend1() {
           "name": "admin",
           "color": ""
         }
-      ]
+      ],
+      "group": false
     },
-    "created_by_application_id": "01F8MGXQRHYF5QPMTMXP78QC2F",
-    "group": false
+    "created_by_application_id": "01F8MGXQRHYF5QPMTMXP78QC2F"
   },
   "statuses": [],
   "rules": [],
@@ -2727,10 +2737,10 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend2() {
           "verified_at": null
         }
       ],
-      "hide_collections": true
+      "hide_collections": true,
+      "group": false
     },
-    "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG",
-    "group": false
+    "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
   },
   "target_account": {
     "id": "01F8MH5ZK5VRH73AKHQM6Y9VNX",
@@ -3557,7 +3567,8 @@ func (suite *InternalToFrontendTestSuite) TestConversationToAPISelfConvo() {
       "last_status_at": "2024-11-01",
       "emojis": [],
       "fields": [],
-      "enable_rss": true
+      "enable_rss": true,
+      "group": false
     }
   ],
   "last_status": {
@@ -3725,7 +3736,8 @@ func (suite *InternalToFrontendTestSuite) TestConversationToAPI() {
           "verified_at": null
         }
       ],
-      "hide_collections": true
+      "hide_collections": true,
+      "group": false
     }
   ],
   "last_status": {

--- a/internal/typeutils/internaltofrontend_test.go
+++ b/internal/typeutils/internaltofrontend_test.go
@@ -695,7 +695,8 @@ func (suite *InternalToFrontendTestSuite) TestWarnFilteredStatusToFrontend() {
         "name": "admin",
         "color": ""
       }
-    ]
+    ],
+    "group": false
   },
   "media_attachments": [
     {
@@ -879,7 +880,8 @@ func (suite *InternalToFrontendTestSuite) TestWarnFilteredBoostToFrontend() {
       "last_status_at": "2024-11-01",
       "emojis": [],
       "fields": [],
-      "enable_rss": true
+      "enable_rss": true,
+      "group": false
     },
     "media_attachments": [
       {
@@ -1014,7 +1016,8 @@ func (suite *InternalToFrontendTestSuite) TestWarnFilteredBoostToFrontend() {
         "name": "admin",
         "color": ""
       }
-    ]
+    ],
+    "group": false
   },
   "media_attachments": [],
   "mentions": [],
@@ -1301,7 +1304,8 @@ func (suite *InternalToFrontendTestSuite) TestStatusToFrontendUnknownAttachments
     "statuses_count": 1,
     "last_status_at": "2023-11-02",
     "emojis": [],
-    "fields": []
+    "fields": [],
+    "group": false
   },
   "media_attachments": [
     {
@@ -1466,7 +1470,8 @@ func (suite *InternalToFrontendTestSuite) TestStatusToWebStatus() {
     "statuses_count": 1,
     "last_status_at": "2023-11-02",
     "emojis": [],
-    "fields": []
+    "fields": [],
+    "group": false
   },
   "media_attachments": [
     {
@@ -1608,7 +1613,8 @@ func (suite *InternalToFrontendTestSuite) TestStatusToFrontendUnknownLanguage() 
         "name": "admin",
         "color": ""
       }
-    ]
+    ],
+    "group": false
   },
   "media_attachments": [
     {
@@ -1748,7 +1754,8 @@ func (suite *InternalToFrontendTestSuite) TestStatusToFrontendPartialInteraction
     "last_status_at": "2024-11-01",
     "emojis": [],
     "fields": [],
-    "enable_rss": true
+    "enable_rss": true,
+    "group": false
   },
   "media_attachments": [],
   "mentions": [],
@@ -1863,7 +1870,8 @@ func (suite *InternalToFrontendTestSuite) TestStatusToAPIStatusPendingApproval()
         "name": "admin",
         "color": ""
       }
-    ]
+    ],
+    "group": false
   },
   "media_attachments": [],
   "mentions": [
@@ -2075,7 +2083,8 @@ func (suite *InternalToFrontendTestSuite) TestInstanceV1ToFrontend() {
         "name": "admin",
         "color": ""
       }
-    ]
+    ],
+    "group": false
   },
   "max_toot_chars": 5000,
   "rules": [],
@@ -2227,7 +2236,8 @@ func (suite *InternalToFrontendTestSuite) TestInstanceV2ToFrontend() {
           "name": "admin",
           "color": ""
         }
-      ]
+      ],
+      "group": false
     }
   },
   "rules": [],
@@ -2340,7 +2350,8 @@ func (suite *InternalToFrontendTestSuite) TestReportToFrontend1() {
     "statuses_count": 4,
     "last_status_at": "2024-11-01",
     "emojis": [],
-    "fields": []
+    "fields": [],
+    "group": false
   }
 }`, string(b))
 }
@@ -2396,7 +2407,8 @@ func (suite *InternalToFrontendTestSuite) TestReportToFrontend2() {
         "verified_at": null
       }
     ],
-    "hide_collections": true
+    "hide_collections": true,
+    "group": false
   }
 }`, string(b))
 }
@@ -2461,7 +2473,8 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend1() {
       "statuses_count": 4,
       "last_status_at": "2024-11-01",
       "emojis": [],
-      "fields": []
+      "fields": [],
+      "group": false
     }
   },
   "target_account": {
@@ -2519,7 +2532,8 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend1() {
           "verified_at": null
         }
       ],
-      "hide_collections": true
+      "hide_collections": true,
+      "group": false
     },
     "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
   },
@@ -2574,7 +2588,8 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend1() {
           "name": "admin",
           "color": ""
         }
-      ]
+      ],
+      "group": false
     },
     "created_by_application_id": "01F8MGXQRHYF5QPMTMXP78QC2F"
   },
@@ -2631,7 +2646,8 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend1() {
         }
       ]
     },
-    "created_by_application_id": "01F8MGXQRHYF5QPMTMXP78QC2F"
+    "created_by_application_id": "01F8MGXQRHYF5QPMTMXP78QC2F",
+    "group": false
   },
   "statuses": [],
   "rules": [],
@@ -2713,7 +2729,8 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend2() {
       ],
       "hide_collections": true
     },
-    "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG"
+    "created_by_application_id": "01F8MGY43H3N2C8EWPR2FPYEXG",
+    "group": false
   },
   "target_account": {
     "id": "01F8MH5ZK5VRH73AKHQM6Y9VNX",
@@ -2758,7 +2775,8 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend2() {
       "statuses_count": 4,
       "last_status_at": "2024-11-01",
       "emojis": [],
-      "fields": []
+      "fields": [],
+      "group": false
     }
   },
   "assigned_account": null,
@@ -2807,7 +2825,8 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontend2() {
         "statuses_count": 4,
         "last_status_at": "2024-11-01",
         "emojis": [],
-        "fields": []
+        "fields": [],
+        "group": false
       },
       "media_attachments": [
         {
@@ -2966,7 +2985,8 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontendSuspendedLoca
       "statuses_count": 4,
       "last_status_at": "2024-11-01",
       "emojis": [],
-      "fields": []
+      "fields": [],
+      "group": false
     }
   },
   "target_account": {
@@ -3014,7 +3034,8 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontendSuspendedLoca
       "emojis": [],
       "fields": [],
       "suspended": true,
-      "hide_collections": true
+      "hide_collections": true,
+      "group": false
     }
   },
   "assigned_account": {
@@ -3068,7 +3089,8 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontendSuspendedLoca
           "name": "admin",
           "color": ""
         }
-      ]
+      ],
+      "group": false
     },
     "created_by_application_id": "01F8MGXQRHYF5QPMTMXP78QC2F"
   },
@@ -3123,7 +3145,8 @@ func (suite *InternalToFrontendTestSuite) TestAdminReportToFrontendSuspendedLoca
           "name": "admin",
           "color": ""
         }
-      ]
+      ],
+      "group": false
     },
     "created_by_application_id": "01F8MGXQRHYF5QPMTMXP78QC2F"
   },
@@ -3270,7 +3293,8 @@ func (suite *InternalToFrontendTestSuite) TestIntReqToAPI() {
         "name": "admin",
         "color": ""
       }
-    ]
+    ],
+    "group": false
   },
   "status": {
     "id": "01F8MHC8VWDRBQR0N1BATDDEM5",
@@ -3331,7 +3355,8 @@ func (suite *InternalToFrontendTestSuite) TestIntReqToAPI() {
           "verified_at": null
         }
       ],
-      "hide_collections": true
+      "hide_collections": true,
+      "group": false
     },
     "media_attachments": [],
     "mentions": [],
@@ -3421,7 +3446,8 @@ func (suite *InternalToFrontendTestSuite) TestIntReqToAPI() {
           "name": "admin",
           "color": ""
         }
-      ]
+      ],
+      "group": false
     },
     "media_attachments": [],
     "mentions": [
@@ -3585,7 +3611,8 @@ func (suite *InternalToFrontendTestSuite) TestConversationToAPISelfConvo() {
       "last_status_at": "2024-11-01",
       "emojis": [],
       "fields": [],
-      "enable_rss": true
+      "enable_rss": true,
+      "group": false
     },
     "media_attachments": [],
     "mentions": [],
@@ -3752,7 +3779,8 @@ func (suite *InternalToFrontendTestSuite) TestConversationToAPI() {
       "last_status_at": "2024-11-01",
       "emojis": [],
       "fields": [],
-      "enable_rss": true
+      "enable_rss": true,
+      "group": false
     },
     "media_attachments": [],
     "mentions": [],
@@ -3837,7 +3865,8 @@ func (suite *InternalToFrontendTestSuite) TestStatusToAPIEdits() {
             "last_status_at": "2024-11-01",
             "emojis": [],
             "fields": [],
-            "enable_rss": true
+            "enable_rss": true,
+            "group": false
         },
         "poll": null,
         "media_attachments": [],
@@ -3873,7 +3902,8 @@ func (suite *InternalToFrontendTestSuite) TestStatusToAPIEdits() {
             "last_status_at": "2024-11-01",
             "emojis": [],
             "fields": [],
-            "enable_rss": true
+            "enable_rss": true,
+            "group": false
         },
         "poll": null,
         "media_attachments": [],
@@ -3909,7 +3939,8 @@ func (suite *InternalToFrontendTestSuite) TestStatusToAPIEdits() {
             "last_status_at": "2024-11-01",
             "emojis": [],
             "fields": [],
-            "enable_rss": true
+            "enable_rss": true,
+            "group": false
         },
         "poll": null,
         "media_attachments": [],


### PR DESCRIPTION
# Description

Not directly related to https://github.com/superseriousbusiness/gotosocial/issues/2619, this patch adds the `group` parameter to GoToSocial's account.go model.

## Background
The `Account` entity in the [Mastodon Spec](https://docs.joinmastodon.org/entities/Account/#group) was updated in release [3.1.0](https://github.com/mastodon/mastodon/releases/tag/v3.1.0) (February 2020) with a new mandatory parameter - `group` - as part of the feature for adding group actors.

GoToSocial doesn't currently implement the Group feature, but the spec requires the parameter and clients like [Tooty](https://github.com/n1k0/tooty) throw [an error](https://github.com/n1k0/tooty/issues/256) when the parameter isn't present in API responses from GoToSocial.

### What is Tooty?
Tooty is a single-page app promoted on the https://joinmastodon.org/apps page (filter by Web).  No install required and can use your federated login to authenticate: https://n1k0.github.io/tooty/

This fixes https://github.com/superseriousbusiness/gotosocial/issues/3745

## Documentation Changes
1. The Contributing.md had the incorrect syntax for handling setting up the clone/fork
2. The swagger step had a suggested command that causes a lot of changes to happen to swagger.yaml - I looked at the `test` directory and saw `test/swagger.sh`.  That file had a different command to run, which generated a much more reasonable change to `swagger.yaml`

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes. 
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.

### Variations from standard checklist
- [x] I used `test/swagger.sh` to update the swagger documentation
- [x] I built `gotosocial` and confirmed the patch resolves the issue with Tooty

  
