### PR TITLE
[performance] Optimize local timeline + local status count queries

### DIFF
--- a/internal/db/bundb/instance.go
+++ b/internal/db/bundb/instance.go
@@ -77,44 +77,52 @@ func (i *instanceDB) CountInstanceUsers(ctx context.Context, domain string) (int
 }
 
 func (i *instanceDB) CountInstanceStatuses(ctx context.Context, domain string) (int, error) {
-	localhost := (domain == config.GetHost() || domain == config.GetAccountDomain())
+	local := (domain == config.GetHost() || domain == config.GetAccountDomain())
 
-	if localhost {
-		// Check for a cached instance statuses count, if so return this.
-		if n := i.state.Caches.DB.LocalInstance.Statuses.Load(); n != nil {
-			return *n, nil
-		}
+	if local {
+		return i.countLocalStatuses(ctx)
 	}
 
 	q := i.db.
 		NewSelect().
-		TableExpr("? AS ?", bun.Ident("statuses"), bun.Ident("status"))
-
-	if localhost {
-		// if the domain is *this* domain, just count where local is true
-		q = q.Where("? = ?", bun.Ident("status.local"), true)
-	} else {
-		// join on the domain of the account
-		q = q.
-			Join("JOIN ? AS ? ON ? = ?", bun.Ident("accounts"), bun.Ident("account"), bun.Ident("account.id"), bun.Ident("status.account_id")).
-			Where("? = ?", bun.Ident("account.domain"), domain)
-	}
-
-	// Ignore statuses that are currently pending approval.
-	q = q.Where("NOT ? = ?", bun.Ident("status.pending_approval"), true)
-
-	// Ignore statuses that are direct messages.
-	q = q.Where("NOT ? = ?", bun.Ident("status.visibility"), gtsmodel.VisibilityDirect)
+		TableExpr("? AS ?", bun.Ident("statuses"), bun.Ident("status")).
+		// Join on the domain of the account.
+		Join(
+			"JOIN ? AS ? ON ? = ?",
+			bun.Ident("accounts"), bun.Ident("account"),
+			bun.Ident("account.id"), bun.Ident("status.account_id"),
+		).
+		Where("? = ?", bun.Ident("account.domain"), domain).
+		// Ignore pending approval.
+		Where("? = ?", bun.Ident("status.pending_approval"), false).
+		// Ignore direct messages.
+		Where("NOT ? = ?", bun.Ident("status.visibility"), gtsmodel.VisibilityDirect)
 
 	count, err := q.Count(ctx)
 	if err != nil {
 		return 0, err
 	}
 
-	if localhost {
-		// Update cached instance statuses account value.
-		i.state.Caches.DB.LocalInstance.Statuses.Store(&count)
+	return count, nil
+}
+
+func (i *instanceDB) countLocalStatuses(ctx context.Context) (int, error) {
+	// Check for a cached instance statuses count, if so return this.
+	if n := i.state.Caches.DB.LocalInstance.Statuses.Load(); n != nil {
+		return *n, nil
 	}
+
+	// Select from local count view.
+	var count int
+	if err := i.db.
+		NewSelect().
+		Table("statuses_local_count_view").
+		Scan(ctx, &count); err != nil {
+		return 0, err
+	}
+
+	// Update cached instance statuses account value.
+	i.state.Caches.DB.LocalInstance.Statuses.Store(&count)
 
 	return count, nil
 }

--- a/internal/db/bundb/migrations/20250310094108_statuses_count_query_optimize.go
+++ b/internal/db/bundb/migrations/20250310094108_statuses_count_query_optimize.go
@@ -1,0 +1,87 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+
+			// Add new local statuses count view.
+			in := []int16{
+				int16(gtsmodel.VisibilityPublic),
+				int16(gtsmodel.VisibilityUnlocked),
+				int16(gtsmodel.VisibilityFollowersOnly),
+				int16(gtsmodel.VisibilityMutualsOnly),
+			}
+			if _, err := tx.
+				NewRaw(
+					"CREATE VIEW IF NOT EXISTS ? AS "+
+						"SELECT COUNT(*) FROM ? "+
+						"WHERE (? = ?) AND (? IN (?)) AND (? = ?)",
+					bun.Ident("statuses_local_count_view"),
+					bun.Ident("statuses"),
+					bun.Ident("local"), true,
+					bun.Ident("visibility"), bun.In(in),
+					bun.Ident("pending_approval"), false,
+				).
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			// Drop existing local index.
+			if _, err := tx.
+				NewDropIndex().
+				Index("statuses_local_idx").
+				IfExists().
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			// Add new multicolumn local statuses
+			// index that works for the local count
+			// view and the local timeline query.
+			if _, err := tx.
+				NewCreateIndex().
+				Table("statuses").
+				Index("statuses_local_idx").
+				Column("local", "visibility", "pending_approval").
+				ColumnExpr("? DESC", bun.Ident("id")).
+				IfNotExists().
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return nil
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}

--- a/internal/db/bundb/migrations/20250310094108_statuses_count_query_optimize.go
+++ b/internal/db/bundb/migrations/20250310094108_statuses_count_query_optimize.go
@@ -37,7 +37,7 @@ func init() {
 			}
 			if _, err := tx.
 				NewRaw(
-					"CREATE VIEW IF NOT EXISTS ? AS "+
+					"CREATE VIEW ? AS "+
 						"SELECT COUNT(*) FROM ? "+
 						"WHERE (? = ?) AND (? IN (?)) AND (? = ?)",
 					bun.Ident("statuses_local_count_view"),


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Queries for counting local statuses and for fetching the local timeline have been annoyingly slow lately so I did some optimization. Count and timeline queries can now both use the updated `statuses_local_idx`, which should make things a lot faster.

Tested on both SQLite and Postgres. Postgres doesn't seem to use `statuses_local_idx` for local timeline queries in my testing, as it prefers to use `statuses_public_timeline_idx` and then filter local, but SQLite does, and both drivers use `statuses_local_idx` for the count query.

SQLite:

```
sqlite> CREATE INDEX IF NOT EXISTS "statuses_local_idx" ON "statuses" ("local", "visibility", "pending_approval", "id" DESC);
sqlite> PRAGMA analysis_limit=0; ANALYZE;
0
sqlite> .expert
sqlite> SELECT * FROM "statuses_local_count_view";
(no new indexes)

CO-ROUTINE statuses_local_count_view
SEARCH statuses USING COVERING INDEX statuses_local_idx (local=? AND visibility=? AND pending_approval=?)
SCAN statuses_local_count_view

sqlite> .expert
sqlite> SELECT "status"."id" FROM "statuses" AS "status" WHERE ("status"."local" = TRUE) AND ("status"."visibility" = 2) AND ("status"."pending_approval" = FALSE) AND ("status"."boost_of_id" IS NULL) AND ("status"."id" < '01JP2FR3VR7P63CZSSERJN7ZXJ') ORDER BY "status"."id" DESC LIMIT 20;
(no new indexes)

SEARCH status USING INDEX statuses_local_idx (local=? AND visibility=? AND pending_approval=? AND id<?)
```

Postgres:

```
postgres=# EXPLAIN ANALYZE SELECT * FROM "statuses_local_count_view";
                                                               QUERY PLAN                                                                
-----------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=8.16..8.17 rows=1 width=8) (actual time=0.042..0.042 rows=1 loops=1)
   ->  Index Only Scan using statuses_local_idx on statuses  (cost=0.14..8.16 rows=1 width=0) (actual time=0.031..0.039 rows=21 loops=1)
         Index Cond: ((local = true) AND (visibility = ANY ('{2,3,4,5}'::integer[])) AND (pending_approval = false))
         Heap Fetches: 21
 Planning Time: 0.732 ms
 Execution Time: 0.065 ms
(6 rows)

postgres=# EXPLAIN ANALYZE SELECT "status"."id" FROM "statuses" AS "status" WHERE ("status"."local" = TRUE) AND ("status"."visibility" = 2) AND ("status"."pending_approval" = FALSE) AND ("status"."boost_of_id" IS NULL) AND ("status"."id" < '01JP2FR3VR7P63CZSSERJN7ZXJ') ORDER BY "status"."id" DESC LIMIT 20;
                                                                      QUERY PLAN                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.14..8.16 rows=1 width=108) (actual time=0.026..0.040 rows=15 loops=1)
   ->  Index Scan using statuses_public_timeline_idx on statuses status  (cost=0.14..8.16 rows=1 width=108) (actual time=0.025..0.037 rows=15 loops=1)
         Index Cond: ((visibility = 2) AND (id < '01JP2FR3VR7P63CZSSERJN7ZXJ'::bpchar))
         Filter: (local AND (NOT pending_approval) AND (boost_of_id IS NULL))
         Rows Removed by Filter: 4
 Planning Time: 0.218 ms
 Execution Time: 0.053 ms
(7 rows)
```

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
