### PR TITLE
[docs] correct docker version format

### DIFF
--- a/docs/getting_started/installation/container.md
+++ b/docs/getting_started/installation/container.md
@@ -42,10 +42,10 @@ If desired, update the GoToSocial Docker image tag to the version of GtS you wan
 
 * `latest`: the default. This points to the latest stable release of GoToSocial.
 * `snapshot`: points to whatever code is currently on the main branch. Not guaranteed to be stable, and may often be broken. Use with caution.
-* `vX.Y.Z`: release tag. This points to a specific, stable, release of GoToSocial.
+* `X.Y.Z`: release tag. This points to a specific, stable, release of GoToSocial.
 
 !!! tip
-    Both the `latest` and `snapshot` tags are moving tags, whereas the `vX.Y.Z` tags are immutable. The result of pulling a moving tag might change from day to day. `latest` on one system might not be the same `latest` on a different system. It's recommended to use the `vX.Y.Z` tags instead so you always know exactly which version of GoToSocial you're running. The list of releases can be found [right here](https://github.com/superseriousbusiness/gotosocial/releases), with the newest release at the top.
+    Both the `latest` and `snapshot` tags are moving tags, whereas the `vX.Y.Z` tags are immutable. The result of pulling a moving tag might change from day to day. `latest` on one system might not be the same `latest` on a different system. It's recommended to use the `X.Y.Z` tags instead so you always know exactly which version of GoToSocial you're running. The list of releases can be found [right here](https://github.com/superseriousbusiness/gotosocial/releases), with the newest release at the top.
 
 ### Host
 


### PR DESCRIPTION
# Description

The documentation explains that the release tag is in the format of `vX.Y.Z` for container images. This does not appear to be correct when looking at the image tags in dockerhub. It seems the `v` prefix has been dropped at some point, or was never in place.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
