### PR TITLE
[bugfix] Suggest lowercase username when creating via OIDC

### DIFF
--- a/internal/api/auth/callback.go
+++ b/internal/api/auth/callback.go
@@ -145,12 +145,18 @@ func (m *Module) CallbackGETHandler(c *gin.Context) {
 			return
 		}
 
+		// Since we require lowercase usernames at this point, lowercase the one
+		// from the claims and use this to autofill the form with a suggestion.
+		//
+		// Pending https://github.com/superseriousbusiness/gotosocial/issues/1813
+		suggestedUsername := strings.ToLower(claims.PreferredUsername)
+
 		page := apiutil.WebPage{
 			Template: "finalize.tmpl",
 			Instance: instance,
 			Extra: map[string]any{
 				"name":              claims.Name,
-				"preferredUsername": claims.PreferredUsername,
+				"suggestedUsername": suggestedUsername,
 			},
 		}
 

--- a/web/template/finalize.tmpl
+++ b/web/template/finalize.tmpl
@@ -42,7 +42,7 @@
                     placeholder="Please enter your desired username"
                     pattern="^[a-z0-9_]{1,64}$"
                     title="lowercase a-z, numbers, and underscores; max 64 characters"
-                    value="{{- .preferredUsername -}}"
+                    value="{{- .suggestedUsername -}}"
                 >
             </div>
             <input type="hidden" name="name" value="{{- .name -}}">


### PR DESCRIPTION
Updates the OIDC callback handler to suggest a lowercase username when registering an account via OIDC, to try to avoid suggesting usernames that aren't valid in any case.

Closes https://github.com/superseriousbusiness/gotosocial/issues/3770
Relates to https://github.com/superseriousbusiness/gotosocial/issues/1813