### PR TITLE
Make requests with optional body work without body

### DIFF
--- a/internal/api/client/accounts/mute.go
+++ b/internal/api/client/accounts/mute.go
@@ -112,9 +112,11 @@ func (m *Module) AccountMutePOSTHandler(c *gin.Context) {
 	}
 
 	form := &apimodel.UserMuteCreateUpdateRequest{}
-	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
-		return
+	if c.Request.ContentLength > 0 {
+		if err := c.ShouldBind(form); err != nil {
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
+			return
+		}
 	}
 
 	if err := normalizeCreateUpdateMute(form); err != nil {

--- a/internal/api/client/admin/reportresolve.go
+++ b/internal/api/client/admin/reportresolve.go
@@ -115,9 +115,11 @@ func (m *Module) ReportResolvePOSTHandler(c *gin.Context) {
 	}
 
 	form := &apimodel.AdminReportResolveRequest{}
-	if err := c.ShouldBind(form); err != nil {
-		apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
-		return
+	if c.Request.ContentLength > 0 {
+		if err := c.ShouldBind(form); err != nil {
+			apiutil.ErrorHandler(c, gtserror.NewErrorBadRequest(err, err.Error()), m.processor.InstanceGetV1)
+			return
+		}
 	}
 
 	report, errWithCode := m.processor.Admin().ReportResolve(c.Request.Context(), authed.Account, reportID, form.ActionTakenComment)


### PR DESCRIPTION
# Description

When calling `/api/v1/admin/reports/{id}/resolve` from my client, I noticed it fails with EOF error from the call to `ShouldBind` because it expects a body, allowing the `ActionTakenComment` param. It works with an empty body, but this shouldn't be a requirement, as [Mastodon doesn't expect it to have a body](https://docs.joinmastodon.org/methods/admin/reports/#resolve). This PR checks for content length in two handlers where this can happen and calls `ShouldBind` conditionally. This is just a workaround, a proper solution would default to an empty body and properly tell the user that body is required in appropriate cases.

Related: https://github.com/gin-gonic/gin/issues/4120

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
