### PR TITLE
[feature] Implement /oauth/revoke for token revocation

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -13197,6 +13197,43 @@ paths:
             summary: Returns a compliant nodeinfo response to node info queries.
             tags:
                 - nodeinfo
+    /oauth/revoke:
+        post:
+            consumes:
+                - multipart/form-data
+            operationId: oauthTokenRevoke
+            parameters:
+                - description: The client ID, obtained during app registration.
+                  in: formData
+                  name: client_id
+                  required: true
+                  type: string
+                - description: The client secret, obtained during app registration.
+                  in: formData
+                  name: client_secret
+                  required: true
+                  type: string
+                - description: The previously obtained token, to be invalidated.
+                  in: formData
+                  name: token
+                  required: true
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: OK - If you own the provided token, the API call will provide OK and an empty response `{}`. This operation is idempotent, so calling this API multiple times will still return OK.
+                "400":
+                    description: bad request
+                "403":
+                    description: forbidden - If you provide a token you do not own, the API call will return a 403 error.
+                "406":
+                    description: not acceptable
+                "500":
+                    description: internal server error
+            summary: Revoke an access token to make it no longer valid for use.
+            tags:
+                - oauth
     /readyz:
         get:
             description: If GtS is not ready, 500 Internal Error will be returned, and an error will be logged (but not returned to the caller, to avoid leaking internals).

