### PR TITLE
[performance] reindex public timeline + tinker with query a bit

### DIFF
--- a/internal/db/bundb/migrations/20250318093828_statuses_public_timeline_reindex.go
+++ b/internal/db/bundb/migrations/20250318093828_statuses_public_timeline_reindex.go
@@ -1,0 +1,63 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/superseriousbusiness/gotosocial/internal/log"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+
+			log.Info(ctx, "updating statuses_public_timeline_idx, this may take a bit of time, please wait!!")
+
+			if _, err := tx.
+				NewDropIndex().
+				Index("statuses_public_timeline_idx").
+				IfExists().
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			if _, err := tx.
+				NewCreateIndex().
+				Table("statuses").
+				Index("statuses_public_timeline_idx").
+				Column("visibility", "boost_of_id", "pending_approval").
+				ColumnExpr("? DESC", bun.Ident("id")).
+				IfNotExists().
+				Exec(ctx); err != nil {
+				return err
+			}
+
+			return nil
+		})
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		return nil
+	}
+
+	if err := Migrations.Register(up, down); err != nil {
+		panic(err)
+	}
+}

--- a/internal/db/bundb/timeline.go
+++ b/internal/db/bundb/timeline.go
@@ -229,6 +229,8 @@ func (t *timelineDB) GetPublicTimeline(
 		Where("? = ?", bun.Ident("status.visibility"), gtsmodel.VisibilityPublic).
 		// Ignore boosts.
 		Where("? IS NULL", bun.Ident("status.boost_of_id")).
+		// Only include statuses that aren't pending approval.
+		Where("? = ?", bun.Ident("status.pending_approval"), false).
 		// Select only IDs from table
 		Column("status.id")
 
@@ -254,9 +256,6 @@ func (t *timelineDB) GetPublicTimeline(
 		// page up
 		frontToBack = false
 	}
-
-	// Only include statuses that aren't pending approval.
-	q = q.Where("NOT ? = ?", bun.Ident("status.pending_approval"), true)
 
 	if limit > 0 {
 		// limit amount of statuses returned


### PR DESCRIPTION
The public timeline query was getting really slow because we kept adding more query parameters to it without really paying attention to their ordering, or updating index. This fixes that by removing the old index, creating a new index, and putting query parameters in a more deliberate order.

sqlite: 

```
sqlite> explain query plan SELECT "status"."id" FROM "statuses" AS "status" WHERE ("status"."visibility" = 2) AND ("status"."boost_of_id" IS NULL) AND ("status"."pending_approval" = FALSE) AND ("status"."id" < '01JPPWJGNR4568JRJ5ZAZP3RV7') ORDER BY "status"."id" DESC LIMIT 20;
QUERY PLAN
`--SEARCH status USING COVERING INDEX statuses_public_timeline_idx (visibility=? AND boost_of_id=? AND pending_approval=? AND id<?)
```

postgres (as usual it's doing its own thing but it seems fine):

```
postgres=# explain analyze SELECT "status"."id" FROM "statuses" AS "status" WHERE ("status"."visibility" = 2) AND ("status"."boost_of_id" IS NULL) AND ("status"."pending_approval" = FALSE) AND ("status"."id" < '01JPPWJGNR4568JRJ5ZAZP3RV7') ORDER BY "status"."id" DESC LIMIT 20;
                                                                      QUERY PLAN                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=8.17..8.18 rows=1 width=108) (actual time=0.028..0.029 rows=0 loops=1)
   ->  Sort  (cost=8.17..8.18 rows=1 width=108) (actual time=0.028..0.028 rows=0 loops=1)
         Sort Key: id DESC
         Sort Method: quicksort  Memory: 25kB
         ->  Index Scan using statuses_visibility_idx on statuses status  (cost=0.14..8.16 rows=1 width=108) (actual time=0.010..0.010 rows=0 loops=1)
               Index Cond: (visibility = 2)
               Filter: ((boost_of_id IS NULL) AND (NOT pending_approval) AND (id < '01JPPWJGNR4568JRJ5ZAZP3RV7'::bpchar))
 Planning Time: 0.906 ms
 Execution Time: 0.042 ms
(9 rows)
```