### PR TITLE
[feature] Allow editing domain blocks/allows, fix comment import

### DIFF
--- a/docs/admin/domain_permission_subscriptions.md
+++ b/docs/admin/domain_permission_subscriptions.md
@@ -118,6 +118,27 @@ JSON lists use content type `application/json`.
   {
     "domain": "bumfaces.net",
     "suspended_at": "2020-05-13T13:29:12.000Z",
+    "comment": "big jerks"
+  },
+  {
+    "domain": "peepee.poopoo",
+    "suspended_at": "2020-05-13T13:29:12.000Z",
+    "comment": "harassment"
+  },
+  {
+    "domain": "nothanks.com",
+    "suspended_at": "2020-05-13T13:29:12.000Z"
+  }
+]
+```
+
+As an alternative to `"comment"`, `"public_comment"` will also work:
+
+```json
+[
+  {
+    "domain": "bumfaces.net",
+    "suspended_at": "2020-05-13T13:29:12.000Z",
     "public_comment": "big jerks"
   },
   {

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -1099,13 +1099,22 @@ definitions:
     domain:
         description: Domain represents a remote domain
         properties:
+            comment:
+                description: |-
+                    If the domain is blocked, what's the publicly-stated reason for the block.
+                    Alternative to `public_comment` to be used when serializing/deserializing via /api/v1/instance.
+                example: they smell
+                type: string
+                x-go-name: Comment
             domain:
                 description: The hostname of the domain.
                 example: example.org
                 type: string
                 x-go-name: Domain
             public_comment:
-                description: If the domain is blocked, what's the publicly-stated reason for the block.
+                description: |-
+                    If the domain is blocked, what's the publicly-stated reason for the block.
+                    Alternative to `comment` to be used when serializing/deserializing NOT via /api/v1/instance.
                 example: they smell
                 type: string
                 x-go-name: PublicComment
@@ -1124,6 +1133,13 @@ definitions:
         x-go-package: github.com/superseriousbusiness/gotosocial/internal/api/model
     domainPermission:
         properties:
+            comment:
+                description: |-
+                    If the domain is blocked, what's the publicly-stated reason for the block.
+                    Alternative to `public_comment` to be used when serializing/deserializing via /api/v1/instance.
+                example: they smell
+                type: string
+                x-go-name: Comment
             created_at:
                 description: Time at which the permission entry was created (ISO 8601 Datetime).
                 example: "2021-07-30T09:20:25+00:00"
@@ -1162,7 +1178,9 @@ definitions:
                 type: string
                 x-go-name: PrivateComment
             public_comment:
-                description: If the domain is blocked, what's the publicly-stated reason for the block.
+                description: |-
+                    If the domain is blocked, what's the publicly-stated reason for the block.
+                    Alternative to `comment` to be used when serializing/deserializing NOT via /api/v1/instance.
                 example: they smell
                 type: string
                 x-go-name: PublicComment

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -5823,6 +5823,53 @@ paths:
             summary: View domain allow with the given ID.
             tags:
                 - admin
+        put:
+            consumes:
+                - multipart/form-data
+            operationId: domainAllowUpdate
+            parameters:
+                - description: The id of the domain allow.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+                - description: Obfuscate the name of the domain when serving it publicly. Eg., `example.org` becomes something like `ex***e.org`.
+                  in: formData
+                  name: obfuscate
+                  type: boolean
+                - description: Public comment about this domain allow. This will be displayed alongside the domain allow if you choose to share allows.
+                  in: formData
+                  name: public_comment
+                  type: string
+                - description: Private comment about this domain allow. Will only be shown to other admins, so this is a useful way of internally keeping track of why a certain domain ended up allowed.
+                  in: formData
+                  name: private_comment
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The updated domain allow.
+                    schema:
+                        $ref: '#/definitions/domainPermission'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin:write:domain_allows
+            summary: Update a single domain allow.
+            tags:
+                - admin
     /api/v1/admin/domain_blocks:
         get:
             operationId: domainBlocksGet
@@ -5988,6 +6035,53 @@ paths:
                 - OAuth2 Bearer:
                     - admin:read:domain_blocks
             summary: View domain block with the given ID.
+            tags:
+                - admin
+        put:
+            consumes:
+                - multipart/form-data
+            operationId: domainBlockUpdate
+            parameters:
+                - description: The id of the domain block.
+                  in: path
+                  name: id
+                  required: true
+                  type: string
+                - description: Obfuscate the name of the domain when serving it publicly. Eg., `example.org` becomes something like `ex***e.org`.
+                  in: formData
+                  name: obfuscate
+                  type: boolean
+                - description: Public comment about this domain block. This will be displayed alongside the domain block if you choose to share blocks.
+                  in: formData
+                  name: public_comment
+                  type: string
+                - description: Private comment about this domain block. Will only be shown to other admins, so this is a useful way of internally keeping track of why a certain domain ended up blocked.
+                  in: formData
+                  name: private_comment
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: The updated domain block.
+                    schema:
+                        $ref: '#/definitions/domainPermission'
+                "400":
+                    description: bad request
+                "401":
+                    description: unauthorized
+                "403":
+                    description: forbidden
+                "404":
+                    description: not found
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            security:
+                - OAuth2 Bearer:
+                    - admin:write:domain_blocks
+            summary: Update a single domain block.
             tags:
                 - admin
     /api/v1/admin/domain_keys_expire:

--- a/internal/api/client/admin/admin.go
+++ b/internal/api/client/admin/admin.go
@@ -102,12 +102,14 @@ func (m *Module) Route(attachHandler func(method string, path string, f ...gin.H
 	attachHandler(http.MethodPost, DomainBlocksPath, m.DomainBlocksPOSTHandler)
 	attachHandler(http.MethodGet, DomainBlocksPath, m.DomainBlocksGETHandler)
 	attachHandler(http.MethodGet, DomainBlocksPathWithID, m.DomainBlockGETHandler)
+	attachHandler(http.MethodPut, DomainBlocksPathWithID, m.DomainBlockUpdatePUTHandler)
 	attachHandler(http.MethodDelete, DomainBlocksPathWithID, m.DomainBlockDELETEHandler)
 
 	// domain allow stuff
 	attachHandler(http.MethodPost, DomainAllowsPath, m.DomainAllowsPOSTHandler)
 	attachHandler(http.MethodGet, DomainAllowsPath, m.DomainAllowsGETHandler)
 	attachHandler(http.MethodGet, DomainAllowsPathWithID, m.DomainAllowGETHandler)
+	attachHandler(http.MethodPut, DomainAllowsPathWithID, m.DomainAllowUpdatePUTHandler)
 	attachHandler(http.MethodDelete, DomainAllowsPathWithID, m.DomainAllowDELETEHandler)
 
 	// domain permission draft stuff

--- a/internal/api/client/admin/domainallowupdate.go
+++ b/internal/api/client/admin/domainallowupdate.go
@@ -1,0 +1,91 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package admin
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+)
+
+// DomainAllowUpdatePUTHandler swagger:operation PUT /api/v1/admin/domain_allows/{id} domainAllowUpdate
+//
+// Update a single domain allow.
+//
+//	---
+//	tags:
+//	- admin
+//
+//	consumes:
+//	- multipart/form-data
+//
+//	produces:
+//	- application/json
+//
+//	parameters:
+//	-
+//		name: id
+//		type: string
+//		description: The id of the domain allow.
+//		in: path
+//		required: true
+//	-
+//		name: obfuscate
+//		in: formData
+//		description: >-
+//			Obfuscate the name of the domain when serving it publicly.
+//			Eg., `example.org` becomes something like `ex***e.org`.
+//		type: boolean
+//	-
+//		name: public_comment
+//		in: formData
+//		description: >-
+//			Public comment about this domain allow.
+//			This will be displayed alongside the domain allow if you choose to share allows.
+//		type: string
+//	-
+//		name: private_comment
+//		in: formData
+//		description: >-
+//			Private comment about this domain allow. Will only be shown to other admins, so this
+//			is a useful way of internally keeping track of why a certain domain ended up allowed.
+//		type: string
+//
+//	security:
+//	- OAuth2 Bearer:
+//		- admin:write:domain_allows
+//
+//	responses:
+//		'200':
+//			description: The updated domain allow.
+//			schema:
+//				"$ref": "#/definitions/domainPermission"
+//		'400':
+//			description: bad request
+//		'401':
+//			description: unauthorized
+//		'403':
+//			description: forbidden
+//		'404':
+//			description: not found
+//		'406':
+//			description: not acceptable
+//		'500':
+//			description: internal server error
+func (m *Module) DomainAllowUpdatePUTHandler(c *gin.Context) {
+	m.updateDomainPermission(c, gtsmodel.DomainPermissionAllow)
+}

--- a/internal/api/client/admin/domainblockupdate.go
+++ b/internal/api/client/admin/domainblockupdate.go
@@ -1,0 +1,91 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package admin
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+)
+
+// DomainBlockUpdatePUTHandler swagger:operation PUT /api/v1/admin/domain_blocks/{id} domainBlockUpdate
+//
+// Update a single domain block.
+//
+//	---
+//	tags:
+//	- admin
+//
+//	consumes:
+//	- multipart/form-data
+//
+//	produces:
+//	- application/json
+//
+//	parameters:
+//	-
+//		name: id
+//		type: string
+//		description: The id of the domain block.
+//		in: path
+//		required: true
+//	-
+//		name: obfuscate
+//		in: formData
+//		description: >-
+//			Obfuscate the name of the domain when serving it publicly.
+//			Eg., `example.org` becomes something like `ex***e.org`.
+//		type: boolean
+//	-
+//		name: public_comment
+//		in: formData
+//		description: >-
+//			Public comment about this domain block.
+//			This will be displayed alongside the domain block if you choose to share blocks.
+//		type: string
+//	-
+//		name: private_comment
+//		in: formData
+//		description: >-
+//			Private comment about this domain block. Will only be shown to other admins, so this
+//			is a useful way of internally keeping track of why a certain domain ended up blocked.
+//		type: string
+//
+//	security:
+//	- OAuth2 Bearer:
+//		- admin:write:domain_blocks
+//
+//	responses:
+//		'200':
+//			description: The updated domain block.
+//			schema:
+//				"$ref": "#/definitions/domainPermission"
+//		'400':
+//			description: bad request
+//		'401':
+//			description: unauthorized
+//		'403':
+//			description: forbidden
+//		'404':
+//			description: not found
+//		'406':
+//			description: not acceptable
+//		'500':
+//			description: internal server error
+func (m *Module) DomainBlockUpdatePUTHandler(c *gin.Context) {
+	m.updateDomainPermission(c, gtsmodel.DomainPermissionBlock)
+}

--- a/internal/api/client/admin/domainpermissiondraftcreate.go
+++ b/internal/api/client/admin/domainpermissiondraftcreate.go
@@ -26,6 +26,7 @@ import (
 	apimodel "github.com/superseriousbusiness/gotosocial/internal/api/model"
 	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
 
 // DomainPermissionDraftsPOSTHandler swagger:operation POST /api/v1/admin/domain_permission_drafts domainPermissionDraftCreate
@@ -148,9 +149,9 @@ func (m *Module) DomainPermissionDraftsPOSTHandler(c *gin.Context) {
 		authed.Account,
 		form.Domain,
 		permType,
-		form.Obfuscate,
-		form.PublicComment,
-		form.PrivateComment,
+		util.PtrOrZero(form.Obfuscate),
+		util.PtrOrZero(form.PublicComment),
+		util.PtrOrZero(form.PrivateComment),
 	)
 	if errWithCode != nil {
 		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)

--- a/internal/api/client/admin/domainpermissionsubscriptiontest_test.go
+++ b/internal/api/client/admin/domainpermissionsubscriptiontest_test.go
@@ -97,14 +97,21 @@ func (suite *DomainPermissionSubscriptionTestTestSuite) TestDomainPermissionSubs
 	suite.Equal(`[
   {
     "domain": "bumfaces.net",
-    "public_comment": "big jerks"
+    "public_comment": "big jerks",
+    "obfuscate": false,
+    "private_comment": ""
   },
   {
     "domain": "peepee.poopoo",
-    "public_comment": "harassment"
+    "public_comment": "harassment",
+    "obfuscate": false,
+    "private_comment": ""
   },
   {
-    "domain": "nothanks.com"
+    "domain": "nothanks.com",
+    "public_comment": "",
+    "obfuscate": false,
+    "private_comment": ""
   }
 ]`, dst.String())
 
@@ -177,13 +184,22 @@ func (suite *DomainPermissionSubscriptionTestTestSuite) TestDomainPermissionSubs
 	// Ensure expected.
 	suite.Equal(`[
   {
-    "domain": "bumfaces.net"
+    "domain": "bumfaces.net",
+    "public_comment": "",
+    "obfuscate": false,
+    "private_comment": ""
   },
   {
-    "domain": "peepee.poopoo"
+    "domain": "peepee.poopoo",
+    "public_comment": "",
+    "obfuscate": false,
+    "private_comment": ""
   },
   {
-    "domain": "nothanks.com"
+    "domain": "nothanks.com",
+    "public_comment": "",
+    "obfuscate": false,
+    "private_comment": ""
   }
 ]`, dst.String())
 

--- a/internal/api/client/instance/instancepeersget_test.go
+++ b/internal/api/client/instance/instancepeersget_test.go
@@ -136,7 +136,7 @@ func (suite *InstancePeersGetTestSuite) TestInstancePeersGetOnlySuspended() {
   {
     "domain": "replyguys.com",
     "suspended_at": "2020-05-13T13:29:12.000Z",
-    "public_comment": "reply-guying to tech posts"
+    "comment": "reply-guying to tech posts"
   }
 ]`, dst.String())
 }
@@ -186,7 +186,7 @@ func (suite *InstancePeersGetTestSuite) TestInstancePeersGetOnlySuspendedAuthori
   {
     "domain": "replyguys.com",
     "suspended_at": "2020-05-13T13:29:12.000Z",
-    "public_comment": "reply-guying to tech posts"
+    "comment": "reply-guying to tech posts"
   }
 ]`, dst.String())
 }
@@ -219,7 +219,7 @@ func (suite *InstancePeersGetTestSuite) TestInstancePeersGetAll() {
   {
     "domain": "replyguys.com",
     "suspended_at": "2020-05-13T13:29:12.000Z",
-    "public_comment": "reply-guying to tech posts"
+    "comment": "reply-guying to tech posts"
   }
 ]`, dst.String())
 }
@@ -263,12 +263,12 @@ func (suite *InstancePeersGetTestSuite) TestInstancePeersGetAllWithObfuscated() 
   {
     "domain": "o*g.*u**.t**.*or*t.*r**ev**",
     "suspended_at": "2021-06-09T10:34:55.000Z",
-    "public_comment": "just absolutely the worst, wowza"
+    "comment": "just absolutely the worst, wowza"
   },
   {
     "domain": "replyguys.com",
     "suspended_at": "2020-05-13T13:29:12.000Z",
-    "public_comment": "reply-guying to tech posts"
+    "comment": "reply-guying to tech posts"
   }
 ]`, dst.String())
 }

