### PR TITLE
Mention where to run the command to grant CREATE permissions

### DIFF
--- a/docs/configuration/database.md
+++ b/docs/configuration/database.md
@@ -42,7 +42,7 @@ create user gotosocial with password 'some_really_good_password';
 grant all privileges on database gotosocial to gotosocial;
 ```
 
-If you start using Postgres after 14, or you encounter `error executing command: error creating dbservice: db migration error: ERROR: permission denied for schema public`, you should grant `CREATE` permission to your db user:
+If you start using Postgres after 14, or you encounter `error executing command: error creating dbservice: db migration error: ERROR: permission denied for schema public`, you should grant `CREATE` permission to your db user *(This **must** be run in a postgres shell that's connected to the gotosocial database)*:
 
 ```psql
 GRANT CREATE ON SCHEMA public TO gotosocial;


### PR DESCRIPTION
# Description

the docs don't mention that the `GRANT CREATE ON SCHEMA public TO gotosocial;` command must be run in a posgres shell that's connected to the database, unlike the other setup commands on this page

## Checklist

- [x] I/we have read the [GoToSocial contribution guidelines](https://github.com/superseriousbusiness/gotosocial/blob/main/CONTRIBUTING.md).
