### PR TITLE
[chore] align email template with new, separate /login page

### DIFF
--- a/web/template/email_signup_approved.tmpl
+++ b/web/template/email_signup_approved.tmpl
@@ -23,7 +23,7 @@ You are receiving this mail because your request for an account on {{ .InstanceN
 
 If you have already confirmed your email address, you can now log in to your new account using a client application of your choice.
 
-Some client applications known to work with GoToSocial are listed here: {{ .InstanceURL -}}#apps.
+Some client applications known to work with GoToSocial are listed here: {{ .InstanceURL -}}/login#apps.
 
 If you have not yet confirmed your email address, you will not be able to log in until you have done so.
 


### PR DESCRIPTION
I just randomly noticed that the link of the email template (for when one's account got approved) didn't point to the correct section on the main page anymore since that got moved to a separate page. This tiny pull request addresses that.

# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request changes the "Sign-Up Approved" email template to point from gts-instance.example.com#apps to gts-instance.example.com/login#apps since the known-working apps section had been moved to the Login page.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [X] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [X] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat. (<-- I pointed that out in the "GoToSocial General" Matrix chat, if that counts)
- [X] I/we have not leveraged AI to create the proposed changes.
- [ ] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.