### PR TITLE
[feature] Use ETag for robots.txt to prevent mishaps

### DIFF
--- a/internal/api/robots.go
+++ b/internal/api/robots.go
@@ -39,7 +39,7 @@ func (rb *Robots) Route(r *router.Router, m ...gin.HandlerFunc) {
 	// https://www.rfc-editor.org/rfc/rfc9309.html#section-2.4
 	robotsGroup.Use(
 		middleware.CacheControl(middleware.CacheControlConfig{
-			Directives: []string{"public", "max-age=86400"},
+			Directives: []string{"public", "no-cache"},
 			Vary:       []string{"Accept-Encoding"},
 		}),
 	)

--- a/internal/api/robots/robots.go
+++ b/internal/api/robots/robots.go
@@ -49,9 +49,13 @@ func (m *Module) Route(attachHandler func(method string, path string, f ...gin.H
 }
 
 func (m *Module) robotsGETHandler(c *gin.Context) {
+	const ETag = "\"" + apiutil.RobotsTxtETag + "\""
+	c.Header("ETag", ETag)
 	c.String(http.StatusOK, apiutil.RobotsTxt)
 }
 
 func (m *Module) robotsGETHandlerDisallowNodeInfo(c *gin.Context) {
+	const ETag = "\"" + apiutil.RobotsTxtDisallowNodeInfoETag + "\""
+	c.Header("ETag", ETag)
 	c.String(http.StatusOK, apiutil.RobotsTxtDisallowNodeInfo)
 }

--- a/internal/api/robots/robots.go
+++ b/internal/api/robots/robots.go
@@ -51,11 +51,27 @@ func (m *Module) Route(attachHandler func(method string, path string, f ...gin.H
 func (m *Module) robotsGETHandler(c *gin.Context) {
 	const ETag = "\"" + apiutil.RobotsTxtETag + "\""
 	c.Header("ETag", ETag)
+
+	if c.Request.Header.Get("If-None-Match") == ETag {
+		// Cached.
+		c.AbortWithStatus(http.StatusNotModified)
+		return
+	}
+
+	// Not cached, serve.
 	c.String(http.StatusOK, apiutil.RobotsTxt)
 }
 
 func (m *Module) robotsGETHandlerDisallowNodeInfo(c *gin.Context) {
 	const ETag = "\"" + apiutil.RobotsTxtDisallowNodeInfoETag + "\""
 	c.Header("ETag", ETag)
+
+	if c.Request.Header.Get("If-None-Match") == ETag {
+		// Cached.
+		c.AbortWithStatus(http.StatusNotModified)
+		return
+	}
+
+	// Not cached, serve.
 	c.String(http.StatusOK, apiutil.RobotsTxtDisallowNodeInfo)
 }

--- a/internal/api/util/robots.go
+++ b/internal/api/util/robots.go
@@ -130,4 +130,9 @@ Disallow: /.well-known/webfinger
 Disallow: /.well-known/nodeinfo
 Disallow: /nodeinfo/
 `
+
+	// MD5 hash of basic robots.txt.
+	RobotsTxtETag = `ce6729aacbb16fae3628210c04b462b7`
+	// MD5 hash of robots.txt with NodeInfo disallowed.
+	RobotsTxtDisallowNodeInfoETag = `a1e4ce6342978bc8d6c3e3dfab07cab4`
 )


### PR DESCRIPTION
Small update to use `no-cache` in the `Cache-Control` header returned from robots.txt, and provide (and parse) an ETag, to ensure crawlers can use the most up-to-date version of the robots.txt file. Relates to the potential caching issue described in https://github.com/fedidb/issues/issues/46.