### PR TITLE
[bugfix] fix refreshed additional media info being ignored

### DIFF
--- a/internal/federation/dereferencing/emoji.go
+++ b/internal/federation/dereferencing/emoji.go
@@ -134,19 +134,23 @@ func (d *Dereferencer) RefreshEmoji(
 	*gtsmodel.Emoji,
 	error,
 ) {
-	// Check emoji is up-to-date
-	// with provided extra info.
-	switch {
-	case info.URI != nil &&
-		*info.URI != emoji.URI:
+	// Check uri up-to-date.
+	if info.URI != nil &&
+		*info.URI != emoji.URI {
 		emoji.URI = *info.URI
 		force = true
-	case info.ImageRemoteURL != nil &&
-		*info.ImageRemoteURL != emoji.ImageRemoteURL:
+	}
+
+	// Check image remote URL up-to-date.
+	if info.ImageRemoteURL != nil &&
+		*info.ImageRemoteURL != emoji.ImageRemoteURL {
 		emoji.ImageRemoteURL = *info.ImageRemoteURL
 		force = true
-	case info.ImageStaticRemoteURL != nil &&
-		*info.ImageStaticRemoteURL != emoji.ImageStaticRemoteURL:
+	}
+
+	// Check image static remote URL up-to-date.
+	if info.ImageStaticRemoteURL != nil &&
+		*info.ImageStaticRemoteURL != emoji.ImageStaticRemoteURL {
 		emoji.ImageStaticRemoteURL = *info.ImageStaticRemoteURL
 		force = true
 	}

--- a/internal/federation/dereferencing/media.go
+++ b/internal/federation/dereferencing/media.go
@@ -125,19 +125,23 @@ func (d *Dereferencer) RefreshMedia(
 		return attach, nil
 	}
 
-	// Check emoji is up-to-date
-	// with provided extra info.
-	switch {
-	case info.Blurhash != nil &&
-		*info.Blurhash != attach.Blurhash:
+	// Check blurhash up-to-date.
+	if info.Blurhash != nil &&
+		*info.Blurhash != attach.Blurhash {
 		attach.Blurhash = *info.Blurhash
 		force = true
-	case info.Description != nil &&
-		*info.Description != attach.Description:
+	}
+
+	// Check description up-to-date.
+	if info.Description != nil &&
+		*info.Description != attach.Description {
 		attach.Description = *info.Description
 		force = true
-	case info.RemoteURL != nil &&
-		*info.RemoteURL != attach.RemoteURL:
+	}
+
+	// Check remote URL up-to-date.
+	if info.RemoteURL != nil &&
+		*info.RemoteURL != attach.RemoteURL {
 		attach.RemoteURL = *info.RemoteURL
 		force = true
 	}
@@ -213,10 +217,10 @@ func (d *Dereferencer) updateAttachment(
 	)
 }
 
-// processingEmojiSafely provides concurrency-safe processing of
-// an emoji with given shortcode+domain. if a copy of the emoji is
+// processingMediaSafely provides concurrency-safe processing of
+// a media with given remote URL string. if a copy of the media is
 // not already being processed, the given 'process' callback will
-// be used to generate new *media.ProcessingEmoji{} instance.
+// be used to generate new *media.ProcessingMedia{} instance.
 func (d *Dereferencer) processMediaSafeley(
 	ctx context.Context,
 	remoteURL string,

--- a/internal/federation/dereferencing/media.go
+++ b/internal/federation/dereferencing/media.go
@@ -128,7 +128,6 @@ func (d *Dereferencer) RefreshMedia(
 	// Check emoji is up-to-date
 	// with provided extra info.
 	switch {
-	case force:
 	case info.Blurhash != nil &&
 		*info.Blurhash != attach.Blurhash:
 		attach.Blurhash = *info.Blurhash


### PR DESCRIPTION
# Description

Previously when additional info was provided, this was skipped being checked over if the force flag was already set, but we actually need to iterate over this information since the additional info isn't actually later passed anywhere.

This should (hopefully!) fix https://github.com/superseriousbusiness/gotosocial/issues/2851

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
