### PR TITLE
Remind the user that password resets don't work without restarting.

### DIFF
--- a/cmd/gotosocial/action/admin/account/account.go
+++ b/cmd/gotosocial/action/admin/account/account.go
@@ -383,6 +383,7 @@ var Password action.GTSAction = func(ctx context.Context) error {
 	}
 
 	user.EncryptedPassword = string(encryptedPassword)
+	log.Info(ctx, "Updating password; you must restart the server to use the new password.")
 	return state.DB.UpdateUser(
 		ctx, user,
 		"encrypted_password",


### PR DESCRIPTION
# Description

Every time I reset the password, I assume that something went wrong, because I forget that the server will not pick up on the reset password until it's been restarted according to the docs:

https://docs.gotosocial.org/en/latest/admin/cli/#gotosocial-admin-account-password

A reminder here would help reduce confusion.

## Checklist

Please put an x inside each checkbox to indicate that you've read and followed it: `[ ]` -> `[x]`

If this is a documentation change, only the first checkbox must be filled (you can delete the others if you want).

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
- [ ] I/we have discussed the proposed changes already, either in an issue on the repository, or in the Matrix chat.
- [x] I/we have not leveraged AI to create the proposed changes.
- [x] I/we have performed a self-review of added code.
- [x] I/we have written code that is legible and maintainable by others.
- [ ] I/we have commented the added code, particularly in hard-to-understand areas.
- [ ] I/we have made any necessary changes to documentation.
- [ ] I/we have added tests that cover new code.
- [ ] I/we have run tests and they pass locally with the changes.
- [ ] I/we have run `go fmt ./...` and `golangci-lint run`.
