### PR TITLE
Fix Atkinson Hyperlegible font embedding on Ecks Pee theme.

### DIFF
--- a/web/assets/themes/ecks-pee.css
+++ b/web/assets/themes/ecks-pee.css
@@ -93,29 +93,29 @@
   font-family: "Atkinson Hyperlegible";
   font-weight: normal;
   font-style: normal;
-  src: url(/assets/fonts/Atkinson-Hyperlegible-Regular-102a.woff2) format('woff2');
-  src: url(/assets/fonts/Atkinson-Hyperlegible-Regular-102.woff) format('woff');
+  src: url(/assets/fonts/Atkinson-Hyperlegible-Regular-102a.woff2) format('woff2'),
+       url(/assets/fonts/Atkinson-Hyperlegible-Regular-102.woff) format('woff');
 }
 @font-face {
   font-family: "Atkinson Hyperlegible";
   font-weight: bold;
   font-style: normal;
-  src: url(/assets/fonts/Atkinson-Hyperlegible-Bold-102a.woff2) format('woff2');
-  src: url(/assets/fonts/Atkinson-Hyperlegible-Bold-102.woff) format('woff');
+  src: url(/assets/fonts/Atkinson-Hyperlegible-Bold-102a.woff2) format('woff2'),
+      url(/assets/fonts/Atkinson-Hyperlegible-Bold-102.woff) format('woff');
 }
 @font-face {
   font-family: "Atkinson Hyperlegible";
   font-weight: normal;
   font-style: italic;
-  src: url(/assets/fonts/Atkinson-Hyperlegible-Italic-102a.woff2) format('woff2');
-  src: url(/assets/fonts/Atkinson-Hyperlegible-Italic-102.woff) format('woff');
+  src: url(/assets/fonts/Atkinson-Hyperlegible-Italic-102a.woff2) format('woff2'),
+       url(/assets/fonts/Atkinson-Hyperlegible-Italic-102.woff) format('woff');
 }
 @font-face {
   font-family: "Atkinson Hyperlegible";
   font-weight: bold;
   font-style: italic;
-  src: url(/assets/fonts/Atkinson-Hyperlegible-BoldItalic-102a.woff2) format('woff2');
-  src: url(/assets/fonts/Atkinson-Hyperlegible-BoldItalic-102.woff) format('woff');
+  src: url(/assets/fonts/Atkinson-Hyperlegible-BoldItalic-102a.woff2) format('woff2'),
+       url(/assets/fonts/Atkinson-Hyperlegible-BoldItalic-102.woff) format('woff');
 }
 
 /* Main page background */


### PR DESCRIPTION
Most browsers just take the second src line and they're fine, but Tor has trouble displaying the woff version on Linux. With two separate lines it doesn't fall back correctly.

closes #3946

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.

Not sure how to add a test to an issue that only shows up in Tor on Linux.
- [ ] I/we have added tests that cover new code.

It's CSS only, so these aren't really applicable
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
