### PR TITLE
[chore/frontend] use localized time string in status & poll info page

### DIFF
--- a/web/source/frontend/index.js
+++ b/web/source/frontend/index.js
@@ -181,3 +181,23 @@ Array.from(document.getElementsByClassName("plyr-video")).forEach((video) => {
 	video._player = player;
 	video._plyrContainer = player.elements.container;
 });
+
+document.addEventListener('DOMContentLoaded', () => {
+	const timeTags = document.getElementsByTagName('time');
+	Array.from(timeTags).forEach(timeTag => {
+		const datetime = timeTag.getAttribute('datetime');
+		const currentText = timeTag.textContent.trim();
+		// Only format if current text contains precise time
+		if (currentText.match(/\d{2}:\d{2}/)) {
+			const date = new Date(datetime);
+			timeTag.textContent = date.toLocaleString(undefined, {
+				year: 'numeric',
+				month: 'short',
+				day: '2-digit',
+				hour: '2-digit',
+				minute: '2-digit',
+				hour12: false
+			});
+		}
+	});
+});

--- a/web/template/status_info.tmpl
+++ b/web/template/status_info.tmpl
@@ -23,14 +23,14 @@
         <div class="stats-item published-at text-cutoff">
             <dt class="sr-only">Published</dt>
             <dd>
-                <time datetime="{{- .CreatedAt -}}">{{- .CreatedAt | timestampPrecise -}}</time>
+                <time datetime="{{- .CreatedAt -}}">{{- .CreatedAt -}}</time>
             </dd>
         </div>
         {{- if .EditedAt -}}
         <div class="stats-item edited-at text-cutoff">
             <dt class="sr-only">Edited</dt>
             <dd>
-                (edited <time datetime="{{- .EditedAt -}}">{{- .EditedAt | timestampPrecise -}}</time>)
+                (edited <time datetime="{{- .EditedAt -}}">{{- .EditedAt -}}</time>)
             </dd>
         </div>
         {{ end }}

--- a/web/template/status_poll.tmpl
+++ b/web/template/status_poll.tmpl
@@ -40,9 +40,9 @@
             Poll&nbsp;
             {{- end -}}
             {{- if .Poll.Expired -}}
-            closed <time datetime="{{- .Poll.ExpiresAt -}}">{{- .Poll.ExpiresAt | timestampPrecise -}}</time>
+            closed <time datetime="{{- .Poll.ExpiresAt -}}">{{- .Poll.ExpiresAt -}}</time>
             {{- else if .Poll.ExpiresAt -}}
-            open until <time datetime="{{- .Poll.ExpiresAt -}}">{{- .Poll.ExpiresAt | timestampPrecise -}}</time>
+            open until <time datetime="{{- .Poll.ExpiresAt -}}">{{- .Poll.ExpiresAt -}}</time>
             {{- else -}}
             open forever
             {{- end -}}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This PR makes a workaround to display timestamps in the user's local timezone:

Precise timestamps (containing hours and minutes) now converted to user's local time using browser's toLocaleString(), while vague timestamps (e.g. "Dec, 2024") are unchanged

Currently, the `timestampPrecise` in the Template has been removed because there's no need to return the server's local time right now. However, the corresponding field in `template.go` is still retained because I'm not sure if we might need it elsewhere.

~~The time format that users actually use might differ from the originally defined format. For example, it might now display as `12/31/2024, 11:11:11 PM` instead of `Dec 31, 2024, 23:11`.~~ It seems that some browsers convert it to a format like `2024-06-06T00:33:54.427Z`, so I'm explicitly specifying it to match the `timestampPrecise` format.

Other parts of the settings panel already use `toLocalString`, so I didn't make any changes there.

closes #3819

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
