### PR TITLE
[bugfix] fix wazero compiler choice logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,9 +294,9 @@ This is the current status of support offered by GoToSocial for different platfo
 
 64-bit platforms require the following (now, very common) CPU features:
 
-- x86-64 require SSE4.1 (for both media decoding and WASM SQLite)
+- x86-64 require SSE4.1
 
-- Armv8 require ARM64 Large System Extensions (specifically when using WASM SQLite)
+- Armv8 require ARM64 Large System Extensions
 
 Without these features, performance will suffer. In these situations, you may have some success building a binary yourself with the totally **unsupported, experimental** [nowasm](https://docs.gotosocial.org/en/latest/advanced/builds/nowasm/) tag.
 


### PR DESCRIPTION
# Description

This removes our own compiler checking logic and instead relies on wazero to determine this, especially since currently we don't do a check for arm64 LSE when we should do (and can't easily do this ourselves).

This also simplifies the related README supported architecture instructions to just say that either amd64 w/ sse4_1 or arm64 w/ lse are required for expected performance.

One thing we could consider doing in the future is making our arm64 builds specifically require LSE (so they would panic if LSE is not available when being run), i.e. as said here https://tip.golang.org/doc/go1.23

> Go 1.23 introduces a new GOARM64 environment variable, which specifies the minimum target version of the ARM64 architecture at compile time. Allowed values are v8.{0-9} and v9.{0-5}. This may be followed by an option specifying extensions implemented by target hardware. Valid options are ,lse and ,crypto.

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