--- a/internal/api/auth/auth.go
+++ b/internal/api/auth/auth.go
@@ -46,6 +46,7 @@ const (
 	OauthFinalizePath  = "/finalize"
 	OauthOOBTokenPath  = "/oob"   // #nosec G101 else we get a hardcoded credentials warning
 	OauthTokenPath     = "/token" // #nosec G101 else we get a hardcoded credentials warning
+	OauthRevokePath    = "/revoke"
 
 	/*
 		params / session keys
@@ -100,6 +101,7 @@ func (m *Module) RouteAuth(attachHandler func(method string, path string, f ...g
 // RouteOAuth routes all paths that should have an 'oauth' prefix
 func (m *Module) RouteOAuth(attachHandler func(method string, path string, f ...gin.HandlerFunc) gin.IRoutes) {
 	attachHandler(http.MethodPost, OauthTokenPath, m.TokenPOSTHandler)
+	attachHandler(http.MethodPost, OauthRevokePath, m.TokenRevokePOSTHandler)
 	attachHandler(http.MethodGet, OauthAuthorizePath, m.AuthorizeGETHandler)
 	attachHandler(http.MethodPost, OauthAuthorizePath, m.AuthorizePOSTHandler)
 	attachHandler(http.MethodPost, OauthFinalizePath, m.FinalizePOSTHandler)

--- a/internal/api/auth/auth_test.go
+++ b/internal/api/auth/auth_test.go
@@ -107,28 +107,40 @@ func (suite *AuthStandardTestSuite) TearDownTest() {
 	testrig.StopWorkers(&suite.state)
 }
 
-func (suite *AuthStandardTestSuite) newContext(requestMethod string, requestPath string, requestBody []byte, bodyContentType string) (*gin.Context, *httptest.ResponseRecorder) {
-	// create the recorder and gin test context
+func (suite *AuthStandardTestSuite) newContext(
+	requestMethod string,
+	requestPath string,
+	requestBody []byte,
+	bodyContentType string,
+) (*gin.Context, *httptest.ResponseRecorder) {
+	// Create the recorder and test context.
 	recorder := httptest.NewRecorder()
 	ctx, engine := testrig.CreateGinTestContext(recorder, nil)
 
-	// load templates into the engine
+	// Load templates into the engine.
 	testrig.ConfigureTemplatesWithGin(engine, "../../../web/template")
 
-	// create the request
+	// Create the request itself.
 	protocol := config.GetProtocol()
 	host := config.GetHost()
 	baseURI := fmt.Sprintf("%s://%s", protocol, host)
 	requestURI := fmt.Sprintf("%s/%s", baseURI, requestPath)
+	ctx.Request = httptest.NewRequest(
+		requestMethod,
+		requestURI,
+		bytes.NewReader(requestBody),
+	)
 
-	ctx.Request = httptest.NewRequest(requestMethod, requestURI, bytes.NewReader(requestBody)) // the endpoint we're hitting
-	ctx.Request.Header.Set("accept", "text/html")
-
+	// Transmit appropriate Content-Type.
 	if bodyContentType != "" {
 		ctx.Request.Header.Set("Content-Type", bodyContentType)
 	}
 
-	// trigger the session middleware on the context
+	// Accept whatever, so we can use
+	// this to test both HTML and JSON.
+	ctx.Request.Header.Set("accept", "*/*")
+
+	// Trigger the session middleware on the context.
 	store := memstore.NewStore(make([]byte, 32), make([]byte, 32))
 	store.Options(middleware.SessionOptions())
 	sessionMiddleware := sessions.Sessions("gotosocial-localhost", store)

--- a/internal/api/auth/revoke.go
+++ b/internal/api/auth/revoke.go
@@ -1,0 +1,133 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"net/http"
+
+	oautherr "codeberg.org/superseriousbusiness/oauth2/v4/errors"
+	"github.com/gin-gonic/gin"
+	apiutil "github.com/superseriousbusiness/gotosocial/internal/api/util"
+	"github.com/superseriousbusiness/gotosocial/internal/gtserror"
+)
+
+// TokenRevokePOSTHandler swagger:operation POST /oauth/revoke oauthTokenRevoke
+//
+// Revoke an access token to make it no longer valid for use.
+//
+//	---
+//	tags:
+//	- oauth
+//
+//	consumes:
+//	- multipart/form-data
+//
+//	produces:
+//	- application/json
+//
+//	parameters:
+//	-
+//		name: client_id
+//		in: formData
+//		description: The client ID, obtained during app registration.
+//		type: string
+//		required: true
+//	-
+//		name: client_secret
+//		in: formData
+//		description: The client secret, obtained during app registration.
+//		type: string
+//		required: true
+//	-
+//		name: token
+//		in: formData
+//		description: The previously obtained token, to be invalidated.
+//		type: string
+//		required: true
+//
+//	responses:
+//		'200':
+//			description: >-
+//				OK - If you own the provided token, the API call will provide OK and an empty response `{}`.
+//				This operation is idempotent, so calling this API multiple times will still return OK.
+//		'400':
+//			description: bad request
+//		'403':
+//			description: >-
+//				forbidden - If you provide a token you do not own, the API call will return a 403 error.
+//		'406':
+//			description: not acceptable
+//		'500':
+//			description: internal server error
+func (m *Module) TokenRevokePOSTHandler(c *gin.Context) {
+	if _, err := apiutil.NegotiateAccept(c, apiutil.JSONAcceptHeaders...); err != nil {
+		apiutil.ErrorHandler(c, gtserror.NewErrorNotAcceptable(err, err.Error()), m.processor.InstanceGetV1)
+		return
+	}
+
+	form := &struct {
+		ClientID     string `form:"client_id" validate:"required"`
+		ClientSecret string `form:"client_secret" validate:"required"`
+		Token        string `form:"token" validate:"required"`
+	}{}
+	if err := c.ShouldBind(form); err != nil {
+		errWithCode := gtserror.NewErrorBadRequest(err, err.Error())
+		apiutil.ErrorHandler(c, errWithCode, m.processor.InstanceGetV1)
+		return
+	}
+
+	if form.Token == "" {
+		errWithCode := gtserror.NewErrorBadRequest(
+			oautherr.ErrInvalidRequest,
+			"token not set",
+		)
+		apiutil.OAuthErrorHandler(c, errWithCode)
+		return
+	}
+
+	if form.ClientID == "" {
+		errWithCode := gtserror.NewErrorBadRequest(
+			oautherr.ErrInvalidRequest,
+			"client_id not set",
+		)
+		apiutil.OAuthErrorHandler(c, errWithCode)
+		return
+	}
+
+	if form.ClientSecret == "" {
+		errWithCode := gtserror.NewErrorBadRequest(
+			oautherr.ErrInvalidRequest,
+			"client_secret not set",
+		)
+		apiutil.OAuthErrorHandler(c, errWithCode)
+		return
+	}
+
+	errWithCode := m.processor.OAuthRevokeAccessToken(
+		c.Request.Context(),
+		form.ClientID,
+		form.ClientSecret,
+		form.Token,
+	)
+	if errWithCode != nil {
+		apiutil.OAuthErrorHandler(c, errWithCode)
+		return
+	}
+
+	apiutil.JSON(c, http.StatusOK, struct{}{})
+}

