### PR TITLE
[chore/frontend] Tweak display of "edited" in web UI a bit

### DIFF
--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -438,7 +438,7 @@ main {
 				column-gap: 1rem;
 
 				.edited-at {
-					font-style: italic;
+					font-size: smaller;
 				}
 			}
 

--- a/web/template/status_info.tmpl
+++ b/web/template/status_info.tmpl
@@ -30,7 +30,7 @@
         <div class="stats-item edited-at text-cutoff">
             <dt class="sr-only">Edited</dt>
             <dd>
-                (last edited <time datetime="{{- .EditedAt -}}">{{- .EditedAt | timestampPrecise -}}</time>)
+                (edited <time datetime="{{- .EditedAt -}}">{{- .EditedAt | timestampPrecise -}}</time>)
             </dd>
         </div>
         {{ end }}


### PR DESCRIPTION
Tweak the edited label on web rendering of statuses a bit:

![image](https://github.com/user-attachments/assets/a69d2acf-cd0c-40fb-985e-4ba0204ec9d3)

Closes https://github.com/superseriousbusiness/gotosocial/issues/3753