### PR TITLE
Fix typo in common.tsx

### DIFF
--- a/web/source/settings/views/moderation/domain-permissions/excludes/common.tsx
+++ b/web/source/settings/views/moderation/domain-permissions/excludes/common.tsx
@@ -23,7 +23,7 @@ export function DomainPermissionExcludeHelpText() {
 	return (
 		<>
 			Domain permission excludes prevent permissions for a domain (and all
-			subdomains) from being auomatically managed by domain permission subscriptions.
+			subdomains) from being automatically managed by domain permission subscriptions.
 			<br/>
 			For example, if you create an exclude entry for <code>example.org</code>, then
 			a blocklist or allowlist subscription will <em>exclude</em> entries for <code>example.org</code>


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request fixes a tiny typo I spotted on the Domain Permissions Excludes page.
"auomatically" is now "automatically"


## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have not leveraged AI to create the proposed changes.
