### PR TITLE
[chore/performance] Reuse Intl.DateTimeFormat for formatting times

### DIFF
--- a/web/source/frontend/index.js
+++ b/web/source/frontend/index.js
@@ -315,22 +315,26 @@ function inLightbox(element) {
 		lightbox.pswp.currSlide.data.attachmentId;
 }
 
+// Define + reuse one DateTimeFormat (cheaper).
+const dateTimeFormat = Intl.DateTimeFormat(
+	undefined,
+	{
+		year: 'numeric',
+		month: 'short',
+		day: '2-digit',
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: false
+	},
+);
+
+// Reformat time text to browser locale.
 Array.from(document.getElementsByTagName('time')).forEach(timeTag => {
 	const datetime = timeTag.getAttribute('datetime');
 	const currentText = timeTag.textContent.trim();
 	// Only format if current text contains precise time.
 	if (currentText.match(/\d{2}:\d{2}/)) {
 		const date = new Date(datetime);
-		timeTag.textContent = date.toLocaleString(
-			undefined,
-			{
-				year: 'numeric',
-				month: 'short',
-				day: '2-digit',
-				hour: '2-digit',
-				minute: '2-digit',
-				hour12: false
-			},
-		);
+		timeTag.textContent = dateTimeFormat.format(date);
 	}
 });

--- a/web/template/status_attributes.tmpl
+++ b/web/template/status_attributes.tmpl
@@ -18,7 +18,7 @@
 */ -}}
 
 {{- define "ariaLabel" -}}
-@{{ .Account.Acct -}}, {{ .CreatedAt | timestampPrecise -}} (server time)
+@{{ .Account.Acct -}}, {{ .CreatedAt | timestampPrecise }} (server time)
 {{- if .LanguageTag -}}
     , language {{ .LanguageTag.DisplayStr -}}
 {{- end -}}


### PR DESCRIPTION
Reuse a formatter as described here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString

And fixes a tiny little aria label issue.