### PR TITLE
[chore] Remove duplicate swagger docs build in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,14 @@
 # stage 1: generate up-to-date swagger.yaml to put in the final container
 FROM --platform=${BUILDPLATFORM} golang:1.23-alpine AS swagger
 
-RUN \
-    ### Installs goswagger for building swagger definitions inside this container
-    go install "github.com/go-swagger/go-swagger/cmd/swagger@c46c303aaa02" && \
-    # Makes swagger executable
-    chmod +x /go/bin/swagger
-
 COPY go.mod /go/src/github.com/superseriousbusiness/gotosocial/go.mod
 COPY go.sum /go/src/github.com/superseriousbusiness/gotosocial/go.sum
 COPY cmd /go/src/github.com/superseriousbusiness/gotosocial/cmd
 COPY internal /go/src/github.com/superseriousbusiness/gotosocial/internal
+COPY vendor /go/src/github.com/superseriousbusiness/gotosocial/vendor
 
 WORKDIR /go/src/github.com/superseriousbusiness/gotosocial
-RUN /go/bin/swagger generate spec -o /go/src/github.com/superseriousbusiness/gotosocial/swagger.yaml --scan-models
+RUN ./vendor/github.com/go-swagger/go-swagger/cmd/swagger generate spec -o /go/src/github.com/superseriousbusiness/gotosocial/swagger.yaml --scan-models
 
 # stage 2: generate the web/assets/dist bundles
 FROM --platform=${BUILDPLATFORM} node:18-alpine AS bundler


### PR DESCRIPTION
We were building the swagger docs once in goreleaser and once inside the docker container, not necessary!