### PR TITLE
add instruction about postgres permission

### DIFF
--- a/docs/configuration/database.md
+++ b/docs/configuration/database.md
@@ -42,6 +42,13 @@ create user gotosocial with password 'some_really_good_password';
 grant all privileges on database gotosocial to gotosocial;
 ```
 
+If you start using Postgres after 14, or you encounter `error executing command: error creating dbservice: db migration error: ERROR: permission denied for schema public`, you should grant `CREATE` permission to your db user:
+
+```psql
+GRANT CREATE ON SCHEMA public TO gotosocial;
+SELECT has_schema_privilege('gotosocial', 'public', 'CREATE'); -- should return t
+```
+
 GoToSocial makes use of ULIDs (Universally Unique Lexicographically Sortable Identifiers) which will not work in non-English collate environments. For this reason it is important to create the database with `C.UTF-8` locale. To do that on systems which were already initialized with non-C locale, `template0` pristine database template must be used.
 
 If you want to use specific options when connecting to Postgres, you can use `db-postgres-connection-string` to define the connection string. If `db-postgres-connection-string` is defined, all other database related configuration fields will be ignored. For example, we can use `db-postgres-connection-string` to connect to `mySchema`, where the user name is `myUser` and password is `myPass` at `localhost` with the database name of `db`:


### PR DESCRIPTION
# Description

On [Postgres Document](https://www.postgresql.org/docs/current/ddl-schemas.html#:~:text=A%20user%20can%20also%20be%20allowed%20to%20create%20objects%20in%20someone%20else's%20schema.%20To%20allow%20that%2C%20the%20CREATE%20privilege%20on%20the%20schema%20needs%20to%20be%20granted.%20In%20databases%20upgraded%20from%20PostgreSQL%2014%20or%20earlier%2C%20everyone%20has%20that%20privilege%20on%20the%20schema%20public.%20Some%20usage%20patterns%20call%20for%20revoking%20that%20privilege:):

> A user can also be allowed to create objects in someone else's schema. To allow that, the CREATE privilege on the schema needs to be granted. In databases upgraded from PostgreSQL 14 or earlier, everyone has that privilege on the schema public. Some [usage patterns](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATTERNS) call for revoking that privilege:

So add some instructions about how to grant this permission in our doc.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
