### PR TITLE
[bugfix] Fix POST to create account endpoint

### DIFF
--- a/internal/processing/user/create_test.go
+++ b/internal/processing/user/create_test.go
@@ -1,0 +1,74 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package user_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
+)
+
+type CreateTestSuite struct {
+	UserStandardTestSuite
+}
+
+func (suite *CreateTestSuite) TestCreateOK() {
+	var (
+		ctx      = context.Background()
+		app      = suite.testApps["application_1"]
+		appToken = suite.testTokens["local_account_1_client_application_token"]
+		form     = &apimodel.AccountCreateRequest{
+			Reason:    "a long enough explanation of why I am doing api calls",
+			Username:  "someone_new",
+			Email:     "someone_new@example.org",
+			Password:  "a long enough password for this endpoint",
+			Agreement: true,
+			Locale:    "en-us",
+			IP:        net.ParseIP("192.0.2.128"),
+		}
+	)
+
+	// Create user via the API endpoint.
+	user, errWithCode := suite.user.Create(ctx, app, form)
+	if errWithCode != nil {
+		suite.FailNow(errWithCode.Error())
+	}
+
+	// Load the app-level access token that was just used.
+	appAccessToken, err := suite.oauthServer.LoadAccessToken(ctx, appToken.Access)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// Create a user-level access token for the new user.
+	userAccessToken, err := suite.user.TokenForNewUser(ctx, appAccessToken, app, user)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// Check returned user-level access token.
+	suite.NotEmpty(userAccessToken.AccessToken)
+	suite.Equal("Bearer", userAccessToken.TokenType)
+}
+
+func TestCreateTestSuite(t *testing.T) {
+	suite.Run(t, &CreateTestSuite{})
+}

--- a/internal/processing/user/user.go
+++ b/internal/processing/user/user.go
@@ -41,6 +41,7 @@ func New(
 	return Processor{
 		state:       state,
 		converter:   converter,
+		oauthServer: oauthServer,
 		emailSender: emailSender,
 	}
 }

--- a/internal/processing/user/user_test.go
+++ b/internal/processing/user/user_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/email"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/oauth"
 	"github.com/superseriousbusiness/gotosocial/internal/processing/user"
 	"github.com/superseriousbusiness/gotosocial/internal/state"
 	"github.com/superseriousbusiness/gotosocial/internal/typeutils"
@@ -34,9 +35,11 @@ type UserStandardTestSuite struct {
 	emailSender email.Sender
 	db          db.DB
 	state       state.State
+	oauthServer oauth.Server
 
-	testUsers map[string]*gtsmodel.User
-
+	testApps   map[string]*gtsmodel.Application
+	testTokens map[string]*gtsmodel.Token
+	testUsers  map[string]*gtsmodel.User
 	sentEmails map[string]string
 
 	user user.Processor
@@ -51,9 +54,12 @@ func (suite *UserStandardTestSuite) SetupTest() {
 	suite.db = testrig.NewTestDB(&suite.state)
 	suite.state.DB = suite.db
 	suite.state.AdminActions = admin.New(suite.state.DB, &suite.state.Workers)
+	suite.oauthServer = testrig.NewTestOauthServer(suite.state.DB)
 
 	suite.sentEmails = make(map[string]string)
 	suite.emailSender = testrig.NewEmailSender("../../../web/template/", suite.sentEmails)
+	suite.testApps = testrig.NewTestApplications()
+	suite.testTokens = testrig.NewTestTokens()
 	suite.testUsers = testrig.NewTestUsers()
 
 	suite.user = user.New(&suite.state, typeutils.NewConverter(&suite.state), testrig.NewTestOauthServer(suite.db), suite.emailSender)


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Lil fix + new test for creating an account by POSTing to the accounts endpoint.

Following command on the testrig:

```bash
curl -H 'content-type: application/json' -H 'authorization: Bearer ZTK1MWMWZDGTMGMXOS0ZY2UXLWI5ZWETMWEZYZZIYTLHMZI4' -d '{"username":"xk063c2xa3insqw3n4nj_sb_persona","email":"xk063c2xa3insqw3n4nj_sb_persona@personas.stringbeanradio.com","password":"20 char long mix of upper lower special and digits","reason":"a long enough explanation of why I am doing api calls","agreement":true,"locale":"en-US"}' localhost:8080/api/v1/accounts
```

Now returns expected response with default scope (it's a bit dorky that it's an empty string but it's got nothing to do with this PR at least):

```json
{
  "access_token": "NDU5MZNLM2ITYJHLYY0ZYTIXLTG5NTCTNTEYOTJKYZK1ZGFM",
  "token_type": "Bearer",
  "scope": "",
  "created_at": 1739103202
}
```

closes https://github.com/superseriousbusiness/gotosocial/issues/3733
closes https://github.com/superseriousbusiness/gotosocial/issues/3612

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
