### PR TITLE
feat: Relax URL matching

### DIFF
--- a/internal/filter/spam/statusable.go
+++ b/internal/filter/spam/statusable.go
@@ -375,7 +375,7 @@ func (f *Filter) errantLinks(
 	}
 
 	// Find + parse every http/https link in the status.
-	rawLinks := regexes.LinkScheme.FindAllString(concat, -1)
+	rawLinks := regexes.URL.FindAllString(concat, -1)
 	links := make([]preppedLink, 0, len(rawLinks))
 	for _, rawLink := range rawLinks {
 		linkURI, err := url.Parse(rawLink)

--- a/internal/regexes/regexes.go
+++ b/internal/regexes/regexes.go
@@ -40,7 +40,6 @@ const (
 	reports   = "reports"
 	accepts   = "accepts"
 
-	schemes                  = `(http|https)://`                                         // Allowed URI protocols for parsing links in text.
 	alphaNumeric             = `\p{L}\p{M}*|\p{N}`                                       // A single number or script character in any language, including chars with accents.
 	usernameGrp              = `(?:` + alphaNumeric + `|\.|\-|\_)`                       // Non-capturing group that matches against a single valid username character.
 	domainGrp                = `(?:` + alphaNumeric + `|\.|\-|\:)`                       // Non-capturing group that matches against a single valid domain character.
@@ -79,14 +78,9 @@ const (
 )
 
 var (
-	// LinkScheme captures http/https schemes in URLs.
-	LinkScheme = func() *regexp.Regexp {
-		rgx, err := xurls.StrictMatchingScheme(schemes)
-		if err != nil {
-			panic(err)
-		}
-		return rgx
-	}()
+	// URL captures anything that looks like a URL. This includes
+	// URLs without a scheme, based on a built-in list of TLDs.
+	URL = xurls.Relaxed()
 
 	// MentionName captures the username and domain part from
 	// a mention string such as @whatever_user@example.org,

--- a/internal/text/markdown.go
+++ b/internal/text/markdown.go
@@ -139,7 +139,7 @@ func (f *Formatter) fromMarkdown(
 			},
 			// Turns URLs into links.
 			extension.NewLinkify(
-				extension.WithLinkifyURLRegexp(regexes.LinkScheme),
+				extension.WithLinkifyURLRegexp(regexes.URL),
 			),
 			extension.Strikethrough,
 		),

--- a/internal/text/plain.go
+++ b/internal/text/plain.go
@@ -168,7 +168,7 @@ func (f *Formatter) fromPlain(
 			},
 			// Turns URLs into links.
 			extension.NewLinkify(
-				extension.WithLinkifyURLRegexp(regexes.LinkScheme),
+				extension.WithLinkifyURLRegexp(regexes.URL),
 			),
 		),
 	)


### PR DESCRIPTION
# Description

Instead of only linkifying things with an explicit http or https scheme, the xurls.Relaxed also matches links with known TLDs. This means that text like 'banana.com' will also be matched, despite the missing http/https scheme. This also works to linkify email addresses, which is handy.

This should also ensure we catch links without a scheme for the purpose of spam checking.


## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [ ] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
