### PR TITLE
[chore] add warning message when wazero compiler not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,13 +292,13 @@ This is the current status of support offered by GoToSocial for different platfo
 
 #### 64-bit
 
-64-bit platforms require the following (now, very common) CPU features:
+Notes on 64-bit CPU feature requirements:
 
-- x86-64 require SSE4.1 (for both media decoding and WASM SQLite)
+- x86_64 requires the SSE4.1 instruction set. (CPUs manufactured after ~2010)
 
-- Armv8 require ARM64 Large System Extensions (specifically when using WASM SQLite)
+- ARM64 requires no specific features, ARMv8 CPUs (and later) have all required features.
 
-Without these features, performance will suffer. In these situations, you may have some success building a binary yourself with the totally **unsupported, experimental** [nowasm](https://docs.gotosocial.org/en/latest/advanced/builds/nowasm/) tag.
+If any of the above features are missing, performance of media processing (and possibly, SQLite) will suffer. In these situations, you may have some success building a binary yourself with the totally **unsupported, experimental** [nowasm](https://docs.gotosocial.org/en/latest/advanced/builds/nowasm/) tag.
 
 #### BSDs
 

--- a/internal/media/ffmpeg/wasm.go
+++ b/internal/media/ffmpeg/wasm.go
@@ -150,7 +150,7 @@ func compilerSupported() (string, bool) {
 		// later update go-ffmpreg to a version that makes
 		// use of threads, i.e. v7.x.x. in that case we would
 		// need to check for cpu.ARM64.HasATOMICS.
-		return "arm64 LSE/atomics required", true
+		return "", true
 	default:
 		return "unsupported ARCH", false
 	}

--- a/internal/media/ffmpeg/wasm.go
+++ b/internal/media/ffmpeg/wasm.go
@@ -28,6 +28,7 @@ import (
 
 	"codeberg.org/gruf/go-ffmpreg/embed"
 	"codeberg.org/gruf/go-ffmpreg/wasm"
+	"github.com/superseriousbusiness/gotosocial/internal/log"
 	"github.com/tetratelabs/wazero"
 	"golang.org/x/sys/cpu"
 )
@@ -50,14 +51,20 @@ func initWASM(ctx context.Context) error {
 
 	var cfg wazero.RuntimeConfig
 
-	// Create new runtime config, taking bug into account:
-	// taking https://github.com/tetratelabs/wazero/pull/2365
-	//
-	// Thanks @ncruces (of go-sqlite3) for the fix!
-	if compilerSupported() {
-		cfg = wazero.NewRuntimeConfigCompiler()
-	} else {
-		cfg = wazero.NewRuntimeConfigInterpreter()
+	// Allocate new runtime config, letting
+	// wazero determine compiler / interpreter.
+	cfg = wazero.NewRuntimeConfig()
+
+	// Though still perform a check of CPU features at
+	// runtime to warn about slow interpreter performance.
+	if reason, supported := compilerSupported(); !supported {
+		log.Warn(ctx, "!!! WAZERO COMPILER MAY NOT BE AVAILABLE !!!"+
+			" Reason: "+reason+"."+
+			" Wazero will likely fall back to interpreter mode,"+
+			" resulting in poor performance for media processing (and SQLite, if in use)."+
+			" For more info and possible workarounds, please check:"+
+			" https://docs.gotosocial.org/en/latest/getting_started/releases/#supported-platforms",
+		)
 	}
 
 	if dir := os.Getenv("GTS_WAZERO_COMPILATION_CACHE"); dir != "" {
@@ -121,7 +128,7 @@ func initWASM(ctx context.Context) error {
 	return nil
 }
 
-func compilerSupported() bool {
+func compilerSupported() (string, bool) {
 	switch runtime.GOOS {
 	case "linux", "android",
 		"windows", "darwin",
@@ -129,15 +136,23 @@ func compilerSupported() bool {
 		"solaris", "illumos":
 		break
 	default:
-		return false
+		return "unsupported OS", false
 	}
 	switch runtime.GOARCH {
 	case "amd64":
-		return cpu.X86.HasSSE41
+		// NOTE: wazero in the future may decouple the
+		// requirement of simd (sse4_1) from requirements
+		// for compiler support in the future, but even
+		// still our module go-ffmpreg makes use of them.
+		return "amd64 SSE4.1 required", cpu.X86.HasSSE41
 	case "arm64":
-		return true
+		// NOTE: this particular check may change if we
+		// later update go-ffmpreg to a version that makes
+		// use of threads, i.e. v7.x.x. in that case we would
+		// need to check for cpu.ARM64.HasATOMICS.
+		return "arm64 LSE/atomics required", true
 	default:
-		return false
+		return "unsupported ARCH", false
 	}
 }
 


### PR DESCRIPTION
Also updates the supported platforms section of our README to note that all arm64 CPUs should be supported and that LSE isn't required (since we currently don't rely on threads).