### PR TITLE
[feature/frontend] add light mode color scheme of base css, adapt to prefers-color-scheme

### DIFF
--- a/web/assets/themes/blurple-light.css
+++ b/web/assets/themes/blurple-light.css
@@ -23,6 +23,10 @@
   --blue2: var(--blurple5);
   --blue3: var(--blurple6);
 
+  /* Use hardcoded grey as gray get restyled in light mode */
+  --gray1: #2a2b2f;
+  --gray2: #35363b;
+
   /* Basic page styling (background + foreground) */
   --bg: var(--blurple1);
   --bg-accent: var(--white2);

--- a/web/assets/themes/brutalist-dark.css
+++ b/web/assets/themes/brutalist-dark.css
@@ -63,6 +63,13 @@ html, body {
 .profile .profile-header .basic-info .avatar-image-wrapper {
   border: var(--single-border);
 }
+
+.profile .statuses .rss-icon .fa {
+  /* enforce dark mode style */
+  background: linear-gradient(to right, var(--almost-black) 100%, transparent 0) no-repeat center center;
+  background-size: 1.2rem 1.4rem;
+}
+
 .status .status-header > address > a .avatar {
   border: var(--single-border);
 }

--- a/web/assets/themes/midnight-trip.css
+++ b/web/assets/themes/midnight-trip.css
@@ -17,6 +17,10 @@
   --blue1: var(--acid-green-dark);
   --blue2: var(--acid-green-light);
   --blue3: var(--acid-green);
+
+  /* enforce dark mode style */
+  --white1: #fafaff;
+  --white2: #b3b5c6;
 }
 
 /* Main page background */

--- a/web/assets/themes/rain-forest.css
+++ b/web/assets/themes/rain-forest.css
@@ -34,6 +34,9 @@
   /* dark blues */
   --gray2: #29485A; /* black forest blue */
   --gray4: #2B3246; /* vintage dark blue */
+  /* enforce dark mode style */
+  --white1: #fafaff;
+  --white2: #b3b5c6;
   /*  statuses */
   --status-bg: var(--dgreen1);
   --status-focus-bg: var(--dgreen1);
@@ -85,6 +88,12 @@ box-shadow: none; /* no "glow" for buttons */
 }
 .profile .about-user .fields .field:first-child {
   border-top: 0.1rem solid var(--sunny);
+}
+
+/* RSS icon */
+.profile .statuses .rss-icon .fa {
+  background: linear-gradient(to right, var(--gray2) 100%, transparent 0) no-repeat center center;
+  background-size: 1.2rem 1.4rem;
 }
 
 /* Block quotes */

--- a/web/assets/themes/soft.css
+++ b/web/assets/themes/soft.css
@@ -18,6 +18,12 @@
   --orange2: var(--blue1);
   --br: 0.8rem;
   --br-inner: 0.4rem; 
+  /* Use hardcoded grey as gray get re-styled in light mode */
+  --white1: #fafaff;
+  --gray1: #2a2b2f;
+  --gray2: #35363b;
+  --gray3: #45464e;
+  --gray8: #696a75;
 
   /* Basic page styling (background + foreground) */
   --bg: var(--soft-pink);

--- a/web/source/css/_colors.css
+++ b/web/source/css/_colors.css
@@ -24,6 +24,8 @@
 
 /* Color definitions */
 
+/* Dark mode - default */
+
 /* Foreground */
 $white1: #fafaff; /* default text color, contrast >= 5.0 with all $grays */
 $white2: #b3b5c6; /* less important text, can be used with $gray1 (6.8), $gray2 (5.5), $gray3 (4.9), $gray4 (4.5) */
@@ -94,7 +96,7 @@ $no-img-desc-fg: $gray1;
 
 $bg-sensitive: $gray1;
 
-$boxshadow: 0 0.4rem 1rem -0.1rem rgba(0,0,0,0.15);
+$boxshadow: 0 0.4rem 1rem -0.1rem rgba(0, 0, 0, 0.15);
 $boxshadow-border: 0.08rem solid $gray1;
 
 $avatar-border: $orange2;
@@ -130,3 +132,40 @@ $plyr-video-controls-background: $bg-accent;
 $plyr-badge-text-color: $fg;
 $plyr-badge-border-radius: $br;
 $plyr-video-progress-buffered-background: $gray8;
