### PR TITLE
[frontend] Add an extra CSS class name to the About This Instance and Register an Account sections in the root index template to allow for easier targeting with custom CSS

### DIFF
--- a/web/template/index.tmpl
+++ b/web/template/index.tmpl
@@ -27,7 +27,7 @@
 
 {{- with . }}
 <main class="about">
-    <section class="about-section" role="region" aria-labelledby="about">
+    <section class="about-section about-this-instance" role="region" aria-labelledby="about">
         <h3 id="about">About this instance</h3>
         <div class="about-section-contents">
             {{- include "shortDescription" . | indent 3 }}

--- a/web/template/index_register.tmpl
+++ b/web/template/index_register.tmpl
@@ -27,7 +27,7 @@ New account registration is currently&nbsp;
 {{- end -}}
 
 {{- with . }}
-<section class="about-section" role="region" aria-labelledby="signup">
+<section class="about-section register-an-account" role="region" aria-labelledby="signup">
     <h3 id="signup">Register an Account on {{ .instance.Title -}}</h3>
     <div class="about-section-contents">
         <p>{{- template "registrationLimits" . -}}</p>


### PR DESCRIPTION
# Description
This is a teeeensy little change that just adds two CSS classes to the main index page. I was mucking around with some custom CSS with 0.18 and realised that while the "What is this?" section has `class="about-section what-is-this"`, the other two sections ("About this instance" and "Register an account") don't have that extra class for distinguishing them more easily.

So this adds them!

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.