### PR TITLE
[bugfix] media v2 endpoint fix unset url

### DIFF
--- a/internal/api/client/media/mediacreate_test.go
+++ b/internal/api/client/media/mediacreate_test.go
@@ -297,7 +297,7 @@ func (suite *MediaCreateTestSuite) TestMediaCreateSuccessfulV2() {
 	}, *attachmentReply.Meta)
 	suite.Equal("LiB|W-#6RQR.~qvzRjWF_3rqV@a$", *attachmentReply.Blurhash)
 	suite.NotEmpty(attachmentReply.ID)
-	suite.Nil(attachmentReply.URL)
+	suite.NotEmpty(attachmentReply.URL)
 	suite.NotEmpty(attachmentReply.PreviewURL)
 	suite.Equal(len(storageKeysBeforeRequest)+2, len(storageKeysAfterRequest)) // 2 images should be added to storage: the original and the thumbnail
 }


### PR DESCRIPTION
The v2 mastodon endpoint always returns TextURL, but in the case that a 202 Accepted (i.e. processing still in progress) is returned then the URL will be nil. Since we only ever return a 200 OK, we behave exactly the same as the v1 endpoint.

see: https://docs.joinmastodon.org/methods/media/#v2