--- a/internal/api/auth/revoke_test.go
+++ b/internal/api/auth/revoke_test.go
@@ -1,0 +1,199 @@
+// GoToSocial
+// Copyright (C) GoToSocial Authors admin@gotosocial.org
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package auth_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/superseriousbusiness/gotosocial/internal/db"
+	"github.com/superseriousbusiness/gotosocial/testrig"
+)
+
+type RevokeTestSuite struct {
+	AuthStandardTestSuite
+}
+
+func (suite *RevokeTestSuite) TestRevokeOK() {
+	var (
+		app   = suite.testApplications["application_1"]
+		token = suite.testTokens["local_account_1"]
+	)
+
+	// Prepare request form.
+	requestBody, w, err := testrig.CreateMultipartFormData(
+		nil,
+		map[string][]string{
+			"token":         {token.Access},
+			"client_id":     {app.ClientID},
+			"client_secret": {app.ClientSecret},
+		})
+	if err != nil {
+		panic(err)
+	}
+
+	// Prepare request ctx.
+	ctx, recorder := suite.newContext(
+		http.MethodPost,
+		"/oauth/revoke",
+		requestBody.Bytes(),
+		w.FormDataContentType(),
+	)
+
+	// Submit the revoke request.
+	suite.authModule.TokenRevokePOSTHandler(ctx)
+
+	// Check response code.
+	// We don't really care about body.
+	suite.Equal(http.StatusOK, recorder.Code)
+	result := recorder.Result()
+	defer result.Body.Close()
+
+	// Ensure token now gone.
+	_, err = suite.state.DB.GetTokenByAccess(
+		context.Background(),
+		token.Access,
+	)
+	suite.ErrorIs(err, db.ErrNoEntries)
+}
+
+func (suite *RevokeTestSuite) TestRevokeWrongSecret() {
+	var (
+		app   = suite.testApplications["application_1"]
+		token = suite.testTokens["local_account_1"]
+	)
+
+	// Prepare request form.
+	requestBody, w, err := testrig.CreateMultipartFormData(
+		nil,
+		map[string][]string{
+			"token":         {token.Access},
+			"client_id":     {app.ClientID},
+			"client_secret": {"Not the right secret :( :( :("},
+		})
+	if err != nil {
+		panic(err)
+	}
+
+	// Prepare request ctx.
+	ctx, recorder := suite.newContext(
+		http.MethodPost,
+		"/oauth/revoke",
+		requestBody.Bytes(),
+		w.FormDataContentType(),
+	)
+
+	// Submit the revoke request.
+	suite.authModule.TokenRevokePOSTHandler(ctx)
+
+	// Check response code + body.
+	suite.Equal(http.StatusForbidden, recorder.Code)
+	result := recorder.Result()
+	defer result.Body.Close()
+
+	// Read json bytes.
+	b, err := io.ReadAll(result.Body)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// Indent nicely.
+	dst := bytes.Buffer{}
+	if err := json.Indent(&dst, b, "", "  "); err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Equal(`{
+  "error": "unauthorized_client",
+  "error_description": "Forbidden: You are not authorized to revoke this token"
+}`, dst.String())
+
+	// Ensure token still there.
+	_, err = suite.state.DB.GetTokenByAccess(
+		context.Background(),
+		token.Access,
+	)
+	suite.NoError(err)
+}
+
+func (suite *RevokeTestSuite) TestRevokeNoClientID() {
+	var (
+		app   = suite.testApplications["application_1"]
+		token = suite.testTokens["local_account_1"]
+	)
+
+	// Prepare request form.
+	requestBody, w, err := testrig.CreateMultipartFormData(
+		nil,
+		map[string][]string{
+			"token":         {token.Access},
+			"client_secret": {app.ClientSecret},
+		})
+	if err != nil {
+		panic(err)
+	}
+
+	// Prepare request ctx.
+	ctx, recorder := suite.newContext(
+		http.MethodPost,
+		"/oauth/revoke",
+		requestBody.Bytes(),
+		w.FormDataContentType(),
+	)
+
+	// Submit the revoke request.
+	suite.authModule.TokenRevokePOSTHandler(ctx)
+
+	// Check response code + body.
+	suite.Equal(http.StatusBadRequest, recorder.Code)
+	result := recorder.Result()
+	defer result.Body.Close()
+
+	// Read json bytes.
+	b, err := io.ReadAll(result.Body)
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	// Indent nicely.
+	dst := bytes.Buffer{}
+	if err := json.Indent(&dst, b, "", "  "); err != nil {
+		suite.FailNow(err.Error())
+	}
+
+	suite.Equal(`{
+  "error": "invalid_request",
+  "error_description": "Bad Request: client_id not set"
+}`, dst.String())
+
+	// Ensure token still there.
+	_, err = suite.state.DB.GetTokenByAccess(
+		context.Background(),
+		token.Access,
+	)
+	suite.NoError(err)
+}
+
+func TestRevokeTestSuite(t *testing.T) {
+	suite.Run(t, new(RevokeTestSuite))
+}

