### PR TITLE
[chore] Add extra `org.opencontainers.image` labels to docker build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -107,11 +107,15 @@ dockers:
     - "{{ if .IsSnapshot }}superseriousbusiness/{{ .ProjectName }}:snapshot-amd64{{ end }}"
     build_flag_templates:
     - "--platform=linux/amd64"
-    - "--label=org.opencontainers.image.created={{.Date}}"
-    - "--label=org.opencontainers.image.title={{.ProjectName}}"
-    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.title=GoToSocial"
+    - "--label=org.opencontainers.image.authors=GoToSocial Authors"
+    - "--label=org.opencontainers.image.description=Fast, fun, small ActivityPub server."
+    - "--label=org.opencontainers.image.url=https://docs.gotosocial.org"
+    - "--label=org.opencontainers.image.documentation=https://docs.gotosocial.org/en/latest/getting_started/installation/container/"
     - "--label=org.opencontainers.image.source=https://github.com/superseriousbusiness/gotosocial"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.licenses=AGPL-3.0-or-later"
     extra_files:
     - web
@@ -132,11 +136,15 @@ dockers:
     - "{{ if .IsSnapshot }}superseriousbusiness/{{ .ProjectName }}:snapshot-arm64v8{{ end }}"
     build_flag_templates:
     - "--platform=linux/arm64/v8"
-    - "--label=org.opencontainers.image.created={{.Date}}"
-    - "--label=org.opencontainers.image.title={{.ProjectName}}"
-    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.title=GoToSocial"
+    - "--label=org.opencontainers.image.authors=GoToSocial Authors"
+    - "--label=org.opencontainers.image.description=Fast, fun, small ActivityPub server."
+    - "--label=org.opencontainers.image.url=https://docs.gotosocial.org"
+    - "--label=org.opencontainers.image.documentation=https://docs.gotosocial.org/en/latest/getting_started/installation/container/"
     - "--label=org.opencontainers.image.source=https://github.com/superseriousbusiness/gotosocial"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.licenses=AGPL-3.0-or-later"
     extra_files:
     - web

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -111,6 +111,8 @@ dockers:
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/superseriousbusiness/gotosocial"
+    - "--label=org.opencontainers.image.licenses=AGPL-3.0-or-later"
     extra_files:
     - web
     - go.mod
@@ -134,6 +136,8 @@ dockers:
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source=https://github.com/superseriousbusiness/gotosocial"
+    - "--label=org.opencontainers.image.licenses=AGPL-3.0-or-later"
     extra_files:
     - web
     - go.mod


### PR DESCRIPTION
Adds a bunch more labels to docker build (https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys)

```json
{
  [... blah blah blah ...],
  "Labels": {
    "org.opencontainers.image.authors": "GoToSocial Authors",
    "org.opencontainers.image.created": "2025-03-23T10:19:01Z",
    "org.opencontainers.image.description": "Fast, fun, small ActivityPub server.",
    "org.opencontainers.image.documentation": "https://docs.gotosocial.org/en/latest/getting_started/installation/container/",
    "org.opencontainers.image.licenses": "AGPL-3.0-or-later",
    "org.opencontainers.image.revision": "b141d93a6aa64f40b18558525ed80ba492b11694",
    "org.opencontainers.image.source": "https://github.com/superseriousbusiness/gotosocial",
    "org.opencontainers.image.title": "GoToSocial",
    "org.opencontainers.image.url": "https://docs.gotosocial.org",
    "org.opencontainers.image.version": "0.18.2-SNAPSHOT"
  },
  [... blah blah blah ...]
}
```

Closes https://github.com/superseriousbusiness/gotosocial/issues/3929