### PR TITLE
[performance] improved enum migrations

### DIFF
--- a/internal/db/bundb/migrations/20241121121623_enum_strings_to_ints.go
+++ b/internal/db/bundb/migrations/20241121121623_enum_strings_to_ints.go
@@ -71,7 +71,7 @@ func init() {
 			// we must drop all indices that rely on it.
 			log.Info(ctx, "dropping old visibility indexes...")
 			for _, index := range visIndices {
-				log.Info(ctx, "dropping old index %s...", index.name)
+				log.Infof(ctx, "dropping old index %s...", index.name)
 				if _, err := tx.NewDropIndex().
 					Index(index.name).
 					Exec(ctx); err != nil {
@@ -93,7 +93,7 @@ func init() {
 			// Recreate the visibility indices.
 			log.Info(ctx, "creating new visibility indexes...")
 			for _, index := range visIndices {
-				log.Info(ctx, "creating new index %s...", index.name)
+				log.Infof(ctx, "creating new index %s...", index.name)
 				q := tx.NewCreateIndex().
 					Table("statuses").
 					Index(index.name).

--- a/internal/db/bundb/migrations/util.go
+++ b/internal/db/bundb/migrations/util.go
@@ -35,11 +35,6 @@ import (
 	"github.com/uptrace/bun/schema"
 )
 
-// formatQuery formats given query + args according to given bun dialect, useful for debug logging.
-func formatQuery(d schema.Dialect, query string, args ...any) string {
-	return schema.NewFormatter(d).FormatQuery(query, args...)
-}
-
 // convertEnums performs a transaction that converts
 // a table's column of our old-style enums (strings) to
 // more performant and space-saving integer types.

--- a/internal/db/bundb/migrations/util.go
+++ b/internal/db/bundb/migrations/util.go
@@ -35,6 +35,11 @@ import (
 	"github.com/uptrace/bun/schema"
 )
 
+// formatQuery formats given query + args according to given bun dialect, using for debug logging.
+func formatQuery(d schema.Dialect, query string, args ...any) string {
+	return schema.NewFormatter(d).FormatQuery(query, args...)
+}
+
 // convertEnums performs a transaction that converts
 // a table's column of our old-style enums (strings) to
 // more performant and space-saving integer types.
@@ -82,26 +87,31 @@ func convertEnums[OldType ~string, NewType ~int16](
 		return gtserror.Newf("error selecting total count: %w", err)
 	}
 
-	var updated int
+	var args []any
+	var qbuf byteutil.Buffer
+
+	// Prepare a singular UPDATE statement using
+	// SET $newColumn = (CASE $column WHEN $old THEN $new ... END)
+	qbuf.WriteString("UPDATE ? SET ? = (CASE ? ")
+	args = append(args, bun.Ident(table))
+	args = append(args, bun.Ident(newColumn))
+	args = append(args, bun.Ident(column))
 	for old, new := range mapping {
+		qbuf.WriteString("WHEN ? THEN ? ")
+		args = append(args, old, new)
+	}
+	qbuf.WriteString("ELSE ? END)")
+	args = append(args, *defaultValue)
 
-		// Update old to new values.
-		res, err := tx.NewUpdate().
-			Table(table).
-			Where("? = ?", bun.Ident(column), old).
-			Set("? = ?", bun.Ident(newColumn), new).
-			Exec(ctx)
-		if err != nil {
-			return gtserror.Newf("error updating old column values: %w", err)
-		}
-
-		// Count number items updated.
-		n, _ := res.RowsAffected()
-		updated += int(n)
+	// Execute the prepared raw query with arguments.
+	res, err := tx.NewRaw(qbuf.String(), args...).Exec(ctx)
+	if err != nil {
+		return gtserror.Newf("error updating old column values: %w", err)
 	}
 
-	// Check total updated.
-	if total != updated {
+	// Count number items updated.
+	updated, _ := res.RowsAffected()
+	if total != int(updated) {
 		log.Warnf(ctx, "total=%d does not match updated=%d", total, updated)
 	}
 

--- a/internal/db/bundb/migrations/util.go
+++ b/internal/db/bundb/migrations/util.go
@@ -87,15 +87,15 @@ func convertEnums[OldType ~string, NewType ~int16](
 
 	// Prepare a singular UPDATE statement using
 	// SET $newColumn = (CASE $column WHEN $old THEN $new ... END)
-	qbuf.WriteString("UPDATE ? SET ? = (CASE ? ")
+	qbuf.B = append(qbuf.B, "UPDATE ? SET ? = (CASE ? "...)
 	args = append(args, bun.Ident(table))
 	args = append(args, bun.Ident(newColumn))
 	args = append(args, bun.Ident(column))
 	for old, new := range mapping {
-		qbuf.WriteString("WHEN ? THEN ? ")
+		qbuf.B = append(qbuf.B, "WHEN ? THEN ? "...)
 		args = append(args, old, new)
 	}
-	qbuf.WriteString("ELSE ? END)")
+	qbuf.B = append(qbuf.B, "ELSE ? END)"...)
 	args = append(args, *defaultValue)
 
 	// Execute the prepared raw query with arguments.

--- a/internal/db/bundb/migrations/util.go
+++ b/internal/db/bundb/migrations/util.go
@@ -35,7 +35,7 @@ import (
 	"github.com/uptrace/bun/schema"
 )
 
-// formatQuery formats given query + args according to given bun dialect, using for debug logging.
+// formatQuery formats given query + args according to given bun dialect, useful for debug logging.
 func formatQuery(d schema.Dialect, query string, args ...any) string {
 	return schema.NewFormatter(d).FormatQuery(query, args...)
 }


### PR DESCRIPTION
# Description

This improves our shared enum migration function to use a singular update query that handles all possible variations using a CASE statement (thank you for the suggestion @mirabilos !). I probably should have gone with this approach first but our ORM doesn't expose CASE logic so it hadn't initially jumped to mind. The ups-and-downs of ORMs, eh!

I ran this on our test suite (which isn't always the best test of migrations) with both SQLite and Postgres just fine. And I had an old backup of my own database which I was able to use to confirm in a production-like environment that this definitely works on SQLite. Obviously if anyone has an old backup of some Postgres data to test this against feel free to let us know and we can wait for a test on that!

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
