### PR TITLE
[bugfix] Don't assume `"manuallyApprovesFollowers": true` if not set

### DIFF
--- a/internal/ap/properties.go
+++ b/internal/ap/properties.go
@@ -520,11 +520,11 @@ func SetDiscoverable(with WithDiscoverable, discoverable bool) {
 
 // GetManuallyApprovesFollowers returns the boolean contained in the ManuallyApprovesFollowers property of 'with'.
 //
-// Returns default 'true' if property unusable or not set.
+// Returns default 'false' if property unusable or not set.
 func GetManuallyApprovesFollowers(with WithManuallyApprovesFollowers) bool {
 	mafProp := with.GetActivityStreamsManuallyApprovesFollowers()
 	if mafProp == nil || !mafProp.IsXMLSchemaBoolean() {
-		return true
+		return false
 	}
 	return mafProp.Get()
 }

--- a/internal/typeutils/astointernal.go
+++ b/internal/typeutils/astointernal.go
@@ -154,7 +154,7 @@ func (c *Converter) ASRepresentationToAccount(
 	// Assume not memorial (todo)
 	acct.MemorializedAt = time.Time{}
 
-	// Extract 'manuallyApprovesFollowers' aka locked account (default = true).
+	// Extract 'manuallyApprovesFollowers' aka locked account (default = false).
 	manuallyApprovesFollowers := ap.GetManuallyApprovesFollowers(accountable)
 	acct.Locked = &manuallyApprovesFollowers
 


### PR DESCRIPTION
We've been assuming that the default value of `manuallyApprovesFollowers` should be `true` if the property isn't set at all on an actor, but this doesn't really make sense and leads to weird UX when users are trying to follow accounts that don't set the property at all, so this PR changes that default. Now accounts on softwares that don't set `manuallyApprovesFollowers` at all should appear as "unlocked" accounts in clients, which should be more accurate.