### PR TITLE
[feature/frontend] Add visibility icon for posts

### DIFF
--- a/web/source/css/status.css
+++ b/web/source/css/status.css
@@ -448,6 +448,10 @@ main {
 				gap: 0.4rem;
 			}
 
+			.stats-item.published-at {
+				text-decoration: underline;
+			}
+
 			.stats-item:not(.published-at):not(.edited-at) {
 				z-index: 1;
 				user-select: none;

--- a/web/template/status_info.tmpl
+++ b/web/template/status_info.tmpl
@@ -17,9 +17,36 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */ -}}
 
+{{- define "visibility_icon" -}}
+    {{- if eq .Visibility "public" -}}
+        globe
+    {{- else if eq .Visibility "unlisted" -}}
+        unlock
+    {{- else -}}
+        question
+    {{- end -}}
+{{- end -}}
+
+{{- define "visibility_title" -}}
+    {{- if eq .Visibility "public" -}}
+        Public
+    {{- else if eq .Visibility "unlisted" -}}
+        Unlisted
+    {{- else -}}
+        Unknown
+    {{- end -}}
+{{- end -}}
+
 {{- with . }}
 <dl class="status-stats">
     <div class="stats-grouping">
+        <div class="stats-item visibility-level" title="{{- template "visibility_title" . -}}">
+            <dt class="sr-only">Visibility</dt>
+            <dd>
+                <i class="fa fa-{{- template "visibility_icon" . -}}" aria-hidden="true"></i>
+                <span class="sr-only">{{- template "visibility_title" . -}}</span>
+            </dd>
+        </div>
         <div class="stats-item published-at text-cutoff">
             <dt class="sr-only">Published</dt>
             <dd>
@@ -30,7 +57,7 @@
         <div class="stats-item edited-at text-cutoff">
             <dt class="sr-only">Edited</dt>
             <dd>
-                (edited <time class="dt-updated" datetime="{{- .EditedAt -}}">{{- .EditedAt | timestampPrecise -}}</time>)
+                edited <time class="dt-updated" datetime="{{- .EditedAt -}}">{{- .EditedAt | timestampPrecise -}}</time>
             </dd>
         </div>
         {{ end }}


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

Adds a visibility icon + alt text for posts, underlines date published, removes parenthesis around edited at.

![Screenshot from 2025-03-14 11-22-16](https://github.com/user-attachments/assets/fb157242-b3a2-4119-8736-1fb7ebf95451)
![Screenshot from 2025-03-14 11-22-09](https://github.com/user-attachments/assets/96d2de33-3794-49ce-90ba-db26228cfd90)

Closes https://github.com/superseriousbusiness/gotosocial/issues/3899