### PR TITLE
[feature] add configurable for amd64 CPUs to allow forcing usage of the wazero compiler

### DIFF
--- a/internal/media/ffmpeg/wasm.go
+++ b/internal/media/ffmpeg/wasm.go
@@ -133,7 +133,8 @@ func compilerSupported() bool {
 	}
 	switch runtime.GOARCH {
 	case "amd64":
-		return cpu.X86.HasSSE41
+		return cpu.X86.HasSSE41 ||
+			os.Getenv("GTS_WAZERO_FORCE_COMPILER") != ""
 	case "arm64":
 		return true
 	default:


### PR DESCRIPTION
# Description

This should help provide a workaround for #3872 in the form of a (potentially very unsafe!) configurable that allows people on amd64 CPUs to force usage of the wazero compiler when they know for sure that they have sse4_1 (i.e. SIMD) available, even if not explicitly exposed as supported by the KVM host.

**Anyone reading this and interested in trying it, you should only do so if you're certain that sse4_1 is available to you but not being exposed! And make sure that you backup your database beforehand.**