--- a/internal/api/model/domain.go
+++ b/internal/api/model/domain.go
@@ -34,7 +34,7 @@ type Domain struct {
 	SilencedAt string `json:"silenced_at,omitempty"`
 	// If the domain is blocked, what's the publicly-stated reason for the block.
 	// example: they smell
-	PublicComment string `form:"public_comment" json:"public_comment,omitempty"`
+	PublicComment *string `form:"public_comment" json:"public_comment,omitempty"`
 }
 
 // DomainPermission represents a permission applied to one domain (explicit block/allow).
@@ -48,10 +48,10 @@ type DomainPermission struct {
 	ID string `json:"id,omitempty"`
 	// Obfuscate the domain name when serving this domain permission entry publicly.
 	// example: false
-	Obfuscate bool `json:"obfuscate,omitempty"`
+	Obfuscate *bool `json:"obfuscate,omitempty"`
 	// Private comment for this permission entry, visible to this instance's admins only.
 	// example: they are poopoo
-	PrivateComment string `json:"private_comment,omitempty"`
+	PrivateComment *string `json:"private_comment,omitempty"`
 	// If applicable, the ID of the subscription that caused this domain permission entry to be created.
 	// example: 01FBW25TF5J67JW3HFHZCSD23K
 	SubscriptionID string `json:"subscription_id,omitempty"`

--- a/internal/api/model/domain.go
+++ b/internal/api/model/domain.go
@@ -80,14 +80,14 @@ type DomainPermissionRequest struct {
 	// Obfuscate the domain name when displaying this permission entry publicly.
 	// Ie., instead of 'example.org' show something like 'e**mpl*.or*'.
 	// example: false
-	Obfuscate bool `form:"obfuscate" json:"obfuscate"`
+	Obfuscate *bool `form:"obfuscate" json:"obfuscate"`
 	// Private comment for other admins on why this permission entry was created.
 	// example: don't like 'em!!!!
-	PrivateComment string `form:"private_comment" json:"private_comment"`
+	PrivateComment *string `form:"private_comment" json:"private_comment"`
 	// Public comment on why this permission entry was created.
 	// Will be visible to requesters at /api/v1/instance/peers if this endpoint is exposed.
 	// example: foss dorks 😫
-	PublicComment string `form:"public_comment" json:"public_comment"`
+	PublicComment *string `form:"public_comment" json:"public_comment"`
 	// Permission type to create (only applies to domain permission drafts, not explicit blocks and allows).
 	PermissionType string `form:"permission_type" json:"permission_type"`
 }

--- a/internal/api/model/domain.go
+++ b/internal/api/model/domain.go
@@ -33,6 +33,11 @@ type Domain struct {
 	// example: 2021-07-30T09:20:25+00:00
 	SilencedAt string `json:"silenced_at,omitempty"`
 	// If the domain is blocked, what's the publicly-stated reason for the block.
+	// Alternative to `public_comment` to be used when serializing/deserializing via /api/v1/instance.
+	// example: they smell
+	Comment *string `form:"comment" json:"comment,omitempty"`
+	// If the domain is blocked, what's the publicly-stated reason for the block.
+	// Alternative to `comment` to be used when serializing/deserializing NOT via /api/v1/instance.
 	// example: they smell
 	PublicComment *string `form:"public_comment" json:"public_comment,omitempty"`
 }

--- a/internal/db/bundb/domain.go
+++ b/internal/db/bundb/domain.go
@@ -36,7 +36,7 @@ type domainDB struct {
 	state *state.State
 }
 
-func (d *domainDB) CreateDomainAllow(ctx context.Context, allow *gtsmodel.DomainAllow) (err error) {
+func (d *domainDB) PutDomainAllow(ctx context.Context, allow *gtsmodel.DomainAllow) (err error) {
 	// Normalize the domain as punycode, note the extra
 	// validation step for domain name write operations.
 	allow.Domain, err = util.PunifySafely(allow.Domain)
@@ -162,7 +162,7 @@ func (d *domainDB) DeleteDomainAllow(ctx context.Context, domain string) error {
 	return nil
 }
 
-func (d *domainDB) CreateDomainBlock(ctx context.Context, block *gtsmodel.DomainBlock) error {
+func (d *domainDB) PutDomainBlock(ctx context.Context, block *gtsmodel.DomainBlock) error {
 	var err error
 
 	// Normalize the domain as punycode, note the extra

--- a/internal/db/bundb/domain_test.go
+++ b/internal/db/bundb/domain_test.go
@@ -46,7 +46,7 @@ func (suite *DomainTestSuite) TestIsDomainBlocked() {
 	suite.NoError(err)
 	suite.False(blocked)
 
-	err = suite.db.CreateDomainBlock(ctx, domainBlock)
+	err = suite.db.PutDomainBlock(ctx, domainBlock)
 	suite.NoError(err)
 
 	// domain block now exists
@@ -75,7 +75,7 @@ func (suite *DomainTestSuite) TestIsDomainBlockedWithAllow() {
 	suite.False(blocked)
 
 	// Block this domain.
-	if err := suite.db.CreateDomainBlock(ctx, domainBlock); err != nil {
+	if err := suite.db.PutDomainBlock(ctx, domainBlock); err != nil {
 		suite.FailNow(err.Error())
 	}
 
@@ -96,7 +96,7 @@ func (suite *DomainTestSuite) TestIsDomainBlockedWithAllow() {
 		CreatedByAccount:   suite.testAccounts["admin_account"],
 	}
 
-	if err := suite.db.CreateDomainAllow(ctx, domainAllow); err != nil {
+	if err := suite.db.PutDomainAllow(ctx, domainAllow); err != nil {
 		suite.FailNow(err.Error())
 	}
 
@@ -124,7 +124,7 @@ func (suite *DomainTestSuite) TestIsDomainBlockedWildcard() {
 	suite.NoError(err)
 	suite.False(blocked)
 
-	err = suite.db.CreateDomainBlock(ctx, domainBlock)
+	err = suite.db.PutDomainBlock(ctx, domainBlock)
 	suite.NoError(err)
 
 	// Start with the base block domain
@@ -164,7 +164,7 @@ func (suite *DomainTestSuite) TestIsDomainBlockedNonASCII() {
 	suite.NoError(err)
 	suite.False(blocked)
 
-	err = suite.db.CreateDomainBlock(ctx, domainBlock)
+	err = suite.db.PutDomainBlock(ctx, domainBlock)
 	suite.NoError(err)
 
 	// domain block now exists
@@ -200,7 +200,7 @@ func (suite *DomainTestSuite) TestIsDomainBlockedNonASCII2() {
 	suite.NoError(err)
 	suite.False(blocked)
 
-	err = suite.db.CreateDomainBlock(ctx, domainBlock)
+	err = suite.db.PutDomainBlock(ctx, domainBlock)
 	suite.NoError(err)
 
 	// domain block now exists
@@ -232,7 +232,7 @@ func (suite *DomainTestSuite) TestIsOtherDomainBlockedWildcardAndExplicit() {
 	}
 
 	for _, block := range blocks {
-		if err := suite.db.CreateDomainBlock(ctx, block); err != nil {
+		if err := suite.db.PutDomainBlock(ctx, block); err != nil {
 			suite.FailNow(err.Error())
 		}
 	}

--- a/internal/db/bundb/domainpermissionsubscription_test.go
+++ b/internal/db/bundb/domainpermissionsubscription_test.go
@@ -80,7 +80,7 @@ func (suite *DomainPermissionSubscriptionTestSuite) TestCount() {
 
 	// Whack the perms in the db.
 	for _, perm := range perms {
-		if err := suite.state.DB.CreateDomainBlock(ctx, perm); err != nil {
+		if err := suite.state.DB.PutDomainBlock(ctx, perm); err != nil {
 			suite.FailNow(err.Error())
 		}
 	}

--- a/internal/db/domain.go
+++ b/internal/db/domain.go
@@ -31,8 +31,8 @@ type Domain interface {
 		Block/allow storage + retrieval functions.
 	*/
 
-	// CreateDomainAllow puts the given instance-level domain allow into the database.
-	CreateDomainAllow(ctx context.Context, allow *gtsmodel.DomainAllow) error
+	// PutDomainAllow puts the given instance-level domain allow into the database.
+	PutDomainAllow(ctx context.Context, allow *gtsmodel.DomainAllow) error
 
 	// GetDomainAllow returns one instance-level domain allow with the given domain, if it exists.
 	GetDomainAllow(ctx context.Context, domain string) (*gtsmodel.DomainAllow, error)
@@ -49,8 +49,8 @@ type Domain interface {
 	// DeleteDomainAllow deletes an instance-level domain allow with the given domain, if it exists.
 	DeleteDomainAllow(ctx context.Context, domain string) error
 
-	// CreateDomainBlock puts the given instance-level domain block into the database.
-	CreateDomainBlock(ctx context.Context, block *gtsmodel.DomainBlock) error
+	// PutDomainBlock puts the given instance-level domain block into the database.
+	PutDomainBlock(ctx context.Context, block *gtsmodel.DomainBlock) error
 
 	// GetDomainBlock returns one instance-level domain block with the given domain, if it exists.
 	GetDomainBlock(ctx context.Context, domain string) (*gtsmodel.DomainBlock, error)

--- a/internal/gtsmodel/domainallow.go
+++ b/internal/gtsmodel/domainallow.go
@@ -26,7 +26,7 @@ type DomainAllow struct {
 	UpdatedAt          time.Time `bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"` // when was item last updated
 	Domain             string    `bun:",nullzero,notnull"`                                           // domain to allow. Eg. 'whatever.com'
 	CreatedByAccountID string    `bun:"type:CHAR(26),nullzero,notnull"`                              // Account ID of the creator of this allow
-	CreatedByAccount   *Account  `bun:"rel:belongs-to"`                                              // Account corresponding to createdByAccountID
+	CreatedByAccount   *Account  `bun:"-"`                                                           // Account corresponding to createdByAccountID
 	PrivateComment     string    `bun:""`                                                            // Private comment on this allow, viewable to admins
 	PublicComment      string    `bun:""`                                                            // Public comment on this allow, viewable (optionally) by everyone
 	Obfuscate          *bool     `bun:",nullzero,notnull,default:false"`                             // whether the domain name should appear obfuscated when displaying it publicly

--- a/internal/gtsmodel/domainblock.go
+++ b/internal/gtsmodel/domainblock.go
@@ -26,7 +26,7 @@ type DomainBlock struct {
 	UpdatedAt          time.Time `bun:"type:timestamptz,nullzero,notnull,default:current_timestamp"` // when was item last updated
 	Domain             string    `bun:",nullzero,notnull"`                                           // domain to block. Eg. 'whatever.com'
 	CreatedByAccountID string    `bun:"type:CHAR(26),nullzero,notnull"`                              // Account ID of the creator of this block
-	CreatedByAccount   *Account  `bun:"rel:belongs-to"`                                              // Account corresponding to createdByAccountID
+	CreatedByAccount   *Account  `bun:"-"`                                                           // Account corresponding to createdByAccountID
 	PrivateComment     string    `bun:""`                                                            // Private comment on this block, viewable to admins
 	PublicComment      string    `bun:""`                                                            // Public comment on this block, viewable (optionally) by everyone
 	Obfuscate          *bool     `bun:",nullzero,notnull,default:false"`                             // whether the domain name should appear obfuscated when displaying it publicly

--- a/internal/processing/admin/domainblock.go
+++ b/internal/processing/admin/domainblock.go
@@ -60,7 +60,7 @@ func (p *Processor) createDomainBlock(
 		}
 
 		// Insert the new block into the database.
-		if err := p.state.DB.CreateDomainBlock(ctx, domainBlock); err != nil {
+		if err := p.state.DB.PutDomainBlock(ctx, domainBlock); err != nil {
 			err = gtserror.Newf("db error putting domain block %s: %w", domain, err)
 			return nil, "", gtserror.NewErrorInternalError(err)
 		}
@@ -91,6 +91,54 @@ func (p *Processor) createDomainBlock(
 	}
 
 	return apiDomainBlock, action.ID, nil
+}
+
+func (p *Processor) updateDomainBlock(
+	ctx context.Context,
+	domainBlockID string,
+	obfuscate *bool,
+	publicComment *string,
+	privateComment *string,
+	subscriptionID *string,
+) (*apimodel.DomainPermission, gtserror.WithCode) {
+	domainBlock, err := p.state.DB.GetDomainBlockByID(ctx, domainBlockID)
+	if err != nil {
+		if !errors.Is(err, db.ErrNoEntries) {
+			// Real error.
+			err = gtserror.Newf("db error getting domain block: %w", err)
+			return nil, gtserror.NewErrorInternalError(err)
+		}
+
+		// There are just no entries for this ID.
+		err = fmt.Errorf("no domain block entry exists with ID %s", domainBlockID)
+		return nil, gtserror.NewErrorNotFound(err, err.Error())
+	}
+
+	var columns []string
+	if obfuscate != nil {
+		domainBlock.Obfuscate = obfuscate
+		columns = append(columns, "obfuscate")
+	}
+	if publicComment != nil {
+		domainBlock.PublicComment = *publicComment
+		columns = append(columns, "public_comment")
+	}
+	if privateComment != nil {
+		domainBlock.PrivateComment = *privateComment
+		columns = append(columns, "private_comment")
+	}
+	if subscriptionID != nil {
+		domainBlock.SubscriptionID = *subscriptionID
+		columns = append(columns, "subscription_id")
+	}
+
+	// Update the domain block.
+	if err := p.state.DB.UpdateDomainBlock(ctx, domainBlock, columns...); err != nil {
+		err = gtserror.Newf("db error updating domain block: %w", err)
+		return nil, gtserror.NewErrorInternalError(err)
+	}
+
+	return p.apiDomainPerm(ctx, domainBlock, false)
 }
 
 func (p *Processor) deleteDomainBlock(

--- a/internal/processing/admin/domainpermission.go
+++ b/internal/processing/admin/domainpermission.go
@@ -84,6 +84,50 @@ func (p *Processor) DomainPermissionCreate(
 	}
 }
 
+// DomainPermissionUpdate updates a domain permission
+// of the given permissionType, with the given ID.
+func (p *Processor) DomainPermissionUpdate(
+	ctx context.Context,
+	permissionType gtsmodel.DomainPermissionType,
+	permID string,
+	obfuscate *bool,
+	publicComment *string,
+	privateComment *string,
+	subscriptionID *string,
+) (*apimodel.DomainPermission, gtserror.WithCode) {
+	switch permissionType {
+
+	// Explicitly block a domain.
+	case gtsmodel.DomainPermissionBlock:
+		return p.updateDomainBlock(
+			ctx,
+			permID,
+			obfuscate,
+			publicComment,
+			privateComment,
+			subscriptionID,
+		)
+
+	// Explicitly allow a domain.
+	case gtsmodel.DomainPermissionAllow:
+		return p.updateDomainAllow(
+			ctx,
+			permID,
+			obfuscate,
+			publicComment,
+			privateComment,
+			subscriptionID,
+		)
+
+	// 🎵 Why don't we all strap bombs to our chests,
+	// and ride our bikes to the next G7 picnic?
+	// Seems easier with every clock-tick. 🎵
+	default:
+		err := gtserror.Newf("unrecognized permission type %d", permissionType)
+		return nil, gtserror.NewErrorInternalError(err)
+	}
+}
+
 // DomainPermissionDelete removes one domain block with the given ID,
 // and processes side effects of removing the block asynchronously.
 //

--- a/internal/processing/admin/domainpermission.go
+++ b/internal/processing/admin/domainpermission.go
@@ -18,6 +18,7 @@
 package admin
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -239,7 +240,7 @@ func (p *Processor) importOrUpdateDomainPerm(
 	var (
 		domain         = apiDomainPerm.Domain.Domain
 		obfuscate      = apiDomainPerm.Obfuscate
-		publicComment  = apiDomainPerm.PublicComment
+		publicComment  = cmp.Or(apiDomainPerm.PublicComment, apiDomainPerm.Comment)
 		privateComment = apiDomainPerm.PrivateComment
 		subscriptionID = "" // No sub ID for imports.
 	)

--- a/internal/processing/admin/domainpermission.go
+++ b/internal/processing/admin/domainpermission.go
@@ -29,6 +29,7 @@ import (
 	"github.com/superseriousbusiness/gotosocial/internal/db"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
 	"github.com/superseriousbusiness/gotosocial/internal/gtsmodel"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
 
 // DomainPermissionCreate creates an instance-level permission
@@ -197,14 +198,14 @@ func (p *Processor) DomainPermissionsImport(
 	}
 	defer file.Close()
 
-	// Parse file as slice of domain blocks.
-	domainPerms := make([]*apimodel.DomainPermission, 0)
-	if err := json.NewDecoder(file).Decode(&domainPerms); err != nil {
+	// Parse file as slice of domain permissions.
+	apiDomainPerms := make([]*apimodel.DomainPermission, 0)
+	if err := json.NewDecoder(file).Decode(&apiDomainPerms); err != nil {
 		err = gtserror.Newf("error parsing attachment as domain permissions: %w", err)
 		return nil, gtserror.NewErrorBadRequest(err, err.Error())
 	}
 
-	count := len(domainPerms)
+	count := len(apiDomainPerms)
 	if count == 0 {
 		err = gtserror.New("error importing domain permissions: 0 entries provided")
 		return nil, gtserror.NewErrorBadRequest(err, err.Error())
@@ -214,50 +215,95 @@ func (p *Processor) DomainPermissionsImport(
 	// between successes and errors so that the caller can
 	// try failed imports again if desired.
 	multiStatusEntries := make([]apimodel.MultiStatusEntry, 0, count)
-
-	for _, domainPerm := range domainPerms {
-		var (
-			domain         = domainPerm.Domain.Domain
-			obfuscate      = domainPerm.Obfuscate
-			publicComment  = domainPerm.PublicComment
-			privateComment = domainPerm.PrivateComment
-			subscriptionID = "" // No sub ID for imports.
-			errWithCode    gtserror.WithCode
+	for _, apiDomainPerm := range apiDomainPerms {
+		multiStatusEntries = append(
+			multiStatusEntries,
+			p.importOrUpdateDomainPerm(
+				ctx,
+				permissionType,
+				account,
+				apiDomainPerm,
+			),
 		)
-
-		domainPerm, _, errWithCode = p.DomainPermissionCreate(
-			ctx,
-			permissionType,
-			account,
-			domain,
-			obfuscate,
-			publicComment,
-			privateComment,
-			subscriptionID,
-		)
-
-		var entry *apimodel.MultiStatusEntry
-
-		if errWithCode != nil {
-			entry = &apimodel.MultiStatusEntry{
-				// Use the failed domain entry as the resource value.
-				Resource: domain,
-				Message:  errWithCode.Safe(),
-				Status:   errWithCode.Code(),
-			}
-		} else {
-			entry = &apimodel.MultiStatusEntry{
-				// Use successfully created API model domain block as the resource value.
-				Resource: domainPerm,
-				Message:  http.StatusText(http.StatusOK),
-				Status:   http.StatusOK,
-			}
-		}
-
-		multiStatusEntries = append(multiStatusEntries, *entry)
 	}
 
 	return apimodel.NewMultiStatus(multiStatusEntries), nil
+}
+
+func (p *Processor) importOrUpdateDomainPerm(
+	ctx context.Context,
+	permType gtsmodel.DomainPermissionType,
+	account *gtsmodel.Account,
+	apiDomainPerm *apimodel.DomainPermission,
+) apimodel.MultiStatusEntry {
+	var (
+		domain         = apiDomainPerm.Domain.Domain
+		obfuscate      = apiDomainPerm.Obfuscate
+		publicComment  = apiDomainPerm.PublicComment
+		privateComment = apiDomainPerm.PrivateComment
+		subscriptionID = "" // No sub ID for imports.
+	)
+
+	// Check if this domain
+	// perm already exists.
+	var (
+		domainPerm gtsmodel.DomainPermission
+		err        error
+	)
+	if permType == gtsmodel.DomainPermissionBlock {
+		domainPerm, err = p.state.DB.GetDomainBlock(ctx, domain)
+	} else {
+		domainPerm, err = p.state.DB.GetDomainAllow(ctx, domain)
+	}
+
+	if err != nil && !errors.Is(err, db.ErrNoEntries) {
+		// Real db error.
+		return apimodel.MultiStatusEntry{
+			Resource: domain,
+			Message:  "db error checking for existence of domain permission",
+			Status:   http.StatusInternalServerError,
+		}
+	}
+
+	var errWithCode gtserror.WithCode
+	if domainPerm != nil {
+		// Permission already exists, update it.
+		apiDomainPerm, errWithCode = p.DomainPermissionUpdate(
+			ctx,
+			permType,
+			domainPerm.GetID(),
+			obfuscate,
+			publicComment,
+			privateComment,
+			nil,
+		)
+	} else {
+		// Permission didn't exist yet, create it.
+		apiDomainPerm, _, errWithCode = p.DomainPermissionCreate(
+			ctx,
+			permType,
+			account,
+			domain,
+			util.PtrOrZero(obfuscate),
+			util.PtrOrZero(publicComment),
+			util.PtrOrZero(privateComment),
+			subscriptionID,
+		)
+	}
+
+	if errWithCode != nil {
+		return apimodel.MultiStatusEntry{
+			Resource: domain,
+			Message:  errWithCode.Safe(),
+			Status:   errWithCode.Code(),
+		}
+	}
+
+	return apimodel.MultiStatusEntry{
+		Resource: apiDomainPerm,
+		Message:  http.StatusText(http.StatusOK),
+		Status:   http.StatusOK,
+	}
 }
 
 // DomainPermissionsGet returns all existing domain

--- a/internal/processing/instance.go
+++ b/internal/processing/instance.go
@@ -108,7 +108,7 @@ func (p *Processor) InstancePeersGet(ctx context.Context, includeSuspended bool,
 			domains = append(domains, &apimodel.Domain{
 				Domain:        d,
 				SuspendedAt:   util.FormatISO8601(domainBlock.CreatedAt),
-				PublicComment: domainBlock.PublicComment,
+				PublicComment: &domainBlock.PublicComment,
 			})
 		}
 	}

--- a/internal/processing/instance.go
+++ b/internal/processing/instance.go
@@ -106,9 +106,9 @@ func (p *Processor) InstancePeersGet(ctx context.Context, includeSuspended bool,
 			}
 
 			domains = append(domains, &apimodel.Domain{
-				Domain:        d,
-				SuspendedAt:   util.FormatISO8601(domainBlock.CreatedAt),
-				PublicComment: &domainBlock.PublicComment,
+				Domain:      d,
+				SuspendedAt: util.FormatISO8601(domainBlock.CreatedAt),
+				Comment:     &domainBlock.PublicComment,
 			})
 		}
 	}

--- a/internal/subscriptions/domainperms.go
+++ b/internal/subscriptions/domainperms.go
@@ -438,7 +438,7 @@ func (s *Subscriptions) processDomainPermission(
 				Obfuscate:          wantedPerm.GetObfuscate(),
 				SubscriptionID:     permSub.ID,
 			}
-			insertF = func() error { return s.state.DB.CreateDomainBlock(ctx, domainBlock) }
+			insertF = func() error { return s.state.DB.PutDomainBlock(ctx, domainBlock) }
 
 			action = &gtsmodel.AdminAction{
 				ID:             id.NewULID(),
@@ -461,7 +461,7 @@ func (s *Subscriptions) processDomainPermission(
 				Obfuscate:          wantedPerm.GetObfuscate(),
 				SubscriptionID:     permSub.ID,
 			}
-			insertF = func() error { return s.state.DB.CreateDomainAllow(ctx, domainAllow) }
+			insertF = func() error { return s.state.DB.PutDomainAllow(ctx, domainAllow) }
 
 			action = &gtsmodel.AdminAction{
 				ID:             id.NewULID(),

--- a/internal/subscriptions/domainperms.go
+++ b/internal/subscriptions/domainperms.go
@@ -742,8 +742,8 @@ func permsFromJSON(
 		}
 
 		// Set remaining fields.
-		perm.SetPublicComment(apiPerm.PublicComment)
-		perm.SetObfuscate(&apiPerm.Obfuscate)
+		perm.SetPublicComment(util.PtrOrZero(apiPerm.PublicComment))
+		perm.SetObfuscate(util.Ptr(util.PtrOrZero(apiPerm.Obfuscate)))
 
 		// We're done.
 		perms = append(perms, perm)

--- a/internal/subscriptions/domainperms.go
+++ b/internal/subscriptions/domainperms.go
@@ -742,7 +742,8 @@ func permsFromJSON(
 		}
 
 		// Set remaining fields.
-		perm.SetPublicComment(util.PtrOrZero(apiPerm.PublicComment))
+		publicComment := cmp.Or(apiPerm.PublicComment, apiPerm.Comment)
+		perm.SetPublicComment(util.PtrOrZero(publicComment))
 		perm.SetObfuscate(util.Ptr(util.PtrOrZero(apiPerm.Obfuscate)))
 
 		// We're done.

--- a/internal/subscriptions/subscriptions_test.go
+++ b/internal/subscriptions/subscriptions_test.go
@@ -775,7 +775,7 @@ func (suite *SubscriptionsTestSuite) TestAdoption() {
 		existingBlock2,
 		existingBlock3,
 	} {
-		if err := testStructs.State.DB.CreateDomainBlock(
+		if err := testStructs.State.DB.PutDomainBlock(
 			ctx, block,
 		); err != nil {
 			suite.FailNow(err.Error())
@@ -876,7 +876,7 @@ func (suite *SubscriptionsTestSuite) TestDomainAllowsAndBlocks() {
 	}
 
 	// Store existing allow.
-	if err := testStructs.State.DB.CreateDomainAllow(ctx, existingAllow); err != nil {
+	if err := testStructs.State.DB.PutDomainAllow(ctx, existingAllow); err != nil {
 		suite.FailNow(err.Error())
 	}
 

--- a/internal/typeutils/internaltofrontend.go
+++ b/internal/typeutils/internaltofrontend.go
@@ -2182,7 +2182,7 @@ func (c *Converter) DomainPermToAPIDomainPerm(
 	domainPerm := &apimodel.DomainPermission{
 		Domain: apimodel.Domain{
 			Domain:        domain,
-			PublicComment: d.GetPublicComment(),
+			PublicComment: util.Ptr(d.GetPublicComment()),
 		},
 	}
 
@@ -2193,8 +2193,8 @@ func (c *Converter) DomainPermToAPIDomainPerm(
 	}
 
 	domainPerm.ID = d.GetID()
-	domainPerm.Obfuscate = util.PtrOrZero(d.GetObfuscate())
-	domainPerm.PrivateComment = d.GetPrivateComment()
+	domainPerm.Obfuscate = d.GetObfuscate()
+	domainPerm.PrivateComment = util.Ptr(d.GetPrivateComment())
 	domainPerm.SubscriptionID = d.GetSubscriptionID()
 	domainPerm.CreatedBy = d.GetCreatedByAccountID()
 	if createdAt := d.GetCreatedAt(); !createdAt.IsZero() {

--- a/testrig/transportcontroller.go
+++ b/testrig/transportcontroller.go
@@ -627,7 +627,7 @@ nothanks.com`
   {
     "domain": "bumfaces.net",
     "suspended_at": "2020-05-13T13:29:12.000Z",
-    "public_comment": "big jerks"
+    "comment": "big jerks"
   },
     {
     "domain": "peepee.poopoo",

--- a/web/source/settings/lib/query/admin/domain-permissions/import.ts
+++ b/web/source/settings/lib/query/admin/domain-permissions/import.ts
@@ -40,39 +40,19 @@ function importEntriesProcessor(formData: ImportDomainPermsParams): (_entry: Dom
 
 	// Override each obfuscate entry if necessary.
 	if (formData.obfuscate !== undefined) {
-		const obfuscateEntry = (entry: DomainPerm) => {
+		processingFuncs.push((entry: DomainPerm) => {
 			entry.obfuscate = formData.obfuscate;
-		};
-		processingFuncs.push(obfuscateEntry);
+		});
 	}
 
-	// Check whether we need to append or replace
-	// private_comment and public_comment.
+	// Check whether we need to replace
+	// private_comment and/or public_comment.
 	["private_comment","public_comment"].forEach((commentType) => {
-		let text = formData.commentType?.trim();
-		if (!text) {
-			return;
-		}
-
-		switch(formData[`${commentType}_behavior`]) {
-			case "append":
-				const appendComment = (entry: DomainPerm) => {
-					if (entry.commentType == undefined) {
-						entry.commentType = text;
-					} else {
-						entry.commentType = [entry.commentType, text].join("\n");
-					}
-				};
-
-				processingFuncs.push(appendComment);
-				break;
-			case "replace":
-				const replaceComment = (entry: DomainPerm) => {
-					entry.commentType = text;
-				};
-
-				processingFuncs.push(replaceComment);
-				break;
+		if (formData[`replace_${commentType}`]) {
+			const text = formData[commentType]?.trim();
+			processingFuncs.push((entry: DomainPerm) => {
+				entry[commentType] = text;
+			});
 		}
 	});
 

--- a/web/source/settings/lib/query/admin/domain-permissions/update.ts
+++ b/web/source/settings/lib/query/admin/domain-permissions/update.ts
@@ -22,6 +22,7 @@ import { gtsApi } from "../../gts-api";
 import {
 	replaceCacheOnMutation,
 	removeFromCacheOnMutation,
+	updateCacheOnMutation,
 } from "../../query-modifiers";
 import { listToKeyedObject } from "../../transforms";
 import type {
@@ -53,6 +54,36 @@ const extended = gtsApi.injectEndpoints({
 			}),
 			transformResponse: listToKeyedObject<DomainPerm>("domain"),
 			...replaceCacheOnMutation("domainAllows")
+		}),
+
+		updateDomainBlock: build.mutation<DomainPerm, any>({
+			query: (formData) => ({
+				method: "PUT",
+				url: `/api/v1/admin/domain_blocks/${formData.id}`,
+				asForm: true,
+				body: formData,
+				discardEmpty: false
+			}),
+			...updateCacheOnMutation("domainBlocks", {
+				key: (_draft, newData) => {
+					return newData.domain;
+				}
+			})
+		}),
+
+		updateDomainAllow: build.mutation<DomainPerm, any>({
+			query: (formData) => ({
+				method: "PUT",
+				url: `/api/v1/admin/domain_allows/${formData.id}`,
+				asForm: true,
+				body: formData,
+				discardEmpty: false
+			}),
+			...updateCacheOnMutation("domainAllows", {
+				key: (_draft, newData) => {
+					return newData.domain;
+				}
+			})
 		}),
 
 		removeDomainBlock: build.mutation<DomainPerm, string>({
@@ -92,6 +123,16 @@ const useAddDomainBlockMutation = extended.useAddDomainBlockMutation;
 const useAddDomainAllowMutation = extended.useAddDomainAllowMutation;
 
 /**
+ * Update a single domain permission (block) by PUTing to `/api/v1/admin/domain_blocks/{id}`.
+ */
+const useUpdateDomainBlockMutation = extended.useUpdateDomainBlockMutation;
+
+/**
+ * Update a single domain permission (allow) by PUTing to `/api/v1/admin/domain_allows/{id}`.
+ */
+const useUpdateDomainAllowMutation = extended.useUpdateDomainAllowMutation;
+
+/**
  * Remove a single domain permission (block) by DELETEing to `/api/v1/admin/domain_blocks/{id}`.
  */
 const useRemoveDomainBlockMutation = extended.useRemoveDomainBlockMutation;
@@ -104,6 +145,8 @@ const useRemoveDomainAllowMutation = extended.useRemoveDomainAllowMutation;
 export {
 	useAddDomainBlockMutation,
 	useAddDomainAllowMutation,
+	useUpdateDomainBlockMutation,
+	useUpdateDomainAllowMutation,
 	useRemoveDomainBlockMutation,
 	useRemoveDomainAllowMutation
 };

--- a/web/source/settings/lib/query/admin/domain-permissions/update.ts
+++ b/web/source/settings/lib/query/admin/domain-permissions/update.ts
@@ -57,9 +57,9 @@ const extended = gtsApi.injectEndpoints({
 		}),
 
 		updateDomainBlock: build.mutation<DomainPerm, any>({
-			query: (formData) => ({
+			query: ({ id, ...formData}) => ({
 				method: "PUT",
-				url: `/api/v1/admin/domain_blocks/${formData.id}`,
+				url: `/api/v1/admin/domain_blocks/${id}`,
 				asForm: true,
 				body: formData,
 				discardEmpty: false
@@ -72,9 +72,9 @@ const extended = gtsApi.injectEndpoints({
 		}),
 
 		updateDomainAllow: build.mutation<DomainPerm, any>({
-			query: (formData) => ({
+			query: ({ id, ...formData}) => ({
 				method: "PUT",
-				url: `/api/v1/admin/domain_allows/${formData.id}`,
+				url: `/api/v1/admin/domain_allows/${id}`,
 				asForm: true,
 				body: formData,
 				discardEmpty: false

--- a/web/source/settings/lib/types/domain-permission.ts
+++ b/web/source/settings/lib/types/domain-permission.ts
@@ -46,8 +46,8 @@ export interface DomainPerm {
 	valid?: boolean;
 	checked?: boolean;
 	commentType?: string;
-	private_comment_behavior?: "append" | "replace";
-	public_comment_behavior?: "append" | "replace";
+	replace_private_comment?: boolean;
+	replace_public_comment?: boolean;
 }
 
 /**
@@ -65,8 +65,8 @@ const domainPermStripOnImport: Set<keyof DomainPerm> = new Set([
 	"valid",
 	"checked",
 	"commentType",
-	"private_comment_behavior",
-	"public_comment_behavior",
+	"replace_private_comment",
+	"replace_public_comment",
 ]);
 
 /**

--- a/web/source/settings/style.css
+++ b/web/source/settings/style.css
@@ -618,6 +618,15 @@ span.form-info {
 	}
 }
 
+section > div.domain-block,
+section > div.domain-allow {
+	height: 100%;
+
+	> a {
+		margin-top: auto;
+	}
+}
+
 .domain-permissions-list {
 	p {
 		margin-top: 0;
@@ -976,32 +985,26 @@ button.tab-button {
 
 .domain-perm-import-list {
 	.checkbox-list-wrapper {
-		overflow-x: auto;
 		display: grid;
 		gap: 1rem;
 	}
 
 	.checkbox-list {
+		overflow-x: auto;
 
 		.header {
+			align-items: center;
 			input[type="checkbox"] {
-				align-self: start;
 				height: 1.5rem;
 			}
 		}
 
 		.entry {
-			gap: 0;
-			width: 100%;
-			grid-template-columns: auto minmax(25ch, 2fr) minmax(40ch, 1fr);
-			grid-template-rows: auto 1fr;
-
-			input[type="checkbox"] {
-				margin-right: 1rem;
-			}
+			grid-template-columns: auto max(50%, 14rem) 1fr;
+			column-gap: 1rem;
+			align-items: center;
 
 			.domain-input {
-				margin-right: 0.5rem;
 				display: grid;
 				grid-template-columns: 1fr $fa-fw;
 				gap: 0.5rem;
@@ -1020,12 +1023,20 @@ button.tab-button {
 			}
 
 			p {
-				align-self: center;
 				margin: 0;
-				grid-column: 4;
-				grid-row: 1 / span 2;
 			}
 		}
+	}
+
+	.set-comment-checkbox {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+
+		padding: 0.5rem 1rem 1rem 1rem;
+		width: 100%;
+		border: 0.1rem solid var(--gray1);
+		border-radius: 0.1rem;
 	}
 }
 

--- a/web/source/settings/style.css
+++ b/web/source/settings/style.css
@@ -1406,6 +1406,7 @@ button.tab-button {
 	}
 }
 
+.domain-permission-details,
 .domain-permission-draft-details,
 .domain-permission-exclude-details,
 .domain-permission-subscription-details {
@@ -1414,6 +1415,7 @@ button.tab-button {
 	}
 }
 
+.domain-permission-details,
 .domain-permission-drafts-view,
 .domain-permission-draft-details,
 .domain-permission-subscriptions-view,

--- a/web/source/settings/views/moderation/domain-permissions/detail.tsx
+++ b/web/source/settings/views/moderation/domain-permissions/detail.tsx
@@ -32,8 +32,18 @@ import Loading from "../../../components/loading";
 import BackButton from "../../../components/back-button";
 import MutationButton from "../../../components/form/mutation-button";
 
-import { useDomainAllowsQuery, useDomainBlocksQuery } from "../../../lib/query/admin/domain-permissions/get";
-import { useAddDomainAllowMutation, useAddDomainBlockMutation, useRemoveDomainAllowMutation, useRemoveDomainBlockMutation } from "../../../lib/query/admin/domain-permissions/update";
+import { 
+	useDomainAllowsQuery,
+	useDomainBlocksQuery,
+} from "../../../lib/query/admin/domain-permissions/get";
+import {
+	useAddDomainAllowMutation,
+	useAddDomainBlockMutation,
+	useRemoveDomainAllowMutation,
+	useRemoveDomainBlockMutation,
+	useUpdateDomainAllowMutation,
+	useUpdateDomainBlockMutation,
+} from "../../../lib/query/admin/domain-permissions/update";
 import { DomainPerm } from "../../../lib/types/domain-permission";
 import { NoArg } from "../../../lib/types/query";
 import { Error } from "../../../components/error";
@@ -41,8 +51,9 @@ import { useBaseUrl } from "../../../lib/navigation/util";
 import { PermType } from "../../../lib/types/perm";
 import { useCapitalize } from "../../../lib/util";
 import { formDomainValidator } from "../../../lib/util/formvalidators";
+import UsernameLozenge from "../../../components/username-lozenge";
 
-export default function DomainPermDetail() {
+export default function DomainPermView() {
 	const baseUrl = useBaseUrl();
 	const search = useSearch();
 
@@ -101,33 +112,16 @@ export default function DomainPermDetail() {
 		? blocks[domain]
 		: allows[domain];
 	
-	// Render different into content depending on
-	// if we have a perm already for this domain.
-	let infoContent: React.JSX.Element;
-	if (existingPerm === undefined) {
-		infoContent = (
-			<span>
-				No stored {permType} yet, you can add one below:
-			</span>
-		);
-	} else {
-		infoContent = (
-			<div className="info">
-				<i className="fa fa-fw fa-exclamation-triangle" aria-hidden="true"></i>
-				<b>Editing existing domain {permTypeRaw} isn't implemented yet, <a href="https://github.com/superseriousbusiness/gotosocial/issues/1198" target="_blank" rel="noopener noreferrer">check here for progress</a></b>
-			</div>
-		);
-	}
+	const title = <span>Domain {permType} for {domain}</span>;
 
 	return (
-		<div>
-			<h1 className="text-cutoff">
-				<BackButton to={`~${baseUrl}/${permTypeRaw}`} />
-				{" "}
-				Domain {permType} for {domain}
-			</h1>
-			{infoContent}
-			<DomainPermForm
+		<div className="domain-permission-details">
+			<h1><BackButton to={`~${baseUrl}/${permTypeRaw}`} /> {title}</h1>
+			{ existingPerm
+				? <DomainPermDetails perm={existingPerm} permType={permType} />
+				: <span>No stored {permType} yet, you can add one below:</span>
+			}
+			<CreateOrUpdateDomainPerm
 				defaultDomain={domain}
 				perm={existingPerm}
 				permType={permType}
@@ -136,23 +130,75 @@ export default function DomainPermDetail() {
 	);
 }
 
-interface DomainPermFormProps {
+interface DomainPermDetailsProps {
+	perm: DomainPerm,
+	permType: PermType,
+}
+
+function DomainPermDetails({
+	perm,
+	permType
+}: DomainPermDetailsProps) {
+	const baseUrl = useBaseUrl();
+	const [ location ] = useLocation();
+	
+	const created = useMemo(() => {
+		if (perm.created_at) {
+			return new Date(perm.created_at).toDateString();
+		}
+		return "unknown";
+	}, [perm.created_at]);
+
+	return (
+		<dl className="info-list">
+			<div className="info-list-entry">
+				<dt>Created</dt>
+				<dd><time dateTime={perm.created_at}>{created}</time></dd>
+			</div>
+			<div className="info-list-entry">
+				<dt>Created By</dt>
+				<dd>
+					<UsernameLozenge
+						account={perm.created_by}
+						linkTo={`~/settings/moderation/accounts/${perm.created_by}`}
+						backLocation={`~${baseUrl}/${location}`}
+					/>
+				</dd>
+			</div>
+			<div className="info-list-entry">
+				<dt>Domain</dt>
+				<dd>{perm.domain}</dd>
+			</div>
+			<div className="info-list-entry">
+				<dt>Permission type</dt>
+				<dd className={`permission-type ${permType}`}>
+					<i
+						aria-hidden={true}
+						className={`fa fa-${permType === "allow" ? "check" : "close"}`}
+					></i>
+					{permType}
+				</dd>
+			</div>
+			<div className="info-list-entry">
+				<dt>Subscription ID</dt>
+				<dd>{perm.subscription_id ?? "[none]"}</dd>
+			</div>
+		</dl>
+	);
+}
+
+interface CreateOrUpdateDomainPermProps {
 	defaultDomain: string;
 	perm?: DomainPerm;
 	permType: PermType;
 }
 
-function DomainPermForm({ defaultDomain, perm, permType }: DomainPermFormProps) {
+function CreateOrUpdateDomainPerm({
+	defaultDomain,
+	perm,
+	permType
+}: CreateOrUpdateDomainPermProps) {
 	const isExistingPerm = perm !== undefined;
-	const disabledForm = isExistingPerm
-		? {
-			disabled: true,
-			title: "Domain permissions currently cannot be edited."
-		}
-		: {
-			disabled: false,
-			title: "",
-		};
 
 	const form = {
 		domain: useTextInput("domain", {
@@ -171,70 +217,80 @@ function DomainPermForm({ defaultDomain, perm, permType }: DomainPermFormProps) 
 	// react is like "weh" (mood), but we can decide
 	// which ones to use conditionally.
 	const [ addBlock, addBlockResult ] = useAddDomainBlockMutation();
+	const [ updateBlock, updateBlockResult ] = useUpdateDomainBlockMutation({ fixedCacheKey: perm?.id });
 	const [ removeBlock, removeBlockResult] = useRemoveDomainBlockMutation({ fixedCacheKey: perm?.id });
 	const [ addAllow, addAllowResult ] = useAddDomainAllowMutation();
+	const [ updateAllow, updateAllowResult ] = useUpdateDomainAllowMutation({ fixedCacheKey: perm?.id });
 	const [ removeAllow, removeAllowResult ] = useRemoveDomainAllowMutation({ fixedCacheKey: perm?.id });
 	
 	const [
-		addTrigger,
-		addResult,
+		createOrUpdateTrigger,
+		createOrUpdateResult,
 		removeTrigger,
 		removeResult,
 	] = useMemo(() => {
-		return permType == "block"
-			? [
-				addBlock,
-				addBlockResult,
-				removeBlock,
-				removeBlockResult,
-			]
-			: [
-				addAllow,
-				addAllowResult,
-				removeAllow,
-				removeAllowResult,
-			];
-	}, [permType,
-		addBlock, addBlockResult, removeBlock, removeBlockResult,
-		addAllow, addAllowResult, removeAllow, removeAllowResult,
+		switch (true) {
+			case (permType === "block" && !isExistingPerm):
+				return [ addBlock, addBlockResult, removeBlock, removeBlockResult ];
+			case (permType === "block"):
+				return [ updateBlock, updateBlockResult, removeBlock, removeBlockResult ];
+			case !isExistingPerm:
+				return [ addAllow, addAllowResult, removeAllow, removeAllowResult ];
+			default:
+				return [ updateAllow, updateAllowResult, removeAllow, removeAllowResult ];
+		}
+	}, [permType, isExistingPerm,
+		addBlock, addBlockResult, updateBlock, updateBlockResult, removeBlock, removeBlockResult,
+		addAllow, addAllowResult, updateAllow, updateAllowResult, removeAllow, removeAllowResult,
 	]);
 
-	// Use appropriate submission params for this permType.
-	const [submitForm, submitFormResult] = useFormSubmit(form, [addTrigger, addResult], { changedOnly: false });
+	// Use appropriate submission params for this
+	// permType, and whether we're creating or updating.
+	const [submit, submitResult] = useFormSubmit(
+		form,
+		[
+			createOrUpdateTrigger,
+			createOrUpdateResult,
+		],
+		{
+			changedOnly: isExistingPerm
+		},
+	);
 
 	// Uppercase first letter of given permType.
 	const permTypeUpper = useCapitalize(permType);
 
 	const [location, setLocation] = useLocation();
-
 	function verifyUrlThenSubmit(e) {
 		// Adding a new domain permissions happens on a url like
 		// "/settings/admin/domain-permissions/:permType/domain.com",
 		// but if domain input changes, that doesn't match anymore
 		// and causes issues later on so, before submitting the form,
 		// silently change url, and THEN submit.
-		let correctUrl = `/${permType}s/${form.domain.value}`;
-		if (location != correctUrl) {
-			setLocation(correctUrl);
+		if (!isExistingPerm) {
+			let correctUrl = `/${permType}s/${form.domain.value}`;
+			if (location != correctUrl) {
+				setLocation(correctUrl);
+			}
 		}
-		return submitForm(e);
+		return submit(e);
 	}
 
 	return (
 		<form onSubmit={verifyUrlThenSubmit}>
-			<TextInput
-				field={form.domain}
-				label="Domain"
-				placeholder="example.com"
-				autoCapitalize="none"
-				spellCheck="false"
-				{...disabledForm}
-			/>
+			{ !isExistingPerm && 
+				<TextInput
+					field={form.domain}
+					label="Domain"
+					placeholder="example.com"
+					autoCapitalize="none"
+					spellCheck="false"
+				/>
+			}
 
 			<Checkbox
 				field={form.obfuscate}
 				label="Obfuscate domain in public lists"
-				{...disabledForm}
 			/>
 
 			<TextArea
@@ -242,7 +298,6 @@ function DomainPermForm({ defaultDomain, perm, permType }: DomainPermFormProps) 
 				label="Private comment"
 				autoCapitalize="sentences"
 				rows={3}
-				{...disabledForm}
 			/>
 
 			<TextArea
@@ -250,15 +305,14 @@ function DomainPermForm({ defaultDomain, perm, permType }: DomainPermFormProps) 
 				label="Public comment"
 				autoCapitalize="sentences"
 				rows={3}
-				{...disabledForm}
 			/>
 
 			<div className="action-buttons row">
 				<MutationButton
-					label={permTypeUpper}
-					result={submitFormResult}
+					label={isExistingPerm ? "Update " + permType.toString() : permTypeUpper}
+					result={submitResult}
 					showError={false}
-					{...disabledForm}
+					disabled={false}
 				/>
 
 				{
@@ -266,7 +320,7 @@ function DomainPermForm({ defaultDomain, perm, permType }: DomainPermFormProps) 
 					<MutationButton
 						type="button"
 						onClick={() => removeTrigger(perm.id?? "")}
-						label="Remove"
+						label={"Remove " + permType.toString()} 
 						result={removeResult}
 						className="button danger"
 						showError={false}
@@ -276,7 +330,7 @@ function DomainPermForm({ defaultDomain, perm, permType }: DomainPermFormProps) 
 			</div>
 
 			<>
-				{addResult.error && <Error error={addResult.error} />}
+				{createOrUpdateResult.error && <Error error={createOrUpdateResult.error} />}
 				{removeResult.error && <Error error={removeResult.error} />}
 			</>
 

--- a/web/source/settings/views/moderation/domain-permissions/import-export.tsx
+++ b/web/source/settings/views/moderation/domain-permissions/import-export.tsx
@@ -61,7 +61,7 @@ export default function ImportExport() {
 									>
 										&lt; back
 									</span>
-									&nbsp; Confirm import of domain {form.permType.value}s:
+									&nbsp; Confirm {form.permType.value}s:
 								</h1>
 								<ProcessImport
 									list={parseResult.data}

--- a/web/source/settings/views/moderation/domain-permissions/process.tsx
+++ b/web/source/settings/views/moderation/domain-permissions/process.tsx
@@ -24,14 +24,12 @@ import { isValidDomainPermission, hasBetterScope } from "../../../lib/util/domai
 import {
 	useTextInput,
 	useBoolInput,
-	useRadioInput,
 	useCheckListInput,
 } from "../../../lib/form";
 
 import {
 	Select,
 	TextArea,
-	RadioGroup,
 	Checkbox,
 	TextInput,
 } from "../../../components/form/inputs";
@@ -113,84 +111,81 @@ function ImportList({ list, data: domainPerms, permType }: ImportListProps) {
 		privateComment: useTextInput("private_comment", {
 			defaultValue: `Imported on ${new Date().toLocaleString()}`
 		}),
-		privateCommentBehavior: useRadioInput("private_comment_behavior", {
-			defaultValue: "append",
-			options: {
-				append: "Append to",
-				replace: "Replace"
-			}
-		}),
+		replacePrivateComment: useBoolInput("replace_private_comment", { defaultValue: false }),
 		publicComment: useTextInput("public_comment"),
-		publicCommentBehavior: useRadioInput("public_comment_behavior", {
-			defaultValue: "append",
-			options: {
-				append: "Append to",
-				replace: "Replace"
-			}
-		}),
+		replacePublicComment: useBoolInput("replace_public_comment", { defaultValue: false }),
 		permType: permType,
 	};
 
-	const [importDomains, importResult] = useFormSubmit(form, useImportDomainPermsMutation(), { changedOnly: false });
+	const [importDomains, importResult] = useFormSubmit(
+		form,
+		useImportDomainPermsMutation(),
+		{ changedOnly: false },
+	);
 
 	return (
-		<>
-			<form
-				onSubmit={importDomains}
-				className="domain-perm-import-list"
-			>
-				<span>{list.length} domain{list.length != 1 ? "s" : ""} in this list</span>
+		<form
+			onSubmit={importDomains}
+			className="domain-perm-import-list"
+		>
+			<span>{list.length} domain{list.length != 1 ? "s" : ""} in this list</span>
 
-				{hasComment.both &&
+			{hasComment.both &&
 					<Select field={showComment} options={
 						<>
 							<option value="public_comment">Show public comments</option>
 							<option value="private_comment">Show private comments</option>
 						</>
 					} />
-				}
+			}
 
-				<div className="checkbox-list-wrapper">
-					<DomainCheckList
-						field={form.domains}
-						domainPerms={domainPerms}
-						commentType={showComment.value as "public_comment" | "private_comment"}
-						permType={form.permType}
-					/>
-				</div>
+			<div className="checkbox-list-wrapper">
+				<DomainCheckList
+					field={form.domains}
+					domainPerms={domainPerms}
+					commentType={showComment.value as "public_comment" | "private_comment"}
+					permType={form.permType}
+				/>
+			</div>
 
+			<Checkbox
+				field={form.obfuscate}
+				label="Obfuscate domains in public lists"
+			/>
+
+			<div className="set-comment-checkbox">
+				<Checkbox
+					field={form.replacePrivateComment}
+					label="Set/replace private comment(s) to:"
+				/>
 				<TextArea
 					field={form.privateComment}
-					label="Private comment"
 					rows={3}
+					disabled={!form.replacePrivateComment.value}
+					placeholder="Private comment"
 				/>
-				<RadioGroup
-					field={form.privateCommentBehavior}
-					label="imported private comment"
-				/>
+			</div>
 
+			<div className="set-comment-checkbox">
+				<Checkbox
+					field={form.replacePublicComment}
+					label="Set/replace public comment(s) to:"
+				/>
 				<TextArea
 					field={form.publicComment}
-					label="Public comment"
 					rows={3}
+					disabled={!form.replacePublicComment.value}
+					placeholder="Public comment"
 				/>
-				<RadioGroup
-					field={form.publicCommentBehavior}
-					label="imported public comment"
-				/>
+			</div>
 
-				<Checkbox
-					field={form.obfuscate}
-					label="Obfuscate domains in public lists"
-				/>
 
-				<MutationButton
-					label="Import"
-					disabled={false}
-					result={importResult}
-				/>
-			</form>
-		</>
+			<MutationButton
+				label="Import"
+				disabled={false}
+				result={importResult}
+			/>
+		</form>
 	);
 }
 

--- a/web/source/settings/views/moderation/router.tsx
+++ b/web/source/settings/views/moderation/router.tsx
@@ -25,7 +25,7 @@ import ReportDetail from "./reports/detail";
 import { ErrorBoundary } from "../../lib/navigation/error";
 import ImportExport from "./domain-permissions/import-export";
 import DomainPermissionsOverview from "./domain-permissions/overview";
-import DomainPermDetail from "./domain-permissions/detail";
+import DomainPermView from "./domain-permissions/detail";
 import AccountsSearch from "./accounts";
 import AccountsPending from "./accounts/pending";
 import AccountDetail from "./accounts/detail";
@@ -160,7 +160,7 @@ function ModerationDomainPermsRouter() {
 						<Route path="/subscriptions/preview" component={DomainPermissionSubscriptionsPreview} />
 						<Route path="/subscriptions/:permSubId" component={DomainPermissionSubscriptionDetail} />
 						<Route path="/:permType" component={DomainPermissionsOverview} />
-						<Route path="/:permType/:domain" component={DomainPermDetail} />
+						<Route path="/:permType/:domain" component={DomainPermView} />
 						<Route><Redirect to="/blocks"/></Route>
 					</Switch>
 				</ErrorBoundary>


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request implements editing of domain blocks + allows via the API and settings panel, fixes import of comments by removing the "append" option (which didn't work very well), and making the "replace" option work, and using `comment` vs `public_comment` correctly according to the mastodon API.

closes https://github.com/superseriousbusiness/gotosocial/issues/1198
closes https://github.com/superseriousbusiness/gotosocial/issues/3211
closes https://github.com/superseriousbusiness/gotosocial/issues/3833

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
