### PR TITLE
[bugfix] Avoid nil ptr if maintenance router can't be started

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -144,8 +144,12 @@ func (c *Caches) Start() error {
 func (c *Caches) Stop() {
 	log.Infof(nil, "stop: %p", c)
 
-	_ = c.Webfinger.Stop()
-	_ = c.StatusesFilterableFields.Stop()
+	if c.Webfinger != nil {
+		_ = c.Webfinger.Stop()
+	}
+	if c.StatusesFilterableFields != nil {
+		_ = c.StatusesFilterableFields.Stop()
+	}
 }
 
 // Sweep will sweep all the available caches to ensure none


### PR DESCRIPTION
If the maintenance router couldn't be started, the call to stop caches would trigger a nil pointer exception, masking useful errors.