+
+/* Light mode */
+
+$white: #fafaff; /* we still use white for something */
+
+@media (prefers-color-scheme: light) {
+	:root {
+		$white1: #000000; /* default text color, contrast >= 5.0 with all $grays */
+		$white2: #59595F; /* less important text, can be used with $gray1 (8.5) ~ $gray5 (5.0) */
+
+		/* Background shades, contrast >= 5.0 with $white1 (#000000) */
+		$gray1: #ffffff;
+		$gray2: #f6f6f6;
+		$gray3: #ededed;
+		$gray4: #e4e4e4;
+		$gray5: #dbdbdb;
+		$gray6: #d2d2d2;
+		$gray7: #c9c9c9;
+		$gray8: #c0c0c0;
+
+		$orange1: #c75300; /* Used for non-text accent colors, can be used as background: $gray1 for text color (contrast 4.5)*/
+		$orange2: #bd4f00; /* hover/selected accent to $orange1, can be used with $gray1 (5.7), $gray2 (4.5) */
+
+		$blue1: #247cb3; /* lighter blue for smaller elements (borders), can only be used with $gray1 (4.5) */
+		$blue2: #166ba0; /* all-round accent color, can be used with $gray1 (5.7), $gray2 (5.3), $gray3 (4.9), $gray4 (4.5) */
+		$blue3: #106193; /* hover/selected accent to $blue2, can be used with $gray1 (6.6), $gray2 (6.1), $gray3 (5.6), $gray4 (5.2), $gray5 (4.8) */
+
+		$error1: #ffc1c1; /* Error border/foreground text, can be used with $error2 (5.0), $white1 (13.6), $white2 (4.5) */
+		$error2: #aa0000; /* Error background text, can be used with $error1 (5.0), $gray1 (7.7), $gray2 (7.1), $gray3 (6.62) */
+		$error3: #d93636; /* Error button background text, can be used with $white1 (4.53) */
+		$error-link: #abd4ff; /* Error link text, can be used with $error2 (5.56) */
+
+		$green1: #367400;
+
+		$info-bg: $blue1;
+	}
+}

--- a/web/source/css/index.css
+++ b/web/source/css/index.css
@@ -70,6 +70,10 @@
 
 	.activitypub-logo {
 		background: $fg;
+		/* light mode */
+		@media (prefers-color-scheme: light) {
+			background: none;
+		}
 		box-shadow: $boxshadow;
 		border-radius: $br;	
 		max-width: 100%;

--- a/web/source/css/profile.css
+++ b/web/source/css/profile.css
@@ -298,6 +298,11 @@
 			*/
 			background: linear-gradient(to right, $white1 100%, transparent 0) no-repeat center center;
 			background-size: 1.2rem 1.4rem;
+			/* light mode */
+			@media (prefers-color-scheme: light) {
+				background: linear-gradient(to right, $white 100%, transparent 0) no-repeat center center;
+				background-size: 1.2rem 1.4rem;
+			}
 		}
 	}
 


### PR DESCRIPTION
# Description

closes #1214

The PR mainly adds a light mode base color scheme to GoToSocial and enables the color theme to follow the client's `prefers-color-theme` setting.

When selecting the light mode base color scheme, my primary consideration was to maintain the contrast requirements of the original dark mode scheme. This results in some colors appearing darker. In some cases, keeping the same contrast means some colors might become too dark and less noticeable. In such instances, the contrast limits are slightly relaxed, but all contrast requirements remain above 4.5.

Additionally:

1. The gray shades for the background are reduced step by step with consistent offsets and are pure gray.
2. The variables `white1` and `white2` in light mode are actually black (`black[12]`). To reuse existing styles, the original variable names from dark mode are retained.
3. In some cases, actual white is still needed, so the light mode color scheme introduces a `white` variable, with values the same as `white1` in dark mode.

As discussed on the discussion in #1214, this changes the default behavior of the webpage of always showing the dark theme. If users want to revert this change, they currently can only do so by writing instance-wide custom CSS.

## Next Steps

If we want to implement all feature requests in #2231, we might need to start with #2230. I have a working commit from a few months ago that adds a simple theme toggle button at the current 'LOGIN' button's location on the homepage and I'd like to make it upstream.

If we also want to implement #2229 and #2228, a reasonable priority order might be: visitor settings > user settings (applies to the user's profile page) > instance administrator settings > result of prefers-color-scheme detection (default).

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
