### PR TITLE
[chore] Change "federating with" to "knows of"

### DIFF
--- a/web/template/page_header.tmpl
+++ b/web/template/page_header.tmpl
@@ -100,6 +100,6 @@ Instance Logo
     <h1>{{- .instance.Title -}}</h1>
 </a>
 {{- if .showStrap }}
-<aside>home to {{ template "strapUsers" . }} who wrote {{ template "strapPosts" . }}, federating with {{ template "strapInstances" . }}</aside>
+<aside>home to {{ template "strapUsers" . }} who wrote {{ template "strapPosts" . }}; knows of {{ template "strapInstances" . }}</aside>
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Just changes "federating with x other instances" to "knows of x other instances" on the home page. The latter is a bit more accurate, as the count just shows the total number of instances that the instance *knows about* through having seen them, it doesn't take account of blocks or allowlists or anything.