--- a/internal/processing/oauth.go
+++ b/internal/processing/oauth.go
@@ -18,6 +18,7 @@
 package processing
 
 import (
+	"context"
 	"net/http"
 
 	"codeberg.org/superseriousbusiness/oauth2/v4"
@@ -37,4 +38,18 @@ func (p *Processor) OAuthHandleTokenRequest(r *http.Request) (map[string]interfa
 func (p *Processor) OAuthValidateBearerToken(r *http.Request) (oauth2.TokenInfo, error) {
 	// todo: some kind of metrics stuff here
 	return p.oauthServer.ValidationBearerToken(r)
+}
+
+func (p *Processor) OAuthRevokeAccessToken(
+	ctx context.Context,
+	clientID string,
+	clientSecret string,
+	accessToken string,
+) gtserror.WithCode {
+	return p.oauthServer.RevokeAccessToken(
+		ctx,
+		clientID,
+		clientSecret,
+		accessToken,
+	)
 }


### PR DESCRIPTION
# Description

> If this is a code change, please include a summary of what you've coded, and link to the issue(s) it closes/implements.
>
> If this is a documentation change, please briefly describe what you've changed and why.

This pull request implements oauth token revocation via `/oauth/revoke` endpoint, in line with the Mastodon API. This allows applications to revoke their own tokens nicely when the user logs out. Also implements this polite log out behavior in the settings panel :)

closes https://github.com/superseriousbusiness/gotosocial/issues/1081

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [x] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [x] I/we have commented the added code, particularly in hard-to-understand areas.
- [x] I/we have made any necessary changes to documentation.
- [x] I/we have added tests that cover new code.
- [x] I/we have run tests and they pass locally with the changes.
- [x] I/we have run `go fmt ./...` and `golangci-lint run`.
