### PR TITLE
[bugfix] Change email `Date` header to use RFC2822

### DIFF
--- a/internal/email/common.go
+++ b/internal/email/common.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/superseriousbusiness/gotosocial/internal/config"
 	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+	"github.com/superseriousbusiness/gotosocial/internal/util"
 )
 
 func (s *sender) sendTemplate(template string, subject string, data any, toAddresses ...string) error {
@@ -105,7 +106,7 @@ func assembleMessage(mailSubject string, mailBody string, mailFrom string, msgID
 		// msg headers.'
 		msg.WriteString("To: Undisclosed Recipients:;" + CRLF)
 	}
-	msg.WriteString("Date: " + time.Now().Format(time.RFC822Z) + CRLF)
+	msg.WriteString("Date: " + util.FormatRFC2822(time.Now()) + CRLF)
 	msg.WriteString("From: " + mailFrom + CRLF)
 	msg.WriteString("Message-ID: <" + uuid.New().String() + "@" + msgIDHost + ">" + CRLF)
 	msg.WriteString("Subject: " + mailSubject + CRLF)

--- a/internal/util/time.go
+++ b/internal/util/time.go
@@ -19,9 +19,11 @@ package util
 
 import "time"
 
-// ISO8601 is a formatter for serializing times that forces ISO8601 behavior.
-const ISO8601 = "2006-01-02T15:04:05.000Z"
-const ISO8601Date = "2006-01-02"
+const (
+	ISO8601     = "2006-01-02T15:04:05.000Z"
+	ISO8601Date = "2006-01-02"
+	RFC2822     = "Mon, 02 Jan 2006 15:04:05 -0700"
+)
 
 // FormatISO8601 converts the given time to UTC and then formats it
 // using the ISO8601 const, which the Mastodon API is able to understand.
@@ -38,4 +40,12 @@ func FormatISO8601Date(t time.Time) string {
 // ParseISO8601 parses the given time string according to the ISO8601 const.
 func ParseISO8601(in string) (time.Time, error) {
 	return time.Parse(ISO8601, in)
+}
+
+// FormatRFC2822 converts the given time to local and then formats it using
+// the RFC2822 const, which conforms with email Date header requirements.
+//
+// See: https://www.rfc-editor.org/rfc/rfc2822#section-3.3
+func FormatRFC2822(t time.Time) string {
+	return t.Local().Format(RFC2822)
 }


### PR DESCRIPTION
Closes https://github.com/superseriousbusiness/gotosocial/issues/3971